### PR TITLE
updates to bootstrap_pdo template

### DIFF
--- a/tests/doctrine/bootstrap_pdo_TEMPLATE.php
+++ b/tests/doctrine/bootstrap_pdo_TEMPLATE.php
@@ -15,7 +15,6 @@
  * @return PHPUnit_Extensions_Database_DB_IDatabaseConnection
  */
 function getConnectionToTestDB() {
-     require_once 'PHPUnit/Extensions/Database/DB/DefaultDatabaseConnection.php';
      
      /*** Uncomment and fill in the connection details for your chosen database ***/
      

--- a/tests/doctrine/bootstrap_pdo_TEMPLATE.php
+++ b/tests/doctrine/bootstrap_pdo_TEMPLATE.php
@@ -11,7 +11,7 @@
 
 /**
  * Returns the database connection to your test databse.
- * Modify as required to return a connection to your test db. 
+ * Modify as required to return a connection to your test db.
  * @return PHPUnit_Extensions_Database_DB_IDatabaseConnection
  */
 function getConnectionToTestDB() {
@@ -27,7 +27,7 @@ function getConnectionToTestDB() {
      /////////////////////////////////////////////////////////////////////////////////////////////
          
      ///////////////////////ORACLE CONNECTION DETAILS/////////////////////////////////////////////
-     // $pdo = new PDO('oci:dbname=//localhost:1521/xe', 'DoctrineUnitTests', 'doc');      
+     // $pdo = new PDO('oci:dbname=//localhost:1521/xe', '<USER>', '<PASSWORD>');      
      // return new PHPUnit_Extensions_Database_DB_DefaultDatabaseConnection($pdo, 'USERS');
      /////////////////////////////////////////////////////////////////////////////////////////////
         


### PR DESCRIPTION
 - Add some clarity to the oracle template
 - remove the include that breaks the tests if it is left in

Also Atom has helpfully cleaned up some white space