### PR TITLE
fixed bug where blank lines caused import failure in .properties upload

### DIFF
--- a/htdocs/web_portal/controllers/utils.php
+++ b/htdocs/web_portal/controllers/utils.php
@@ -17,7 +17,7 @@ function parse_properties($txtProperties) {
         $isWaitingOtherLine = false;
         foreach($lines as $i=>$line) {
 
-            if(empty($line) || (!$isWaitingOtherLine && strpos($line,"#") === 0)) continue;
+            if(empty(trim($line)) || (!$isWaitingOtherLine && strpos($line,"#") === 0)) continue;
 
             if(!$isWaitingOtherLine) {
                 $key = trim(substr($line,0,strpos($line,'=')));


### PR DESCRIPTION
The parser wasn't trimming the whitespace, causing it to try and interpret the blank line as a kvp.