### PR TITLE
Update gitignore to ignore the composer set up file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,4 @@ nb-configuration.xml
 #==============
 error.log
 transfer.log
+Composer-Setup.exe


### PR DESCRIPTION
One more file to ignore, comes from installing composer on windows machines using the .exe file they provide