### PR TITLE
Remove trailing whitespace from lines in php files

### DIFF
--- a/htdocs/PI/index.php
+++ b/htdocs/PI/index.php
@@ -5,7 +5,7 @@ namespace org\gocdb\services;
 /* ______________________________________________________
  * ======================================================
  * File: index.php
- * Author: John Casson, David Meredith 
+ * Author: John Casson, David Meredith
  * Description: Entry point for the programmatic interface
  *
  * License information
@@ -31,21 +31,21 @@ require_once __DIR__ . '/../web_portal/components/Get_User_Principle.php';
 #foreach ($files as $file) {
 #        require_once($file);
 #}
-// The default is 30secs, but some queries can take longer so we may need to 
-// up the limit. This should only be necessary for certain PI queries such as 
-// get_downtime and should not be used in the GUI/portal scripts. 
-set_time_limit(60); 
-// Set the timezone to UTC for rendering all times/dates in PI.  
-// The date-times stored in the DB are in UTC, however, we still need to 
-// set the TZ to utc when re-readig those date-times for subsequent 
-// getTimestamp() calls; without setting the TZ to UTC, the calculated timestamp 
-// value will be according to the server's default timezone (e.g. GMT). 
+// The default is 30secs, but some queries can take longer so we may need to
+// up the limit. This should only be necessary for certain PI queries such as
+// get_downtime and should not be used in the GUI/portal scripts.
+set_time_limit(60);
+// Set the timezone to UTC for rendering all times/dates in PI.
+// The date-times stored in the DB are in UTC, however, we still need to
+// set the TZ to utc when re-readig those date-times for subsequent
+// getTimestamp() calls; without setting the TZ to UTC, the calculated timestamp
+// value will be according to the server's default timezone (e.g. GMT).
 date_default_timezone_set("UTC");
 
 /**
- * Safely escape and return the data string (xss mitigation function). 
- * The string is esacped using htmlspecialchars.  
- * @see see https://www.owasp.org/index.php/PHP_Security_Cheat_Sheet  
+ * Safely escape and return the data string (xss mitigation function).
+ * The string is esacped using htmlspecialchars.
+ * @see see https://www.owasp.org/index.php/PHP_Security_Cheat_Sheet
  * @param string $data to encode
  * @param string $encoding
  * @return string
@@ -56,8 +56,8 @@ function xssafe($data, $encoding = 'UTF-8') {
 }
 
 /**
- * Safely escape then echo the given string (xss mitigation function).  
- * @see see https://www.owasp.org/index.php/PHP_Security_Cheat_Sheet  
+ * Safely escape then echo the given string (xss mitigation function).
+ * @see see https://www.owasp.org/index.php/PHP_Security_Cheat_Sheet
  * @param string $data to encode
  */
 function xecho($data) {
@@ -73,18 +73,18 @@ class PIRequest {
     private $output = null;
     private $params = array();
     private $dn = null;
-    private $baseUrl; 
-    
-    // params used to set the default behaviour of all paging queries, 
-    // these vals can be overidden per query if needed. 
-    // defaultPaging = true means that even if the 'page' URL param is 
-    // not specified, then the query will be paged by default (true is 
-    // the preference for large/production datasets). 
-    private $defaultPageSize = 200; 
+    private $baseUrl;
+
+    // params used to set the default behaviour of all paging queries,
+    // these vals can be overidden per query if needed.
+    // defaultPaging = true means that even if the 'page' URL param is
+    // not specified, then the query will be paged by default (true is
+    // the preference for large/production datasets).
+    private $defaultPageSize = 200;
     private $defaultPaging = TRUE; //FALSE;
-    
+
     public function __construct(){
-        // returns the base portal URL as defined in conf file 
+        // returns the base portal URL as defined in conf file
         $this->baseUrl = \Factory::getConfigService()->GetPortalURL();
     }
 
@@ -94,7 +94,7 @@ class PIRequest {
         $this->parseGET();
         $xml = $this->getXml();
         // don't do search/replace on large XML docs => mem-hungry/expensive!
-        //$xml = str_replace("#GOCDB_BASE_PORTAL_URL#", $this->portal_url, $xml); 
+        //$xml = str_replace("#GOCDB_BASE_PORTAL_URL#", $this->portal_url, $xml);
         echo($xml);
         //echo('<test>val</test>');
     }
@@ -195,8 +195,8 @@ class PIRequest {
                     require_once($directory . 'GetService.php');
                     $getSE = new GetService($em, $this->baseUrl);
                     if($getSE instanceof IPIQueryPageable){
-                        $getSE->setDefaultPaging($this->defaultPaging); 
-                        $getSE->setPageSize($this->defaultPageSize); 
+                        $getSE->setDefaultPaging($this->defaultPaging);
+                        $getSE->setPageSize($this->defaultPageSize);
                     }
                     $getSE->validateParameters($this->params);
                     $getSE->createQuery();

--- a/htdocs/PI/private/index.php
+++ b/htdocs/PI/private/index.php
@@ -19,7 +19,7 @@
      * limitations under the License.
      *
     /*====================================================== */
-    
+
     include '../index.php';
-    
+
 ?>

--- a/htdocs/PI/public/index.php
+++ b/htdocs/PI/public/index.php
@@ -2,7 +2,7 @@
     /*______________________________________________________
      *======================================================
      * File: index.php
-     * Author: John Casson, David Meredith 
+     * Author: John Casson, David Meredith
      * Description: Entry point for the programmatic interface
      *
      * License information
@@ -19,6 +19,6 @@
      * limitations under the License.
      *
     /*====================================================== */
-    
+
     include '../index.php';
 ?>

--- a/htdocs/web_portal/GOCDB_monitor/check.php
+++ b/htdocs/web_portal/GOCDB_monitor/check.php
@@ -7,7 +7,7 @@ $res[2] = test_url(PI_URL);
 $res[3] = test_url(SERVER_BASE_URL);
 
 
-$counts=array(	"ok" => 0, 
+$counts=array(	"ok" => 0,
                 "warn" => 0,
                 "error" => 0
             );
@@ -25,7 +25,7 @@ else if ($counts["warn"] != 0) {
     exit(0); // we don't want notifications if there is just a warning
 }
 else {
-    echo("All GOCDB tests are looking good\n"); 
+    echo("All GOCDB tests are looking good\n");
     exit(0);
 }
 

--- a/htdocs/web_portal/GOCDB_monitor/index.php
+++ b/htdocs/web_portal/GOCDB_monitor/index.php
@@ -23,8 +23,8 @@ $res = test_url(SERVER_BASE_URL);
 $test_statuses["GOCDB5 central portal availability"] = $res["status"];
 $test_messages["GOCDB5 central portal availability"] = $res["message"];
 
-            
-// DISPLAY RESULTS			
+
+// DISPLAY RESULTS
 echo("<H2>Service status overview</H2>");
 echo("<table border=1 cellspacing=0 cellpadding=5>");
 echo("<tr><td><b>Test</b></td><td><b>Status</b></td><td><b>Details</b></td><td><b>Doc/help</b></td></tr>");
@@ -35,7 +35,7 @@ foreach ($test_statuses as $test => $status){
             .$disp[$status]."<td><font size='1'>".
             $test_messages[$test]."</font></td><td><font size='1'>".
             $test_doc[$test]."</font></td></tr>");
-}			
+}
 echo("</table>");
 
 echo("<hr/><br/><br/>");

--- a/htdocs/web_portal/GOCDB_monitor/ops_monitor_check.php
+++ b/htdocs/web_portal/GOCDB_monitor/ops_monitor_check.php
@@ -1,13 +1,13 @@
 <?php
 require_once "tests.php";
 
-// function returns associative array 
-$res[1] = test_db_connection(); 
+// function returns associative array
+$res[1] = test_db_connection();
 $res[2] = test_url(PI_URL);
 //$res[3] = test_url(PORTAL_URL);
 $res[3] = test_url(SERVER_BASE_URL);
 
-$counts=array(	
+$counts=array(
         "ok" => 0,
         "warn" => 0,
         "error" => 0
@@ -17,13 +17,13 @@ foreach ($res as $r){
     $counts[$r["status"]]++;
 }
 /*
-If there is an error, counts["error"] is incremented, e.g. 
+If there is an error, counts["error"] is incremented, e.g.
 Array
 (
     [ok] => 0
     [warn] => 0
     [error] => 1
-) 
+)
  */
 
 

--- a/htdocs/web_portal/GOCDB_monitor/tests.php
+++ b/htdocs/web_portal/GOCDB_monitor/tests.php
@@ -108,7 +108,7 @@ function get_https2($url){
     if ($return == false) {
         throw new Exception("no result returned. curl says: ".curl_getinfo($handle));
     }
-     
+
     return $return;
 }
 

--- a/htdocs/web_portal/GOCDB_monitor/tests/URL.php
+++ b/htdocs/web_portal/GOCDB_monitor/tests/URL.php
@@ -1,12 +1,12 @@
 <?php
 namespace org\gocdb\tests;
 
-// TODO: Finish and use. This class isn't yet in use. Once it's finished 
-// it can will replace the procedural 
+// TODO: Finish and use. This class isn't yet in use. Once it's finished
+// it can will replace the procedural
 // code in ../index.php and ../check.php to check a URL.
 /**
  * Test a URL
- * 
+ *
  * Connects to a passed URL and says whether it's reachable
  * @author John Casson, David Meredith
  *
@@ -16,11 +16,11 @@ class URL {
     private $url;
     private $error;
     private $hasRun = false;
-     
+
     function __construct($url) {
         $this->url = $url;
     }
-    
+
     /**
      * Is the test successful
      * @throws Exception If the test hasn't been run
@@ -30,12 +30,12 @@ class URL {
         if(!$this->hasRun) {
             throw new \Exception("Test hasn't been run");
         }
-        
+
         if(empty($this->error)) {
             return true;
         }
     }
-    
+
     /**
      * If the test wasn't successful, return the error
      */
@@ -45,19 +45,19 @@ class URL {
         }
         return $this->error;
     }
-    
+
     /**
      * Runs the test
-     * 
+     *
      */
     public function run() {
         $this->get_https($this->url);
-        $this->hasRun = true;  
+        $this->hasRun = true;
     }
-    
+
     /**
      * Performs an http request
-     * 
+     *
      * Side effect: sets $this->error if the request fails
      * @param string $url
      * @throws Exception
@@ -77,21 +77,21 @@ class URL {
             CURLOPT_RETURNTRANSFER => '1',
             CURLOPT_CAPATH => self::CA_PATH
         );
-    
+
         $handle = curl_init();
         curl_setopt_array($handle, $curloptions);
-    
+
         $return = curl_exec($handle);
         if (curl_errno($handle)) {
             $this->error = curl_error($handle);
             return;
         }
         curl_close($handle);
-    
+
         if ($return == false) {
             $this->error = curl_getinfo($handle);
         }
-         
+
         return;
     }
 }

--- a/htdocs/web_portal/GocContextPath.php
+++ b/htdocs/web_portal/GocContextPath.php
@@ -1,17 +1,17 @@
 <?php
 
 /**
- * Get/set the directory path (context path) that is used as a prefix in 
- * the relative path of web assests (e.g. in the 'src' value of javascript and images). 
+ * Get/set the directory path (context path) that is used as a prefix in
+ * the relative path of web assests (e.g. in the 'src' value of javascript and images).
  * <p>
  * This is needed if deploying gocdb within another environment (such as a Symfony
- * component) which may require a context-path to that component. 
+ * component) which may require a context-path to that component.
  * If deploying GOCDB standalone, this path will normally be an empty string.
   </p>
- * Sample usage within an html view: 
- * <code> 
+ * Sample usage within an html view:
+ * <code>
  *    <img src="<?php echo \GocContextPath::getPath()?>img/site.png"/>
- * </code>   
+ * </code>
  *
  * @author David Meredith
  */
@@ -22,7 +22,7 @@ class GocContextPath {
         return self::$path;
     }
     public static function setPath($path){
-        self::$path = $path; 
+        self::$path = $path;
     }
-    
+
 }

--- a/htdocs/web_portal/components/Draw_Components/draw_page_components.php
+++ b/htdocs/web_portal/components/Draw_Components/draw_page_components.php
@@ -49,15 +49,15 @@
 
         // right side of the page
         $HTML .= "<div class=\"right_box\">";
-        
-        // logout button (if set - does not always need to be rendered)  
+
+        // logout button (if set - does not always need to be rendered)
         if(!empty(\Factory::$properties['LOGOUTURL'])){
-            $HTML .= "<div style='text-align: right;'>"; 
+            $HTML .= "<div style='text-align: right;'>";
             //$HTML .= '<a href="'.htmlspecialchars(\Factory::$properties['LOGOUTURL']).'"><b><font colour="red">Logout</font></b></a>';
             $HTML .= '<a href="'.htmlspecialchars(\Factory::$properties['LOGOUTURL']).'"><b><font class="btn btn-danger btn-xs">Logout</font></b></a>';
-            $HTML .= "</div>"; 
+            $HTML .= "</div>";
         }
-       
+
 
         return $HTML;
     }
@@ -128,7 +128,7 @@
         $HTML .= '<a href="http://www.egi.eu" target="_blank"><img src="'.\GocContextPath::getPath().'img/egi_logo.jpg" height="25"/></a>';
         $HTML .= '</div>';
         $HTML .= '<br>';
-        $HTML .= 'GOCDB is an EGI service provided by <a href="http://stfc.ac.uk">STFC</a> co-funded by <a href="http://egi.eu">EGI.eu</a> and <a href="http://go.egi.eu/eng">EGI-Engage</a>'; 
+        $HTML .= 'GOCDB is an EGI service provided by <a href="http://stfc.ac.uk">STFC</a> co-funded by <a href="http://egi.eu">EGI.eu</a> and <a href="http://go.egi.eu/eng">EGI-Engage</a>';
         $HTML .= '</div>';
 
         return $HTML;

--- a/htdocs/web_portal/components/Draw_Components/menu.php
+++ b/htdocs/web_portal/components/Draw_Components/menu.php
@@ -55,7 +55,7 @@ function xml_to_menu($menu_name, $menus_xml)
 
 function add_menu_item($menu_item)
 {
-    //Get user in order to correctly display GOCDB admin menu Items 
+    //Get user in order to correctly display GOCDB admin menu Items
     include_once __DIR__ . '/../Get_User_Principle.php';
     $dn = Get_User_Principle();
     $userserv = \Factory::getUserService();
@@ -66,10 +66,10 @@ function add_menu_item($menu_item)
     else {
         $userisadmin = $user->isAdmin();
     }
-    
+
     //Find out if the portal is currently read only from local_info.xml
     $portalIsReadOnly = \Factory::getConfigService()->IsPortalReadOnly();
- 
+
     foreach($menu_item->children() as $key => $value)
     {
         $html = "";

--- a/htdocs/web_portal/components/Get_User_Principle.php
+++ b/htdocs/web_portal/components/Get_User_Principle.php
@@ -21,24 +21,24 @@
  *
  /*====================================================== */
 
-require_once __DIR__ . '/../../../lib/Authentication/_autoload.php';  
+require_once __DIR__ . '/../../../lib/Authentication/_autoload.php';
 /**
- * Holds the principle string of the authenticated user.  
+ * Holds the principle string of the authenticated user.
  * <p>
- * Saving the principle string in a singleton after authentication 
- * allows fast lookups during current request processing. Calling code such as 
- * {@link Get_User_Principle()} can callout for the stored value rather than 
- * running through the authentication process again for each invocation  
- * (for to the current request only).       
+ * Saving the principle string in a singleton after authentication
+ * allows fast lookups during current request processing. Calling code such as
+ * {@link Get_User_Principle()} can callout for the stored value rather than
+ * running through the authentication process again for each invocation
+ * (for to the current request only).
  */
 class MyStaticPrincipleHolder {
     private static $_instance;
-    private $principleString = null; 
+    private $principleString = null;
     private function __construct() {
     }
     private function __clone() {
-       // defining an empty clone closes small loophole in PHP that could make 
-       // a copy of the object and defeat singletone responsibility 
+       // defining an empty clone closes small loophole in PHP that could make
+       // a copy of the object and defeat singletone responsibility
     }
     public static function getInstance() {
         if (!(self::$_instance instanceof self)) {
@@ -47,29 +47,29 @@ class MyStaticPrincipleHolder {
         return self::$_instance;
     }
     public function getPrincipleString(){
-        return $this->principleString;  
+        return $this->principleString;
     }
     public function setPrincipleString($principleString){
-        $this->principleString = $principleString;  
+        $this->principleString = $principleString;
     }
 }
 /**
- * Holds the AuthToken of the authenticated user.  
+ * Holds the AuthToken of the authenticated user.
  * <p>
- * Saving the token in a singleton after authentication 
- * allows fast lookups during current request processing. Calling code such as 
- * {@link Get_User_AuthToken()} can callout for the stored value rather than 
- * running through the authentication process again for each invocation  
- * (applies to the current request only).       
+ * Saving the token in a singleton after authentication
+ * allows fast lookups during current request processing. Calling code such as
+ * {@link Get_User_AuthToken()} can callout for the stored value rather than
+ * running through the authentication process again for each invocation
+ * (applies to the current request only).
  */
 class MyStaticAuthTokenHolder {
-    private static $_instance; 
-    private $authToken = null; 
+    private static $_instance;
+    private $authToken = null;
     private function __construct() {
     }
     private function __clone(){
-       // defining an empty clone closes small loophole in PHP that could make 
-       // a copy of the object and defeat singletone responsibility  
+       // defining an empty clone closes small loophole in PHP that could make
+       // a copy of the object and defeat singletone responsibility
     }
     public static function getInstance() {
         if (!(self::$_instance instanceof self)) {
@@ -78,106 +78,106 @@ class MyStaticAuthTokenHolder {
         return self::$_instance;
     }
     public function getAuthToken(){
-        return $this->authToken; 
+        return $this->authToken;
     }
     public function setAuthToken($authToken){
-        $this->authToken = $authToken;   
+        $this->authToken = $authToken;
     }
 }
 
 /**
- * Get the IAuthenticationToken for the user. 
+ * Get the IAuthenticationToken for the user.
  * <p>
- * Called from the portal to allow authentication.  
- * This method serves as the global integration point for all authentication requests. 
- * If you intend to support a different authentication mechanism, you will need 
- * to modify this method to support your chosen authentication scheme or call another version. 
- * 
- * @return \org\gocdb\security\authentication\IAuthenticationToken or null if can't authenticate request 
+ * Called from the portal to allow authentication.
+ * This method serves as the global integration point for all authentication requests.
+ * If you intend to support a different authentication mechanism, you will need
+ * to modify this method to support your chosen authentication scheme or call another version.
+ *
+ * @return \org\gocdb\security\authentication\IAuthenticationToken or null if can't authenticate request
  */
 function Get_User_AuthToken(){
-    // The token may have already been set in the static holder, 
+    // The token may have already been set in the static holder,
     // if true/not-null, then return rather than going through slower auth process again
     if(MyStaticAuthTokenHolder::getInstance()->getAuthToken() != null){
-        return MyStaticAuthTokenHolder::getInstance()->getAuthToken(); 
+        return MyStaticAuthTokenHolder::getInstance()->getAuthToken();
     }
-    // Token has not yet been stored for the current request, 
-    // therefore we need to authenticate. 
-    $fwMan = \org\gocdb\security\authentication\FirewallComponentManager::getInstance(); 
-    $firewallArray = $fwMan->getFirewallArray(); 
+    // Token has not yet been stored for the current request,
+    // therefore we need to authenticate.
+    $fwMan = \org\gocdb\security\authentication\FirewallComponentManager::getInstance();
+    $firewallArray = $fwMan->getFirewallArray();
     /* @var $firewall \org\gocdb\security\authentication\IFirewallComponent */
-    $firewall = $firewallArray['fwC1']; // select which firewall component you need  
-    $auth = $firewall->getAuthentication();  // invoke token resolution process 
+    $firewall = $firewallArray['fwC1']; // select which firewall component you need
+    $auth = $firewall->getAuthentication();  // invoke token resolution process
     if ($auth != null) {
-        $principleString = $auth->getPrinciple();  
-        // update the static holder so we can quickly return the token 
-        // for the current request on repeat callouts to Get_User_AuthToken (is quicker than authenticating again). 
-        MyStaticPrincipleHolder::getInstance()->setPrincipleString($principleString); 
-        MyStaticAuthTokenHolder::getInstance()->setAuthToken($auth); 
+        $principleString = $auth->getPrinciple();
+        // update the static holder so we can quickly return the token
+        // for the current request on repeat callouts to Get_User_AuthToken (is quicker than authenticating again).
+        MyStaticPrincipleHolder::getInstance()->setPrincipleString($principleString);
+        MyStaticAuthTokenHolder::getInstance()->setAuthToken($auth);
         return $auth;
-    } 
-    return null; 
+    }
+    return null;
 }
 
 /**
- * Get the user's principle string (x509 DN from certificate or from SAML attribute). 
+ * Get the user's principle string (x509 DN from certificate or from SAML attribute).
  * <p>
- * Called from the portal to allow authentication.  
- * This method serves as the global integration point for all authentication requests. 
- * If you intend to support a different authentication mechanism, you will need 
- * to modify this method to support your chosen authentication scheme or call another version. 
- * 
- * @return string or null if can't authenticate request 
+ * Called from the portal to allow authentication.
+ * This method serves as the global integration point for all authentication requests.
+ * If you intend to support a different authentication mechanism, you will need
+ * to modify this method to support your chosen authentication scheme or call another version.
+ *
+ * @return string or null if can't authenticate request
  */
 function Get_User_Principle(){
-    // The principle may have already been set in the static holder, 
+    // The principle may have already been set in the static holder,
     // if true/not-null, then return rather than going through slower auth process again
     if(MyStaticPrincipleHolder::getInstance()->getPrincipleString() != null){
-        return MyStaticPrincipleHolder::getInstance()->getPrincipleString(); 
+        return MyStaticPrincipleHolder::getInstance()->getPrincipleString();
     }
-    
-    // Principle has not yet been stored for the current request, 
-    // therefore we need to authenticate. 
-    $fwMan = \org\gocdb\security\authentication\FirewallComponentManager::getInstance(); 
-    $firewallArray = $fwMan->getFirewallArray(); 
+
+    // Principle has not yet been stored for the current request,
+    // therefore we need to authenticate.
+    $fwMan = \org\gocdb\security\authentication\FirewallComponentManager::getInstance();
+    $firewallArray = $fwMan->getFirewallArray();
     /* @var $firewall \org\gocdb\security\authentication\IFirewallComponent */
-    $firewall = $firewallArray['fwC1']; // select which firewall component you need  
-    $auth = $firewall->getAuthentication();  // invoke token resolution process 
+    $firewall = $firewallArray['fwC1']; // select which firewall component you need
+    $auth = $firewall->getAuthentication();  // invoke token resolution process
     if ($auth != null) {
-        $principleString = $auth->getPrinciple();  
-        // update the static holder so we can quickly return the principle 
-        // for the current request on repeat callouts to Get_User_Principle (is quicker than authenticating again). 
-        MyStaticPrincipleHolder::getInstance()->setPrincipleString($principleString); 
+        $principleString = $auth->getPrinciple();
+        // update the static holder so we can quickly return the principle
+        // for the current request on repeat callouts to Get_User_Principle (is quicker than authenticating again).
+        MyStaticPrincipleHolder::getInstance()->setPrincipleString($principleString);
         MyStaticAuthTokenHolder::getInstance()->setAuthToken($auth);
-        
+
         // Is user registered/known in the DB? if true, update their last login time
-        // once for the current request. 
+        // once for the current request.
         $user = \Factory::getUserService()->getUserByPrinciple($principleString);
         if($user != null){
-            \Factory::getUserService()->updateLastLoginTime($user); 
-        } 
+            \Factory::getUserService()->updateLastLoginTime($user);
+        }
         return $principleString;
-    } 
-    return null; 
+    }
+    return null;
 }
 
 /**
- * Get the DN from an x509 cert or null if a user certificate can't be loaded. 
- * Called from the PI to authenticate requests using certificates only. 
- * @return string or null if can't authenticate request 
+ * Get the DN from an x509 cert or null if a user certificate can't be loaded.
+ * Called from the PI to authenticate requests using certificates only.
+ * @return string or null if can't authenticate request
  */
 function Get_User_Principle_PI() {
-    $fwMan = \org\gocdb\security\authentication\FirewallComponentManager::getInstance(); 
-    $firewallArray = $fwMan->getFirewallArray(); 
-    try { 
-       $x509Token = new org\gocdb\security\authentication\X509AuthenticationToken(); 
-       $auth = $firewallArray['fwC1']->authenticate($x509Token); 
-       return $auth->getPrinciple(); 
+    $fwMan = \org\gocdb\security\authentication\FirewallComponentManager::getInstance();
+    $firewallArray = $fwMan->getFirewallArray();
+    try {
+       $x509Token = new org\gocdb\security\authentication\X509AuthenticationToken();
+       $auth = $firewallArray['fwC1']->authenticate($x509Token);
+       return $auth->getPrinciple();
     } catch(org\gocdb\security\authentication\AuthenticationException $ex){
-       // failed auth, so return null and let calling page decide to allow 
-       // access or not (some PI methods don't need to be authenticated with a cert) 
+       // failed auth, so return null and let calling page decide to allow
+       // access or not (some PI methods don't need to be authenticated with a cert)
     }
-    return null; 
+    return null;
 }
 
 
@@ -185,23 +185,23 @@ function Get_User_Principle_PI() {
 
 /*function Get_User_Principle_back()
 {
-    // Return hard wired user's principle string (DN) e.g. for testing     
+    // Return hard wired user's principle string (DN) e.g. for testing
     // =======================================================
     //return '/C=UK/O=eScience/OU=CLRC/L=DL/CN=david meredith';
 
-    // Check if an authentication token has been set in the SecurityContext class  
+    // Check if an authentication token has been set in the SecurityContext class
     // by higher level code, eg Symfony Security which provides a Firewall component
-    // may have been used to intercept the HTTP request and authenticate the 
-    // user (using whatever auth scheme was configured in the Firewall). A 
+    // may have been used to intercept the HTTP request and authenticate the
+    // user (using whatever auth scheme was configured in the Firewall). A
     // Symfony controller can then subsequently set the token in the SecurityContext
-    // before invoking the GOCDB code. 
+    // before invoking the GOCDB code.
     // =======================================================
     require_once __DIR__.'/../../../lib/Gocdb_Services/SecurityContextSource.php';
     if(\SecurityContextSource::getContext() != null){
-       $token = \SecurityContextSource::getContext()->getToken(); 
-       return str_replace("emailAddress=", "Email=", $token->getUser()->getUserName()); 
+       $token = \SecurityContextSource::getContext()->getToken();
+       return str_replace("emailAddress=", "Email=", $token->getUser()->getUserName());
     }
-    
+
     // ================Use x509 Authentication=======================
     //if(!isset($_SERVER['SSL_CLIENT_CERT']))
     //	return "";
@@ -230,7 +230,7 @@ function Get_User_Principle_PI() {
 
     // Fall back to try saml authentication (simplesaml)
     // =======================================================
-    if(false){ // disable by default - to use saml requires install of simplesamlphp and config below 
+    if(false){ // disable by default - to use saml requires install of simplesamlphp and config below
         require_once('/var/simplesamlphp/lib/_autoload.php');
         $as = new SimpleSAML_Auth_Simple('default-sp');
         $as->requireAuth();
@@ -240,16 +240,16 @@ function Get_User_Principle_PI() {
             //return $attributes['eduPersonPrincipalName'][0];
             $dnAttribute = $attributes['urn:oid:1.3.6.1.4.1.11433.2.2.1.9'][0];
             if(!empty($dnAttribute)){
-                return str_replace("emailAddress=", "Email=", $dnAttribute); 
+                return str_replace("emailAddress=", "Email=", $dnAttribute);
             } else {
                 die('Did not retrieve a valid certificate DN from identify provider - your SSO '
-                        . 'account needs to be associated with a certificate to login via this route'); 
+                        . 'account needs to be associated with a certificate to login via this route');
             }
         }
     }
 
-    // Couldn't authetnicate the user, so finally return null 
-    return null; 
+    // Couldn't authetnicate the user, so finally return null
+    return null;
 }*/
 
 

--- a/htdocs/web_portal/controllers/admin/add_ngi.php
+++ b/htdocs/web_portal/controllers/admin/add_ngi.php
@@ -23,16 +23,16 @@
  /*======================================================*/
 require_once __DIR__ . '/../../../../lib/Gocdb_Services/Factory.php';
 require_once __DIR__ . '/../utils.php';
-    
+
 /**
- * Controller for an add NGI request. Is only used by gocdb admin. 
+ * Controller for an add NGI request. Is only used by gocdb admin.
  * @global array $_POST only set if the browser has POSTed data
  * @return null
  */
 function add_ngi() {
     //The following line will be needed if this controller is ever used for non administrators:
     //checkPortalIsNotReadOnlyOrUserIsAdmin($user);
-    
+
     if($_POST) {     // If we receive a POST request it's to add a NGI
         submit();
     } else { // If there is no post data, draw the add NGI form
@@ -46,17 +46,17 @@ function add_ngi() {
  */
 function draw() {
     require_once __DIR__.'/../../../../lib/Gocdb_Services/Factory.php';
-    
-    //Check the user has permission to see the page, will throw exception 
+
+    //Check the user has permission to see the page, will throw exception
     //if correct permissions are lacking
     checkUserIsAdmin();
-   
-    // pass 2 nulls because we haven't created the ngi yet and we don't yet 
-    // support cascading of project scopes (not sure this is needed) 
-    $scopejsonStr = getEntityScopesAsJSON2(null, null, false); 
+
+    // pass 2 nulls because we haven't created the ngi yet and we don't yet
+    // support cascading of project scopes (not sure this is needed)
+    $scopejsonStr = getEntityScopesAsJSON2(null, null, false);
     $params['numberOfScopesRequired'] = \Factory::getConfigService()->getMinimumScopesRequired('ngi');
-    $params['scopejson'] = $scopejsonStr; 
-    
+    $params['scopejson'] = $scopejsonStr;
+
     //show the add NGI view
     show_view("admin/add_ngi.php", $params, "Add NGI");
 }
@@ -71,7 +71,7 @@ function submit() {
 
     //Get the posted NGI data
     $newValues = getNGIDataFromWeb();
-    
+
     //get the user data for the add NGI function (so it can check permissions)
     $dn = Get_User_Principle();
     $user = \Factory::getUserService()->getUserByPrinciple($dn);

--- a/htdocs/web_portal/controllers/admin/add_project.php
+++ b/htdocs/web_portal/controllers/admin/add_project.php
@@ -23,7 +23,7 @@
  /*======================================================*/
     require_once __DIR__.'/../../../../lib/Gocdb_Services/Factory.php';
     require_once __DIR__ . '/../utils.php';
-    
+
 /**
  * Controller for an add project request
  * @global array $_POST only set if the browser has POSTed data
@@ -32,8 +32,8 @@
 function add_project() {
     //The following line will be needed if this controller is ever used for non administrators:
     //checkPortalIsNotReadOnlyOrUserIsAdmin($user);
-    
-    if($_POST) {     // If we receive a POST request it's to add a project 
+
+    if($_POST) {     // If we receive a POST request it's to add a project
        submit();
     } else { // If there is no post data, draw the add NGI form
         draw();
@@ -46,11 +46,11 @@ function add_project() {
  */
 function draw() {
 
-    //Check the user has permission to see the page, will throw exception 
+    //Check the user has permission to see the page, will throw exception
     //if correct permissions are lacking
     checkUserIsAdmin();
-    
-    
+
+
     //show the add NGI view
     show_view("admin/add_project.php", null, "Add Project");
 }
@@ -65,7 +65,7 @@ function submit() {
 
     //Get the posted NGI data
     $newValues = getProjectDataFromWeb();
-    
+
     //get the user data for the add NGI function (so it can check permissions)
     $dn = Get_User_Principle();
     $user = \Factory::getUserService()->getUserByPrinciple($dn);

--- a/htdocs/web_portal/controllers/admin/add_scope.php
+++ b/htdocs/web_portal/controllers/admin/add_scope.php
@@ -32,7 +32,7 @@ require_once __DIR__.'/../../../../lib/Gocdb_Services/Factory.php';
 function add_scope() {
     //The following line will be needed if this controller is ever used for non administrators:
     //checkPortalIsNotReadOnlyOrUserIsAdmin($user);
-    
+
     if($_POST) {     // If we receive a POST request it's to add a scope
         submit();
     } else { // If there is no post data, draw the add scope form
@@ -45,10 +45,10 @@ function add_scope() {
  * @return null
  */
 function draw() {
-    //Check the user has permission to see the page, will throw exception 
+    //Check the user has permission to see the page, will throw exception
     //if correct permissions are lacking
     checkUserIsAdmin();
-      
+
     //show the add service type view
     show_view("admin/add_scope.php", null, "Add Scope");
 }
@@ -63,7 +63,7 @@ function submit() {
 
     //Get the posted service type data
     $values = getScopeDataFromWeb();
-    
+
     //get the user data for the add scope function (so it can check permissions)
     $dn = Get_User_Principle();
     $user = \Factory::getUserService()->getUserByPrinciple($dn);

--- a/htdocs/web_portal/controllers/admin/add_service_type.php
+++ b/htdocs/web_portal/controllers/admin/add_service_type.php
@@ -23,7 +23,7 @@
  /*======================================================*/
 require_once __DIR__ . '/../utils.php';
 require_once __DIR__.'/../../../../lib/Gocdb_Services/Factory.php';
-    
+
 /**
  * Controller for an add service type request
  * @global array $_POST only set if the browser has POSTed data
@@ -32,7 +32,7 @@ require_once __DIR__.'/../../../../lib/Gocdb_Services/Factory.php';
 function add_type() {
     //The following line will be needed if this controller is ever used for non administrators:
     //checkPortalIsNotReadOnlyOrUserIsAdmin($user);
-    
+
     if($_POST) {     // If we receive a POST request it's to add a service type
         submit();
     } else { // If there is no post data, draw the add service type form
@@ -44,11 +44,11 @@ function add_type() {
  * Draws the add service type form
  * @return null
  */
-function draw() {    
-    //Check the user has permission to see the page, will throw exception 
+function draw() {
+    //Check the user has permission to see the page, will throw exception
     //if correct permissions are lacking
     checkUserIsAdmin();
-      
+
     //show the add service type view
     show_view("admin/add_service_type.php", null, "Add Service Type");
 }
@@ -63,7 +63,7 @@ function submit() {
 
     //Get the posted service type data
     $newValues = getSTDataFromWeb();
-    
+
     //get the user data for the add service type function (so it can check permissions)
     $dn = Get_User_Principle();
     $user = \Factory::getUserService()->getUserByPrinciple($dn);
@@ -71,7 +71,7 @@ function submit() {
     try {
         //function will through error if user does not have the correct permissions
         $serviceType = \Factory::getServiceTypeService()->addServiceType($newValues, $user);
-        $params = array('Name' => $serviceType->getName(), 
+        $params = array('Name' => $serviceType->getName(),
                         'Description'=> $serviceType->getDescription(),
                         'ID'=> $serviceType->getId());
         show_view("admin/added_service_type.php", $params, "Successfuly added new service type");

--- a/htdocs/web_portal/controllers/admin/delete_ngi.php
+++ b/htdocs/web_portal/controllers/admin/delete_ngi.php
@@ -24,7 +24,7 @@ require_once __DIR__ . '/../../../../lib/Gocdb_Services/Factory.php';
 
 function delete_ngi() {
     checkUserIsAdmin();
-       
+
     if($_POST) {
         submit();
     }
@@ -43,7 +43,7 @@ function draw() {
      else {
          throw new \Exception("A NGI must be specified in the url");
      }
-     
+
      $params['NGI']= $ngi;
      $sites = $ngi->getSites();
      $params['Sites'] = $sites;
@@ -53,10 +53,10 @@ function draw() {
              $params['Services'][]=$service;
          }
      }
-      
-     
+
+
      show_view('/admin/delete_ngi.php', $params);
-     
+
 }
 
 function submit() {
@@ -71,21 +71,21 @@ function submit() {
      else {
          throw new \Exception("A NGI must be specified in the url");
      }
-     
+
      //save name to display later
      $params['Name'] = $ngi->getName();
-    
+
      $dn = Get_User_Principle();
      $user = \Factory::getUserService()->getUserByPrinciple($dn);
-    
+
      //remove ngi
      try {
        \Factory::getNgiService()->deleteNgi($ngi, $user);
     } catch(\Exception $e) {
         show_view('error.php', $e->getMessage());
         die();
-    }   
-    
+    }
+
     show_view('/site/deleted_site.php', $params);
 
 }

--- a/htdocs/web_portal/controllers/admin/delete_scope.php
+++ b/htdocs/web_portal/controllers/admin/delete_scope.php
@@ -22,44 +22,44 @@ require_once __DIR__.'/../../../web_portal/components/Get_User_Principle.php';
 require_once __DIR__.'/../utils.php';
 
 function remove_scope(){
-    
+
     //The following line will be needed if this controller is ever used for non administrators:
     //checkPortalIsNotReadOnlyOrUserIsAdmin($user);
-    
+
     //Check user has permission
     checkUserIsAdmin();
     if (!isset($_REQUEST['id']) || !is_numeric($_REQUEST['id']) ){
         throw new Exception("An id must be specified");
     }
-    
+
     //Get the scope from the id
     $serv= \Factory::getScopeService();
     $scope =$serv ->getScope($_REQUEST['id']);
-    
+
     //keep the name to display later
     $params['Name'] = $scope -> getName();
-    
+
     //check to see if there are NGIs, Sites, Service Groups, & services,
     // with this scope tag. If there are, prevent deletion of it.
     $ngisWithScope = $serv->getNgisFromScope($scope);
     $sitesWithScope = $serv->getSitesFromScope($scope);
     $sGroupWithScope = $serv->getServiceGroupsFromScope($scope);
     $serviceWithScope = $serv->getServicesFromScope($scope);
-    
+
     $deletionAllowed = true;
     if(sizeof($ngisWithScope)>0){
-      $deletionAllowed = false;  
+      $deletionAllowed = false;
     }
     if(sizeof($sitesWithScope )>0){
-      $deletionAllowed = false;  
+      $deletionAllowed = false;
     }
    if(sizeof($sGroupWithScope)>0){
-      $deletionAllowed = false;  
+      $deletionAllowed = false;
    }
    if(sizeof($serviceWithScope)>0){
-      $deletionAllowed = false;  
+      $deletionAllowed = false;
     }
-    
+
     //Allow the deletion of scopes that are in use
     $scopeInUseOveride=false;
     if(isset($_REQUEST['ScopeInUseOveride'])){
@@ -68,9 +68,9 @@ function remove_scope(){
             $deletionAllowed  = true;
         }
     }
-    
+
     if($deletionAllowed){
-        //Delete the scope. This fuction will check the user is allowed to 
+        //Delete the scope. This fuction will check the user is allowed to
         //perform this action and throw an error if not.
         $dn = Get_User_Principle();
         $user = \Factory::getUserService()->getUserByPrinciple($dn);
@@ -89,8 +89,8 @@ function remove_scope(){
         $params['Sites'] = $sitesWithScope;
         $params['ServiceGroups']=$sGroupWithScope;
         $params['Services']=$serviceWithScope;
-        show_view('admin/delete_scope_denied.php', $params, "Scope still in use");        
+        show_view('admin/delete_scope_denied.php', $params, "Scope still in use");
     }
-            
+
 }
 

--- a/htdocs/web_portal/controllers/admin/delete_service_type.php
+++ b/htdocs/web_portal/controllers/admin/delete_service_type.php
@@ -21,21 +21,21 @@
 require_once __DIR__.'/../../../web_portal/components/Get_User_Principle.php';
 
 function delete_service_type(){
-    
+
     //The following line will be needed if this controller is ever used for non administrators:
     //checkPortalIsNotReadOnlyOrUserIsAdmin($user);
-   
+
     if (!isset($_REQUEST['id']) || !is_numeric($_REQUEST['id']) ){
         throw new Exception("An id must be specified");
     }
     //Get the service type from the id
     $serv= \Factory::getServiceTypeService();
     $serviceType =$serv ->getServiceType($_REQUEST['id']);
-    
+
     //keep the name to display later
     $params['Name'] = $serviceType -> getName();
-    
-    //Delete the service type. This fuction will check the user is allowed to 
+
+    //Delete the service type. This fuction will check the user is allowed to
     //perform this action and throw an error if not.
     $dn = Get_User_Principle();
     $user = \Factory::getUserService()->getUserByPrinciple($dn);
@@ -45,7 +45,7 @@ function delete_service_type(){
         show_view('error.php', $e->getMessage());
         die();
     }
-    
+
     show_view("admin/deleted_service_type.php", $params, $params['Name'].'deleted');
-            
+
 }

--- a/htdocs/web_portal/controllers/admin/delete_service_type_denied.php
+++ b/htdocs/web_portal/controllers/admin/delete_service_type_denied.php
@@ -4,9 +4,9 @@
  * File: delete_service_type_denied.php
  * Author: George Ryall
  * Description: Displays a page explaining a service type delition has failed
- *              this happens when there are still services of that 
+ *              this happens when there are still services of that
  *              service type in the database
- * 
+ *
  * License information
  *
  * Copyright 2013 STFC
@@ -23,19 +23,19 @@
 require_once __DIR__ . '/../utils.php';
 
 function deny_delete_type(){
-     //Check the user has permission to see the page, will throw exception 
+     //Check the user has permission to see the page, will throw exception
     //if correct permissions are lacking
     checkUserIsAdmin();
-    
+
     //Get a service type service and then the service type to be deleted
     $serv= \Factory::getServiceTypeService();
     $serviceType =$serv ->getServiceType($_REQUEST['id']);
-    
+
     //Get the services for that service and pass them to the denied view
     $params['ServiceType'] = $serviceType;
     $params['Services'] = $serv ->getServices($serviceType->getId());
-    
+
     //display the deletion denied view
     show_view("admin/delete_service_type_denied.php", $params, 'Deletion Failed');
-            
+
 }

--- a/htdocs/web_portal/controllers/admin/edit_scope.php
+++ b/htdocs/web_portal/controllers/admin/edit_scope.php
@@ -32,7 +32,7 @@ require_once __DIR__ . '/../../../../lib/Gocdb_Services/Factory.php';
 function edit_scope() {
      //The following line will be needed if this controller is ever used for non administrators:
     //checkPortalIsNotReadOnlyOrUserIsAdmin($user);
-    
+
     if($_POST) {     // If we receive a POST request it's to edit a scope
         submit();
     } else { // If there is no post data, draw the edit scope form
@@ -45,8 +45,8 @@ function edit_scope() {
  * @return null
  */
 function draw() {
-  
-    //Check the user has permission to see the page, will throw exception 
+
+    //Check the user has permission to see the page, will throw exception
     //if correct permissions are lacking
     checkUserIsAdmin();
     if (!isset($_REQUEST['id']) || !is_numeric($_REQUEST['id']) ){
@@ -58,7 +58,7 @@ function draw() {
     $params = array('Name' => $scope->getName(),
                     'Id' => $scope->getId(),
                     'Description' => $scope->getDescription());
-    
+
     //show the add service type view
     show_view("admin/edit_scope.php", $params, "Edit Scope");
 }
@@ -72,12 +72,12 @@ function submit() {
     require_once __DIR__ . '/../../../../htdocs/web_portal/components/Get_User_Principle.php';
 
     $serv =\Factory::getScopeService();
-    
+
     //Get the posted service type data
     $values = getScopeDataFromWeb();
-    
+
     $scope = $serv->getScope($values['Id']);
-    
+
     //get the user data for the add scope function (so it can check permissions)
     $dn = Get_User_Principle();
     $user = \Factory::getUserService()->getUserByPrinciple($dn);

--- a/htdocs/web_portal/controllers/admin/edit_service_type.php
+++ b/htdocs/web_portal/controllers/admin/edit_service_type.php
@@ -32,7 +32,7 @@ require_once __DIR__.'/../../../../lib/Gocdb_Services/Factory.php';
 function edit_type() {
     //The following line will be needed if this controller is ever used for non administrators:
     //checkPortalIsNotReadOnlyOrUserIsAdmin($user);
-    
+
     if($_POST) {     // If we receive a POST request it's for a service type edit
         submit();
     } else { // If there is no post data, draw the service type edit
@@ -45,7 +45,7 @@ function edit_type() {
  * @return null
  */
 function draw() {
-    //Check the user has permission to see the page, will throw exception 
+    //Check the user has permission to see the page, will throw exception
     //if correct permissions are lacking
     checkUserIsAdmin();
     if (!isset($_REQUEST['id']) || !is_numeric($_REQUEST['id']) ){
@@ -71,15 +71,15 @@ function submit() {
 
     //Get the posted service type data
     $newValues = getSTDataFromWeb();
-    
+
     //get the user data for the add site function (so it can check permissions)
     $dn = Get_User_Principle();
     $user = \Factory::getUserService()->getUserByPrinciple($dn);
-    
+
     //get the service type service and the service type being edited
     $serv = \Factory::getServiceTypeService();
     $unalteredServiceType = $serv->getServiceType($newValues['ID']);
-    
+
     try {
         //function will throw error if user does not have the correct permissions
         $alteredServiceType =$serv->editServiceType($unalteredServiceType, $newValues, $user);

--- a/htdocs/web_portal/controllers/admin/edit_user_dn.php
+++ b/htdocs/web_portal/controllers/admin/edit_user_dn.php
@@ -18,7 +18,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  /*======================================================*/
-require_once __DIR__.'/../../../../lib/Gocdb_Services/Factory.php'; 
+require_once __DIR__.'/../../../../lib/Gocdb_Services/Factory.php';
 require_once __DIR__ . '/../utils.php';
 
 /**
@@ -29,7 +29,7 @@ require_once __DIR__ . '/../utils.php';
 function edit_dn() {
     //The following line will be needed if this controller is ever used for non administrators:
     //checkPortalIsNotReadOnlyOrUserIsAdmin($user);
-    
+
     if($_POST) {     // If we receive a POST request it's to edit a user dn
         submit();
     } else { // If there is no post data, draw the edit DN page
@@ -42,7 +42,7 @@ function edit_dn() {
  * @return null
  */
 function draw() {
-    //Check the user has permission to see the page, will throw exception 
+    //Check the user has permission to see the page, will throw exception
     //if correct permissions are lacking
     checkUserIsAdmin();
     if (!isset($_REQUEST['id']) || !is_numeric($_REQUEST['id']) ){
@@ -51,18 +51,18 @@ function draw() {
     //Get user details
     $serv = \Factory::getUserService();
     $user = $serv->getUser($_REQUEST['id']);
-    
+
     //Throw exception if not a valid user id
     if(is_null($user)) {
         throw new \Exception("A user with ID '".$_REQUEST['id']."' Can not be found");
-    }    
-    
+    }
+
     $params["ID"]=$user->getId();
     $params["Title"]=$user->getTitle();
-    $params["Forename"]=$user->getForename();  
-    $params["Surname"]=$user->getSurname();     
+    $params["Forename"]=$user->getForename();
+    $params["Surname"]=$user->getSurname();
     $params["CertDN"]=$user->getCertificateDn();
-    
+
     //show the edit user dn view
     show_view("admin/edit_user_dn.php", $params, "Edit Certificate DN");
 }
@@ -70,19 +70,19 @@ function draw() {
 /**
  * Retrieves the new dn from a portal request and submit it to the
  * services layer's user functions.
- * @return null 
+ * @return null
 */
 function submit() {
     require_once __DIR__ . '/../../../../htdocs/web_portal/components/Get_User_Principle.php';
-    
+
     //Get a user service
     $serv = \Factory::getUserService();
-    
+
     //Get the posted service type data
    $userID =$_REQUEST['ID'];
    $newDN = $_REQUEST['DN'];
    $user = $serv->getUser($userID);
-    
+
     //get the user data for the edit user DN function (so it can check permissions)
     $currentUserDN = Get_User_Principle();
     $currentUser = $serv->getUserByPrinciple($currentUserDN);
@@ -90,7 +90,7 @@ function submit() {
     try {
         //function will through error if user does not have the correct permissions
         $serv->editUserDN($user, $newDN, $currentUser);
-        
+
         $params = array('Name' => $user->getForename()." ".$user->getSurname(),
                         'ID'=> $user->getId());
         show_view("admin/edited_user_dn.php", $params, "Success");

--- a/htdocs/web_portal/controllers/admin/edit_user_isadmin.php
+++ b/htdocs/web_portal/controllers/admin/edit_user_isadmin.php
@@ -18,9 +18,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  /*======================================================*/
-require_once __DIR__.'/../../../../lib/Gocdb_Services/Factory.php'; 
+require_once __DIR__.'/../../../../lib/Gocdb_Services/Factory.php';
 require_once __DIR__ . '/../utils.php';
-    
+
 /**
  * Controller for promoting/demoting administrators using isAdmin property
  * @global array $_POST only set if the browser has POSTed data
@@ -29,7 +29,7 @@ require_once __DIR__ . '/../utils.php';
 function make_admin() {
     //The following line will be needed if this controller is ever used for non administrators:
     //checkPortalIsNotReadOnlyOrUserIsAdmin($user);
-    
+
     if($_POST) {     // If we receive a POST request it's to change an admin status
         submit();
     } else { // If there is no post data, draw the edit isAdmin page
@@ -42,7 +42,7 @@ function make_admin() {
  * @return null
  */
 function draw() {
-    //Check the user has permission to see the page, will throw exception 
+    //Check the user has permission to see the page, will throw exception
     //if correct permissions are lacking
     checkUserIsAdmin();
     if (!isset($_REQUEST['id']) || !is_numeric($_REQUEST['id']) ){
@@ -51,25 +51,25 @@ function draw() {
     //Get user details
     $serv = \Factory::getUserService();
     $user = $serv->getUser($_REQUEST['id']);
-    
+
     //Throw exception if not a valid user
     if(is_null($user)) {
         throw new \Exception("A user with ID '".$_REQUEST['id']."' Can not be found");
-    }    
-    
+    }
+
     $params["ID"]=$user->getId();
-    $params["Forename"]=$user->getForename();  
-    $params["Surname"]=$user->getSurname();     
+    $params["Forename"]=$user->getForename();
+    $params["Surname"]=$user->getSurname();
     $params["CertDN"]=$user->getCertificateDn();
     $params["IsAdmin"]=$user->isAdmin();
-    
+
     if($params["IsAdmin"]){
         $title = "Demote ".$params["IsAdmin"]." ".$params["Surname"];
     }
     else{
         $title = "Promote ".$params["IsAdmin"]." ".$params["Surname"];
     }
-    
+
     //show the edit user Admin view
     show_view("admin/edit_user_isadmin.php", $params, $title);
 }
@@ -77,24 +77,24 @@ function draw() {
 /**
  * Retrieves the new isadmin value from a portal request and submit it to the
  * services layer's user functions.
- * @return null 
+ * @return null
 */
 function submit() {
     require_once __DIR__ . '/../../../../htdocs/web_portal/components/Get_User_Principle.php';
     if(true){
-        throw new Exception("Disabled in controller"); 
-    } 
-    //Check the user has permission, will throw exception 
+        throw new Exception("Disabled in controller");
+    }
+    //Check the user has permission, will throw exception
     //if correct permissions are lacking
     /*checkUserIsAdmin();
-    
+
     //Get a user service
     $serv = \Factory::getUserService();
-    
+
     //Get the posted user data
    $userID =$_REQUEST['ID'];
    $user = $serv->getUser($userID);
-   
+
    //Note that a string is recived from post and must be converted to boolean
    if($_REQUEST['IsAdmin']=="true"){
        $isAdmin=true;
@@ -110,7 +110,7 @@ function submit() {
     try {
         //function will through error if user does not have the correct permissions
         $serv->setUserIsAdmin($user, $currentUser, $isAdmin);
-        
+
         $params = array('Name' => $user->getForename()." ".$user->getSurname(),
                         'IsAdmin'=> $user->isAdmin(),
                         'ID'=> $user->getId());

--- a/htdocs/web_portal/controllers/admin/move_service_end_point.php
+++ b/htdocs/web_portal/controllers/admin/move_service_end_point.php
@@ -30,8 +30,8 @@ require_once __DIR__ . '/../utils.php';
 function move_service_end_point() {
     //The following line will be needed if this controller is ever used for non administrators:
     //checkPortalIsNotReadOnlyOrUserIsAdmin($user);
-    
-    if($_POST) {    
+
+    if($_POST) {
         // If we receive a POST request it's for a service movement
         submit();
     } else {
@@ -49,7 +49,7 @@ function submit() {
     require_once __DIR__.'/../../../../lib/Gocdb_Services/Factory.php';
     require_once __DIR__.'/../../../web_portal/components/Get_User_Principle.php';
 
-    
+
     //Get the submitted data
     $movementrequest = getSEPMoveDataFromWeb();
 
@@ -58,11 +58,11 @@ function submit() {
     if(!array_key_exists('NewSite',$movementrequest)){
         //Run the submit old site and display the service_end_point_move view
         submitOldSite($movementrequest);
-    }	
+    }
     else {
         //Carry out the move with submitted data then show success view
         submitMoveSEP($movementrequest);
-    } 
+    }
 }
 
 /**
@@ -71,14 +71,14 @@ function submit() {
  *  @return null
  */
 function drawMoveSite(\Site $oldSite) {
-    //Check the user has permission to see the page, will throw exception 
+    //Check the user has permission to see the page, will throw exception
     //if the user is not an admin
     checkUserIsAdmin();
- 
+
     //Get a list of services and list of sites to select from
     $sites= \Factory::getSiteService()->getSitesBy();
     $services = $oldSite->getServices();
-    
+
     //Put into an array to be passed to view
     $params = array('Sites' => $sites, 'Services' => $services,
                     'OldSite' => $oldSite->getShortName());
@@ -87,17 +87,17 @@ function drawMoveSite(\Site $oldSite) {
 }
 
 /**
- *  Draws a form to select the Site from which you wish to move a service 
+ *  Draws a form to select the Site from which you wish to move a service
  *  @return null
  */
 function drawSelectOldSite() {
-    // Check the user has permission to see the page, will throw exception 
+    // Check the user has permission to see the page, will throw exception
     //if the user does not
-    checkUserIsAdmin();   
+    checkUserIsAdmin();
 
     //Get a list  of Sites to select from
     $sites= \Factory::getSiteService()->getSitesBy();
-    
+
     //Put into an array to be passed to view
     $params = array('Sites' => $sites);
 
@@ -114,7 +114,7 @@ function drawSelectOldSite() {
 function getSEPMoveDataFromWeb() {
     // Fields that are used to link other objects to the site
     $fields = array('OldSite', 'NewSite', 'Services');
-    
+
     foreach($fields as $field) {
         if(array_key_exists($field,$_REQUEST)){
             $SEP_move_data[$field] = $_REQUEST[$field];
@@ -131,7 +131,7 @@ function getSEPMoveDataFromWeb() {
  */
 function submitOldSite($submitvalues) {
     //Get the old site
-    $oldSite_id = $submitvalues['OldSite'];        
+    $oldSite_id = $submitvalues['OldSite'];
     $oldSite = \Factory::getSiteService()->getSite($oldSite_id);
     //Draw the move site form
     drawMoveSite($oldSite);
@@ -171,7 +171,7 @@ function submitMoveSEP($movementDetails) {
         foreach($service_ids as $service_id){
             $serviceInstance = $serv->getService($service_id);
             $serv->moveService($serviceInstance, $newSite, $user);
-            $services[] = $serviceInstance; 
+            $services[] = $serviceInstance;
         }
     } catch(\Exception $e) {
         show_view('error.php', $e->getMessage());

--- a/htdocs/web_portal/controllers/admin/move_site.php
+++ b/htdocs/web_portal/controllers/admin/move_site.php
@@ -30,7 +30,7 @@ require_once __DIR__ . '/../utils.php';
 function move_site() {
     //The following line will be needed if this controller is ever used for non administrators:
     //checkPortalIsNotReadOnlyOrUserIsAdmin($user);
-    
+
     if($_POST) {     // If we receive a POST request it's for a site move
         submit();
     } else { // If there is no post data, draw the select old NGI form
@@ -47,7 +47,7 @@ function submit() {
     require_once __DIR__.'/../../../../lib/Gocdb_Services/Factory.php';
     require_once __DIR__.'/../../../web_portal/components/Get_User_Principle.php';
 
-    
+
     //Get the submitted data
     $movementrequest = getSiteMoveDataFromWeb();
 
@@ -56,11 +56,11 @@ function submit() {
     if(!array_key_exists('NewNGI',$movementrequest)){
         //Run the submit old NGI and display the site_move view
         submitOldNgi($movementrequest);
-    }	
+    }
     else {
         //Carry out the move with submitted data then show success view
         submitMoveSite($movementrequest);
-    } 
+    }
 }
 
 /**
@@ -69,14 +69,14 @@ function submit() {
  *  @return null
  */
 function drawMoveSite(\NGI $oldNgi) {
-    //Check the user has permission to see the page, will throw exception 
+    //Check the user has permission to see the page, will throw exception
     //if correct permissions are lacking
     checkUserIsAdmin();
- 
+
     //Get a list of sites and list of NGIs to select from
     $ngis= \Factory::getNgiService()->getNGIs();
     $sites = $oldNgi->getSites();
-    
+
     //Put into an array to be passed to view
     $params = array('Ngis' => $ngis, 'sites' => $sites, 'OldNgi' => $oldNgi->getName());
 
@@ -88,13 +88,13 @@ function drawMoveSite(\NGI $oldNgi) {
  *  @return null
  */
 function drawSelectOldNgi() {
-    // Check the user has permission to see the page, will throw exception 
+    // Check the user has permission to see the page, will throw exception
     //if correct permissions are lacking
-    checkUserIsAdmin();   
+    checkUserIsAdmin();
 
     //Get a list  of NGIs to select from
     $ngis= \Factory::getSiteService()->getNGIs();
-    
+
     //Put into an array to be passed to view
     $params = array('Ngis' => $ngis);
 
@@ -111,7 +111,7 @@ function drawSelectOldNgi() {
 function getSiteMoveDataFromWeb() {
     // Fields that are used to link other objects to the site
     $fields = array('OldNGI', 'NewNGI', 'Sites');
-    
+
     foreach($fields as $field) {
         if(array_key_exists($field,$_REQUEST)){
             $site_move_data[$field] = $_REQUEST[$field];
@@ -128,7 +128,7 @@ function getSiteMoveDataFromWeb() {
  */
 function submitOldNgi($submitvalues) {
     //Get the NGI
-    $oldNgi_id = $submitvalues['OldNGI'];        
+    $oldNgi_id = $submitvalues['OldNGI'];
     $oldNgi = \Factory::getNgiService()->getNGI($oldNgi_id);
     //Draw the move site form
     drawMoveSite($oldNgi);
@@ -168,7 +168,7 @@ function submitMoveSite($movementDetails) {
         foreach($site_ids as $site_id){
             $site= $serv->getSite($site_id);
             $serv->moveSite($site, $newNgi, $user);
-            $sites[] = $site; 
+            $sites[] = $site;
         }
     } catch(\Exception $e) {
         show_view('error.php', $e->getMessage());

--- a/htdocs/web_portal/controllers/admin/scope.php
+++ b/htdocs/web_portal/controllers/admin/scope.php
@@ -22,7 +22,7 @@ require_once __DIR__ . '/../utils.php';
 require_once __DIR__ . '/../../../web_portal/components/Get_User_Principle.php';
 
 function view_scope(){
-    //Check the user has permission to see the page, will throw exception 
+    //Check the user has permission to see the page, will throw exception
     //if correct permissions are lacking
     checkUserIsAdmin();
     if (!isset($_REQUEST['id']) || !is_numeric($_REQUEST['id']) ){
@@ -30,10 +30,10 @@ function view_scope(){
     }
     $dn = Get_User_Principle();
     $user = \Factory::getUserService()->getUserByPrinciple($dn);
-    
+
     $serv= \Factory::getScopeService();
     $scope =$serv ->getScope($_REQUEST['id']);
-            
+
     $params['Name'] = $scope -> getName();
     $params['Description'] = $scope->getDescription();
     $params['ID']= $scope ->getId();
@@ -42,8 +42,8 @@ function view_scope(){
     $params['ServiceGroups'] = $serv ->getServiceGroupsFromScope($scope);
     $params['Services'] = $serv ->getServicesFromScope($scope);
     $params['portalIsReadOnly'] = portalIsReadOnlyAndUserIsNotAdmin($user);
-    
+
     show_view("admin/scope.php", $params, $params['Name']);
-    die();          
+    die();
 }
 

--- a/htdocs/web_portal/controllers/admin/scopes.php
+++ b/htdocs/web_portal/controllers/admin/scopes.php
@@ -23,19 +23,19 @@ require_once __DIR__ . '/../utils.php';
 require_once __DIR__ . '/../../../web_portal/components/Get_User_Principle.php';
 
 function show_scopes(){
-    //Check the user has permission to see the page, will throw exception 
+    //Check the user has permission to see the page, will throw exception
     //if correct permissions are lacking
     checkUserIsAdmin();
-    
+
     $scopes = \Factory::getScopeService()->getScopes();
     $params['Scopes']= $scopes;
-    
 
-    
+
+
     $dn = Get_User_Principle();
     $user = \Factory::getUserService()->getUserByPrinciple($dn);
     $params['portalIsReadOnly'] = portalIsReadOnlyAndUserIsNotAdmin($user);
-    
-    show_view('admin/scopes.php', $params, 'Scopes'); 
-    die(); 
+
+    show_view('admin/scopes.php', $params, 'Scopes');
+    die();
 }

--- a/htdocs/web_portal/controllers/admin/users.php
+++ b/htdocs/web_portal/controllers/admin/users.php
@@ -1,56 +1,56 @@
 <?php
-/*______________________________________________________ 
+/*______________________________________________________
  *======================================================
  * File: users.php
  * Author: George Ryall, David Meredith
  * Description: Controller for viewing all users in GOCDB
- * 
+ *
  * License information
- *   
- * Copyright 2009 STFC 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
+ *
+ * Copyright 2009 STFC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * http://www.apache.org/licenses/LICENSE-2.0 
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
- *  
-/*====================================================== */ 
+ *
+/*====================================================== */
 
 function show_users(){
     require_once __DIR__.'/../../../../lib/Gocdb_Services/Factory.php';
     require_once __DIR__ . '/../utils.php';
     require_once __DIR__ . '/../../../web_portal/components/Get_User_Principle.php';
-     
-    //Check the user has permission to see the page, will throw exception 
+
+    //Check the user has permission to see the page, will throw exception
     //if correct permissions are lacking
     checkUserIsAdmin();
-    
+
     //If specified, set parameters
     $surname = null;
-    if(!empty($_REQUEST['Surname'])) { 
+    if(!empty($_REQUEST['Surname'])) {
        $surname = $_REQUEST['Surname'];
     }
     $params["Surname"] = $surname;
-    
+
     $forename = null;
-    if(!empty($_REQUEST['Forename'])) { 
+    if(!empty($_REQUEST['Forename'])) {
         $forename = $_REQUEST['Forename'];
     }
     $params["Forename"] = $forename;
-    
+
     $dn = null;
-    if(!empty($_REQUEST['DN'])) { 
+    if(!empty($_REQUEST['DN'])) {
         $dn = $_REQUEST['DN'];
     }
     $params["DN"] = $dn;
-    
+
     //Note that the true/false specified must be converted into boolean true/false.
     $isAdmin = null;
-    if(!empty($_REQUEST['IsAdmin'])) { 
+    if(!empty($_REQUEST['IsAdmin'])) {
        if($_REQUEST['IsAdmin']=="true"){
             $isAdmin = true;
        }
@@ -59,14 +59,14 @@ function show_users(){
        }
     }
     $params["IsAdmin"] = $isAdmin;
-       
+
     $currentUserDN = Get_User_Principle();
     $user = \Factory::getUserService()->getUserByPrinciple($currentUserDN);
     $params['portalIsReadOnly'] = portalIsReadOnlyAndUserIsNotAdmin($user);
-    
+
     //get users
     $params["Users"] = \Factory::getUserService()->getUsers($surname, $forename, $dn, $isAdmin);
-    
-    
+
+
     show_view("admin/users.php", $params, "Users");
 }

--- a/htdocs/web_portal/controllers/admin/view_service_type.php
+++ b/htdocs/web_portal/controllers/admin/view_service_type.php
@@ -2,8 +2,8 @@
 /*______________________________________________________
  *======================================================
  * File: view_service_type.php
- * Author: George Ryall, David Meredith 
- * Description: Controller for displaying a service type and associated services 
+ * Author: George Ryall, David Meredith
+ * Description: Controller for displaying a service type and associated services
  *
  * License information
  *
@@ -22,7 +22,7 @@ require_once __DIR__ . '/../utils.php';
 require_once __DIR__ . '/../../../web_portal/components/Get_User_Principle.php';
 
 function view_service_type(){
-     //Check the user has permission to see the page, will throw exception 
+     //Check the user has permission to see the page, will throw exception
     //if correct permissions are lacking
     checkUserIsAdmin();
     if (!isset($_REQUEST['id']) || !is_numeric($_REQUEST['id']) ){
@@ -30,17 +30,17 @@ function view_service_type(){
     }
     $dn = Get_User_Principle();
     $user = \Factory::getUserService()->getUserByPrinciple($dn);
-    
+
     $serv= \Factory::getServiceTypeService();
     $serviceType =$serv ->getServiceType($_REQUEST['id']);
-            
+
     $params['Name'] = $serviceType -> getName();
     $params['Description'] = $serviceType -> getDescription();
     $params['ID']= $serviceType ->getId();
     $params['Services'] = $serv ->getServices($params['ID']);
     $params['portalIsReadOnly'] = portalIsReadOnlyAndUserIsNotAdmin($user);
-    
+
     show_view("admin/view_service_type.php", $params, $params['Name']);
-            
+
 }
 

--- a/htdocs/web_portal/controllers/admin/view_service_types.php
+++ b/htdocs/web_portal/controllers/admin/view_service_types.php
@@ -23,15 +23,15 @@ require_once __DIR__ . '/../utils.php';
 require_once __DIR__ . '/../../../web_portal/components/Get_User_Principle.php';
 
 function show_all(){
-    //Check the user has permission to see the page, will throw exception 
+    //Check the user has permission to see the page, will throw exception
     //if correct permissions are lacking
     checkUserIsAdmin();
-    
+
     $dn = Get_User_Principle();
     $user = \Factory::getUserService()->getUserByPrinciple($dn);
-    
+
     $serviceTypes = \Factory::getServiceTypeService()->getServiceTypes();
     $params['ServiceTypes']= $serviceTypes;
     $params['portalIsReadOnly'] = portalIsReadOnlyAndUserIsNotAdmin($user);
-    show_view('admin/view_service_types.php', $params, 'Service Types'); 
+    show_view('admin/view_service_types.php', $params, 'Service Types');
 }

--- a/htdocs/web_portal/controllers/downtime/add_downtime.php
+++ b/htdocs/web_portal/controllers/downtime/add_downtime.php
@@ -24,21 +24,21 @@
 require_once __DIR__.'/../../../../lib/Gocdb_Services/Factory.php';
 require_once __DIR__.'/../utils.php';
 require_once __DIR__.'/../../../web_portal/components/Get_User_Principle.php';
-    
+
 /**
- * Controller for a new_downtime request. 
- * 
- * DM: The downtime interface/logic needs to be reworked and tidied-up: 
- * - It needs to allow services from multiple sites to be put into downtime 
- * (currently it only allows a single site to be selected which limits the
- * selectable services to those only from that site). 
+ * Controller for a new_downtime request.
  *
- * - There is almost certainly a more elegant way to pass down the UTC offset 
- * (secs) and timezoneId label for each site (rather than using an AJAX call to query 
- * for these values on site selection). This will be needed in order to cater for 
+ * DM: The downtime interface/logic needs to be reworked and tidied-up:
+ * - It needs to allow services from multiple sites to be put into downtime
+ * (currently it only allows a single site to be selected which limits the
+ * selectable services to those only from that site).
+ *
+ * - There is almost certainly a more elegant way to pass down the UTC offset
+ * (secs) and timezoneId label for each site (rather than using an AJAX call to query
+ * for these values on site selection). This will be needed in order to cater for
  * multi-site selection. Perhaps pass down a set of DataTransferObjects or JSON string
- * rather than the Site entities themselves, and specify tz, offset in the DTO/JSON. 
- * 
+ * rather than the Site entities themselves, and specify tz, offset in the DTO/JSON.
+ *
  * @global array $_POST only set if the browser has POSTed data
  * @return null
  */
@@ -49,7 +49,7 @@ function add() {
 
     //Check the portal is not in read only mode, returns exception if it is and user is not an admin
     checkPortalIsNotReadOnlyOrUserIsAdmin($user);
-    
+
     if($_POST) {     // If we receive a POST request it's for a new downtime
         submit($user);
     } else { // If there is no post data, draw the New downtime form
@@ -61,31 +61,31 @@ function add() {
  * Retrieves the raw new downtime's data from a portal request and submit it
  * to the services layer's downtime functions.
  * @param \User $user current user
- * @return null 
+ * @return null
  */
 function submit(\User $user = null) {
-    
-    
+
+
     //Check if this is a confirmed submit or intial submit
-    $confirmed = $_POST['CONFIRMED'];	
+    $confirmed = $_POST['CONFIRMED'];
     if($confirmed == true){
         //Downtime is confirmed, submit it
-        //$downtimeInfo = unserialize($_REQUEST['newValues']);  // didn't cater for UTF-8 chars   	
-        $downtimeInfo = json_decode($_POST['newValues'], TRUE); 
-        $serv = \Factory::getDowntimeService();   	
-        
-        $params['dt'] = $serv->addDowntime($downtimeInfo, $user);    	
+        //$downtimeInfo = unserialize($_REQUEST['newValues']);  // didn't cater for UTF-8 chars
+        $downtimeInfo = json_decode($_POST['newValues'], TRUE);
+        $serv = \Factory::getDowntimeService();
+
+        $params['dt'] = $serv->addDowntime($downtimeInfo, $user);
         show_view("downtime/added_downtime.php", $params);
     }else{
         //Show user confirmation screen with their input
-        $downtimeInfo = getDtDataFromWeb(); 
-        
+        $downtimeInfo = getDtDataFromWeb();
+
         //Need to sort the impacted_ids into impacted services and impacted endpoints
         $impactedids = $downtimeInfo['IMPACTED_IDS'];
 
         $services=array();
         $endpoints=array();
-        
+
         //For each impacted id sort between endpoints and services using the prepended letter
         foreach($impactedids as $id){
             if (strpos($id, 's') !== FALSE){
@@ -96,14 +96,14 @@ function submit(\User $user = null) {
                 $endpoints[] = str_replace('e', '', $id); //trim off the identifying char before storing in array
             }
         }
-        
+
         unset($downtimeInfo['IMPACTED_IDS']); //Delete the unsorted Ids from the downtime info
-         
+
         $downtimeInfo['Impacted_Endpoints'] = $endpoints;
-         
-        
+
+
         $serv = \Factory::getServiceService();
-        
+
         /** For endpoint put into downtime we want the parent service also. If a user has selected
          * endpoints but not the parent service here we will add the service to maintain the link beteween
          * a downtime having both the service and the endpoint.
@@ -112,20 +112,20 @@ function submit(\User $user = null) {
            $endpoint = $serv->getEndpoint($endpointIds);
            $services[] = $endpoint->getService()->getId();
         }
-        
+
         //Remove any duplicate service ids and store the array of ids
         $services = array_unique($services);
-        
+
         //Assign the impacted services and endpoints to their own arrays for us by the addDowntime method
         $downtimeInfo['Impacted_Services'] = $services;
-                
+
         show_view("downtime/confirm_add_downtime.php", $downtimeInfo);
-    }  
+    }
 }
 
 /**
  * Draws a form to add a new downtime
- * @param \User $user current user 
+ * @param \User $user current user
  * @return null
  */
 function draw(\User $user = null) {
@@ -135,35 +135,35 @@ function draw(\User $user = null) {
 
     $nowUtcDateTime = new \DateTime(null, new \DateTimeZone("UTC"));
     //$twoDaysAgoUtcDateTime = $nowUtcDateTime->sub(\DateInterval::createFromDateString('2 days'));
-    //$twoDaysAgoUtc = $twoDaysAgoUtcDateTime->format('d/m/Y H:i'); //e.g.  02/10/2013 13:20 
+    //$twoDaysAgoUtc = $twoDaysAgoUtcDateTime->format('d/m/Y H:i'); //e.g.  02/10/2013 13:20
 
-    
+
     // URL mapping
-    // Return the specified site's timezone label and the offset from now in UTC 
+    // Return the specified site's timezone label and the offset from now in UTC
     // Used in ajax requests for display purposes
     if(isset($_GET['siteid_timezone']) && is_numeric($_GET['siteid_timezone'])){
-        $site = \Factory::getSiteService()->getSite($_GET['siteid_timezone']); 
+        $site = \Factory::getSiteService()->getSite($_GET['siteid_timezone']);
         if($site != null){
-            $siteTzId = $site->getTimeZoneId();  
+            $siteTzId = $site->getTimeZoneId();
             if( !empty($siteTzId) ){
-                $nowInTargetTz = new \DateTime(null, new \DateTimeZone($siteTzId)); 
-                $offsetInSecsFromUtc = $nowInTargetTz->getOffset(); 
+                $nowInTargetTz = new \DateTime(null, new \DateTimeZone($siteTzId));
+                $offsetInSecsFromUtc = $nowInTargetTz->getOffset();
             } else {
-                $siteTzId = 'UTC';  
-                $offsetInSecsFromUtc = 0;  // assume 0 (no offset from UTC)  
+                $siteTzId = 'UTC';
+                $offsetInSecsFromUtc = 0;  // assume 0 (no offset from UTC)
             }
-            $timezoneId_Offset = array($siteTzId, $offsetInSecsFromUtc); 
-            die(json_encode($timezoneId_Offset)); 
+            $timezoneId_Offset = array($siteTzId, $offsetInSecsFromUtc);
+            die(json_encode($timezoneId_Offset));
         }
-        die(json_encode(array('UTC', 0))); 
+        die(json_encode(array('UTC', 0)));
     }
 
-    // URL Mapping 
+    // URL Mapping
     // If the user wants to add a downtime to a specific site, show only that site's SEs
     else if(isset($_GET['site'])) {
         $site = \Factory::getSiteService()->getSite($_GET['site']);
         if(\Factory::getRoleActionAuthorisationService()->authoriseAction(\Action::EDIT_OBJECT, $site, $user)->getGrantAction() == FALSE){
-           throw new \Exception("You don't have permission over $site"); 
+           throw new \Exception("You don't have permission over $site");
         }
         $ses = $site->getServices();
         $params = array('ses' => $ses, 'nowUtc' => $nowUtcDateTime->format('H:i T'), 'selectAll' => true);
@@ -171,15 +171,15 @@ function draw(\User $user = null) {
         die();
     }
 
-    // URL Mapping 
+    // URL Mapping
     // If the user wants to add a downtime to a specific SE, show only that SE
     else if(isset($_GET['se'])) {
         $se = \Factory::getServiceService()->getService($_GET['se']);
         $site = \Factory::getSiteService()->getSite($se->getParentSite()->getId());
         if(\Factory::getRoleActionAuthorisationService()->authoriseAction(\Action::EDIT_OBJECT, $se->getParentSite(), $user)->getGrantAction() == FALSE){
-           throw new \Exception("You do not have permission over $se."); 
-        } 
-        
+           throw new \Exception("You do not have permission over $se.");
+        }
+
         //$ses = array($se);
         $ses = $site->getServices();
         $params = array('ses' => $ses, 'nowUtc' => $nowUtcDateTime->format('H:i T'), 'selectAll' => true);
@@ -189,30 +189,30 @@ function draw(\User $user = null) {
 
     // If the user doesn't want to add a downtime to a specific SE or site show all SEs
     else {
-        $ses = array(); 
+        $ses = array();
         if($user->isAdmin()){
             //If a user is an admin, return all SEs instead
-            $ses = \Factory::getServiceService()->getAllSesJoinParentSites(); 
+            $ses = \Factory::getServiceService()->getAllSesJoinParentSites();
         } else {
-             //$allSites = \Factory::getUserService()->getSitesFromRoles($user);          
-            
-            // Get all ses where the user has a GRANTED role over one of its 
-            // parent OwnedObjects (includes Site and NGI but not currently Project) 
+             //$allSites = \Factory::getUserService()->getSitesFromRoles($user);
+
+            // Get all ses where the user has a GRANTED role over one of its
+            // parent OwnedObjects (includes Site and NGI but not currently Project)
             $sesAll = \Factory::getRoleService()->getReachableServicesFromOwnedObjectRoles($user);
-            // drop the ses where the user does not have edit permissions over  
+            // drop the ses where the user does not have edit permissions over
             foreach($sesAll as $se){
-                if(\Factory::getRoleActionAuthorisationService()->authoriseAction(\Action::EDIT_OBJECT, $se->getParentSite(), $user)->getGrantAction() ){ 
-                    $ses[] = $se; 
+                if(\Factory::getRoleActionAuthorisationService()->authoriseAction(\Action::EDIT_OBJECT, $se->getParentSite(), $user)->getGrantAction() ){
+                    $ses[] = $se;
                 }
             }
         }
         if(empty($ses)) {
-            throw new Exception("You don't hold a role over a NGI " 
+            throw new Exception("You don't hold a role over a NGI "
                     . "or site with child services.");
         }
         $params = array('ses' => $ses, 'nowUtc' => $nowUtcDateTime->format('H:i T'));
         show_view("downtime/add_downtime.php", $params);
-        die(); 
+        die();
     }
 }
 

--- a/htdocs/web_portal/controllers/downtime/delete_downtime.php
+++ b/htdocs/web_portal/controllers/downtime/delete_downtime.php
@@ -27,7 +27,7 @@ function delete() {
     require_once __DIR__ . '/../../../../lib/Gocdb_Services/Factory.php';
     require_once __DIR__ . '/../../../../htdocs/web_portal/components/Get_User_Principle.php';
     require_once __DIR__ . '/../utils.php';
-    
+
     $dn = Get_User_Principle();
     $user = \Factory::getUserService()->getUserByPrinciple($dn);
     if(is_null($user)) {
@@ -36,7 +36,7 @@ function delete() {
 
     //Check the portal is not in read only mode, returns exception if it is and user is not an admin
     checkPortalIsNotReadOnlyOrUserIsAdmin($user);
-    
+
     if (!isset($_REQUEST['id']) || !is_numeric($_REQUEST['id']) ){
         throw new Exception("An id must be specified");
     }

--- a/htdocs/web_portal/controllers/downtime/downtimes_overview.php
+++ b/htdocs/web_portal/controllers/downtime/downtimes_overview.php
@@ -22,23 +22,23 @@
 function view() {
     require_once __DIR__ . '/../utils.php';
     require_once __DIR__ . '/../../../web_portal/components/Get_User_Principle.php';
-    
+
     $dn = Get_User_Principle();
     $user = \Factory::getUserService()->getUserByPrinciple($dn);
     $params['portalIsReadOnly'] = portalIsReadOnlyAndUserIsNotAdmin($user);
-    
+
     //date_default_timezone_set("UTC");
-    
+
     $timePeriod = 1;
     if(isset($_REQUEST['timePeriod'])) {
         $timePeriod = $_REQUEST['timePeriod'];
     }
-    
+
     $days = 7 * $timePeriod;
-    
-    $windowStart = date("Y-m-d");    
+
+    $windowStart = date("Y-m-d");
     $windowEnd = date_add(date_create(date("Y-m-d")), date_interval_create_from_date_string($days.' days'));
-    
+
     $downtimesA = \Factory::getDowntimeService()->getActiveDowntimes();
     $downtimesI = \Factory::getDowntimeService()->getImminentDowntimes($windowStart,$windowEnd);
     $params['timePeriod'] = $timePeriod;

--- a/htdocs/web_portal/controllers/downtime/edit_downtime.php
+++ b/htdocs/web_portal/controllers/downtime/edit_downtime.php
@@ -30,10 +30,10 @@ require_once __DIR__ . '/../utils.php';
 function edit() {
     $dn = Get_User_Principle();
     $user = \Factory::getUserService()->getUserByPrinciple($dn);
-    
+
     //Check the portal is not in read only mode, returns exception if it is and user is not an admin
     checkPortalIsNotReadOnlyOrUserIsAdmin($user);
-    
+
     if($_POST) {     // If we receive a POST request it's to update a downtime
         submit($user);
     } else { // If there is no post data, draw the edit downtime form
@@ -57,55 +57,55 @@ function draw(\User $user = null) {
     $serv = \Factory::getDowntimeService();
     $dt = $serv->getDowntime($_GET['id']);
     if($dt == null){
-        throw new Exception("No downtime with that id"); 
+        throw new Exception("No downtime with that id");
     }
 
-    // check that this downtime is eligible for editing, throws exception if not.  
-    $serv->editValidationDatePreConditions($dt); 
+    // check that this downtime is eligible for editing, throws exception if not.
+    $serv->editValidationDatePreConditions($dt);
     $serv->authorisation($dt->getServices(), $user);
-    
+
     $nowUtcDateTime = new \DateTime(null, new \DateTimeZone("UTC"));
     $twoDaysAgoUtcDateTime = $nowUtcDateTime->sub(\DateInterval::createFromDateString('2 days'));
     $twoDaysAgoUtc = $twoDaysAgoUtcDateTime->format('d/m/Y H:i'); //e.g.  02/10/2013 13:20
-    
+
     $params = array(
-        'dt' => $dt, 
-        'format' => getDateFormat(), 
-        'nowUtc' => $nowUtcDateTime->format('H:i T'), 
-        'twoDaysAgoUtc' => $twoDaysAgoUtc);  
+        'dt' => $dt,
+        'format' => getDateFormat(),
+        'nowUtc' => $nowUtcDateTime->format('H:i T'),
+        'twoDaysAgoUtc' => $twoDaysAgoUtc);
     show_view('downtime/edit_downtime.php', $params);
 }
 
 /**
- * 
+ *
  * @param \User $user current user
  * @throws Exception
  */
 function submit(\User $user = null) {
- 
+
     //Check if this is a confirmed submit or intial submit
-    $confirmed = $_POST['CONFIRMED'];	
+    $confirmed = $_POST['CONFIRMED'];
     if($confirmed == true){
         //Downtime is confirmed, submit it
-        $downtimeInfo = json_decode($_POST['newValues'], TRUE); 
-        
-        $serv = \Factory::getDowntimeService();   	
+        $downtimeInfo = json_decode($_POST['newValues'], TRUE);
+
+        $serv = \Factory::getDowntimeService();
         $dt = $serv->getDowntime($downtimeInfo['DOWNTIME']['EXISTINGID']);
         unset($downtimeInfo['DOWNTIME']['EXISTINGID']);
         unset($downtimeInfo['isEdit']);
-        $params['dt'] = $serv->editDowntime($dt, $downtimeInfo, $user); 
-            
+        $params['dt'] = $serv->editDowntime($dt, $downtimeInfo, $user);
+
         show_view("downtime/edited_downtime.php", $params);
     }else{
         //Show user confirmation screen with their input
-        $downtimeInfo = getDtDataFromWeb(); 
-        
+        $downtimeInfo = getDtDataFromWeb();
+
         //Need to sort the impacted_ids into impacted services and impacted endpoints
         $impactedids = $downtimeInfo['IMPACTED_IDS'];
 
         $services=array();
         $endpoints=array();
-        
+
         //For each impacted id sort between endpoints and services using the prepended letter
         foreach($impactedids as $id){
             if (strpos($id, 's') !== FALSE){
@@ -116,14 +116,14 @@ function submit(\User $user = null) {
                 $endpoints[] = str_replace('e', '', $id); //trim off the identifying char before storing in array
             }
         }
-        
+
         unset($downtimeInfo['IMPACTED_IDS']); //Delete the unsorted Ids from the downtime info
-         
+
         $downtimeInfo['Impacted_Endpoints'] = $endpoints;
-         
-        
+
+
         $serv = \Factory::getServiceService();
-        
+
         /** For endpoint put into downtime we want the parent service also. If a user has selected
          * endpoints but not the parent service here we will add the service to maintain the link beteween
          * a downtime having both the service and the endpoint.
@@ -132,16 +132,16 @@ function submit(\User $user = null) {
            $endpoint = $serv->getEndpoint($endpointIds);
            $services[] = $endpoint->getService()->getId();
         }
-        
+
         //Remove any duplicate service ids and store the array of ids
         $services = array_unique($services);
-        
+
         //Assign the impacted services and endpoints to their own arrays for us by the addDowntime method
-        $downtimeInfo['Impacted_Services'] = $services;    	
+        $downtimeInfo['Impacted_Services'] = $services;
         //Pass the edit variable so the confirm_add view works as the confirm edit view.
-        $downtimeInfo['isEdit'] = true;    	
+        $downtimeInfo['isEdit'] = true;
         show_view("downtime/confirm_add_downtime.php", $downtimeInfo);
-    }  
+    }
 }
 
 ?>

--- a/htdocs/web_portal/controllers/downtime/end_downtime.php
+++ b/htdocs/web_portal/controllers/downtime/end_downtime.php
@@ -29,22 +29,22 @@ function endDt() {
     require_once __DIR__.'/../../../../lib/Gocdb_Services/Factory.php';
     require_once __DIR__ . '/../../../../htdocs/web_portal/components/Get_User_Principle.php';
     require_once __DIR__ . '/../utils.php';
-    
+
     if (!isset($_POST['id']) || !is_numeric($_POST['id']) ){
         throw new Exception("A downtime id must be specified");
     }
     $serv = \Factory::getDowntimeService();
     $dt = $serv->getDowntime($_POST['id']);
     if($dt == null){
-        throw new Exception("No downtime with that id"); 
+        throw new Exception("No downtime with that id");
     }
-    
+
     $dn = Get_User_Principle();
     $user = \Factory::getUserService()->getUserByPrinciple($dn);
- 
+
     //Check the portal is not in read only mode, returns exception if it is and user is not an admin
     checkPortalIsNotReadOnlyOrUserIsAdmin($user);
-    
+
 
     $serv->endDowntime($dt, $user);
 

--- a/htdocs/web_portal/controllers/downtime/view_downtime.php
+++ b/htdocs/web_portal/controllers/downtime/view_downtime.php
@@ -29,12 +29,12 @@ function view() {
     //date_default_timezone_set("UTC");
     $downtime = \Factory::getDowntimeService()->getDowntime($_REQUEST['id']);
     if($downtime == null){
-        throw new Exception('No downtime with id ['.$_REQUEST['id'].']'); 
+        throw new Exception('No downtime with id ['.$_REQUEST['id'].']');
     }
     $dn = Get_User_Principle();
     $user = \Factory::getUserService()->getUserByPrinciple($dn);
     $params['portalIsReadOnly'] = portalIsReadOnlyAndUserIsNotAdmin($user);
-    
+
     $params['downtime'] = $downtime;
     $title = $downtime->getDescription();
     show_view("downtime/view_downtime.php", $params, $title);

--- a/htdocs/web_portal/controllers/downtime/view_endpoint_tree.php
+++ b/htdocs/web_portal/controllers/downtime/view_endpoint_tree.php
@@ -22,11 +22,11 @@
 function getServiceandEndpointList() {
     require_once __DIR__ . '/../utils.php';
     require_once __DIR__ . '/../../../web_portal/components/Get_User_Principle.php';
-    
+
     $dn = Get_User_Principle();
     $user = \Factory::getUserService()->getUserByPrinciple($dn);
     $params['portalIsReadOnly'] = portalIsReadOnlyAndUserIsNotAdmin($user);
-    
+
     if (!isset($_REQUEST['site_id']) || !is_numeric($_REQUEST['site_id']) ){
         throw new Exception("An id must be specified");
     }
@@ -44,7 +44,7 @@ function editDowntimePopulateEndpointTree() {
     $dn = Get_User_Principle();
     $user = \Factory::getUserService()->getUserByPrinciple($dn);
     $params['portalIsReadOnly'] = portalIsReadOnlyAndUserIsNotAdmin($user);
-    
+
     if (!isset($_REQUEST['site_id']) || !is_numeric($_REQUEST['site_id']) ){
         throw new Exception("A site id must be specified");
     }
@@ -54,9 +54,9 @@ function editDowntimePopulateEndpointTree() {
     $site = \Factory::getSiteService()->getSite($_REQUEST['site_id']);
     $services = $site->getServices();
     $params['services'] = $services;
-     
+
     $downtime = \Factory::getDowntimeService()->getDowntime($_REQUEST['dt_id']);
     $params['downtime'] = $downtime;
-   
+
     show_view("downtime/downtime_edit_view_nested_endpoints_list.php", $params, null, true);
 }

--- a/htdocs/web_portal/controllers/downtime/view_services.php
+++ b/htdocs/web_portal/controllers/downtime/view_services.php
@@ -22,11 +22,11 @@
 function getSitesServices() {
     require_once __DIR__ . '/../utils.php';
     require_once __DIR__ . '/../../../web_portal/components/Get_User_Principle.php';
-    
+
     $dn = Get_User_Principle();
     $user = \Factory::getUserService()->getUserByPrinciple($dn);
     $params['portalIsReadOnly'] = portalIsReadOnlyAndUserIsNotAdmin($user);
-    
+
     if (!isset($_REQUEST['site_id']) || !is_numeric($_REQUEST['site_id']) ){
         throw new Exception("A site_id must be specified");
     }

--- a/htdocs/web_portal/controllers/my_sites.php
+++ b/htdocs/web_portal/controllers/my_sites.php
@@ -50,7 +50,7 @@ function my_sites() {
     if (!empty($ngis)) {
         $params['ngis_from_roles'] = $ngis;
     }
-    
+
     $projects = $userServ->getProjectsFromRoles($user);
     if (!empty($projects)) {
         $params['projects_from_roles'] = $projects;

--- a/htdocs/web_portal/controllers/ngi/edit_ngi.php
+++ b/htdocs/web_portal/controllers/ngi/edit_ngi.php
@@ -33,7 +33,7 @@ function edit_ngi() {
 
     //Check the portal is not in read only mode, returns exception if it is and user is not an admin
     checkPortalIsNotReadOnlyOrUserIsAdmin($user);
-    
+
     if($_POST) {     // If we receive a POST request it's to update a downtime
         submit($user);
     } else { // If there is no post data, draw the edit form
@@ -53,24 +53,24 @@ function draw(\User $user = null) {
     $ngi = \Factory::getNgiService()->getNgi($_REQUEST['id']);
 
     if($user == null){
-       throw new Exception('You do not have permission to edit this NGI, null user'); 
+       throw new Exception('You do not have permission to edit this NGI, null user');
     }
     if(\Factory::getRoleActionAuthorisationService()->authoriseAction(
             Action::EDIT_OBJECT, $ngi, $user)->getGrantAction() == FALSE){
         throw new Exception('You do not have permission to edit this NGI');
     }
     // can user assign reserved scopes ?
-    $disableReservedScopes = true; 
+    $disableReservedScopes = true;
     if($user->isAdmin()){
-    $disableReservedScopes = false; 
+    $disableReservedScopes = false;
     }
-    // pass null for the parent as we don't consider project scopes (yet) 
-    $scopejsonStr = getEntityScopesAsJSON2($ngi, null, $disableReservedScopes); 
-     
+    // pass null for the parent as we don't consider project scopes (yet)
+    $scopejsonStr = getEntityScopesAsJSON2($ngi, null, $disableReservedScopes);
+
     $params = array('ngi' => $ngi);
     $params['numberOfScopesRequired'] = \Factory::getConfigService()->getMinimumScopesRequired('ngi');
-    $params['scopejson'] = $scopejsonStr; 
-    
+    $params['scopejson'] = $scopejsonStr;
+
     show_view('ngi/edit_ngi.php', $params);
 }
 
@@ -82,9 +82,9 @@ function draw(\User $user = null) {
 function submit(\User $user = null) {
     $serv = \Factory::getNgiService();
     $newValues = getNgiDataFromWeb();
-//        print_r($newValues); 
-//        die(); 
-        
+//        print_r($newValues);
+//        die();
+
     $ngi = $serv->getNgi($newValues['ID']);
     $ngi = $serv->editNgi($ngi, $newValues, $user);
     $params = array('ngi' => $ngi);

--- a/htdocs/web_portal/controllers/ngi/view_ngi.php
+++ b/htdocs/web_portal/controllers/ngi/view_ngi.php
@@ -24,7 +24,7 @@ function view_ngi() {
     require_once __DIR__.'/../../../../lib/Gocdb_Services/Factory.php';
     require_once __DIR__ . '/../utils.php';
     require_once __DIR__ . '/../../../web_portal/components/Get_User_Principle.php';
-    
+
     if (!isset($_GET['id']) || !is_numeric($_GET['id']) ){
         throw new Exception("An id must be specified");
     }
@@ -33,19 +33,19 @@ function view_ngi() {
     //get user for case that portal is read only and user is admin, so they can still see edit links
     $dn = Get_User_Principle();
     $user = \Factory::getUserService()->getUserByPrinciple($dn);
-    
+
     $params['portalIsReadOnly'] = portalIsReadOnlyAndUserIsNotAdmin($user);
-    
+
     $params['UserIsAdmin']=false;
     if(!is_null($user)) {
         $params['UserIsAdmin']=$user->isAdmin();
     }
-    
-    $params['authenticated'] = false; 
+
+    $params['authenticated'] = false;
     if($user != null){
-        $params['authenticated'] = true; 
+        $params['authenticated'] = true;
     }
-    
+
     $ngiServ = \Factory::getNgiService();
     $siteServ = \Factory::getSiteService();
     $ngi = $ngiServ->getNgi($ngiId);
@@ -56,33 +56,33 @@ function view_ngi() {
     if (\Factory::getRoleActionAuthorisationService()->authoriseAction(\Action::EDIT_OBJECT, $ngi, $user)->getGrantAction())  {
         $params['ShowEdit'] = true;
     }
-      
-    // Add ngi to params 
+
+    // Add ngi to params
     $params['ngi'] = $ngi;
 
-    // Add all roles over ngi to params 
+    // Add all roles over ngi to params
     $allRoles = $ngi->getRoles();
-    $roles = array(); 
+    $roles = array();
     foreach ($allRoles as $role){
         if($role->getStatus() == \RoleStatus::GRANTED){
-            $roles[] = $role; 
+            $roles[] = $role;
         }
     }
     $params['roles'] = $roles;
 
-    // Add ngi's project to params 
+    // Add ngi's project to params
     $projects = $ngi->getProjects();
     $params['Projects']= $projects;
 
-    // Add sites and scopes to params 
+    // Add sites and scopes to params
     $params['SitesAndScopes']=array();
     foreach($ngi->getSites() as $site){
         $params['SitesAndScopes'][]=array('Site'=>$site, 'Scopes'=>$siteServ->getScopesWithParentScopeInfo($site));
     }
-   
-    // Add RoleActionRecords to params 
-    $params['RoleActionRecords'] = \Factory::getRoleService()->getRoleActionRecordsById_Type($ngi->getId(), 'ngi'); 
-    
+
+    // Add RoleActionRecords to params
+    $params['RoleActionRecords'] = \Factory::getRoleService()->getRoleActionRecordsById_Type($ngi->getId(), 'ngi');
+
     show_view('ngi/view_ngi.php', $params, $ngi->getName());
     die();
 }

--- a/htdocs/web_portal/controllers/ngi/view_ngis.php
+++ b/htdocs/web_portal/controllers/ngi/view_ngis.php
@@ -22,36 +22,36 @@
 
 function view_ngis() {
     require_once __DIR__.'/../../../../lib/Gocdb_Services/Factory.php';
-    
-    $filterParams = array(); 
-    
+
+    $filterParams = array();
+
 //    $scope = '%%';
-//    if(!empty($_GET['scope'])) { 
+//    if(!empty($_GET['scope'])) {
 //       $scope = $_GET['scope'];
 //    }
 
-    // Scope parameters 
-    // By default, use an empty value to return all scopes, i.e. in the PI '&scope=' 
-    // which is same as the PI. If the 'scope' param is not set, then it would fall 
-    // back to the default scope (if set), but this is not what we want in this interface.  
-    $filterParams['scope'] = ''; 	
+    // Scope parameters
+    // By default, use an empty value to return all scopes, i.e. in the PI '&scope='
+    // which is same as the PI. If the 'scope' param is not set, then it would fall
+    // back to the default scope (if set), but this is not what we want in this interface.
+    $filterParams['scope'] = '';
     $selectedScopes = array();
-    if(!empty($_GET['mscope'])) { 
-    $scopeStringParam = ''; 
+    if(!empty($_GET['mscope'])) {
+    $scopeStringParam = '';
     foreach($_GET['mscope'] as $key => $scopeVal){
-        $scopeStringParam .= $scopeVal.','; 
-        $selectedScopes[] = $scopeVal; 
+        $scopeStringParam .= $scopeVal.',';
+        $selectedScopes[] = $scopeVal;
     }
-    $filterParams['scope'] = $scopeStringParam; 
+    $filterParams['scope'] = $scopeStringParam;
     $filterParams['scope_match'] = 'all';
-    } 
-    
+    }
+
     $scopes = \Factory::getScopeService()->getScopes();
-    
+
     $ngis = \Factory::getNgiService()->getNGIsFilterByParams($filterParams);
     //$ngis = \Factory::getNgiService()->getNGIs($scope);
-    
-    
+
+
     $params['ngis'] = $ngis;
     $params['scopes']=$scopes;
     //$params['selectedScope']=$scope;

--- a/htdocs/web_portal/controllers/political_role/accept_request.php
+++ b/htdocs/web_portal/controllers/political_role/accept_request.php
@@ -2,7 +2,7 @@
 /*______________________________________________________
  *======================================================
  * File: accept_request.php
- * Author: John Casson, David Meredith 
+ * Author: John Casson, David Meredith
  * Description: Accepts a political role request
  *
  * License information
@@ -25,27 +25,27 @@ function view_accept_request() {
     require_once __DIR__ . '/../../../../lib/Gocdb_Services/Factory.php';
     require_once __DIR__ . '/../../components/Get_User_Principle.php';
     require_once __DIR__ . '/../utils.php';
-    
+
     $dn = Get_User_Principle();
     $user = \Factory::getUserService()->getUserByPrinciple($dn);
     if($user == null){
-        throw new Exception("Unregistered users can't grant role requests"); 
+        throw new Exception("Unregistered users can't grant role requests");
     }
 
     //Check the portal is not in read only mode, returns exception if it is and user is not an admin
     checkPortalIsNotReadOnlyOrUserIsAdmin($user);
-   
+
     $requestId = $_POST['id'];
-    
+
     if(!isset($requestId) || !is_numeric($requestId)) {
         throw new LogicException("Invalid role request id");
     }
-    
-    // Lookup role request with id  
-    $roleRequest = \Factory::getRoleService()->getRoleById($requestId); 
-    
-    \Factory::getRoleService()->grantRole($roleRequest, $user); 
-   
+
+    // Lookup role request with id
+    $roleRequest = \Factory::getRoleService()->getRoleById($requestId);
+
+    \Factory::getRoleService()->grantRole($roleRequest, $user);
+
     show_view('political_role/request_accepted.php');
-    die(); 
+    die();
 }

--- a/htdocs/web_portal/controllers/political_role/deny_request.php
+++ b/htdocs/web_portal/controllers/political_role/deny_request.php
@@ -23,27 +23,27 @@ function view_deny_request() {
     require_once __DIR__.'/../../../../lib/Gocdb_Services/Factory.php';
     require_once __DIR__.'/../../components/Get_User_Principle.php';
     require_once __DIR__ . '/../utils.php';
-      
+
     $dn = Get_User_Principle();
     $user = \Factory::getUserService()->getUserByPrinciple($dn);
     if($user == null) {
-        throw new Exception("Unregistered users can't view/deny role requests"); 
+        throw new Exception("Unregistered users can't view/deny role requests");
     }
     $requestId = $_POST['id'];
-    
+
     //Check the portal is not in read only mode, returns exception if it is and user is not an admin
     checkPortalIsNotReadOnlyOrUserIsAdmin($user);
-    
+
     if(!isset($requestId) || !is_numeric($requestId)) {
         throw new LogicException("Invalid role request id");
     }
 
-    // Lookup role request with id  
-    $roleRequest = \Factory::getRoleService()->getRoleById($requestId); 
-    
-    \Factory::getRoleService()->rejectRoleRequest($roleRequest, $user); 
-   
+    // Lookup role request with id
+    $roleRequest = \Factory::getRoleService()->getRoleById($requestId);
+
+    \Factory::getRoleService()->rejectRoleRequest($roleRequest, $user);
+
     show_view('political_role/request_denied.php');
-    die(); 
+    die();
 
 }

--- a/htdocs/web_portal/controllers/political_role/request_role.php
+++ b/htdocs/web_portal/controllers/political_role/request_role.php
@@ -24,34 +24,34 @@ require_once __DIR__.'/../../../../lib/Gocdb_Services/Factory.php';
 require_once '../web_portal/components/Get_User_Principle.php';
 
 /**
- * Controller for a Site role request. 
- * Is called by 'Page_Type=Request_Role' page mapping in index.php front controller. 
+ * Controller for a Site role request.
+ * Is called by 'Page_Type=Request_Role' page mapping in index.php front controller.
  * @global array $_POST only set if the browser has POSTed data
  */
-function request_role() {   
+function request_role() {
     $user = \Factory::getUserService()->getUserByPrinciple(Get_User_Principle());
     if($user == null) {
-        throw new Exception("Unregistered users can't request roles"); 
+        throw new Exception("Unregistered users can't request roles");
     }
-    
+
     //Check the portal is not in read only mode, returns exception if it is and user is not an admin
     checkPortalIsNotReadOnlyOrUserIsAdmin($user);
 
     // If we receive a POST request it's for a new role
-    if(isset($_REQUEST['Role_Name_Value']) && isset($_REQUEST['Object_ID']) ) {     
+    if(isset($_REQUEST['Role_Name_Value']) && isset($_REQUEST['Object_ID']) ) {
         submitRoleRequest($_REQUEST['Role_Name_Value'], $_REQUEST['Object_ID'], $user);
-        
+
     } else if(isset($_REQUEST['id'])){
-       drawViewRequestRole($_REQUEST['id'], $user); 
-    } 
-    else { 
+       drawViewRequestRole($_REQUEST['id'], $user);
+    }
+    else {
         // If there is no post data, draw the request role form
     }
 }
 
 
 /**
- * Show the select role page for the given entityId. 
+ * Show the select role page for the given entityId.
  * @param \User $user Current user
  * @param int $entityId
  */
@@ -59,20 +59,20 @@ function drawViewRequestRole($entityId, \User $user = null){
     if(!is_numeric($entityId)){
         throw new Exception('Invalid entityId');
     }
-    
+
     $ownedEntity = \Factory::getOwnedEntityService()->getOwnedEntityById($entityId);
-    
-    // build model to be passed to view (a parameter map/array)  
-    $params['entityName'] = $ownedEntity->getName(); 
+
+    // build model to be passed to view (a parameter map/array)
+    $params['entityName'] = $ownedEntity->getName();
     $params['entityType'] = \Factory::getOwnedEntityService()->getOwnedEntityDerivedClassName($ownedEntity);
     $params['objectId'] = $entityId;
-    // array ([0] => array(RoleTypeName => ProjectName)) 
+    // array ([0] => array(RoleTypeName => ProjectName))
     $roleTypes = \Factory::getRoleService()->getRoleTypeNamesForOwnedEntity($ownedEntity);
     $params['roles'] = $roleTypes;
-    //print_r($params['roles']); 
-    
+    //print_r($params['roles']);
+
     show_view('political_role/request_role.php', $params);
-    die(); 
+    die();
 }
 
 /**
@@ -87,17 +87,17 @@ function submitRoleRequest($roleName, $entityId, \User $user =null) {
    if(!is_numeric($entityId)){
         throw new Exception('Invalid entityId');
    }
-   
-   // Get the owned entity instance 
+
+   // Get the owned entity instance
    $entity = \Factory::getOwnedEntityService()->getOwnedEntityById($entityId);
-   
-   // Create a new Role linking user, entity and roletype. The addRole 
-   // perfoms role validation and throws exceptios accordingly. 
+
+   // Create a new Role linking user, entity and roletype. The addRole
+   // perfoms role validation and throws exceptios accordingly.
    $newRole = \Factory::getRoleService()->addRole($roleName, $user, $entity);
-  
+
    if(\Factory::getConfigService()->getSendEmails()){
        \Factory::getNotificationService()->roleRequest($entity);
-   } 
-       
-   show_view('political_role/new_request.php');    
+   }
+
+   show_view('political_role/new_request.php');
 }

--- a/htdocs/web_portal/controllers/political_role/revoke_request.php
+++ b/htdocs/web_portal/controllers/political_role/revoke_request.php
@@ -3,7 +3,7 @@
  *======================================================
  * File: view_deny_request.php
  * Author: John Casson, David Meredith
- * Description: Revokes a role regardless of its status 
+ * Description: Revokes a role regardless of its status
  *
  * License information
  *
@@ -24,34 +24,34 @@ function view_revoke_request(){
     require_once __DIR__.'/../../../../lib/Gocdb_Services/Factory.php';
     require_once __DIR__.'/../../components/Get_User_Principle.php';
     require_once __DIR__ . '/../utils.php';
-    
+
     $dn = Get_User_Principle();
     $user = \Factory::getUserService()->getUserByPrinciple($dn);
     if($user == null){
-        throw new Exception("Unregistered users can't revoke roles"); 
+        throw new Exception("Unregistered users can't revoke roles");
     }
     //Check the portal is not in read only mode, returns exception if it is and user is not an admin
     checkPortalIsNotReadOnlyOrUserIsAdmin($user);
-    
-    $requestId = $_POST['id']; 
-    
+
+    $requestId = $_POST['id'];
+
     if(!isset($requestId) || !is_numeric($requestId)) {
         throw new LogicException("Invalid role id");
     }
 
-    // Either a self revocation or revoke is requested by 2nd party 
-    // check to see that user has permission to revoke role 
-    $role = \Factory::getRoleService()->getRoleById($requestId); 
-    
-    \Factory::getRoleService()->revokeRole($role, $user); 
+    // Either a self revocation or revoke is requested by 2nd party
+    // check to see that user has permission to revoke role
+    $role = \Factory::getRoleService()->getRoleById($requestId);
+
+    \Factory::getRoleService()->revokeRole($role, $user);
     if($role->getUser() != $user){
-        // revoke by 2nd party 
+        // revoke by 2nd party
         show_view('political_role/role_revoked.php');
     } else {
-        // Self revocation 
+        // Self revocation
         show_view('political_role/role_self_revoked.php');
     }
-    
-    die(); 
+
+    die();
 }
 ?>

--- a/htdocs/web_portal/controllers/political_role/view_requests.php
+++ b/htdocs/web_portal/controllers/political_role/view_requests.php
@@ -2,7 +2,7 @@
 /*______________________________________________________
  *======================================================
  * File: view_requests.php
- * Author: John Casson, David Meredith 
+ * Author: John Casson, David Meredith
  * Description: Shows all available role requests
  *
  * License information
@@ -23,110 +23,110 @@ function view_requests() {
     require_once __DIR__ . '/../../../../lib/Gocdb_Services/Factory.php';
     require_once __DIR__ . '/../../components/Get_User_Principle.php';
     require_once __DIR__ . '/../utils.php';
-    
+
     $dn = Get_User_Principle();
     $user = \Factory::getUserService()->getUserByPrinciple($dn);
     if($user == null) {
-        throw new Exception("Unregistered users can't view/request roles"); 
-    }
-    
-    
-    // Entites is a two-dimensional array that lists both the id and name of 
-    // OwnedEntities that a user can reqeust a role over (Projects, NGIs, Sites, 
-    // ServiceGroups). If an inner dimesional array does not contain an Object_ID
-    // array key, then it is used as a section title in a pull-down list. 
-    $entities = array(); 
-    
-    $entities[] = array('Name' => 'Projects'); 
-    $allProjects = \Factory::getProjectService()->getProjects(); 
-    foreach($allProjects as $proj){
-       $entities[] = array('Object_ID' => $proj->getId(), 'Name' => $proj->getName()); 
-    }
-    
-    $entities[] = array('Name' => 'NGIs'); 
-    $allNGIs = \Factory::getNgiService()->getNGIs(); 
-    foreach($allNGIs as $ngi){
-       $entities[] = array('Object_ID' => $ngi->getId(), 'Name' => $ngi->getName()); 
+        throw new Exception("Unregistered users can't view/request roles");
     }
 
-    $entities[] = array('Name' => 'Sites'); 
-    $allSites = \Factory::getSiteService()->getSitesBy(); 
+
+    // Entites is a two-dimensional array that lists both the id and name of
+    // OwnedEntities that a user can reqeust a role over (Projects, NGIs, Sites,
+    // ServiceGroups). If an inner dimesional array does not contain an Object_ID
+    // array key, then it is used as a section title in a pull-down list.
+    $entities = array();
+
+    $entities[] = array('Name' => 'Projects');
+    $allProjects = \Factory::getProjectService()->getProjects();
+    foreach($allProjects as $proj){
+       $entities[] = array('Object_ID' => $proj->getId(), 'Name' => $proj->getName());
+    }
+
+    $entities[] = array('Name' => 'NGIs');
+    $allNGIs = \Factory::getNgiService()->getNGIs();
+    foreach($allNGIs as $ngi){
+       $entities[] = array('Object_ID' => $ngi->getId(), 'Name' => $ngi->getName());
+    }
+
+    $entities[] = array('Name' => 'Sites');
+    $allSites = \Factory::getSiteService()->getSitesBy();
     foreach($allSites as $site){
-        $entities[] = array('Object_ID' => $site->getId(), 'Name' => $site->getShortName()); 
+        $entities[] = array('Object_ID' => $site->getId(), 'Name' => $site->getShortName());
     }
-    
-    $entities[] = array('Name' => 'ServiceGroups'); 
-    $allSGs = \Factory::getServiceGroupService()->getServiceGroups(); 
+
+    $entities[] = array('Name' => 'ServiceGroups');
+    $allSGs = \Factory::getServiceGroupService()->getServiceGroups();
     foreach($allSGs as $sg){
-       $entities[] = array('Object_ID' => $sg->getId(), 'Name' => $sg->getName()); 
+       $entities[] = array('Object_ID' => $sg->getId(), 'Name' => $sg->getName());
     }
-   
-    // Current user's own pending roles 
-    $myPendingRoleRequests = \Factory::getRoleService()->getUserRoles($user, \RoleStatus::PENDING); 
-    // foreach role, lookup corresponding RoleActionRecord (if any) and populate 
-    // the role.decoratorObject with the roleActionRecord for subsequent display 
+
+    // Current user's own pending roles
+    $myPendingRoleRequests = \Factory::getRoleService()->getUserRoles($user, \RoleStatus::PENDING);
+    // foreach role, lookup corresponding RoleActionRecord (if any) and populate
+    // the role.decoratorObject with the roleActionRecord for subsequent display
 //    foreach($myPendingRoleRequests as $role){
-//       $rar = \Factory::getRoleService()->getRoleActionRecordByRoleId($role->getId());  
-//       $role->setDecoratorObject($rar); 
+//       $rar = \Factory::getRoleService()->getRoleActionRecordByRoleId($role->getId());
+//       $role->setDecoratorObject($rar);
 //    }
-    
-    // Other roles current user can approve 
-    $otherRolesUserCanApprove = \Factory::getRoleService()->getPendingRolesUserCanApprove($user); 
-    
-     // can the calling user grant or reject each role?  
+
+    // Other roles current user can approve
+    $otherRolesUserCanApprove = \Factory::getRoleService()->getPendingRolesUserCanApprove($user);
+
+     // can the calling user grant or reject each role?
     foreach ($otherRolesUserCanApprove as $r) {
-        $grantRejectRoleNamesArray = array(); 
-        $grantRejectRoleNamesArray['grant'] = ''; 
-        $grantRejectRoleNamesArray['deny'] = ''; 
-        
+        $grantRejectRoleNamesArray = array();
+        $grantRejectRoleNamesArray['grant'] = '';
+        $grantRejectRoleNamesArray['deny'] = '';
+
         // get list of roles that allows user to to grant the role request
-        //$grantRoleAuthorisingRoleNames = \Factory::getRoleService()->authorize Action(\Action::GRANT_ROLE, $r->getOwnedEntity(), $user); 
-        $grantRoleAuthorisingRoles = \Factory::getRoleActionAuthorisationService()->authoriseAction(\Action::GRANT_ROLE, $r->getOwnedEntity(), $user)->getGrantingRoles(); 
-        $grantRoleAuthorisingRoleNames = array(); 
+        //$grantRoleAuthorisingRoleNames = \Factory::getRoleService()->authorize Action(\Action::GRANT_ROLE, $r->getOwnedEntity(), $user);
+        $grantRoleAuthorisingRoles = \Factory::getRoleActionAuthorisationService()->authoriseAction(\Action::GRANT_ROLE, $r->getOwnedEntity(), $user)->getGrantingRoles();
+        $grantRoleAuthorisingRoleNames = array();
         foreach($grantRoleAuthorisingRoles as $grantRole){
-            $grantRoleAuthorisingRoleNames[] = $grantRole->getRoleType()->getName(); 
+            $grantRoleAuthorisingRoleNames[] = $grantRole->getRoleType()->getName();
         }
-        
+
         if(count($grantRoleAuthorisingRoleNames)>=1){
-            $allAuthorisingRoleNames = ''; 
+            $allAuthorisingRoleNames = '';
             foreach($grantRoleAuthorisingRoleNames as $arName){
-                $allAuthorisingRoleNames .= $arName.', '; 
+                $allAuthorisingRoleNames .= $arName.', ';
             }
-            $allAuthorisingRoleNames = substr($allAuthorisingRoleNames, 0, strlen($allAuthorisingRoleNames)-2);  
-            $grantRejectRoleNamesArray['grant'] = '['.$allAuthorisingRoleNames.']'; 
-        } 
+            $allAuthorisingRoleNames = substr($allAuthorisingRoleNames, 0, strlen($allAuthorisingRoleNames)-2);
+            $grantRejectRoleNamesArray['grant'] = '['.$allAuthorisingRoleNames.']';
+        }
         if($user->isAdmin()){
-           $grantRejectRoleNamesArray['grant'] = 'GOCDB ADMIN ' . $grantRejectRoleNamesArray['grant']; 
+           $grantRejectRoleNamesArray['grant'] = 'GOCDB ADMIN ' . $grantRejectRoleNamesArray['grant'];
         }
 
         // get list of roles that allows user to reject the role request
-        //$denyRoleAuthorisingRoleNames = \Factory::getRoleService()->authorize Action(\Action::REJECT_ROLE, $r->getOwnedEntity(), $user); 
-        $denyRoleAuthorisingRoles = \Factory::getRoleActionAuthorisationService()->authoriseAction(\Action::REJECT_ROLE, $r->getOwnedEntity(), $user)->getGrantingRoles();  
-        $denyRoleAuthorisingRoleNames = array();  
+        //$denyRoleAuthorisingRoleNames = \Factory::getRoleService()->authorize Action(\Action::REJECT_ROLE, $r->getOwnedEntity(), $user);
+        $denyRoleAuthorisingRoles = \Factory::getRoleActionAuthorisationService()->authoriseAction(\Action::REJECT_ROLE, $r->getOwnedEntity(), $user)->getGrantingRoles();
+        $denyRoleAuthorisingRoleNames = array();
         foreach($denyRoleAuthorisingRoles as $denyingRole){
-          $denyRoleAuthorisingRoleNames[] = $denyingRole->getRoleType()->getName();   
-        } 
-        
+          $denyRoleAuthorisingRoleNames[] = $denyingRole->getRoleType()->getName();
+        }
+
         if(count($denyRoleAuthorisingRoleNames)>=1){
-           $allAuthorisingRoleNames = ''; 
+           $allAuthorisingRoleNames = '';
             foreach($denyRoleAuthorisingRoleNames as $arName){
-                $allAuthorisingRoleNames .= $arName.', '; 
+                $allAuthorisingRoleNames .= $arName.', ';
             }
-            $allAuthorisingRoleNames = substr($allAuthorisingRoleNames, 0, strlen($allAuthorisingRoleNames)-2);  
-            $grantRejectRoleNamesArray['deny'] = '['.$allAuthorisingRoleNames.']'; 
+            $allAuthorisingRoleNames = substr($allAuthorisingRoleNames, 0, strlen($allAuthorisingRoleNames)-2);
+            $grantRejectRoleNamesArray['deny'] = '['.$allAuthorisingRoleNames.']';
         }
         if($user->isAdmin()){
-           $grantRejectRoleNamesArray['deny'] = 'GOCDB ADMIN ' . $grantRejectRoleNamesArray['deny']; 
+           $grantRejectRoleNamesArray['deny'] = 'GOCDB ADMIN ' . $grantRejectRoleNamesArray['deny'];
         }
-        // store array of role names in decorator object 
-        $r->setDecoratorObject($grantRejectRoleNamesArray); 
+        // store array of role names in decorator object
+        $r->setDecoratorObject($grantRejectRoleNamesArray);
     }
-    
+
     $params = array();
     $params['entities'] = $entities;
     $params['myRequests'] = $myPendingRoleRequests;
     $params['allRequests'] = $otherRolesUserCanApprove;
     $params['portalIsReadOnly'] = portalIsReadOnlyAndUserIsNotAdmin($user);
     show_view("political_role/view_requests.php", $params, "Role Requests");
-    die(); 
+    die();
 }

--- a/htdocs/web_portal/controllers/political_role/view_role_action_mappings.php
+++ b/htdocs/web_portal/controllers/political_role/view_role_action_mappings.php
@@ -14,59 +14,59 @@
  */
 
 /**
- * Page controller for viewing the GOCDB's Role Action Mappings rules, i.e. 
- * show a map which defines which roles held over which objects enable which 
- * permissions over which target object types. 
- * 
- * @author David Meredith 
+ * Page controller for viewing the GOCDB's Role Action Mappings rules, i.e.
+ * show a map which defines which roles held over which objects enable which
+ * permissions over which target object types.
+ *
+ * @author David Meredith
  */
 function view_role_action_mappings() {
     require_once __DIR__ . '/../../../../lib/Gocdb_Services/Factory.php';
 
-    // Get all the role type names from the role action mapping xml file 
-    // Returns an associative array where keys map to unique role type names and 
-    // values define the name of the object type that the role is over, 
-    // e.g. ['Service Group Administrator'] => 'ServiceGroup' 
-    //      ['Site Administrator'] => 'Site' 
-    $roleTypesOver = \Factory::getRoleActionMappingService()->getRoleTypeNamesForProject(null); 
+    // Get all the role type names from the role action mapping xml file
+    // Returns an associative array where keys map to unique role type names and
+    // values define the name of the object type that the role is over,
+    // e.g. ['Service Group Administrator'] => 'ServiceGroup'
+    //      ['Site Administrator'] => 'Site'
+    $roleTypesOver = \Factory::getRoleActionMappingService()->getRoleTypeNamesForProject(null);
 
-    // debug 
-//    $allActionsOverByRoleType = array(); 
+    // debug
+//    $allActionsOverByRoleType = array();
 //    foreach($roleTypesOver as $roleTypeName => $heldOverObjectType){
-//	print_r($roleTypeName.' : '.$heldOverObjectType.'<br>'); 
+//	print_r($roleTypeName.' : '.$heldOverObjectType.'<br>');
 //        $actionsOverArray = \Factory::getRoleActionMappingService()->getEnabledActionsForRoleType($roleTypeName);
 //	foreach($actionsOverArray as $actionsOver){
-//	    print_r($actionsOver[0]. ' '.$actionsOver[1].'<br>'); 
+//	    print_r($actionsOver[0]. ' '.$actionsOver[1].'<br>');
 //	}
-//	$allActionsOverByRoleType[$roleTypeName.':'.$heldOverObjectType] = $actionsOverArray; 
+//	$allActionsOverByRoleType[$roleTypeName.':'.$heldOverObjectType] = $actionsOverArray;
 //    }
 
-    // Associative array where keys are the objectTypeName that the role is held over, 
+    // Associative array where keys are the objectTypeName that the role is held over,
     // and Values are 3 element array instances holding strings for the roleName, actionName, targetObjectTypeName
     // e.g. ['ServiceGroup'] => array('Service Group Administrator', 'ACTION_EDIT_OBJECT', 'ServiceGroup')
     //      ['Project'] => array('COD Staff', 'ACTION_EDIT_OBJECT', 'Project')
     //      ...
-    $roleTypeActionTarget_byObjectType = array(); 
+    $roleTypeActionTarget_byObjectType = array();
     foreach($roleTypesOver as $roleTypeName => $heldOverObjectType){
     if(!array_key_exists($heldOverObjectType, $roleTypeActionTarget_byObjectType)){
-       $roleTypeActionTarget_byObjectType[$heldOverObjectType] = array();  
+       $roleTypeActionTarget_byObjectType[$heldOverObjectType] = array();
     }
         $actionsOverArray = \Factory::getRoleActionMappingService()->getEnabledActionsForRoleType($roleTypeName);
     foreach($actionsOverArray as $actionOverArray){
-        $roleActionTarget = array(); 
-        $roleActionTarget[0] = $roleTypeName;       //RoleType: 'Site Administrator' 
+        $roleActionTarget = array();
+        $roleActionTarget[0] = $roleTypeName;       //RoleType: 'Site Administrator'
         $roleActionTarget[1] = $actionOverArray[0]; //Action: 'EDIT_OBJECT'
         $roleActionTarget[2] = $actionOverArray[1]; //TargetObj: 'Site'
-        
-        // add element to result array (element is a new array) 
-        $roleTypeActionTarget_byObjectType[$heldOverObjectType][] = $roleActionTarget; 
+
+        // add element to result array (element is a new array)
+        $roleTypeActionTarget_byObjectType[$heldOverObjectType][] = $roleActionTarget;
     }
     }
 
     $params = array();
-    $params['roleTypeActionTarget_byObjectType'] = $roleTypeActionTarget_byObjectType; 
+    $params['roleTypeActionTarget_byObjectType'] = $roleTypeActionTarget_byObjectType;
     show_view("political_role/view_role_action_mappings.php", $params, "Role Action Mappings");
-    die(); 
-    
+    die();
+
 }
 

--- a/htdocs/web_portal/controllers/project/add_ngis.php
+++ b/htdocs/web_portal/controllers/project/add_ngis.php
@@ -19,7 +19,7 @@
  * limitations under the License.
  /*======================================================*/
 require_once __DIR__ . '/../utils.php';
-require_once __DIR__.'/../../../../lib/Gocdb_Services/Factory.php'; 
+require_once __DIR__.'/../../../../lib/Gocdb_Services/Factory.php';
 require_once __DIR__ . '/../../../web_portal/components/Get_User_Principle.php';
 
 /**
@@ -33,13 +33,13 @@ function add_ngis_to_project() {
 
     //Check the portal is not in read only mode, returns exception if it is and user is not an admin
     checkPortalIsNotReadOnlyOrUserIsAdmin($user);
-    
-    
-    ////Check the user has permission to see the page, will throw exception 
+
+
+    ////Check the user has permission to see the page, will throw exception
     //if correct permissions are lacking
     checkUserIsAdmin();
-    
-    
+
+
     if($_POST) {     // If we receive a POST request it's to add ngis
         submit();
     } else { // If there is no post data, draw the add NGI page
@@ -58,53 +58,53 @@ function draw() {
     //Get project details
     $serv = \Factory::getProjectService();
     $project = $serv->getProject($_REQUEST['id']);
-    
+
     //Throw exception if not a valid project id
     if(is_null($project)) {
         throw new \Exception("A project with ID '".$_REQUEST['id']."' Can not be found");
-    }    
-    
+    }
+
     $params["Name"]=$project->getName();
     $params["ID"]=$project->getId();
     $params["NGIs"]=  $serv->getNgisNotinProject($project);
-          
-    
+
+
     //show the add ngis view
     show_view("project/add_ngis.php", $params, "Add NGIs to". $params['Name']);
 }
 
 /**
  * Retrieves the NGIS to be added and then add them.
- * @return null 
+ * @return null
 */
 function submit() {
     require_once __DIR__ . '/../../../../htdocs/web_portal/components/Get_User_Principle.php';
-    
+
     //Get user details (for the remove ngi function so it can check permissions)
     $dn = Get_User_Principle();
     $user = \Factory::getUserService()->getUserByPrinciple($dn);
-    
+
     //Get a project and NGI services
     $projectServ=  \Factory::getProjectService();
     $ngiServ= \Factory::getNgiService();
-    
+
     //Get the posted service type data
     $projectId =$_REQUEST['ID'];
     $ngiIds = $_REQUEST['NGIs'];
-    
+
     //turn ngiIds into NGIs
     $ngis = new Doctrine\Common\Collections\ArrayCollection;
     foreach ($ngiIds as $ngiId){
         $ngis[]=$ngiServ->getNgi($ngiId);
     }
-    
+
     //get the project
     $project = $projectServ->getProject($projectId);
 
     try {
         //function will throw error if user does not have the correct permissions
         $projectServ->addNgisToProject($project, $ngis, $user);
-        
+
         $params = array('Name' => $project->getName(),
                         'ID'=> $project->getId(),
                         'NGIs'=>$ngis);

--- a/htdocs/web_portal/controllers/project/delete_project.php
+++ b/htdocs/web_portal/controllers/project/delete_project.php
@@ -23,7 +23,7 @@ require_once __DIR__ . '/../utils.php';
 
 function delete_project(){
     if(true){
-        throw new Exception("Project deletion is disabled - see controller to enable"); 
+        throw new Exception("Project deletion is disabled - see controller to enable");
     }
     if (!isset($_REQUEST['id']) || !is_numeric($_REQUEST['id']) ){
         throw new Exception("An id must be specified");
@@ -33,26 +33,26 @@ function delete_project(){
 
     //Check the portal is not in read only mode, returns exception if it is and user is not an admin
     checkPortalIsNotReadOnlyOrUserIsAdmin($user);
-    
-    
+
+
     //Get the project from the id
     $serv= \Factory::getProjectService();
     $project =$serv ->getProject($_REQUEST['id']);
-    
+
     //keep the name to display later
     $params['Name'] = $project -> getName();
-     
-    // Delete the project. This fuction will check the user is allowed to 
+
+    // Delete the project. This fuction will check the user is allowed to
     // perform this action and throw an error if not (only gocdb admins allowed).
-    // Project deletion does not delete child NGIs and automatically cascade 
-    // deletes the user Roles over the OwnedEntity. 
+    // Project deletion does not delete child NGIs and automatically cascade
+    // deletes the user Roles over the OwnedEntity.
     try {
         $serv->deleteProject($project, $user);
     } catch(\Exception $e) {
         show_view('error.php', $e->getMessage());
         die();
     }
-    
+
     show_view("project/deleted_project.php", $params, $params['Name'].'deleted');
-            
+
 }

--- a/htdocs/web_portal/controllers/project/edit_project.php
+++ b/htdocs/web_portal/controllers/project/edit_project.php
@@ -36,7 +36,7 @@ function edit_project() {
 
     //Check the portal is not in read only mode, returns exception if it is and user is not an admin
     checkPortalIsNotReadOnlyOrUserIsAdmin($user);
-    
+
     if($_POST) {     // If we receive a POST request it's for a projecte edit
         submit($user);
     } else { // If there is no post data, draw the edit project view
@@ -48,17 +48,17 @@ function edit_project() {
  * Draws the edit project form
  * @return null
  */
-function draw() {              
+function draw() {
     if (!isset($_REQUEST['id']) || !is_numeric($_REQUEST['id']) ){
         throw new Exception("An id must be specified");
     }
     // Get the project
     $project = \Factory::getProjectService()->getProject($_REQUEST['id']);
 
-    //Check the user has permission to edit the project (and so view the page, 
+    //Check the user has permission to edit the project (and so view the page,
     //will throw exception if correct permissions are lacking
     CheckCurrentUserCanEditProject($project);
-  
+
     //show view
     $params = array('Name' => $project->getName(),
                     'ID' => $project->getId(),
@@ -75,24 +75,24 @@ function draw() {
  */
 function submit(\User $user = null) {
     require_once __DIR__ . '/../../../../htdocs/web_portal/components/Get_User_Principle.php';
-    
+
     //get the post data
     $newValues = getProjectDataFromWeb();
 
-    
+
     //get the project service and the project being edited
     $serv = \Factory::getProjectService();
     $unalteredProject = $serv->getProject($newValues['ID']);
-           
+
     try {
         //function will throw error if user does not have the correct permissions
         $alteredProject= $serv->editProject($unalteredProject, $newValues, $user);
-        
+
         $params = array('Name' => $alteredProject->getName(),
                         'Description'=> $alteredProject->getDescription(),
                         'ID'=> $alteredProject->getId());
         show_view("project/edited_project.php", $params);
-    
+
     } catch (Exception $e) {
          show_view('error.php', $e->getMessage());
          die();

--- a/htdocs/web_portal/controllers/project/remove_ngis.php
+++ b/htdocs/web_portal/controllers/project/remove_ngis.php
@@ -19,7 +19,7 @@
  * limitations under the License.
  /*======================================================*/
 require_once __DIR__ . '/../utils.php';
-require_once __DIR__.'/../../../../lib/Gocdb_Services/Factory.php'; 
+require_once __DIR__.'/../../../../lib/Gocdb_Services/Factory.php';
 require_once __DIR__ . '/../../../web_portal/components/Get_User_Principle.php';
 
 /**
@@ -27,18 +27,18 @@ require_once __DIR__ . '/../../../web_portal/components/Get_User_Principle.php';
  * @global array $_POST only set if the browser has POSTed data
  * @return null
  */
-function remove_ngis_project() {    
+function remove_ngis_project() {
     $dn = Get_User_Principle();
     $user = \Factory::getUserService()->getUserByPrinciple($dn);
 
     //Check the portal is not in read only mode, returns exception if it is and user is not an admin
     checkPortalIsNotReadOnlyOrUserIsAdmin($user);
-    
-    ////Check the user has permission to see the page, will throw exception 
+
+    ////Check the user has permission to see the page, will throw exception
     //if correct permissions are lacking
     checkUserIsAdmin();
-    
-    
+
+
     if($_POST) {     // If we receive a POST request it's to remove ngis
         submit();
     } else { // If there is no post data, draw the remove NGI page
@@ -57,53 +57,53 @@ function draw() {
     //Get project details
     $serv = \Factory::getProjectService();
     $project = $serv->getProject($_REQUEST['id']);
-    
+
     //Throw exception if not a valid project id
     if(is_null($project)) {
         throw new \Exception("A project with ID '".$_REQUEST['id']."' Can not be found");
-    }    
-    
+    }
+
     $params["Name"]=$project->getName();
     $params["ID"]=$project->getId();
-    $params["NGIs"]=$project->getNgis();  
-    
-    
+    $params["NGIs"]=$project->getNgis();
+
+
     //show the remove ngis view
     show_view("project/remove_ngis.php", $params, "Remove NGIS from". $params['Name']);
 }
 
 /**
  * Retrieves the NGIS to be removed and then removes them.
- * @return null 
+ * @return null
 */
 function submit() {
     require_once __DIR__ . '/../../../../htdocs/web_portal/components/Get_User_Principle.php';
-    
+
     //Get user details (for the remove ngi function so it can check permissions)
     $dn = Get_User_Principle();
     $user = \Factory::getUserService()->getUserByPrinciple($dn);
-    
+
     //Get a project and NGI services
     $projectServ=  \Factory::getProjectService();
     $ngiServ= \Factory::getNgiService();
-    
+
     //Get the posted service type data
     $projectId =$_REQUEST['ID'];
     $ngiIds = $_REQUEST['NGIs'];
-    
+
     //turn ngiIds into NGIs
     $ngis = new Doctrine\Common\Collections\ArrayCollection;
     foreach ($ngiIds as $ngiId){
         $ngis[]=$ngiServ->getNgi($ngiId);
     }
-    
+
     //get the project
     $project = $projectServ->getProject($projectId);
 
     try {
         //function will throw error if user does not have the correct permissions
         $projectServ->removeNgisFromProject($project, $ngis, $user);
-        
+
         $params = array('Name' => $project->getName(),
                         'ID'=> $project->getId());
         show_view("project/removed_ngis.php", $params, "Success");

--- a/htdocs/web_portal/controllers/project/view_project.php
+++ b/htdocs/web_portal/controllers/project/view_project.php
@@ -24,48 +24,48 @@ function show_project() {
     require_once __DIR__ . '/../../../../lib/Gocdb_Services/Factory.php';
     require_once __DIR__ . '/../utils.php';
     require_once __DIR__ . '/../../../../htdocs/web_portal/components/Get_User_Principle.php';
-   
+
     if (!isset($_GET['id']) || !is_numeric($_GET['id']) ){
         throw new Exception("An id must be specified");
     }
-    $projId = $_GET['id']; 
-    
+    $projId = $_GET['id'];
+
     $serv=\Factory::getProjectService();
     $project = $serv->getProject($projId);
-    $allRoles = $project->getRoles(); 
-    $roles = array(); 
+    $allRoles = $project->getRoles();
+    $roles = array();
     foreach ($allRoles as $role){
-        if($role->getStatus() == \RoleStatus::GRANTED && 
+        if($role->getStatus() == \RoleStatus::GRANTED &&
                 $role->getRoleType()->getName() != \RoleTypeName::CIC_STAFF){
-            $roles[] = $role; 
+            $roles[] = $role;
         }
     }
-    
+
     //get user for case that portal is read only and user is admin, so they can still see edit links
     $dn = Get_User_Principle();
     $user = \Factory::getUserService()->getUserByPrinciple($dn);
-    $params['ShowEdit'] = false;  
+    $params['ShowEdit'] = false;
     if (\Factory::getRoleActionAuthorisationService()->authoriseAction(\Action::EDIT_OBJECT, $project, $user)->getGrantAction())  {
         $params['ShowEdit'] = true;
     }
 //    if(count($serv->authorize Action(\Action::EDIT_OBJECT, $project, $user))>=1){
-//       $params['ShowEdit'] = true;  
+//       $params['ShowEdit'] = true;
 //    }
-    
-    $params['authenticated'] = false; 
+
+    $params['authenticated'] = false;
     if($user != null){
-        $params['authenticated'] = true; 
+        $params['authenticated'] = true;
     }
 
-    // Add RoleActionRecords to params 
-    $params['RoleActionRecords'] = \Factory::getRoleService()->getRoleActionRecordsById_Type($project->getId(), 'project'); 
-    
+    // Add RoleActionRecords to params
+    $params['RoleActionRecords'] = \Factory::getRoleService()->getRoleActionRecordsById_Type($project->getId(), 'project');
+
     $params['Name'] = $project->getName();
     $params['Description'] = $project->getDescription();
     $params['ID']=$project->getId();
     $params['NGIs'] = $project->getNgis();
     $params['Sites']= $serv->getSites($project);
-    $params['Roles'] =$roles;    
+    $params['Roles'] =$roles;
     $params['portalIsReadOnly'] = portalIsReadOnlyAndUserIsNotAdmin($user);
     show_view('project/view_project.php', $params, $params['Name']);
 }

--- a/htdocs/web_portal/controllers/scope_help.php
+++ b/htdocs/web_portal/controllers/scope_help.php
@@ -24,12 +24,12 @@ function show_help() {
     //$params['Scopes'] = \Factory::getScopeService()->getScopes();
 
     $optionalScopes = \Factory::getScopeService()->getScopesFilterByParams(
-                    array('excludeReserved' => true), null);  
+                    array('excludeReserved' => true), null);
     $reservedScopes = \Factory::getScopeService()->getScopesFilterByParams(
-                    array('excludeNonReserved' => true), null); 
+                    array('excludeNonReserved' => true), null);
 
-    $params['optionalScopes'] = $optionalScopes; 
-    $params['reservedScopes'] = $reservedScopes; 
-    
+    $params['optionalScopes'] = $optionalScopes;
+    $params['reservedScopes'] = $reservedScopes;
+
     show_view("scope_help.php", $params, "Scopes");
 }

--- a/htdocs/web_portal/controllers/search.php
+++ b/htdocs/web_portal/controllers/search.php
@@ -22,37 +22,37 @@
 
 function search() {
     require_once __DIR__.'/../../../lib/Gocdb_Services/Factory.php';
-    
-   
+
+
     $dn = Get_User_Principle();
     $user = \Factory::getUserService()->getUserByPrinciple($dn);
 
-    $params['authenticated'] = false; 
+    $params['authenticated'] = false;
     if($user != null){
-        $params['authenticated'] = true; 
+        $params['authenticated'] = true;
     }
-    
+
     $searchTerm = isset($_POST['SearchString']) ? $_POST['SearchString'] : '';
-    
+
     //strip leading and trailing whitespace off search term
     $searchTerm = strip_tags(trim($searchTerm));
-    if(1 === preg_match("/[';\"]/", $searchTerm)){ throw new Exception("Invalid char in search term"); } 
-    
-    /* Check to see if search string already has either a leading or trailing % 
+    if(1 === preg_match("/[';\"]/", $searchTerm)){ throw new Exception("Invalid char in search term"); }
+
+    /* Check to see if search string already has either a leading or trailing %
      * supplied by the user, if not then add them. This is to aid searching*/
-    
-    
+
+
     $params['searchTerm'] = $searchTerm;
     $params['siteResults'] = null;
     $params['serviceResults'] = null;
     $params['userResults'] = null;
     $params['ngiResults'] = null;
-    
+
     if($params['searchTerm'] == "") {
         show_view('search_results.php', $params, "Searching for {$params['searchTerm']}");
         die();
     }
-    
+
     $searchServ = \Factory::getSearchService();
     $siteResults = $searchServ->getSites($params['searchTerm']);
     $serviceResults = $searchServ->getServices($params['searchTerm']);
@@ -63,7 +63,7 @@ function search() {
     $params['serviceResults'] = $serviceResults;
     $params['userResults'] = $userResults;
     $params['ngiResults'] = $ngiResults;
-    
+
     show_view('search_results.php', $params, "Searching for \"{$params['searchTerm']}\"");
 }
 

--- a/htdocs/web_portal/controllers/service/add_endpoint_properties.php
+++ b/htdocs/web_portal/controllers/service/add_endpoint_properties.php
@@ -24,7 +24,7 @@
 require_once __DIR__.'/../../../../lib/Gocdb_Services/Factory.php';
 require_once __DIR__.'/../utils.php';
 require_once __DIR__.'/../../../web_portal/components/Get_User_Principle.php';
-    
+
 /**
  * Controller for a new_property request
  * @global array $_POST only set if the browser has POSTed data

--- a/htdocs/web_portal/controllers/service/add_service.php
+++ b/htdocs/web_portal/controllers/service/add_service.php
@@ -3,7 +3,7 @@
  *======================================================
  * Author: John Casson, George Ryall, David Meredith
  * Description: Processes a new service request. If the user
- *              hasn't POSTed any data we draw the new service 
+ *              hasn't POSTed any data we draw the new service
  *              form. If they post data we assume they've posted it from
  *              the form and validate then insert it into the DB.
  *
@@ -35,7 +35,7 @@ function add_service() {
 
     //Check the portal is not in read only mode, returns exception if it is and user is not an admin
     checkPortalIsNotReadOnlyOrUserIsAdmin($user);
-    
+
     if($_POST) {     // If we receive a POST request it's for a new SE
         submit($user);
     } else { // If there is no post data, draw the New SE form
@@ -48,10 +48,10 @@ function add_service() {
  * @param \User $user Current user
  * @return null
  */
-function submit(\User $user = null) { 
+function submit(\User $user = null) {
     $newValues = getSeDataFromWeb();
 
-    if($user == null) throw new Exception("Unregistered users can't add services"); 
+    if($user == null) throw new Exception("Unregistered users can't add services");
     $se = \Factory::getServiceService()->addService($newValues, $user);
     $params = array('se' => $se);
     show_view("service/submit_add_service.php", $params);
@@ -59,7 +59,7 @@ function submit(\User $user = null) {
 
 /**
  * Draw the add service form
- * @param \User $user current user 
+ * @param \User $user current user
  * @return null
  */
 function draw($user) {
@@ -83,12 +83,12 @@ function draw($user) {
 
     $sites = array();
     if ($user->isAdmin()) {
-        $disableReservedScopes = false; 
+        $disableReservedScopes = false;
         //For admin users, return all sites instead.
         $sites = \Factory::getSiteService()->getSitesBy();
     } else {
-        $disableReservedScopes = true; 
-        // Collate sites which user has required action permission to array. 
+        $disableReservedScopes = true;
+        // Collate sites which user has required action permission to array.
         $allUserSites = \Factory::getUserService()->getSitesFromRoles($user);
         foreach ($allUserSites as $s) {
             if (\Factory::getRoleActionAuthorisationService()->authoriseAction(
@@ -99,25 +99,25 @@ function draw($user) {
     }
 
     if(count($sites)==0 and !$user->isAdmin()){
-      throw new Exception("You need at least one NGI or Site level role to add a new service.");  
+      throw new Exception("You need at least one NGI or Site level role to add a new service.");
     }
 
     // URL mapping
-    // Return all scopes for the parent Site with the specified Id as a JSON object 
+    // Return all scopes for the parent Site with the specified Id as a JSON object
     // Used in ajax requests for display purposes
     if(isset($_GET['getAllScopesForScopedEntity']) && is_numeric($_GET['getAllScopesForScopedEntity'])){
-        // Return all scopes for the parent Site with the specified Id as a JSON object.  
-        // Used in ajax requests for generating UI checkboxes. 
-        // AJAX is needed here because the parent Site is not known until the user selects 
-        // which parent Site in the pull-down which then fires the AJAX request. 
-        $scopedEntityId = $_GET['getAllScopesForScopedEntity']; 
-        $siteScopedEntity =  \Factory::getSiteService()->getSite($scopedEntityId); 
-        $scopeJson = getEntityScopesAsJSON2(null, $siteScopedEntity, $disableReservedScopes, true);  
-        //$scopeJson = getEntityScopesAsJSON($siteScopedEntity, $disableReservedScopes);  
+        // Return all scopes for the parent Site with the specified Id as a JSON object.
+        // Used in ajax requests for generating UI checkboxes.
+        // AJAX is needed here because the parent Site is not known until the user selects
+        // which parent Site in the pull-down which then fires the AJAX request.
+        $scopedEntityId = $_GET['getAllScopesForScopedEntity'];
+        $siteScopedEntity =  \Factory::getSiteService()->getSite($scopedEntityId);
+        $scopeJson = getEntityScopesAsJSON2(null, $siteScopedEntity, $disableReservedScopes, true);
+        //$scopeJson = getEntityScopesAsJSON($siteScopedEntity, $disableReservedScopes);
         header('Content-type: application/json');
-        die($scopeJson);  
-    } 
-    
+        die($scopeJson);
+    }
+
     $serviceTypes = \Factory::getServiceService()->getServiceTypes();
     // remove the deprecated CE type (temp hack)
     foreach($serviceTypes as $key => $st) {
@@ -128,17 +128,17 @@ function draw($user) {
 
     //get the number of scopes that we require
     $numberScopesRequired = \Factory::getConfigService()->getMinimumScopesRequired('service');
-    
+
     $params = array('sites' => $sites, 'serviceTypes' => $serviceTypes,
                     "disableReservedScopes"=> $disableReservedScopes,
-                    'site' => $site, 
+                    'site' => $site,
                     'numberOfScopesRequired' => $numberScopesRequired);
-    
+
     //Check that there is at least one Site available before allowing a user to add a service.
     if($params['sites'] == null){
         show_view('error.php', "GocDB requires one or more Sites to be able to add a service.");
     }
-    
+
     show_view("service/add_service.php", $params);
 }
 

--- a/htdocs/web_portal/controllers/service/add_service_endpoint.php
+++ b/htdocs/web_portal/controllers/service/add_service_endpoint.php
@@ -22,7 +22,7 @@
 require_once __DIR__.'/../../../../lib/Gocdb_Services/Factory.php';
 require_once __DIR__.'/../utils.php';
 require_once __DIR__.'/../../../web_portal/components/Get_User_Principle.php';
-    
+
 /**
  * Controller for a endpoint request
  * @global array $_POST only set if the browser has POSTed data
@@ -34,7 +34,7 @@ function add_service_endpoint() {
 
     //Check the portal is not in read only mode, returns exception if it is and user is not an admin
     checkPortalIsNotReadOnlyOrUserIsAdmin($user);
-    
+
     if($_POST) {     	// If we receive a POST request it's for a new endpoint
         submit($user);
     } else { 			// If there is no post data, draw the new endpoint form
@@ -48,7 +48,7 @@ function add_service_endpoint() {
  * @param \User $user current user
  * @return null */
 function submit(\User $user = null) {
-    $serv = \Factory::getServiceService();    
+    $serv = \Factory::getServiceService();
     $newValues = getEndpointDataFromWeb();
     $serviceid = $newValues['SERVICEENDPOINT']['SERVICE'];
     $serv->addEndpoint($newValues, $user);
@@ -57,7 +57,7 @@ function submit(\User $user = null) {
 
 /**
  * Draws a form to add a new service property
- * @param \User $user current user 
+ * @param \User $user current user
  * @return null
  */
 function draw(\User $user = null) {
@@ -68,16 +68,16 @@ function draw(\User $user = null) {
     if (!isset($_REQUEST['se']) || !is_numeric($_REQUEST['se']) ){
         throw new Exception("An id must be specified");
     }
-    
+
     $serv = \Factory::getServiceService();
     $service = $serv->getService($_REQUEST['se']); //get service by id
-    $seType = $service->getServiceType()->getName(); 
+    $seType = $service->getServiceType()->getName();
     //Check user has permissions to add service endpoint
     $serv->validateAddEditDeleteActions($user, $service);
-        
+
     $params['serviceid'] = $_REQUEST['se'];
     $params['se'] = $service;
-    $params['serviceType'] = $seType; 
+    $params['serviceType'] = $seType;
     $params['serviceTypes'] = $serv->getServiceTypes();
     show_view("service/add_service_endpoint.php", $params);
 

--- a/htdocs/web_portal/controllers/service/add_service_properties.php
+++ b/htdocs/web_portal/controllers/service/add_service_properties.php
@@ -24,7 +24,7 @@
 require_once __DIR__.'/../../../../lib/Gocdb_Services/Factory.php';
 require_once __DIR__.'/../utils.php';
 require_once __DIR__.'/../../../web_portal/components/Get_User_Principle.php';
-    
+
 /**
  * Controller for a new_property request
  * @global array $_POST only set if the browser has POSTed data
@@ -39,7 +39,7 @@ function add_service_properties() {
 
 
 
-    
+
     if($_POST) {     	// If we receive a POST request it's for new properties
 
         //COMMENT
@@ -148,7 +148,7 @@ function confirm(array $propArr, \Service $service, \User $user = null){
 
 /**
  *  Draws a form to add a new service property
- * @param \User $user current user 
+ * @param \User $user current user
  * @return null
  */
 function draw(\User $user = null) {
@@ -163,7 +163,7 @@ function draw(\User $user = null) {
     $service = $serv->getService($_REQUEST['parentid']); //get service by id
     //Check user has permissions to add service property
     $serv->validateAddEditDeleteActions($user, $service);
-        
+
     $params['parentid'] = $_REQUEST['parentid'];
     show_view("service/add_service_properties.php", $params);
 

--- a/htdocs/web_portal/controllers/service/delete_endpoint_properties.php
+++ b/htdocs/web_portal/controllers/service/delete_endpoint_properties.php
@@ -53,16 +53,16 @@ function submit(array $propertyArray, \Service $service, \EndpointLocation $endp
 
     $params['propArr'] = $propertyArray;
     $params['service'] = $service;
-    $params['endpoint'] = $endpoint; 
-    
+    $params['endpoint'] = $endpoint;
+
     //remove property
     try {
         $serv->deleteEndpointProperties($user, $propertyArray);
     } catch(\Exception $e) {
         show_view('error.php', $e->getMessage());
         die();
-    }   
-    
+    }
+
     show_view('/service/deleted_endpoint_properties.php', $params);
 
 }

--- a/htdocs/web_portal/controllers/service/delete_service.php
+++ b/htdocs/web_portal/controllers/service/delete_service.php
@@ -2,7 +2,7 @@
 /*______________________________________________________
  *======================================================
  * Author: John Casson, David Meredith
- * Description: Answers a request to delete a service 
+ * Description: Answers a request to delete a service
  *
  * License information
  *
@@ -20,7 +20,7 @@
 require_once __DIR__.'/../../../../lib/Gocdb_Services/Factory.php';
 require_once __DIR__ . '/../../../../htdocs/web_portal/components/Get_User_Principle.php';
 require_once __DIR__ . '/../utils.php';
-    
+
 /**
  * Controller for a delete service request
  * @return null
@@ -29,8 +29,8 @@ function delete() {
     $dn = Get_User_Principle();
     $user = \Factory::getUserService()->getUserByPrinciple($dn);
     if($user == null){
-        throw new \Exception("Unregistered users can't delete services. "); 
-    } 
+        throw new \Exception("Unregistered users can't delete services. ");
+    }
 
     //Check the portal is not in read only mode, returns exception if it is and user is not an admin
     checkPortalIsNotReadOnlyOrUserIsAdmin($user);
@@ -41,7 +41,7 @@ function delete() {
     $se = $serv->getService($_REQUEST['id']);
 
     $serv->deleteService($se, $user);
-    
+
     show_view('service/service_deleted.php');
 }
 ?>

--- a/htdocs/web_portal/controllers/service/delete_service_endpoint.php
+++ b/htdocs/web_portal/controllers/service/delete_service_endpoint.php
@@ -25,7 +25,7 @@ require_once __DIR__ . '/../../../../lib/Gocdb_Services/Factory.php';
 function delete_endpoint() {
     $dn = Get_User_Principle();
     $user = \Factory::getUserService()->getUserByPrinciple($dn);
-    
+
     if (!isset($_REQUEST['endpointid']) || !is_numeric($_REQUEST['endpointid']) ){
         throw new Exception("An endpointid must be specified");
     }
@@ -41,22 +41,22 @@ function delete_endpoint() {
     }else{
         draw($endpoint, $service, $user);
     }
-    
+
 }
 
 function draw(\EndpointLocation $endpoint, \Service $service, \User $user) {
     if(is_null($user)) {
         throw new Exception("Unregistered users can't delete a endpoint.");
     }
-    
+
     //Check user has permissions to delete endpoint
-    $serv = \Factory::getServiceService();    
-    $serv->validateAddEditDeleteActions($user, $service);   
-          
+    $serv = \Factory::getServiceService();
+    $serv->validateAddEditDeleteActions($user, $service);
+
     $params['endpoint'] = $endpoint;
     $params['service'] = $service;
-     
-    show_view('/service/delete_service_endpoint.php', $params);     
+
+    show_view('/service/delete_service_endpoint.php', $params);
 }
 
 function submit(\EndpointLocation $endpoint, \Service $service, \User $user = null) {
@@ -66,11 +66,11 @@ function submit(\EndpointLocation $endpoint, \Service $service, \User $user = nu
     } catch(\Exception $e) {
         show_view('error.php', $e->getMessage());
         die();
-    }   
-   
+    }
+
     $params['endpoint'] = $endpoint;
     $params['service'] = $service;
-    
+
     show_view('/service/deleted_service_endpoint.php', $params);
 
 }

--- a/htdocs/web_portal/controllers/service/delete_service_properties.php
+++ b/htdocs/web_portal/controllers/service/delete_service_properties.php
@@ -58,9 +58,9 @@ function submit(array $propertyArray, \Service $service, \User $user = null) {
     } catch(\Exception $e) {
         show_view('error.php', $e->getMessage());
         die();
-    }   
-    
-    
+    }
+
+
     show_view('/service/deleted_service_properties.php', $params);
 
 }

--- a/htdocs/web_portal/controllers/service/edit_endpoint_property.php
+++ b/htdocs/web_portal/controllers/service/edit_endpoint_property.php
@@ -33,7 +33,7 @@ function edit_property() {
 
     //Check the portal is not in read only mode, returns exception if it is and user is not an admin
     checkPortalIsNotReadOnlyOrUserIsAdmin($user);
-    
+
     if($_POST) {
         submit($user);
     } else {
@@ -54,21 +54,21 @@ function draw(\User $user = null) {
     if (!isset($_REQUEST['propertyid']) || !is_numeric($_REQUEST['propertyid']) ){
         throw new Exception("An id must be specified");
     }
-    $serv = \Factory::getServiceService(); 
+    $serv = \Factory::getServiceService();
     //$service = $serv->getService($_REQUEST['serviceid']);
     $property = $serv->getEndpointProperty($_REQUEST['propertyid']);
-    $endpoint = $property->getParentEndpoint();  
-    $service = $endpoint->getService(); 
-    
+    $endpoint = $property->getParentEndpoint();
+    $service = $endpoint->getService();
+
     //Check user has permissions to edit endpoint property
     $serv->validateAddEditDeleteActions($user, $service);
-    
+
     $params['prop'] = $property;
     $params['service'] = $service;
-    $params['endpoint'] = $endpoint; 
-    
-    show_view("service/edit_endpoint_property.php", $params);     
-    
+    $params['endpoint'] = $endpoint;
+
+    show_view("service/edit_endpoint_property.php", $params);
+
 
 }
 
@@ -79,7 +79,7 @@ function draw(\User $user = null) {
  */
 function submit(\User $user = null) {
     try {
-        $newValues = getEndpointPropDataFromWeb();  
+        $newValues = getEndpointPropDataFromWeb();
         $endpointID = $newValues['ENDPOINTPROPERTIES']['ENDPOINTID'];
         $propID = $newValues['ENDPOINTPROPERTIES']['PROP'];
         if($newValues['ENDPOINTPROPERTIES']['NAME'] == null || $newValues['ENDPOINTPROPERTIES']['VALUE'] == null){
@@ -87,9 +87,9 @@ function submit(\User $user = null) {
             die();
         }
         $property = \Factory::getServiceService()->getEndpointProperty($propID);
-        $service = $property->getParentEndpoint()->getService();  
+        $service = $property->getParentEndpoint()->getService();
         \Factory::getServiceService()->editEndpointProperty($service, $user, $property, $newValues);
-        
+
         $params['endpointid'] = $endpointID;
         show_view('service/endpoint_property_updated.php', $params);
     } catch(Exception $e) {

--- a/htdocs/web_portal/controllers/service/edit_service.php
+++ b/htdocs/web_portal/controllers/service/edit_service.php
@@ -32,7 +32,7 @@ function edit_service() {
 
     //Check the portal is not in read only mode, returns exception if it is and user is not an admin
     checkPortalIsNotReadOnlyOrUserIsAdmin($user);
-    
+
     if($_POST) {     // If we receive a POST request it's for a new site
         submit($user);
     } else { // If there is no post data, draw the edit site form
@@ -41,7 +41,7 @@ function edit_service() {
 }
 
 /**
- * Processes an edit service request. 
+ * Processes an edit service request.
  * @param \User $user Current user
  * @return null
  */
@@ -54,44 +54,44 @@ function submit(\User $user = null) {
 }
 
 /**
- * Draw the edit site form. 
+ * Draw the edit site form.
  * @param \User $user
  * @throws \Exception
  */
 function draw(\User $user = null) {
     // can user assign reserved scopes to this site?
-    $disableReservedScopes = true; 
+    $disableReservedScopes = true;
     if($user->isAdmin()){
-    $disableReservedScopes = false; 
+    $disableReservedScopes = false;
     }
-    
+
     // URL mapping
-    // Return all scopes for the Site with the specified Id as a JSON object 
+    // Return all scopes for the Site with the specified Id as a JSON object
     // Used in ajax requests for display purposes
     /*if(isset($_GET['getAllScopesForScopedEntity']) && is_numeric($_GET['getAllScopesForScopedEntity'])){
-        $service = \Factory::getServiceService()->getService($_GET['getAllScopesForScopedEntity']); 
-        die(getEntityScopesAsJSON($service, $disableReservedScopes));  
-        
-    } else*/ 
+        $service = \Factory::getServiceService()->getService($_GET['getAllScopesForScopedEntity']);
+        die(getEntityScopesAsJSON($service, $disableReservedScopes));
+
+    } else*/
     if (!isset($_REQUEST['id']) || !is_numeric($_REQUEST['id']) ){
         throw new Exception("An id must be specified");
     }
-    
+
     $id = $_REQUEST['id'];
     /* @var $se \Service */
     $se = \Factory::getServiceService()->getService($id);
 
     if(\Factory::getRoleActionAuthorisationService()->authoriseAction(
             \Action::EDIT_OBJECT, $se->getParentSite(), $user)->getGrantAction()==FALSE){
-       throw new \Exception("You do not have permission over this service.");  
+       throw new \Exception("You do not have permission over this service.");
     }
-    
+
 
     $params['se'] = $se;
     $params['serviceTypes'] = \Factory::getServiceService()->getServiceTypes();
     $params['numberOfScopesRequired'] = \Factory::getConfigService()->getMinimumScopesRequired('service');
     $params["disableReservedScopes"]=$disableReservedScopes;
-    $params['scopejson'] = getEntityScopesAsJSON2($se, $se->getParentSite(), $disableReservedScopes); 
+    $params['scopejson'] = getEntityScopesAsJSON2($se, $se->getParentSite(), $disableReservedScopes);
     show_view('service/edit_service.php', $params);
 }
 

--- a/htdocs/web_portal/controllers/service/edit_service_endpoint.php
+++ b/htdocs/web_portal/controllers/service/edit_service_endpoint.php
@@ -33,7 +33,7 @@ function edit_endpoint() {
 
     //Check the portal is not in read only mode, returns exception if it is and user is not an admin
     checkPortalIsNotReadOnlyOrUserIsAdmin($user);
-    
+
     if($_POST) {
         submit($user);
     } else {
@@ -57,17 +57,17 @@ function draw(\User $user = null) {
     if (!isset($_REQUEST['endpointid']) || !is_numeric($_REQUEST['endpointid']) ){
         throw new Exception("An endpointid must be specified");
     }
-    $serv = \Factory::getServiceService(); 
+    $serv = \Factory::getServiceService();
     $service = $serv->getService($_REQUEST['serviceid']);
-    $endpoint = $serv->getEndpoint($_REQUEST['endpointid']);    
+    $endpoint = $serv->getEndpoint($_REQUEST['endpointid']);
     //Check user has permissions to edit endpoints
     $serv->validateAddEditDeleteActions($user, $service);
-    
-    
+
+
     $params['endpoint'] = $endpoint;
     $params['service'] = $service;
-    $params['serviceTypes'] = $serv->getServiceTypes(); 
-    show_view("service/edit_service_endpoint.php", $params); 
+    $params['serviceTypes'] = $serv->getServiceTypes();
+    show_view("service/edit_service_endpoint.php", $params);
 }
 
 /**
@@ -78,15 +78,15 @@ function draw(\User $user = null) {
 function submit(\User $user = null) {
     try {
         $newValues = getEndpointDataFromWeb();
-        $serviceID = $newValues['SERVICEENDPOINT']['SERVICE']; 
+        $serviceID = $newValues['SERVICEENDPOINT']['SERVICE'];
         $endpointID = $newValues['SERVICEENDPOINT']['ENDPOINTID'];
 
         $serv = \Factory::getServiceService();
         $endpoint = $serv->getEndpoint($endpointID);
-        $service = $serv->getService($serviceID);    	
+        $service = $serv->getService($serviceID);
         $serv->editEndpoint($service, $user, $endpoint, $newValues);
         $params['serviceid'] = $serviceID;
-        $params['endpointid'] = $endpointID; 
+        $params['endpointid'] = $endpointID;
         show_view('service/service_endpoint_updated.php', $params);
     } catch(Exception $e) {
         show_view('error.php', $e->getMessage());

--- a/htdocs/web_portal/controllers/service/edit_service_property.php
+++ b/htdocs/web_portal/controllers/service/edit_service_property.php
@@ -33,7 +33,7 @@ function edit_property() {
 
     //Check the portal is not in read only mode, returns exception if it is and user is not an admin
     checkPortalIsNotReadOnlyOrUserIsAdmin($user);
-    
+
     if($_POST) {
         submit($user);
     } else {
@@ -57,19 +57,19 @@ function draw(\User $user = null) {
     if (!isset($_REQUEST['propertyid']) || !is_numeric($_REQUEST['propertyid']) ){
         throw new Exception("A propertyid must be specified");
     }
-    $serv = \Factory::getServiceService(); 
+    $serv = \Factory::getServiceService();
     $service = $serv->getService($_REQUEST['id']);
     $property = $serv->getProperty($_REQUEST['propertyid']);
-    
+
     //Check user has permissions to add site property
     $serv->validateAddEditDeleteActions($user, $service);
-    
-    
+
+
     $params['prop'] = $property;
     $params['service'] = $service;
-    
-    show_view("service/edit_service_property.php", $params);     
-    
+
+    show_view("service/edit_service_property.php", $params);
+
 
 }
 
@@ -80,7 +80,7 @@ function draw(\User $user = null) {
  */
 function submit(\User $user = null) {
     try {
-        $newValues = getSerPropDataFromWeb();  
+        $newValues = getSerPropDataFromWeb();
         $serviceID = $newValues['SERVICEPROPERTIES']['SERVICE'];
         $propID = $newValues['SERVICEPROPERTIES']['PROP'];
         if($newValues['SERVICEPROPERTIES']['NAME'] == null || $newValues['SERVICEPROPERTIES']['VALUE'] == null){
@@ -88,7 +88,7 @@ function submit(\User $user = null) {
             die();
         }
         $property = \Factory::getServiceService()->getProperty($propID);
-        $service = \Factory::getServiceService()->getService($serviceID);    	
+        $service = \Factory::getServiceService()->getService($serviceID);
         $service = \Factory::getServiceService()->editServiceProperty($service, $user, $property, $newValues);
         $params['serviceid'] = $serviceID;
         show_view('service/service_property_updated.php', $params);

--- a/htdocs/web_portal/controllers/service/se_downtimes.php
+++ b/htdocs/web_portal/controllers/service/se_downtimes.php
@@ -1,5 +1,5 @@
 <?php
-function se_downtimes() {    
+function se_downtimes() {
     if (!isset($_REQUEST['id']) || !is_numeric($_REQUEST['id']) ){
         throw new Exception("An id must be specified");
     }

--- a/htdocs/web_portal/controllers/service/view_all.php
+++ b/htdocs/web_portal/controllers/service/view_all.php
@@ -23,7 +23,7 @@ function drawSEs(){
     require_once __DIR__.'/../../../../lib/Gocdb_Services/Factory.php';
     $seServ = \Factory::getServiceService();
     $exServ = \Factory::getExtensionsService();
-    
+
     $startRecord = 1;
     if(isset($_GET['record'])) {
        $startRecord = $_GET['record'];
@@ -48,16 +48,16 @@ function drawSEs(){
     if(isset($_GET['scopeMatch'])) {
         $scopeMatch = $_GET['scopeMatch'];
     }
-    // By default, use an empty value to return all scopes, i.e. in the PI '&scope=' 
+    // By default, use an empty value to return all scopes, i.e. in the PI '&scope='
     // which is same as the PI. We don't want to fall back on default scope if scope param is not set.
     $selectedScopes = array();
-    $scope = ''; 
-    if(!empty($_GET['mscope'])) { 
+    $scope = '';
+    if(!empty($_GET['mscope'])) {
     foreach($_GET['mscope'] as $key => $scopeVal){
-        $scope .= $scopeVal.','; 
-        $selectedScopes[] = $scopeVal; 
+        $scope .= $scopeVal.',';
+        $selectedScopes[] = $scopeVal;
     }
-    } 
+    }
     $ngi = "";
     if(isset($_GET['ngi'])) {
         $ngi = $_GET['ngi'];
@@ -66,20 +66,20 @@ function drawSEs(){
     if(isset($_GET['servKeyNames'])) {
         $servKeyNames = $_GET['servKeyNames'];
     }
-    $servKeyValue ="";    
+    $servKeyValue ="";
     if(isset($_GET['servKeyValue'])) {
         $servKeyValue = $_GET['servKeyValue'];
     }
     //must be done before the if certstatus in the block that sets $certStatus
     $showClosed = false;
     if(isset($_GET['showClosed'])){
-    // showClosed is a bool, so presence of param indicates it was 
-    // checked, no need to parse the value. 
-        $showClosed = true; 
+    // showClosed is a bool, so presence of param indicates it was
+    // checked, no need to parse the value.
+        $showClosed = true;
     }
     $certStatus = "";
-    if(!empty($_GET['certStatus'])) { 
-       $certStatus = $_GET['certStatus']; 
+    if(!empty($_GET['certStatus'])) {
+       $certStatus = $_GET['certStatus'];
        //set show closed as true if production status selected is 'closed' - otherwise
        // there will be no results
        if($certStatus == 'Closed'){
@@ -88,37 +88,37 @@ function drawSEs(){
     }
 
 
-    // If parsed vars have a value, validate and set the filterParams 
-    $filterParams = array(); 
+    // If parsed vars have a value, validate and set the filterParams
+    $filterParams = array();
     if($startRecord < 1) {
         $startRecord = 1;
     }
     if($serviceType != "") {
-    $filterParams['serviceType'] = $serviceType; 
+    $filterParams['serviceType'] = $serviceType;
     }
     if($production != "") {
-    $filterParams['production'] = $production; 
+    $filterParams['production'] = $production;
     }
     if($monitored != "") {
-    $filterParams['monitored'] = $monitored; 
+    $filterParams['monitored'] = $monitored;
     }
     if($scope != "") {
-    $filterParams['scope'] = $scope; 
+    $filterParams['scope'] = $scope;
     }
     if($scopeMatch != "") {
         $filterParams['scopeMatch'] = $scopeMatch;
     }
     if($ngi != "") {
-    $filterParams['ngi'] = $ngi; 
+    $filterParams['ngi'] = $ngi;
     }
     if($certStatus != "") {
-    $filterParams['certStatus'] = $certStatus; 
+    $filterParams['certStatus'] = $certStatus;
     }
     if($servKeyNames != "") {
-    $filterParams['servKeyNames'] = $servKeyNames; 
+    $filterParams['servKeyNames'] = $servKeyNames;
     }
     if($servKeyValue != "") {
-    $filterParams['servKeyValue'] = $servKeyValue; 
+    $filterParams['servKeyValue'] = $servKeyValue;
     }
     if ($searchTerm != "") {
     $searchTerm = strip_tags(trim($searchTerm));
@@ -131,21 +131,21 @@ function drawSEs(){
     if (substr($searchTerm, -1) != '%') {
         $searchTerm = $searchTerm . '%';
     }
-    $filterParams['searchTerm'] = $searchTerm; 
+    $filterParams['searchTerm'] = $searchTerm;
     }
     if($showClosed) {
-    $filterParams['showClosed'] = $showClosed; 
+    $filterParams['showClosed'] = $showClosed;
     }
 
 
-    // Update the URL params for idempotent page refresh  
+    // Update the URL params for idempotent page refresh
     $thisPage = 'index.php?Page_Type=Services';
     $thisPage .= '&serviceType=' . $serviceType;
     $thisPage .= '&production=' . $production;
     $thisPage .= '&monitored=' . $monitored;
     //$thisPage .= '&scope=' . $scope;
     foreach($selectedScopes as $sc){
-        $thisPage .= '&mscope[]='.$sc;	    
+        $thisPage .= '&mscope[]='.$sc;
     }
     $thisPage .= '&scopeMatch=' . $scopeMatch;
     $thisPage .= '&ngi=' . $ngi;
@@ -154,22 +154,22 @@ function drawSEs(){
     $thisPage .= '&servKeyValue=' . $servKeyValue;
     $thisPage .= '&searchTerm=' . $searchTerm;
     if($showClosed){
-    // showClosed is a bool, so presence of param indicates it was 
-    // checked, no need to add a value. 
+    // showClosed is a bool, so presence of param indicates it was
+    // checked, no need to add a value.
         $thisPage .= '&showClosed=';
     }
-    //print_r($filterParams); // debug 
-    
-    
-    // Count the total number of services that match the query 
+    //print_r($filterParams); // debug
+
+
+    // Count the total number of services that match the query
     $filterParams['count'] = TRUE;
-    $numResults = $seServ->getServicesFilterByParams($filterParams); 
-   
-    // create links to scroll forward/back through results 
-    $recordsPerPage = 50; 
-    $nextInt = 1; 
-    $prevInt = 1; 
-    $lastInt = 1; 
+    $numResults = $seServ->getServicesFilterByParams($filterParams);
+
+    // create links to scroll forward/back through results
+    $recordsPerPage = 50;
+    $nextInt = 1;
+    $prevInt = 1;
+    $lastInt = 1;
 
     // < Set the "Previous" link
     if ($startRecord > $recordsPerPage) {
@@ -188,16 +188,16 @@ function drawSEs(){
     }
     }
     if($nextInt < 1){
-    $nextInt = 1; 
+    $nextInt = 1;
     }
-    // Set the "Last" link >> 
+    // Set the "Last" link >>
     if (($numResults - $startRecord) <= 1) {
     $lastInt = 1;
     } else {
     $lastInt = ($numResults + 1 - $recordsPerPage);
     }
     if($lastInt < 1){
-    $lastInt = 1; 
+    $lastInt = 1;
     }
 
     $firstLink = $thisPage . "&record=1";
@@ -208,11 +208,11 @@ function drawSEs(){
 
 
     $filterParams['count'] = FALSE;
-    $filterParams['startRecord'] = $startRecord - 1; 
-    $filterParams['maxResults'] = $recordsPerPage; 
-    $ses = $seServ->getServicesFilterByParams($filterParams); 
-    
-    
+    $filterParams['startRecord'] = $startRecord - 1;
+    $filterParams['maxResults'] = $recordsPerPage;
+    $ses = $seServ->getServicesFilterByParams($filterParams);
+
+
     $endRecord = $startRecord + $recordsPerPage - 1;
     /* Due to differences in counting, startRecord is still set to 1
      * even if there are zero results. If this is the case it's
@@ -220,24 +220,24 @@ function drawSEs(){
     if(count($ses) == 0) {
         $startRecord = 0;
     }
-    
-    
+
+
     /* Doctrine will provide keynames that are the same even when selecting distinct becase the object
      * is distinct even though the name is not unique. To avoid showing the same name repeatdly in the filter
     * we will load all the keynames into an array before making it unique
     */
-    $keynames=array();		
+    $keynames=array();
     foreach($exServ->getServiceExtensionsKeyNames() as $extension){
         $keynames[] = $extension->getKeyName();
     }
     $keynames = array_unique($keynames);
-    
-        
+
+
     $params['scopes'] = \Factory::getScopeService()->getScopes();
     $params['scopeMatch'] = $scopeMatch;
     $params['serviceTypes'] = $seServ->getServiceTypes();
-    $params['servKeyNames'] = $keynames;    
-    $params['selectedServiceType'] = $serviceType;        
+    $params['servKeyNames'] = $keynames;
+    $params['selectedServiceType'] = $serviceType;
     $params['searchTerm'] = $searchTerm;
     $params['services'] = $ses;
     $params['totalServices'] = $numResults;

--- a/htdocs/web_portal/controllers/service/view_service.php
+++ b/htdocs/web_portal/controllers/service/view_service.php
@@ -8,37 +8,37 @@ function view_se() {
         throw new Exception("An id must be specified");
     }
     $id = $_GET['id'];
-    
+
     //get user for case that portal is read only and user is admin, so they can still see edit links
     $dn = Get_User_Principle();
     $user = \Factory::getUserService()->getUserByPrinciple($dn);
-    
+
     $serv = \Factory::getServiceService();
 
-    $params['authenticated'] = false; 
+    $params['authenticated'] = false;
     if($user != null){
-        $params['authenticated'] = true; 
+        $params['authenticated'] = true;
     }
-    
+
     $params['portalIsReadOnly'] = portalIsReadOnlyAndUserIsNotAdmin($user);
     $se = $serv->getService($id);
 
     // Does current viewer have edit permissions over object ?
-    $params['ShowEdit'] = false;  
+    $params['ShowEdit'] = false;
 //    if($user != null && count($serv->authorize Action(\Action::EDIT_OBJECT, $se, $user))>=1){
-//       $params['ShowEdit'] = true;  
-//    } 
+//       $params['ShowEdit'] = true;
+//    }
     if(\Factory::getRoleActionAuthorisationService()->authoriseAction(\Action::EDIT_OBJECT, $se->getParentSite(), $user)->getGrantAction()){
-       $params['ShowEdit'] = true;   
-    } 
-        
+       $params['ShowEdit'] = true;
+    }
+
 
     $title = $se->getHostName() . " - " . $se->getServiceType()->getName();
     $params['se'] = $se;
     $params['sGroups'] = $se->getServiceGroups();
-    
+
     $params['Scopes']= $serv->getScopesWithParentScopeInfo($se);
-    
+
     // Show upcoming downtimes and downtimes that started within the last thirty days
     $downtimes = $serv->getDowntimes($id, 31);
 

--- a/htdocs/web_portal/controllers/service/view_service_endpoint.php
+++ b/htdocs/web_portal/controllers/service/view_service_endpoint.php
@@ -1,6 +1,6 @@
 <?php
 
-/* 
+/*
  * To change this license header, choose License Headers in Project Properties.
  * To change this template file, choose Tools | Templates
  * and open the template in the editor.
@@ -14,25 +14,25 @@ function view_endpoint() {
         throw new Exception("An id must be specified");
     }
     $id = $_GET['id'];
-    
+
     //get user for case that portal is read only and user is admin, so they can still see edit links
     $dn = Get_User_Principle();
     $user = \Factory::getUserService()->getUserByPrinciple($dn);
-    
+
     $serv = \Factory::getServiceService();
-    
+
     $params['portalIsReadOnly'] = portalIsReadOnlyAndUserIsNotAdmin($user);
     /* @var $endpoint \EndpointLocation */
     $endpoint = $serv->getEndpoint($id);
     /* @var $service \Service */
-    $service = $endpoint->getService(); 
-    $site = $service->getParentSite(); 
+    $service = $endpoint->getService();
+    $site = $service->getParentSite();
 
     // Does current viewer have edit permissions over object ?
-    $params['ShowEdit'] = false;  
+    $params['ShowEdit'] = false;
     //if(count($serv->authorize Action(\Action::EDIT_OBJECT, $endpoint->getService(), $user))>=1){
     if(\Factory::getRoleActionAuthorisationService()->authoriseAction(\Action::EDIT_OBJECT, $site, $user)->getGrantAction()){
-       $params['ShowEdit'] = true;  
+       $params['ShowEdit'] = true;
     }
 
     $title = $endpoint->getName();
@@ -43,6 +43,6 @@ function view_endpoint() {
     //$downtimes = $serv->getDowntimes($id, 31);
     //$params['Downtimes'] = $downtimes;
     show_view("service/view_service_endpoint.php", $params, $title);
-    
-    
+
+
 }

--- a/htdocs/web_portal/controllers/service_group/add_service_group.php
+++ b/htdocs/web_portal/controllers/service_group/add_service_group.php
@@ -73,7 +73,7 @@ function draw($user) {
         if (is_null($user)) {
             throw new \Exception("Unregistered users can't create service groups.");
         }
-        
+
         // can user assign reserved scopes ?
         $disableReservedScopes = true;
         if ($user->isAdmin()) {
@@ -83,10 +83,10 @@ function draw($user) {
         $configService = \Factory::getConfigService();
         //$scopes = \Factory::getScopeService()->getAllScopesMarkDefault();
         $numberScopesRequired = $configService->getMinimumScopesRequired('service_group');
-        $scopejsonStr = getEntityScopesAsJSON2(null, null, $disableReservedScopes); 
+        $scopejsonStr = getEntityScopesAsJSON2(null, null, $disableReservedScopes);
 
         $params = array(
-            //'scopes' => $scopes, 
+            //'scopes' => $scopes,
             'numberOfScopesRequired' => $numberScopesRequired,
             'scopejson' => $scopejsonStr);
 

--- a/htdocs/web_portal/controllers/service_group/add_service_group_properties.php
+++ b/htdocs/web_portal/controllers/service_group/add_service_group_properties.php
@@ -24,7 +24,7 @@
 require_once __DIR__.'/../../../../lib/Gocdb_Services/Factory.php';
 require_once __DIR__.'/../utils.php';
 require_once __DIR__.'/../../../web_portal/components/Get_User_Principle.php';
-    
+
 /**
  * Controller for a new_property request
  * @global array $_POST only set if the browser has POSTed data

--- a/htdocs/web_portal/controllers/service_group/add_ses.php
+++ b/htdocs/web_portal/controllers/service_group/add_ses.php
@@ -33,7 +33,7 @@ function add_ses() {
 
     //Check the portal is not in read only mode, returns exception if it is and user is not an admin
     checkPortalIsNotReadOnlyOrUserIsAdmin($user);
-    
+
     if($_POST) {     // If we receive a POST request it's after form submission
         submit($user);
     } else { // If there is no post data, draw the add SEs form
@@ -64,7 +64,7 @@ function draw(\User $user = null) {
         show_view('error.php', 'You do not have permission to edit this ServiceGroup');
         die();
     }
-        
+
     // Check to see whether to show the link to "add a new SE to this virtual site"
     if(\Factory::getConfigService()
             ->IsOptionalFeatureSet("siteless_services")) {

--- a/htdocs/web_portal/controllers/service_group/delete_service_group.php
+++ b/htdocs/web_portal/controllers/service_group/delete_service_group.php
@@ -38,7 +38,7 @@ function delete() {
 
     //Check the portal is not in read only mode, returns exception if it is and user is not an admin
     checkPortalIsNotReadOnlyOrUserIsAdmin($user);
-    
+
     try {
         $serv->deleteServiceGroup($sg, $user);
     } catch(\Exception $e) {

--- a/htdocs/web_portal/controllers/service_group/delete_service_group_properties.php
+++ b/htdocs/web_portal/controllers/service_group/delete_service_group_properties.php
@@ -49,7 +49,7 @@ function submit(array $propertyArray, \ServiceGroup $serviceGroup, \User $user =
 
      $params['propArr'] = $propertyArray;
      $params['serviceGroup'] = $serviceGroup;
-     
+
      //remove service group property
      try {
         $serv = \Factory::getServiceGroupService();
@@ -57,9 +57,9 @@ function submit(array $propertyArray, \ServiceGroup $serviceGroup, \User $user =
     } catch(\Exception $e) {
         show_view('error.php', $e->getMessage());
         die();
-    }   
-    
-    
+    }
+
+
     show_view('/service_group/deleted_service_group_properties.php', $params);
 
 }

--- a/htdocs/web_portal/controllers/service_group/edit_service_group.php
+++ b/htdocs/web_portal/controllers/service_group/edit_service_group.php
@@ -24,7 +24,7 @@
 require_once __DIR__ . '/../../../../lib/Gocdb_Services/Factory.php';
 require_once __DIR__ . '/../../../../htdocs/web_portal/components/Get_User_Principle.php';
 require_once __DIR__ . '/../utils.php';
-    
+
 /**
  * Controller for an edit service group request
  * @global array $_POST only set if the browser has POSTed data
@@ -36,7 +36,7 @@ function edit_service_group() {
 
     //Check the portal is not in read only mode, returns exception if it is and user is not an admin
     checkPortalIsNotReadOnlyOrUserIsAdmin($user);
-    
+
     if($_POST) {     // If we receive a POST request it's for a new vsite
         submit($user);
     } else { // If there is no post data, draw the new vsite form
@@ -78,17 +78,17 @@ function draw(\User $user = null) {
     $sg = \Factory::getServiceGroupService()->getServiceGroup($_REQUEST['id']);
     if(\Factory::getRoleActionAuthorisationService()->authoriseAction(
             \Action::EDIT_OBJECT, $sg, $user)->getGrantAction() == FALSE){
-       show_view('error.php', 'You do not have permission to edit this ServiceGroup'); 
-       die(); 
+       show_view('error.php', 'You do not have permission to edit this ServiceGroup');
+       die();
     }
-    
+
     $scopes = \Factory::getScopeService()->getAllScopesMarkProvided($sg->getScopes());
     $numberScopesRequired = \Factory::getConfigService()->getMinimumScopesRequired('service_group');
     // a ServiceGroup has no parent hence pass null
-    $scopejsonStr = getEntityScopesAsJSON2($sg, null, $user->isAdmin() ? false : true); 
+    $scopejsonStr = getEntityScopesAsJSON2($sg, null, $user->isAdmin() ? false : true);
 
-    $params = array('serviceGroup' => $sg, 'scopes' => $scopes, 
-            'numberOfScopesRequired'=>$numberScopesRequired, 
+    $params = array('serviceGroup' => $sg, 'scopes' => $scopes,
+            'numberOfScopesRequired'=>$numberScopesRequired,
             'scopejson'=>$scopejsonStr);
 
     show_view("service_group/edit_service_group.php", $params, "Edit " . $sg->getName());

--- a/htdocs/web_portal/controllers/service_group/edit_service_group_property.php
+++ b/htdocs/web_portal/controllers/service_group/edit_service_group_property.php
@@ -33,7 +33,7 @@ function edit_property() {
 
     //Check the portal is not in read only mode, returns exception if it is and user is not an admin
     checkPortalIsNotReadOnlyOrUserIsAdmin($user);
-    
+
     if($_POST) {
         submit($user);
     } else {
@@ -57,19 +57,19 @@ function draw(\User $user = null) {
     if (!isset($_REQUEST['propertyid']) || !is_numeric($_REQUEST['propertyid']) ){
         throw new Exception("An id must be specified");
     }
-    
-    $serv = \Factory::getServiceGroupService(); 
+
+    $serv = \Factory::getServiceGroupService();
     $serviceGroup = $serv->getServiceGroup($_REQUEST['id']);
     $property = $serv->getProperty($_REQUEST['propertyid']);
-    
+
     //Check user has permissions to add site property
     $serv->validatePropertyActions($user, $serviceGroup);
-    
+
     $params['prop'] = $property;
     $params['serviceGroup'] = $serviceGroup;
-    
-    show_view("service_group/edit_service_group_property.php", $params);     
-    
+
+    show_view("service_group/edit_service_group_property.php", $params);
+
 
 }
 
@@ -80,7 +80,7 @@ function draw(\User $user = null) {
  */
 function submit(\User $user = null) {
     try {
-        $newValues = getSerGroupPropDataFromWeb();  
+        $newValues = getSerGroupPropDataFromWeb();
         $serviceGroupID = $newValues['SERVICEGROUPPROPERTIES']['SERVICEGROUP'];
         $propID = $newValues['SERVICEGROUPPROPERTIES']['PROP'];
         if($newValues['SERVICEGROUPPROPERTIES']['NAME'] == null || $newValues['SERVICEGROUPPROPERTIES']['VALUE'] == null){
@@ -88,7 +88,7 @@ function submit(\User $user = null) {
             die();
         }
         $property = \Factory::getServiceGroupService()->getProperty($propID);
-        $serviceGroup = \Factory::getServiceGroupService()->getServiceGroup($serviceGroupID);    	
+        $serviceGroup = \Factory::getServiceGroupService()->getServiceGroup($serviceGroupID);
         $serviceGroup = \Factory::getServiceGroupService()->editServiceGroupProperty($serviceGroup, $user, $property, $newValues);
         $params['serviceGroupId'] = $serviceGroupID;
         show_view('service_group/service_group_property_updated.php', $params);

--- a/htdocs/web_portal/controllers/service_group/remove_ses.php
+++ b/htdocs/web_portal/controllers/service_group/remove_ses.php
@@ -33,7 +33,7 @@ function remove_ses() {
 
     //Check the portal is not in read only mode, returns exception if it is and user is not an admin
     checkPortalIsNotReadOnlyOrUserIsAdmin($user);
-    
+
     if($_POST) { // If we receive a POST request it's during form submission
         submit($user);
     } else { // If there is no post data, draw the remove ses form
@@ -61,8 +61,8 @@ function draw(\User $user = null) {
     //    show_view('error.php', $e->getMessage()); die(); }
     //if(count($serv->authorize Action(\Action::EDIT_OBJECT, $sg, $user))==0){
     if(\Factory::getRoleActionAuthorisationService()->authoriseAction(\Action::EDIT_OBJECT, $sg, $user)->getGrantAction() == FALSE){
-       show_view('error.php', 'You do not have permission to edit this ServiceGroup'); 
-       die(); 
+       show_view('error.php', 'You do not have permission to edit this ServiceGroup');
+       die();
     }
 
     $params = array('sg' => $sg);
@@ -71,7 +71,7 @@ function draw(\User $user = null) {
 
 /**
  * Validates the user's input, removes the services and
- * returns the object ID of the removed service 
+ * returns the object ID of the removed service
  * @global array $_REQUEST only set if the browser has sent parameters
  * @param \User $user current User
  * @return null
@@ -85,7 +85,7 @@ function submit(\User $user = null) {
     if (!isset($_REQUEST['seId']) || !is_numeric($_REQUEST['seId']) ){
         throw new Exception("An id must be specified");
     }
-    
+
     // The service group to remove SEs from
     $sg =  $serv->getServiceGroup($_REQUEST['sgId']);
 

--- a/htdocs/web_portal/controllers/service_group/search_ses.php
+++ b/htdocs/web_portal/controllers/service_group/search_ses.php
@@ -4,10 +4,10 @@ use Doctrine\Common\Cache\ArrayCache;
  *======================================================
  * File: search_ses.php
  * Author: John Casson, James McCarthy
- * Description: Returns a JSON view of service 
+ * Description: Returns a JSON view of service
  *              affected by a downtime, also used to add
  *              SEs to a service group.
- *              
+ *
  *
  * License information
  *
@@ -31,20 +31,20 @@ function search_ses() {
         $searchTerm = strip_tags(trim($_REQUEST['term']));
     }
     if(1 === preg_match("/[';\"]/", $searchTerm)){ throw new Exception("Invalid char in search term"); }
-    
+
     if(substr($searchTerm, 0,1) != '%'){
         $searchTerm ='%'.$searchTerm;
     }
-    
+
     if(substr($searchTerm,-1) != '%'){
         $searchTerm = $searchTerm.'%';
     }
     require_once __DIR__.'/../../../../lib/Gocdb_Services/Factory.php';
     try {
        $ses = \Factory::getServiceService()->getSes($searchTerm,null,null,null,null,null,null,null,null,null,null,null,true);
-       
-       
-       
+
+
+
     } catch(Exception $ex){
         show_view(  'error.php', $ex->getMessage() . "<br /><br />Please contact the "
         . "<a href=\"index.php?Page_Type=Static_HTML&Page=Help_And_Contact\">"

--- a/htdocs/web_portal/controllers/service_group/view_all.php
+++ b/htdocs/web_portal/controllers/service_group/view_all.php
@@ -1,75 +1,75 @@
 <?php
-/*______________________________________________________ 
+/*______________________________________________________
  *======================================================
  * File: view_all.php
  * Author: John Casson, David Meredith
  * Description: Controller for viewing all VSites in GOCDB
- * 
+ *
  * License information
- *  
- * Copyright 2009 STFC 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
+ *
+ * Copyright 2009 STFC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * http://www.apache.org/licenses/LICENSE-2.0 
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
- * 
-/*====================================================== */ 
+ *
+/*====================================================== */
 function showAllServiceGroups(){
     require_once __DIR__.'/../../../../lib/Gocdb_Services/Factory.php';
 
-    $filterParams = array(); 
-    
-    // Scope parameters 
-    // By default, use an empty value to return all scopes, i.e. in the PI '&scope=' 
-    // which is same as the PI. If the 'scope' param is not set, then it would fall 
-    // back to the default scope (if set), but this is not what we want in this interface.  
-    $filterParams['scope'] = ''; 	
+    $filterParams = array();
+
+    // Scope parameters
+    // By default, use an empty value to return all scopes, i.e. in the PI '&scope='
+    // which is same as the PI. If the 'scope' param is not set, then it would fall
+    // back to the default scope (if set), but this is not what we want in this interface.
+    $filterParams['scope'] = '';
     $selectedScopes = array();
-    if(!empty($_GET['mscope'])) { 
-    $scopeStringParam = ''; 
+    if(!empty($_GET['mscope'])) {
+    $scopeStringParam = '';
     foreach($_GET['mscope'] as $key => $scopeVal){
-        $scopeStringParam .= $scopeVal.','; 
-        $selectedScopes[] = $scopeVal; 
+        $scopeStringParam .= $scopeVal.',';
+        $selectedScopes[] = $scopeVal;
     }
-    $filterParams['scope'] = $scopeStringParam; 
+    $filterParams['scope'] = $scopeStringParam;
     $filterParams['scope_match'] = 'all';
-    } 
-    
-    
-    // extension property (currently only support filtering by one ext prop) 
-    // Can add filtering by many like scopes in future 
+    }
+
+
+    // extension property (currently only support filtering by one ext prop)
+    // Can add filtering by many like scopes in future
     $extensionPropName = "";
     $extensionPropValue ="";
     if(!empty($_GET['extKeyNames'])) {
         $extensionPropName = $_GET['extKeyNames'];
     // only set the ext prop value if the keyName has been set too, otherwise
-    // we could end up with an illegal extensions parameter such as: '(=value)' 
+    // we could end up with an illegal extensions parameter such as: '(=value)'
     if(!empty($extensionPropName) && !empty($_GET['selectedExtKeyValue']) ) {
         $extensionPropValue = $_GET['selectedExtKeyValue'];
     }
-    $filterParams['extensions'] = '('.$extensionPropName.'='.$extensionPropValue.')'; 
+    $filterParams['extensions'] = '('.$extensionPropName.'='.$extensionPropValue.')';
     }
-    
+
     $scopes = \Factory::getScopeService()->getScopes();
     //$sGroups = \Factory::getServiceGroupService()->getServiceGroups($scope, $sgKeyNames, $sgKeyValues);
     $sGroups = \Factory::getServiceGroupService()->getServiceGroupsFilterByParams($filterParams);
     $exServ = \Factory::getExtensionsService();
-    
+
     /* Doctrine will provide keynames that are the same even when selecting distinct becase the object
      * is distinct even though the name is not unique. To avoid showing the same name repeatdly in the filter
     * we will load all the keynames into an array before making it unique
     */
-    $keynames=array();		
+    $keynames=array();
     foreach($exServ->getServiceGroupExtensionsKeyNames() as $extension){
         $keynames[] = $extension->getKeyName();
     }
     $keynames = array_unique($keynames);
-        
+
     $params['sGroups'] = $sGroups;
     $params['scopes']=$scopes;
     $params['selectedScopes']=$selectedScopes; //$scope;

--- a/htdocs/web_portal/controllers/service_group/view_sgroup.php
+++ b/htdocs/web_portal/controllers/service_group/view_sgroup.php
@@ -5,7 +5,7 @@ function showServiceGroup() {
 
     if (!isset($_GET['id']) || !is_numeric($_GET['id']) ){
         throw new Exception("An id must be specified");
-    } 
+    }
     $sGroupId = $_GET['id'];
 
     $sGroup = \Factory::getServiceGroupService()->getServiceGroup($sGroupId);
@@ -15,36 +15,36 @@ function showServiceGroup() {
     // 31 = the number of days worth of historical downtimes to show
     $downtimes = \Factory::getServiceGroupService()->getDowntimes($sGroupId, 31);
     $params['downtimes'] = $downtimes;
-    
+
     //get user for case that portal is read only and user is admin, so they can still see edit links
     $dn = Get_User_Principle();
     $user = \Factory::getUserService()->getUserByPrinciple($dn);
-    
+
     $params['portalIsReadOnly'] = portalIsReadOnlyAndUserIsNotAdmin($user);
 
-    $params['authenticated'] = false; 
+    $params['authenticated'] = false;
     if($user != null){
-        $params['authenticated'] = true; 
+        $params['authenticated'] = true;
     }
 
-    $allRoles = $sGroup->getRoles(); 
-    $roles = array(); 
+    $allRoles = $sGroup->getRoles();
+    $roles = array();
     foreach ($allRoles as $role){
         if($role->getStatus() == \RoleStatus::GRANTED){
-            $roles[] = $role; 
+            $roles[] = $role;
         }
     }
-    $params['Roles'] = $roles; 
+    $params['Roles'] = $roles;
 
     // Does current viewer have edit permissions over object ?
-    $params['ShowEdit'] = false;  
+    $params['ShowEdit'] = false;
     //if(count( \Factory::getServiceGroupService()->authorize Action(\Action::EDIT_OBJECT, $sGroup, $user))>=1){
     if(\Factory::getRoleActionAuthorisationService()->authoriseAction(\Action::EDIT_OBJECT, $sGroup, $user)->getGrantAction()){
-       $params['ShowEdit'] = true;  
-    } 
+       $params['ShowEdit'] = true;
+    }
 
-    // Add RoleActionRecords to params 
-    $params['RoleActionRecords'] = \Factory::getRoleService()->getRoleActionRecordsById_Type($sGroup->getId(), 'servicegroup'); 
+    // Add RoleActionRecords to params
+    $params['RoleActionRecords'] = \Factory::getRoleService()->getRoleActionRecordsById_Type($sGroup->getId(), 'servicegroup');
 
     $title = $sGroup->getName();
 

--- a/htdocs/web_portal/controllers/site/add_site.php
+++ b/htdocs/web_portal/controllers/site/add_site.php
@@ -36,7 +36,7 @@ function add_site() {
 
     //Check the portal is not in read only mode, returns exception if it is and user is not an admin
     checkPortalIsNotReadOnlyOrUserIsAdmin($user);
-    
+
     if($_POST) {     // If we receive a POST request it's for a new site
         submit($user);
     } else { // If there is no post data, draw the new site form
@@ -52,7 +52,7 @@ function add_site() {
  */
 function submit(\User $user = null) {
     $newValues = getSiteDataFromWeb();
-    
+
     $serv = \Factory::getSiteService();
     try {
         $site = $serv->addSite($newValues, $user);
@@ -62,65 +62,65 @@ function submit(\User $user = null) {
     }
     $params['site'] = $site;
     show_view("site/submit_new_site.php", $params);
-    die(); 
+    die();
 }
 
 
 /**
  * Draws a form to add a new site
- * @param \User $user current user 
+ * @param \User $user current user
  * @return null
  */
 function draw(\User $user = null) {
     if(is_null($user)){
-        throw new Exception("Unregistered users can't add a new site"); 
+        throw new Exception("Unregistered users can't add a new site");
     }
 
     $siteService = \Factory::getSiteService();
 
     if($user->isAdmin()){
         // can user assign reserved scopes to this site, even though site has not been created yet?
-        $disableReservedScopes = false; 
+        $disableReservedScopes = false;
         // if user is admin, then get all NGIs
-        $userNGIs = \Factory::getNgiService()->getNGIs(); 
+        $userNGIs = \Factory::getNgiService()->getNGIs();
     } else {
-        $disableReservedScopes = true; 
+        $disableReservedScopes = true;
         // otherwise, get only the NGIs the non-admin user has roles over that support add_site
-        $userNGIs = \Factory::getNgiService()->getNGIsBySupportedAction(Action::NGI_ADD_SITE, $user); 
+        $userNGIs = \Factory::getNgiService()->getNGIsBySupportedAction(Action::NGI_ADD_SITE, $user);
         if(count($userNGIs) == 0){
            show_view('error.php', "You do not have permission to add a new site."
-                        ." To add a new site you require a managing role over an NGI"); 
-           die(); 
+                        ." To add a new site you require a managing role over an NGI");
+           die();
         }
     }
-//   // todo - site will be created under one of the user's ngis, so we can 
-//   // create a temporary site and add it to those ngis in order to apply role model. 
-//    $site = new \Site(); 
-//    foreach($userNGIs as $ngis){ $ngis->addSiteDoJoin($site); } 
+//   // todo - site will be created under one of the user's ngis, so we can
+//   // create a temporary site and add it to those ngis in order to apply role model.
+//    $site = new \Site();
+//    foreach($userNGIs as $ngis){ $ngis->addSiteDoJoin($site); }
 //    if(\Factory::getRoleActionAuthorisationService()->authoriseAction(
 //        "ACTION_APPLY_RESERVED_SCOPE_TAG", $site , $user)->getGrantAction()){
-//       $disableReservedScopes = false;  
-//    } 
+//       $disableReservedScopes = false;
+//    }
 
     // URL mapping
     if(isset($_GET['getAllScopesForScopedEntity']) && is_numeric($_GET['getAllScopesForScopedEntity'])){
-        // Return all scopes for the parent NGI with the specified Id as a JSON object.  
-        // Used in ajax requests for generating UI checkboxes. 
-        // AJAX is needed here because the parent NGI is not known until the user selects 
-        // which parent NGI in the pull-down which then fires the AJAX request. 
-        $scopedEntityId = $_GET['getAllScopesForScopedEntity']; 
-        $ngiScopedEntity =  \Factory::getNgiService()->getNgi($scopedEntityId); 
-        $jsonScopes = getEntityScopesAsJSON2(null, $ngiScopedEntity, $disableReservedScopes, true); 
+        // Return all scopes for the parent NGI with the specified Id as a JSON object.
+        // Used in ajax requests for generating UI checkboxes.
+        // AJAX is needed here because the parent NGI is not known until the user selects
+        // which parent NGI in the pull-down which then fires the AJAX request.
+        $scopedEntityId = $_GET['getAllScopesForScopedEntity'];
+        $ngiScopedEntity =  \Factory::getNgiService()->getNgi($scopedEntityId);
+        $jsonScopes = getEntityScopesAsJSON2(null, $ngiScopedEntity, $disableReservedScopes, true);
         header('Content-type: application/json');
-        die($jsonScopes);  
-    } 
-   
+        die($jsonScopes);
+    }
+
     $countries = $siteService->getCountries();
-    $timezones = DateTimeZone::listIdentifiers(); 
-    
+    $timezones = DateTimeZone::listIdentifiers();
+
     //Remove SC and PPS infrastructures from drop down list. TODO: Delete this block once they no longer exist
     $SCInfrastructure = $siteService->getProdStatusByName('SC');
-    $PPSInfrastructure = $siteService->getProdStatusByName('PPS'); 
+    $PPSInfrastructure = $siteService->getProdStatusByName('PPS');
     $hackprodStatuses=array();
     foreach($siteService->getProdStatuses() as $ps){
         if($ps != $SCInfrastructure and $ps != $PPSInfrastructure){
@@ -132,18 +132,18 @@ function draw(\User $user = null) {
     $certStatuses = $siteService->getCertStatuses();
     $numberOfScopesRequired = \Factory::getConfigService()->getMinimumScopesRequired('site');
 
-    $params = array('ngis' => $userNGIs, 'countries' => $countries, 'timezones' => $timezones, 
-        'prodStatuses' => $prodStatuses, 'certStatuses' => $certStatuses, 
-        'numberOfScopesRequired' => $numberOfScopesRequired, 
+    $params = array('ngis' => $userNGIs, 'countries' => $countries, 'timezones' => $timezones,
+        'prodStatuses' => $prodStatuses, 'certStatuses' => $certStatuses,
+        'numberOfScopesRequired' => $numberOfScopesRequired,
         'disableReservedScopes' => $disableReservedScopes);
 
-    //Check that there is at least one NGI available before allowing an add site. 
+    //Check that there is at least one NGI available before allowing an add site.
     if($params['ngis'] == null){
         show_view('error.php', "GocDB requires one or more NGI's to be able to add a site.");
     }
-    
+
     show_view("site/add_site.php", $params);
-    die(); 
+    die();
 }
 
 ?>

--- a/htdocs/web_portal/controllers/site/add_site_properties.php
+++ b/htdocs/web_portal/controllers/site/add_site_properties.php
@@ -24,7 +24,7 @@
 require_once __DIR__.'/../../../../lib/Gocdb_Services/Factory.php';
 require_once __DIR__.'/../utils.php';
 require_once __DIR__.'/../../../web_portal/components/Get_User_Principle.php';
-    
+
 /**
  * Controller for a new_property request
  * @global array $_POST only set if the browser has POSTed data

--- a/htdocs/web_portal/controllers/site/delete_site.php
+++ b/htdocs/web_portal/controllers/site/delete_site.php
@@ -32,42 +32,42 @@ function delete() {
 
     //get the site
     $site = \Factory::getSiteService()->getSite($_REQUEST['id']);
-    
+
     if($_POST or (sizeof($site->getServices()) == 0)) {
         submit($site, $user);
     }
     else {
         draw($site);
     }
-    
+
 }
 
 function draw(\Site $site) {
      //Only administrators can delete sites, double check user is an administrator
      checkUserIsAdmin();
-     
+
      $params['Site'] = $site;
      $params['Services'] = $site->getServices();
-     
+
      show_view('/site/delete_site.php', $params);
-     
+
 }
 
 function submit(\Site $site, \User $user = null) {
     //Only administrators can delete sites, double check user is an administrator
      checkUserIsAdmin();
-     
+
      //save name to display later
      $params['Name'] = $site->getName();
-     
+
      //remove Site
      try {
        \Factory::getSiteService()->deleteSite($site, $user);
     } catch(\Exception $e) {
         show_view('error.php', $e->getMessage());
         die();
-    }   
-    
+    }
+
     show_view('/site/deleted_site.php', $params);
 
 }

--- a/htdocs/web_portal/controllers/site/delete_site_properties.php
+++ b/htdocs/web_portal/controllers/site/delete_site_properties.php
@@ -59,9 +59,9 @@ function submit(array $propertyArray, \Site $site, \User $user = null) {
     } catch(\Exception $e) {
         show_view('error.php', $e->getMessage());
         die();
-    }   
-    
-    
+    }
+
+
     show_view('/site/deleted_site_properties.php', $params);
 
 }

--- a/htdocs/web_portal/controllers/site/edit_cert_status.php
+++ b/htdocs/web_portal/controllers/site/edit_cert_status.php
@@ -32,7 +32,7 @@ function edit() {
 
     //Check the portal is not in read only mode, returns exception if it is and user is not an admin
     checkPortalIsNotReadOnlyOrUserIsAdmin($user);
-    
+
     if($_POST) {
         submit($user);
     } else {
@@ -52,7 +52,7 @@ function draw(\User $user = null) {
     if (!isset($_REQUEST['id']) || !is_numeric($_REQUEST['id']) ){
         throw new Exception("An id must be specified");
     }
-    
+
     $dn = Get_User_Principle();
     $user = \Factory::getUserService()->getUserByPrinciple($dn);
     $site = \Factory::getSiteService()->getSite($_REQUEST['id']);
@@ -62,8 +62,8 @@ function draw(\User $user = null) {
     //if(count(\Factory::getSiteService()->authorize Action(Action::SITE_EDIT_CERT_STATUS, $site, $user))==0 ){
     if(\Factory::getRoleActionAuthorisationService()->authoriseAction(\Action::SITE_EDIT_CERT_STATUS, $site, $user)->getGrantAction() == FALSE){
        show_view('error.php', 'You do not have permission to change site certification status.'
-               ." Either an NGI level role on the parent NGI, or a Project level role on one of the parent NGIs owning projects is required."); 
-       die(); 
+               ." Either an NGI level role on the parent NGI, or a Project level role on one of the parent NGIs owning projects is required.");
+       die();
     }
 
     $statuses = \Factory::getCertStatusService()->getCertificationStatuses();
@@ -79,21 +79,21 @@ function draw(\User $user = null) {
  */
 function submit(\User $user = null) {
     // TODO use validate service
-    $reason = $_REQUEST['COMMENT']; 
+    $reason = $_REQUEST['COMMENT'];
     if(empty($reason) ){
-       throw new Exception('A reason is required');     
+       throw new Exception('A reason is required');
     }
     if(strlen($reason) > 300){
-        throw new Exception('Invalid reason - 300 char max'); 
+        throw new Exception('Invalid reason - 300 char max');
     }
     try {
         require_once __DIR__ . '/../../../../lib/Gocdb_Services/Factory.php';
-        
+
         try {
             $site = \Factory::getSiteService()->getSite($_REQUEST['SITEID']);
-           
+
             $certStatus = \Factory::getCertStatusService()->getCertificationStatus($_REQUEST['CERTSTATUSID']);
-            \Factory::getCertStatusService()->editCertificationStatus($site, $certStatus, $user, $reason); 
+            \Factory::getCertStatusService()->editCertificationStatus($site, $certStatus, $user, $reason);
         } catch (\Exception $e) {
             show_view('error.php', $e->getMessage());
             die();

--- a/htdocs/web_portal/controllers/site/edit_site.php
+++ b/htdocs/web_portal/controllers/site/edit_site.php
@@ -33,7 +33,7 @@ function edit_site() {
 
     //Check the portal is not in read only mode, returns exception if it is and user is not an admin
     checkPortalIsNotReadOnlyOrUserIsAdmin($user);
-    
+
     if($_POST) {
         submit($user);
     } else {
@@ -49,21 +49,21 @@ function edit_site() {
  */
 function draw(\User $user = null) {
     // can user assign reserved scopes to this site, even though site has not been created yet?
-    $disableReservedScopes = true; 
+    $disableReservedScopes = true;
     if($user->isAdmin()){
-    $disableReservedScopes = false; 
-    } 
-    
+    $disableReservedScopes = false;
+    }
+
     // URL mapping
     /*if(isset($_GET['getAllScopesForScopedEntity']) && is_numeric($_GET['getAllScopesForScopedEntity'])){
-        // Return all scopes for the Site with the specified Id as a JSON object 
-        // Used in ajax requests for generating UI checkboxes 
-        $site = \Factory::getSiteService()->getSite($_GET['getAllScopesForScopedEntity']); 
-        die(getEntityScopesAsJSON($site, $disableReservedScopes));  
-        
+        // Return all scopes for the Site with the specified Id as a JSON object
+        // Used in ajax requests for generating UI checkboxes
+        $site = \Factory::getSiteService()->getSite($_GET['getAllScopesForScopedEntity']);
+        die(getEntityScopesAsJSON($site, $disableReservedScopes));
+
     } else */
     if (!isset($_GET['id']) || !is_numeric($_GET['id']) ){
-        // Else to render the page, an id must be specified 
+        // Else to render the page, an id must be specified
         throw new Exception("An id must be specified");
     }
 
@@ -72,15 +72,15 @@ function draw(\User $user = null) {
     if(\Factory::getRoleActionAuthorisationService()->authoriseAction(
             \Action::EDIT_OBJECT, $site, $user)->getGrantAction() == FALSE){
         throw new Exception('You do not have permission to edit this Site');
-    } 
+    }
 
 
     $countries = \Factory::getSiteService()->getCountries();
-    $timezones =  DateTimeZone::listIdentifiers(); // get the standard values 
-    
+    $timezones =  DateTimeZone::listIdentifiers(); // get the standard values
+
     //Remove SC and PPS infrastructures from drop down list (unless site has one of them). TODO: Delete this block once they no longer exist
     $SCInfrastructure = \Factory::getSiteService()->getProdStatusByName('SC');
-    $PPSInfrastructure = \Factory::getSiteService()->getProdStatusByName('PPS'); 
+    $PPSInfrastructure = \Factory::getSiteService()->getProdStatusByName('PPS');
     $hackprodStatuses=array();
     foreach(\Factory::getSiteService()->getProdStatuses() as $ps){
         if(($ps != $SCInfrastructure and $ps != $PPSInfrastructure) or $ps == $site->getInfrastructure()){
@@ -91,12 +91,12 @@ function draw(\User $user = null) {
 
     $numberOfScopesRequired = \Factory::getConfigService()->getMinimumScopesRequired('site');
     $scopeJson = getEntityScopesAsJSON2($site, $site->getNgi(), $disableReservedScopes);
-    //die($scopeJson); 
+    //die($scopeJson);
 
     $params = array("site" => $site, "timezones" => $timezones,
         "countries" => $countries, "prodStatuses" => $prodStatuses,
         "numberOfScopesRequired" =>$numberOfScopesRequired,
-        "disableReservedScopes"=>$disableReservedScopes, 
+        "disableReservedScopes"=>$disableReservedScopes,
         "scopejson"=> $scopeJson);
 
     show_view('site/edit_site.php', $params);
@@ -111,7 +111,7 @@ function submit(\User $user = null) {
     try {
         //print_r($_POST);
         $newValues = getSiteDataFromWeb();
-        //print_r($newValues); 
+        //print_r($newValues);
         $siteId = \Factory::getSiteService()->getSite($newValues['ID']);
         $site = \Factory::getSiteService()->editSite($siteId, $newValues, $user);
         $params = array('site' => $site);

--- a/htdocs/web_portal/controllers/site/edit_site_property.php
+++ b/htdocs/web_portal/controllers/site/edit_site_property.php
@@ -33,7 +33,7 @@ function edit_property() {
 
     //Check the portal is not in read only mode, returns exception if it is and user is not an admin
     checkPortalIsNotReadOnlyOrUserIsAdmin($user);
-    
+
     if($_POST) {
         submit($user);
     } else {
@@ -48,16 +48,16 @@ function edit_property() {
  * @return null
  */
 function draw(\User $user = null) {
-    $serv = \Factory::getSiteService(); 
+    $serv = \Factory::getSiteService();
     $site = $serv->getSite($_REQUEST['id']);
     $property = $serv->getProperty($_REQUEST['propertyid']);
     $serv->validatePropertyActions($user, $site);
-    
+
     $params['prop'] = $property;
     $params['site'] = $site;
-    
-    show_view("site/edit_site_property.php", $params);     
-    
+
+    show_view("site/edit_site_property.php", $params);
+
 
 }
 
@@ -68,7 +68,7 @@ function draw(\User $user = null) {
  */
 function submit(\User $user = null) {
     try {
-        $newValues = getSpDataFromWeb();  
+        $newValues = getSpDataFromWeb();
         $siteID = $newValues['SITEPROPERTIES']['SITE'];
         $propID = $newValues['SITEPROPERTIES']['PROP'];
         if($newValues['SITEPROPERTIES']['NAME'] == null || $newValues['SITEPROPERTIES']['VALUE'] == null){
@@ -76,7 +76,7 @@ function submit(\User $user = null) {
             die();
         }
         $property = \Factory::getSiteService()->getProperty($propID);
-        $site = \Factory::getSiteService()->getSite($siteID);    	
+        $site = \Factory::getSiteService()->getSite($siteID);
         $site = \Factory::getSiteService()->editSiteProperty($site, $user, $property, $newValues);
         $params['siteid'] = $siteID;
         show_view('site/site_property_updated.php', $params);

--- a/htdocs/web_portal/controllers/site/view_all.php
+++ b/htdocs/web_portal/controllers/site/view_all.php
@@ -1,92 +1,92 @@
 <?php
-/*______________________________________________________ 
+/*______________________________________________________
  *======================================================
  * File: view_all.php
  * Author: John Casson, David Meredith
  * Description: Controller for viewing all Sites in GOCDB
- * 
+ *
  * License information
- *   
- * Copyright 2009 STFC 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
+ *
+ * Copyright 2009 STFC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * http://www.apache.org/licenses/LICENSE-2.0 
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
- *  
-/*====================================================== */ 
+ *
+/*====================================================== */
 function showAllSites(){
     require_once __DIR__.'/../../../../lib/Gocdb_Services/Factory.php';
-    
-    $exServ = \Factory::getExtensionsService();    
-   
-    // Do we really need to validate the URL parameter values, as the query 
-    // to the DB always uses bind variables to protect against injection? 
+
+    $exServ = \Factory::getExtensionsService();
+
+    // Do we really need to validate the URL parameter values, as the query
+    // to the DB always uses bind variables to protect against injection?
     require_once __DIR__.'/../../../../lib/Gocdb_Services/Validate.php';
-    $validatorService = new \org\gocdb\services\Validate();  
-  
-    // stores params to send to the doctrine query 
-    $filterParams = array(); 
-    
-    $ngi = ''; 
-    if(!empty($_GET['NGI'])) { 
+    $validatorService = new \org\gocdb\services\Validate();
+
+    // stores params to send to the doctrine query
+    $filterParams = array();
+
+    $ngi = '';
+    if(!empty($_GET['NGI'])) {
        $ngi = $_GET['NGI'];
        if(!$validatorService->validate('ngi', 'NAME', $ngi)){
-          throw new Exception("Invalid NGI parameter value");  
+          throw new Exception("Invalid NGI parameter value");
        }
-       $filterParams['roc'] = $ngi; 
+       $filterParams['roc'] = $ngi;
     }
-        
-    $prodStatus = ''; 
-    if(!empty($_GET['prodStatus'])) { 
+
+    $prodStatus = '';
+    if(!empty($_GET['prodStatus'])) {
        $prodStatus = $_GET['prodStatus'];
-       $filterParams['production_status'] = $prodStatus; 
+       $filterParams['production_status'] = $prodStatus;
     }
-    
+
     $showClosed = false;
     if(isset($_GET['showClosed'])) {
     $showClosed = true;
     } else {
-    $filterParams['exclude_certification_status'] = 'Closed'; 
+    $filterParams['exclude_certification_status'] = 'Closed';
     }
-    
-    $certStatus = ''; 
-    if(!empty($_GET['certStatus'])) { 
-       $certStatus = $_GET['certStatus']; 
-       $filterParams['certification_status'] = $certStatus; 
+
+    $certStatus = '';
+    if(!empty($_GET['certStatus'])) {
+       $certStatus = $_GET['certStatus'];
+       $filterParams['certification_status'] = $certStatus;
        $showClosed = false;
     }
-   
-    // Site extension property (currently only support filtering by one ext prop) 
-    // Can add filtering by many like scopes in future 
+
+    // Site extension property (currently only support filtering by one ext prop)
+    // Can add filtering by many like scopes in future
     $siteExtensionPropName = "";
     $siteExtensionPropValue ="";
     if(!empty($_GET['siteKeyNames'])) {
         $siteExtensionPropName = $_GET['siteKeyNames'];
     // only set the ext prop value if the keyName has been set too, otherwise
-    // we could end up with an illegal extensions parameter such as: '(=value)' 
+    // we could end up with an illegal extensions parameter such as: '(=value)'
     if(!empty($siteExtensionPropName) && !empty($_GET['selectedSiteKeyValue']) ) {
         $siteExtensionPropValue = $_GET['selectedSiteKeyValue'];
     }
-    $filterParams['extensions'] = '('.$siteExtensionPropName.'='.$siteExtensionPropValue.')'; 
+    $filterParams['extensions'] = '('.$siteExtensionPropName.'='.$siteExtensionPropValue.')';
     }
 
-    // Scope parameters 
-    // By default, use an empty value to return all scopes, i.e. in the PI '&scope=' 
-    // which is same as the PI. If the 'scope' param is not set, then it would fall 
-    // back to the default scope (if set), but this is not what we want in this interface.  
+    // Scope parameters
+    // By default, use an empty value to return all scopes, i.e. in the PI '&scope='
+    // which is same as the PI. If the 'scope' param is not set, then it would fall
+    // back to the default scope (if set), but this is not what we want in this interface.
     $filterParams['scope'] = '';
     $filterParams['scope_match'] = '';
     $selectedScopes = array();
-    if(!empty($_GET['mscope'])) { 
-    $scopeStringParam = ''; 
+    if(!empty($_GET['mscope'])) {
+    $scopeStringParam = '';
     foreach($_GET['mscope'] as $key => $scopeVal){
-        $scopeStringParam .= $scopeVal.','; 
-        $selectedScopes[] = $scopeVal; 
+        $scopeStringParam .= $scopeVal.',';
+        $selectedScopes[] = $scopeVal;
     }
     $filterParams['scope'] = $scopeStringParam;
         $scopeMatch = 'all';
@@ -94,20 +94,20 @@ function showAllSites(){
         $scopeMatch = $_GET['scopeMatch'];
     }
     $filterParams['scope_match'] = $scopeMatch;
-    } 
-    
+    }
+
     $serv = \Factory::getSiteService();
 
-    $params['scopes']=  \Factory::getScopeService()->getScopes(); 
+    $params['scopes']=  \Factory::getScopeService()->getScopes();
     $params['scopeMatch']= $filterParams['scope_match'];
     //$params['sites'] = $serv->getSitesBy($ngi, $prodStatus, $certStatus, $scope, $showClosed, null, $siteKeyNames, $siteKeyValues);
-    $params['sites'] = $serv->getSitesFilterByParams($filterParams); 
+    $params['sites'] = $serv->getSitesFilterByParams($filterParams);
     $params['NGIs'] = $serv->getNGIs();
     $params['prodStatuses'] = $serv->getProdStatuses();
-        
+
     //Remove SC and PPS infrastructures from drop down list. TODO: Delete this block once they no longer exist
     $SCInfrastructure = $serv->getProdStatusByName('SC');
-    $PPSInfrastructure = $serv->getProdStatusByName('PPS'); 
+    $PPSInfrastructure = $serv->getProdStatusByName('PPS');
     $productionStatuses=array();
     foreach($params['prodStatuses'] as $ps){
         if($ps != $SCInfrastructure and $ps != $PPSInfrastructure){
@@ -116,17 +116,17 @@ function showAllSites(){
     }
     $params['prodStatuses'] = $productionStatuses;
     //delete up to here once pps and sc infrastructures have been removed from database
-        
+
     /* Doctrine will provide keynames that are the same even when selecting distinct becase the object
      * is distinct even though the name is not unique. To avoid showing the same name repeatdly in the filter
      * we will load all the keynames into an array before making it unique
      */
-    $keynames=array();	
+    $keynames=array();
     foreach($exServ->getSiteExtensionsKeyNames() as $extension){
         $keynames[] = $extension->getKeyName();
     }
     $keynames = array_unique($keynames);
-    
+
     $params['selectedNgi'] = $ngi;
     $params['certStatuses'] = $serv->getCertStatuses();
     $params['selectedProdStatus'] = $prodStatus;
@@ -135,7 +135,7 @@ function showAllSites(){
     $params['showClosed'] = $showClosed;
     $params['siteKeyNames'] = $keynames;
     $params['selectedSiteKeyNames'] = $siteExtensionPropName;
-    $params['selectedSiteKeyValue'] = $siteExtensionPropValue;   
-    
+    $params['selectedSiteKeyValue'] = $siteExtensionPropValue;
+
     show_view("site/view_all.php", $params, "Sites");
 }

--- a/htdocs/web_portal/controllers/site/view_site.php
+++ b/htdocs/web_portal/controllers/site/view_site.php
@@ -3,24 +3,24 @@ function view_site() {
     require_once __DIR__ . '/../../../../lib/Gocdb_Services/Factory.php';
     require_once __DIR__ . '/../utils.php';
     require_once __DIR__ . '/../../../web_portal/components/Get_User_Principle.php';
-    
+
     $serv = \Factory::getSiteService();
     $servServ  = \Factory::getServiceService();
 
     if (!isset($_GET['id']) || !is_numeric($_GET['id']) ){
         throw new Exception("An id must be specified");
     }
-    $siteId = $_GET['id']; 
-    
+    $siteId = $_GET['id'];
+
     $site = $serv->getSite($siteId);
     $allRoles = $site->getRoles();
-    $roles = array(); 
+    $roles = array();
     foreach ($allRoles as $role){
         if($role->getStatus() == \RoleStatus::GRANTED){
-            $roles[] = $role; 
+            $roles[] = $role;
         }
     }
-    
+
     //get user for case that portal is read only and user is admin, so they can still see edit links
     $dn = Get_User_Principle();
     $user = \Factory::getUserService()->getUserByPrinciple($dn);
@@ -29,33 +29,33 @@ function view_site() {
         $params['UserIsAdmin']=$user->isAdmin();
     }
 
-    $params['authenticated'] = false; 
+    $params['authenticated'] = false;
     if($user != null){
-        $params['authenticated'] = true; 
+        $params['authenticated'] = true;
     }
 
     // Does current viewer have edit permissions over Site ?
-    $params['ShowEdit'] = false;  
+    $params['ShowEdit'] = false;
     //if(count($serv->authorize Action(\Action::EDIT_OBJECT, $site, $user))>=1){
     if(\Factory::getRoleActionAuthorisationService()->authoriseAction(\Action::EDIT_OBJECT, $site, $user)->getGrantAction()){
-       $params['ShowEdit'] = true;  
-    } 
-    
+       $params['ShowEdit'] = true;
+    }
+
     $params['Scopes']= $serv->getScopesWithParentScopeInfo($site);
     $params['ServicesAndScopes']=array();
     foreach($site->getServices() as $service){
         $params['ServicesAndScopes'][]=array('Service'=>$service,
                                              'Scopes'=>$servServ->getScopesWithParentScopeInfo($service));
     }
-    
+
     $params['Downtimes'] = $serv->getDowntimes($site->getId(), 31);
     $params['portalIsReadOnly'] = portalIsReadOnlyAndUserIsNotAdmin($user);
     $title = $site->getShortName();
     $params['site'] = $site;
     $params['roles'] = $roles;
 
-    // Add RoleActionRecords to params 
-    $params['RoleActionRecords'] = \Factory::getRoleService()->getRoleActionRecordsById_Type($site->getId(), 'site'); 
-    
+    // Add RoleActionRecords to params
+    $params['RoleActionRecords'] = \Factory::getRoleService()->getRoleActionRecordsById_Type($site->getId(), 'site');
+
     show_view("site/view_site.php", $params, $title);
 }

--- a/htdocs/web_portal/controllers/sitesForGoogleMapXML.php
+++ b/htdocs/web_portal/controllers/sitesForGoogleMapXML.php
@@ -2,7 +2,7 @@
 /*======================================================
  * File: sitesForGoogleMapXML.php
  * Author: George Ryall
- * Description: Returns xml containing all sites that are not closed and have 
+ * Description: Returns xml containing all sites that are not closed and have
  * lcation information. Used by google map on start page.
  *
  *

--- a/htdocs/web_portal/controllers/start_page.php
+++ b/htdocs/web_portal/controllers/start_page.php
@@ -25,14 +25,14 @@ function startPage() {
     require_once __DIR__.'/../components/Get_User_Principle.php';
     $dn = Get_User_Principle();
     $user = \Factory::getUserService()->getUserByPrinciple($dn);
-    
+
     $roles = \Factory::getRoleService()->getPendingRolesUserCanApprove($user);
-   
+
     $configServ = \Factory::getConfigService();
     $showMap = $configServ->getShowMapOnStartPage();
     $apiKey = $configServ->getGoogleAPIKey();
-    
-    $params = array('roles' => $roles, 
+
+    $params = array('roles' => $roles,
                     'googleAPIKey'=>$apiKey,
                     'showMap'=>$showMap);
     $title = "GOCDB";

--- a/htdocs/web_portal/controllers/user/delete_user.php
+++ b/htdocs/web_portal/controllers/user/delete_user.php
@@ -27,7 +27,7 @@ function delete() {
     require_once __DIR__ . '/../../../../lib/Gocdb_Services/Factory.php';
     require_once __DIR__ . '/../../../../htdocs/web_portal/components/Get_User_Principle.php';
     require_once __DIR__ . '/utils.php';
-    
+
     //Check the portal is not in read only mode, returns exception if it is
     checkPortalIsNotReadOnly();
     if (!isset($_REQUEST['id']) || !is_numeric($_REQUEST['id']) ){

--- a/htdocs/web_portal/controllers/user/edit_user.php
+++ b/htdocs/web_portal/controllers/user/edit_user.php
@@ -21,7 +21,7 @@
 require_once __DIR__.'/../../../../lib/Gocdb_Services/Factory.php';
 require_once __DIR__.'/../../components/Get_User_Principle.php';
 require_once __DIR__.'/utils.php';
-    
+
 /**
  * Controller for an edit_user request
  * @global array $_POST only set if the browser has POSTed data
@@ -30,7 +30,7 @@ require_once __DIR__.'/utils.php';
 function edit_user() {
     //Check the portal is not in read only mode, returns exception if it is
     checkPortalIsNotReadOnly();
-    
+
     if($_POST) {     // If we receive a POST request it's to update a user
         submit();
     } else { // If there is no post data, draw the edit user form

--- a/htdocs/web_portal/controllers/user/register.php
+++ b/htdocs/web_portal/controllers/user/register.php
@@ -30,7 +30,7 @@ require_once __DIR__.'/utils.php';
 function register() {
     //Check the portal is not in read only mode, returns exception if it is
     checkPortalIsNotReadOnly();
-    
+
     if($_POST) { // If we receive a POST request it's to update a user
         submit();
     } else { // If there is no post data, draw the edit user form
@@ -47,7 +47,7 @@ function draw() {
     $dn = Get_User_Principle();
     if(empty($dn)){
         show_view('error.php', "Could not authenticate user - null user principle");
-    die(); 
+    die();
     }
     $user = $serv->getUserByPrinciple($dn);
 
@@ -59,7 +59,7 @@ function draw() {
     /* @var $authToken \org\gocdb\security\authentication\IAuthentication */
     $authToken = Get_User_AuthToken();
     $params['authAttributes'] = $authToken->getDetails();
-    
+
     $params['dn'] = $dn;
     show_view('user/register.php', $params);
 }
@@ -70,12 +70,12 @@ function submit() {
     $dn = Get_User_Principle();
     if(empty($dn)){
         show_view('error.php', "Could not authenticate user - null user principle");
-    die(); 
+    die();
     }
     $values['CERTIFICATE_DN'] = $dn;
 
-    // todo: on registering, we also want to persist the authAttributes, this 
-    // will require new UserProperty records owned by the User.php entity. 
+    // todo: on registering, we also want to persist the authAttributes, this
+    // will require new UserProperty records owned by the User.php entity.
     /* @var $authToken \org\gocdb\security\authentication\IAuthentication */
     //$authToken = Get_User_AuthToken();
     //$params['authAttributes'] = $authToken->getDetails();

--- a/htdocs/web_portal/controllers/user/retrieve_account.php
+++ b/htdocs/web_portal/controllers/user/retrieve_account.php
@@ -21,7 +21,7 @@
 require_once __DIR__.'/../../../../lib/Gocdb_Services/Factory.php';
 require_once __DIR__.'/../../components/Get_User_Principle.php';
 require_once __DIR__.'/utils.php';
-    
+
 /**
  * Controller for a retrieve account request.
  * @global array $_POST only set if the browser has POSTed data
@@ -30,7 +30,7 @@ require_once __DIR__.'/utils.php';
 function retrieve() {
     //Check the portal is not in read only mode, returns exception if it is
     checkPortalIsNotReadOnly();
-    
+
     if($_POST) { // If we receive a POST request it's to update a user
         submit();
     } else { // If there is no post data, draw the edit user form
@@ -46,7 +46,7 @@ function draw() {
     $dn = Get_User_Principle();
     if(empty($dn)){
         show_view('error.php', "Could not authenticate user - null user principle");
-        die(); 
+        die();
     }
     $user = \Factory::getUserService()->getUserByPrinciple($dn);
 
@@ -56,7 +56,7 @@ function draw() {
     }
 
     $params['DN'] = $dn;
-    
+
     show_view('user/retrieve_account.php', $params, 'Retrieve Account');
 }
 
@@ -66,15 +66,15 @@ function submit() {
     $currentDn = Get_User_Principle();
     if(empty($currentDn)){
         show_view('error.php', "Could not authenticate user - null user principle");
-        die(); 
+        die();
     }
-    
+
     try {
         $changeReq = \Factory::getRetrieveAccountService()->newRetrieveAccountRequest($currentDn, $givenEmail, $oldDn);
     } catch(\Exception $e) {
         show_view('error.php', $e->getMessage());
         die();
     }
-    
+
     show_view('user/retrieve_account_accepted.php');
 }

--- a/htdocs/web_portal/controllers/user/retrieve_account_user_validate.php
+++ b/htdocs/web_portal/controllers/user/retrieve_account_user_validate.php
@@ -29,10 +29,10 @@ function validate_dn_change() {
     require_once __DIR__ . '/../../../../lib/Gocdb_Services/Factory.php';
     require_once __DIR__ . '/../../../../htdocs/web_portal/components/Get_User_Principle.php';
     require_once __DIR__ . '/utils.php';
-    
+
     //Check the portal is not in read only mode, returns exception if it is
     checkPortalIsNotReadOnly();
-    
+
     if(!isset($_REQUEST['c'])){
         show_view('error.php', "a confirmation code must be specified");
     }
@@ -41,7 +41,7 @@ function validate_dn_change() {
     $currentDn = Get_User_Principle();
     if(empty($currentDn)){
         show_view('error.php', "Could not authenticate user - null user principle");
-        die(); 
+        die();
     }
 
     try {

--- a/htdocs/web_portal/controllers/user/utils.php
+++ b/htdocs/web_portal/controllers/user/utils.php
@@ -40,7 +40,7 @@ function getUserDataFromWeb() {
 
 
 /**
- * Checks witht the config service if the portal is in read only mode and if 
+ * Checks witht the config service if the portal is in read only mode and if
  * it is throws an exception
  * @throws \Exception
  */

--- a/htdocs/web_portal/controllers/user/view_user.php
+++ b/htdocs/web_portal/controllers/user/view_user.php
@@ -22,103 +22,103 @@
 function view_user() {
     require_once __DIR__.'/../../../../lib/Gocdb_Services/Factory.php';
     require_once __DIR__.'/../../components/Get_User_Principle.php';
-    
+
     if (!isset($_GET['id']) || !is_numeric($_GET['id']) ){
         throw new Exception("An id must be specified");
     }
-    $userId =  $_GET['id']; 
-    
+    $userId =  $_GET['id'];
+
     $user = \Factory::getUserService()->getUser($userId);
     if($user === null){
-       throw new Exception("No user with that ID"); 
+       throw new Exception("No user with that ID");
     }
     $params['user'] = $user;
 
 
-    // 2D array, each element stores role and a child array holding project Ids 
-    $role_ProjIds = array(); 
-    
+    // 2D array, each element stores role and a child array holding project Ids
+    $role_ProjIds = array();
+
     // get the targetUser's roles
     $roles = \Factory::getRoleService()->getUserRoles($user, \RoleStatus::GRANTED); //$user->getRoles();
 
     $callingUser = \Factory::getUserService()->getUserByPrinciple(Get_User_Principle());
-   
-    // can the calling user revoke the targetUser's roles?  
+
+    // can the calling user revoke the targetUser's roles?
     /* @var $r \Role */
     foreach ($roles as $r) {
     //echo $r->getId().', '.$r->getRoleType()->getName().', '.$r->getOwnedEntity()->getName().'<br>';
 
     // determine if callingUser can REVOKE this role instance
     if($user != $callingUser){
-        //echo '<br>'.$r->getOwnedEntity()->getName().' '; 
-        
+        //echo '<br>'.$r->getOwnedEntity()->getName().' ';
+
             $authorisingRoles = \Factory::getRoleActionAuthorisationService()
             ->authoriseAction(\Action::REVOKE_ROLE, $r->getOwnedEntity(), $callingUser)
-            ->getGrantingRoles(); 
-            $authorisingRoleNames = array(); 
+            ->getGrantingRoles();
+            $authorisingRoleNames = array();
         //echo ' callingUser authorising Roles: ';
             /* @var $authRole \Role */
             foreach($authorisingRoles as $authRole){
-               $authorisingRoleNames[] = $authRole->getRoleType()->getName();  
+               $authorisingRoleNames[] = $authRole->getRoleType()->getName();
            //echo $authRole->getRoleType()->getName().', ';
             }
-            
+
             if(count($authorisingRoleNames)>=1){
-                $allAuthorisingRoleNames = ''; 
+                $allAuthorisingRoleNames = '';
                 foreach($authorisingRoleNames as $arName){
-                    $allAuthorisingRoleNames .= $arName.', '; 
+                    $allAuthorisingRoleNames .= $arName.', ';
                 }
-                $allAuthorisingRoleNames = substr($allAuthorisingRoleNames, 0, strlen($allAuthorisingRoleNames)-2);  
+                $allAuthorisingRoleNames = substr($allAuthorisingRoleNames, 0, strlen($allAuthorisingRoleNames)-2);
                 $r->setDecoratorObject('['.$allAuthorisingRoleNames.'] ');
-            } 
+            }
             if($callingUser->isAdmin()){
-                $existingVal = $r->getDecoratorObject(); 
+                $existingVal = $r->getDecoratorObject();
                 if($existingVal != null){
                    $r->setDecoratorObject('GOCDB ADMIN: '.$existingVal);
                 } else {
-                    $r->setDecoratorObject('GOCDB ADMIN'); 
+                    $r->setDecoratorObject('GOCDB ADMIN');
                 }
             }
     } else {
-        // current user is viewing their own roles, so they can revoke their own roles 
-        $r->setDecoratorObject('[Self revoke own role]'); 
+        // current user is viewing their own roles, so they can revoke their own roles
+        $r->setDecoratorObject('[Self revoke own role]');
     }
 
-    // Get the names of the parent project(s) for this role so we can 
-    // group by project in the view 
+    // Get the names of the parent project(s) for this role so we can
+    // group by project in the view
     $parentProjectsForRole = \Factory::getRoleActionAuthorisationService()
-        ->getReachableProjectsFromOwnedEntity($r->getOwnedEntity()); 
-    $projIds = array(); 
+        ->getReachableProjectsFromOwnedEntity($r->getOwnedEntity());
+    $projIds = array();
     foreach($parentProjectsForRole as $_proj){
-        $projIds[] = $_proj->getId(); 
+        $projIds[] = $_proj->getId();
     }
-    
-    // store role and parent projIds in a 2D array for viewing
-    $role_ProjIds[] = array($r, $projIds); 
-    
-    }// end iterating roles 
 
-    // Get a list of the projects and their Ids for grouping roles by proj in view  
-    $projectNamesIds = array(); 
+    // store role and parent projIds in a 2D array for viewing
+    $role_ProjIds[] = array($r, $projIds);
+
+    }// end iterating roles
+
+    // Get a list of the projects and their Ids for grouping roles by proj in view
+    $projectNamesIds = array();
     $projects = \Factory::getProjectService()->getProjects();
     foreach($projects as $proj){
-    $projectNamesIds[$proj->getId()] = $proj->getName();  
+    $projectNamesIds[$proj->getId()] = $proj->getName();
     }
 
-    // Check to see if the current calling user has permission to edit the target user 
+    // Check to see if the current calling user has permission to edit the target user
     try {
         \Factory::getUserService()->editUserAuthorization($user, $callingUser);
-        $params['ShowEdit'] = true; 
+        $params['ShowEdit'] = true;
     } catch (Exception $e) {
-        $params['ShowEdit'] = false; 
+        $params['ShowEdit'] = false;
     }
 
     /* @var $authToken \org\gocdb\security\authentication\IAuthentication */
     $authToken = Get_User_AuthToken();
-    $params['authAttributes'] = $authToken->getDetails(); 
-    
-    $params['projectNamesIds'] = $projectNamesIds; 
-    $params['role_ProjIds'] = $role_ProjIds; 
+    $params['authAttributes'] = $authToken->getDetails();
+
+    $params['projectNamesIds'] = $projectNamesIds;
+    $params['role_ProjIds'] = $role_ProjIds;
     $params['portalIsReadOnly'] = \Factory::getConfigService()->IsPortalReadOnly();
     $title = $user->getFullName();
     show_view("user/view_user.php", $params, $title);

--- a/htdocs/web_portal/controllers/utils.php
+++ b/htdocs/web_portal/controllers/utils.php
@@ -57,26 +57,26 @@ function parse_properties($txtProperties) {
 
 
 /**
- * Builds a JSON string that lists scope tags in different categories based 
- * on the provided arguments - used when editing or adding a IScopedEntity. 
+ * Builds a JSON string that lists scope tags in different categories based
+ * on the provided arguments - used when editing or adding a IScopedEntity.
  * <p>
- * Different JSON keys are used to define the scope tag categories: 
+ * Different JSON keys are used to define the scope tag categories:
  * <ul>
  *   <li>'optional' - Lists optional tags that are freely assignable.</li>
- *   <li>'reserved_optional' - Lists reserved tags that have already been directly 
+ *   <li>'reserved_optional' - Lists reserved tags that have already been directly
  *      assigned to the $targetScopedEntity, but CAN'T be inherited from the $parentScopedEntity.</li>
- *   <li>'reserved_optional_inheritable' - Lists reserved tags that CAN be inherited 
+ *   <li>'reserved_optional_inheritable' - Lists reserved tags that CAN be inherited
  *      from the $parentScopedEntity (the tag may/may-not be already assigned to the target).</li>
  *   <li>'reserved' - The remaining Reserved tags.</li>
  *   <li>'disableReserved' - Defines a boolean rather than a tag list - true to disable the 'reserved' tags or false to enable.</li>
- * </ul>  
+ * </ul>
  * <p>
  * For each scope value, the attributes are ["PK/ID", "tagValue", "boolCheckedOrNot"].
  * <p>
- * If both target and parent scopedEntities are null, then 'reserved_optional' and 
- * 'reserved_optional_inheritable' lists will be empty.  
+ * If both target and parent scopedEntities are null, then 'reserved_optional' and
+ * 'reserved_optional_inheritable' lists will be empty.
  * <p>
- * Sample output: 
+ * Sample output:
  * <code>
  * {
  * "optional":[[2,"EGI",true],[1,"Local",false]],
@@ -85,88 +85,88 @@ function parse_properties($txtProperties) {
  * "reserved":[[26,"alice",false],[23,"cms",false],[22,"tier1",false],[21,"tier2",false]],
  * "disableReserved":true
  * }
- * </code>  
- * @param \IScopedEntity $targetScopedEntity Optional, use Null if creating a new IScopedEntity 
- * @param \IScopedEntity $parentScopedEntity Optional, the parent to inherit tags from 
- * @param bool $disableReservedScopes True to disable 'reserved' tags 
- * @param bool $inheritParentScopeChecked True to set the checked status of each scope value 
- *   according to whether the parent has the same scope checked (every scope will always be 
- *   false if the $parentScopedEntity is null) 
- * @return string  
+ * </code>
+ * @param \IScopedEntity $targetScopedEntity Optional, use Null if creating a new IScopedEntity
+ * @param \IScopedEntity $parentScopedEntity Optional, the parent to inherit tags from
+ * @param bool $disableReservedScopes True to disable 'reserved' tags
+ * @param bool $inheritParentScopeChecked True to set the checked status of each scope value
+ *   according to whether the parent has the same scope checked (every scope will always be
+ *   false if the $parentScopedEntity is null)
+ * @return string
  * @throws \LogicException
  */
-function getEntityScopesAsJSON2($targetScopedEntity = null, $parentScopedEntity = null, 
+function getEntityScopesAsJSON2($targetScopedEntity = null, $parentScopedEntity = null,
         $disableReservedScopes = true, $inheritParentScopeChecked = false){
 
-    $targetScopes = array(); 
+    $targetScopes = array();
     if($targetScopedEntity != null){
         if(!($targetScopedEntity instanceof \IScopedEntity)){
-            throw new \LogicException('Invalid $scopedEntityChild, does not implement IScopedEntity'); 
+            throw new \LogicException('Invalid $scopedEntityChild, does not implement IScopedEntity');
         }
        $targetScopes =  $targetScopedEntity->getScopes()->toArray();
     }
-    $parentScopes = array(); 
+    $parentScopes = array();
     if($parentScopedEntity != null) {
         if(!($parentScopedEntity instanceof \IScopedEntity)){
-            throw new \LogicException('Invalid scopedEntityParent, does not implement IScopedEntity'); 
+            throw new \LogicException('Invalid scopedEntityParent, does not implement IScopedEntity');
         }
-        $parentScopes = $parentScopedEntity->getScopes()->toArray(); 
+        $parentScopes = $parentScopedEntity->getScopes()->toArray();
     }
 
     $reservedScopeNames = \Factory::getConfigService()->getReservedScopeList();
-    $allScopes = \Factory::getScopeService()->getScopes(); 
-    $optionalScopeIds = array(); 
-    $reservedOptionalScopeIds = array(); 
-    $reservedOptionalInheritableScopeIds = array(); 
-    $reservedScopeIds = array(); 
+    $allScopes = \Factory::getScopeService()->getScopes();
+    $optionalScopeIds = array();
+    $reservedOptionalScopeIds = array();
+    $reservedOptionalInheritableScopeIds = array();
+    $reservedScopeIds = array();
 
     /* @var $scope \Scope */
     foreach($allScopes as $scope){
         $targetChecked = false;
         $parentChecked = false;
-        // is scope already joined to target 
+        // is scope already joined to target
         if(in_array($scope, $targetScopes)){
-            $targetChecked = true; 
-        } 
-        // is scope already joined to parent 
+            $targetChecked = true;
+        }
+        // is scope already joined to parent
         if(in_array($scope, $parentScopes)){
-            $parentChecked = true; 
-        } 
+            $parentChecked = true;
+        }
         // Determine if this tag should be checked = t/f
-        $isChecked = $targetChecked; 
+        $isChecked = $targetChecked;
         if($inheritParentScopeChecked){
-            $isChecked = $parentChecked; 
+            $isChecked = $parentChecked;
         }
 
         // Is scope tag in the reserved list ?
-        if(in_array($scope->getName(), $reservedScopeNames)){ 
+        if(in_array($scope->getName(), $reservedScopeNames)){
             // A reserved scope tag:
             if($parentChecked || $targetChecked){
                 if($parentChecked){
-                    // tag CAN be inherited from parent, so put in relevant array 
+                    // tag CAN be inherited from parent, so put in relevant array
                     $reservedOptionalInheritableScopeIds[] = array($scope->getId(), $scope->getName(), $isChecked);
                 } else {
-                    // tag CAN'T be inherited from parent, but it has already been directly assigned, so put in relevant array  
-                    $reservedOptionalScopeIds[] = array($scope->getId(), $scope->getName(), $isChecked);  
+                    // tag CAN'T be inherited from parent, but it has already been directly assigned, so put in relevant array
+                    $reservedOptionalScopeIds[] = array($scope->getId(), $scope->getName(), $isChecked);
                 }
             } else {
                 // tag is not inheritable and has not been directly assigned, so its reserved/protected
-                $reservedScopeIds[] = array($scope->getId(), $scope->getName(), $isChecked); 
+                $reservedScopeIds[] = array($scope->getId(), $scope->getName(), $isChecked);
             }
         } else {
-            // An optional scope tag: 
-            $optionalScopeIds[] = array($scope->getId(), $scope->getName(), $isChecked); 
+            // An optional scope tag:
+            $optionalScopeIds[] = array($scope->getId(), $scope->getName(), $isChecked);
         }
     }
-    // build the response 
-    $scopeCategories = array(); 
-    $scopeCategories['optional'] = $optionalScopeIds; 
-    $scopeCategories['reserved_optional'] = $reservedOptionalScopeIds; 
-    $scopeCategories['reserved_optional_inheritable'] = $reservedOptionalInheritableScopeIds;  
-    $scopeCategories['reserved'] = $reservedScopeIds; 
-    $scopeCategories['disableReserved'] = $disableReservedScopes ? true : false;  
-    
-    return json_encode($scopeCategories); 
+    // build the response
+    $scopeCategories = array();
+    $scopeCategories['optional'] = $optionalScopeIds;
+    $scopeCategories['reserved_optional'] = $reservedOptionalScopeIds;
+    $scopeCategories['reserved_optional_inheritable'] = $reservedOptionalInheritableScopeIds;
+    $scopeCategories['reserved'] = $reservedScopeIds;
+    $scopeCategories['disableReserved'] = $disableReservedScopes ? true : false;
+
+    return json_encode($scopeCategories);
 }
 
 /**
@@ -192,7 +192,7 @@ function checkPortalIsNotReadOnlyOrUserIsAdmin(\User $user = null) {
  */
 function portalIsReadOnlyAndUserIsNotAdmin(\user $user = null) {
     require_once __DIR__ . '/../../../lib/Gocdb_Services/Factory.php';
-    
+
     // this block is required to deal with unregistered users (where $user is null)
     $userIsAdmin = false;
     if (! is_null($user)){
@@ -200,7 +200,7 @@ function portalIsReadOnlyAndUserIsNotAdmin(\user $user = null) {
             $userIsAdmin = true;
         }
     }
-    
+
     if (\Factory::getConfigService()->IsPortalReadOnly() and ! $userIsAdmin){
         return true;
     }else{
@@ -210,7 +210,7 @@ function portalIsReadOnlyAndUserIsNotAdmin(\user $user = null) {
 
 /**
  * Checks the user has permission to perform/view admin functionality
- * 
+ *
  * @return null
  *
  */
@@ -229,7 +229,7 @@ function CheckCurrentUserCanEditProject(\Project $project) {
     require_once __DIR__ . '/../../web_portal/components/Get_User_Principle.php';
     $dn = Get_User_Principle();
     $user = \Factory::getUserService()->getUserByPrinciple($dn);
-    
+
     //$enablingRoles = \Factory::getProjectService()->authorize Action('ACTION_EDIT_OBJECT', $project, $user);
     //if (count($enablingRoles) == 0){
     if(\Factory::getRoleActionAuthorisationService()->authoriseAction(\Action::EDIT_OBJECT, $project, $user)->getGrantAction() == FALSE){
@@ -241,7 +241,7 @@ function CheckCurrentUserCanEditProject(\Project $project) {
  * Gets the relevant fields from a user's web request
  * ($_REQUEST) and returns an associative array compatible with
  * add_site().
- * 
+ *
  * @global array $_REQUEST site data submitted by the end user
  * @return array an array representation of a site
  */
@@ -249,46 +249,46 @@ function getSiteDataFromWeb() {
     // Fields that are used to link other objects to the site
     $fields = array (
             'Country',
-            'ProductionStatus' 
+            'ProductionStatus'
     );
-    
+
     foreach($fields as $field){
         $site_data [$field] = $_REQUEST [$field];
     }
-   
+
     if(isset($_REQUEST['childServiceScopeAction'])){
-        $site_data['childServiceScopeAction'] = $_REQUEST['childServiceScopeAction']; 
+        $site_data['childServiceScopeAction'] = $_REQUEST['childServiceScopeAction'];
     } else {
-        $site_data['childServiceScopeAction'] = 'noModify'; 
+        $site_data['childServiceScopeAction'] = 'noModify';
     }
-    
-    // get non-reserved scopes if any are selected, if not set as empty array 
+
+    // get non-reserved scopes if any are selected, if not set as empty array
     if (isset($_REQUEST ['Scope_ids'])){
         $site_data ['Scope_ids'] = $_REQUEST ['Scope_ids'];
     }else{
         $site_data ['Scope_ids'] = array ();
     }
-    // get reserved scopes if any are selected, if not set as empty array 
+    // get reserved scopes if any are selected, if not set as empty array
     if (isset($_REQUEST ['ReservedScope_ids'])){
         $site_data ['ReservedScope_ids'] = $_REQUEST ['ReservedScope_ids'];
     }else{
         $site_data ['ReservedScope_ids'] = array ();
     }
-    
+
     /*
      * Certification status is only set during the add_site procedure. Editing an existing site's cert status uses a separate form
      */
     if (isset($_REQUEST ['Certification_Status'])){
         $site_data ['Certification_Status'] = $_REQUEST ['Certification_Status'];
     }
-    
+
     /*
      * ROC is only set during the add_site procedure. A site's ROC can't be edited in the web portal
      */
     if (isset($_REQUEST ['NGI'])){
         $site_data ['NGI'] = $_REQUEST ['NGI'];
     }
-    
+
     // Fields specific to the site object and not linked to other entities
     $site_object_fields = array (
             'SHORT_NAME',
@@ -308,30 +308,30 @@ function getSiteDataFromWeb() {
             'CSIRTTEL',
             'EMERGENCYEMAIL',
             'HELPDESKEMAIL',
-            'DOMAIN', 
+            'DOMAIN',
             'TIMEZONE'
     );
-    
+
     foreach($site_object_fields as $field){
         $site_data ['Site'] [$field] = $_REQUEST [$field];
     }
-    
+
     /*
      * If the user is updating a site the optional cobjectid parameter will be set. If it is set we return it as part of the array
      */
     if (! empty($_REQUEST ['ID'])){
         $site_data ['ID'] = $_REQUEST ['ID'];
     }
-    
+
     //
-    
+
     return $site_data;
 }
 
 /**
  * Gets the relevant fields from a user's web request
  * ($_REQUEST)
- * 
+ *
  * @global array $_REQUEST site data submitted by the end user
  * @return array An array of service group data
  */
@@ -344,17 +344,17 @@ function getSGroupDataFromWeb() {
     }else{
         $monitored = 'N';
     }
-    
+
     $sg ['MONITORED'] = $monitored;
-    
+
     if (isset($_REQUEST ['objectId'])){
         $sg ['ID'] = $_REQUEST ['objectId'];
     }
-    
+
     $sg ['SERVICEGROUP'] ['NAME'] = $_REQUEST ['name'];
     $sg ['SERVICEGROUP'] ['DESCRIPTION'] = $_REQUEST ['description'];
     $sg ['SERVICEGROUP'] ['EMAIL'] = $_REQUEST ['email'];
-    
+
     // get scopes if any are selected, if not set as null
     if (isset($_REQUEST ['Scope_ids'])){
         $sg ['Scope_ids'] = $_REQUEST ['Scope_ids'];
@@ -366,7 +366,7 @@ function getSGroupDataFromWeb() {
     }else{
         $sg['ReservedScope_ids'] = array ();
     }
-    
+
     return $sg;
 }
 
@@ -374,7 +374,7 @@ function getSGroupDataFromWeb() {
  * Gets the relevant fields from a user's web request
  * ($_REQUEST) and returns an associative array compatible with
  * add_new_service() or editService.
- * 
+ *
  * @global array $_REQUEST SE data submitted by the end user
  * @return array an array representation of a service
  */
@@ -382,21 +382,21 @@ function getSeDataFromWeb() {
     // Fields that are used to link other objects to the site
     $fields = array (
             'serviceType',
-            'endpointUrl' 
+            'endpointUrl'
     );
-    
+
     foreach($fields as $field){
         $se_data [$field] = $_REQUEST [$field];
     }
-    
+
     /*
-     * If the user is adding a new service the optional HOSTING_SITE parameter will be set. 
+     * If the user is adding a new service the optional HOSTING_SITE parameter will be set.
      * If it is set we return it as part of the array
      */
     if (! empty($_REQUEST ['hostingSite'])){
         $se_data ['hostingSite'] = $_REQUEST ['hostingSite'];
     }
-    
+
     // $se_data['SE']['ENDPOINT'] = $_REQUEST['HOSTNAME'] . $_REQUEST['serviceType'];
     $se_data ['SE'] ['HOSTNAME'] = $_REQUEST ['HOSTNAME'];
     $se_data ['SE'] ['HOST_IP'] = $_REQUEST ['HOST_IP'];
@@ -414,20 +414,20 @@ function getSeDataFromWeb() {
     if (! empty($_REQUEST ['ID'])){
         $se_data ['ID'] = $_REQUEST ['ID'];
     }
-    
+
     // get scopes if any are selected, if not set as null
     if (isset($_REQUEST ['Scope_ids'])){
         $se_data ['Scope_ids'] = $_REQUEST ['Scope_ids'];
     }else{
         $se_data ['Scope_ids'] = array ();
     }
-    
+
     if (isset($_REQUEST ['ReservedScope_ids'])){
         $se_data ['ReservedScope_ids'] = $_REQUEST ['ReservedScope_ids'];
     }else{
         $se_data ['ReservedScope_ids'] = array ();
     }
-    
+
     return $se_data;
 }
 
@@ -440,13 +440,13 @@ function getProjectDataFromWeb() {
     if (isset($_REQUEST ['ID'])){
         $projectValues ['ID'] = $_REQUEST ['ID'];
     }
-    
+
     // Get the rest of the project post data into an array
     $fields = array (
             'Name',
-            'Description' 
+            'Description'
     );
-    
+
     foreach($fields as $field){
         $projectValues [$field] = $_REQUEST [$field];
     }
@@ -458,57 +458,57 @@ function getNGIDataFromWeb() {
             'EMAIL',
             'HELPDESK_EMAIL',
             'ROD_EMAIL',
-            'SECURITY_EMAIL', 
-            'GGUS_SU' 
+            'SECURITY_EMAIL',
+            'GGUS_SU'
     );
-    
+
     foreach($fields as $field){
         $NGIValues [$field] = $_REQUEST [$field];
     }
-    
+
     if (isset($_REQUEST ['NAME'])){
         $NGIValues ['NAME'] = $_REQUEST ['NAME'];
     }
-    
+
 //    $scopes = array ();
 //    if (isset($_REQUEST ['SCOPE_IDS'])){
 //        $scopes = $_REQUEST ['SCOPE_IDS'];
 //    }
 
     // get scopes if any are selected, if not set as null
-    $optionalScopes = array(); 
+    $optionalScopes = array();
     if (isset($_REQUEST ['Scope_ids'])){
         $optionalScopes['Scope_ids'] = $_REQUEST ['Scope_ids'];
     }else{
         $optionalScopes['Scope_ids'] = array ();
     }
-    $reservedScopes = array(); 
+    $reservedScopes = array();
     if (isset($_REQUEST ['ReservedScope_ids'])){
         $reservedScopes['ReservedScope_ids'] = $_REQUEST ['ReservedScope_ids'];
     }else{
         $reservedScopes['ReservedScope_ids'] = array ();
     }
-    
+
     $id = null;
     if (isset($_REQUEST ['ID'])){
         $id = $_REQUEST ['ID'];
     }
-    
+
     $values = array (
             'NGI' => $NGIValues,
             //'SCOPES' => $scopes,
-            'Scope_ids' => $optionalScopes['Scope_ids'], 
-            'ReservedScope_ids' => $reservedScopes['ReservedScope_ids'], 
-            'ID' => $id 
+            'Scope_ids' => $optionalScopes['Scope_ids'],
+            'ReservedScope_ids' => $reservedScopes['ReservedScope_ids'],
+            'ID' => $id
     );
-    
+
     return $values;
 }
 
 /**
  * Gets the relevant fields from a user's web request
  * ($_REQUEST) and returns an associative array.
- * 
+ *
  * @global array $_REQUEST Downtime data submitted by the end user
  * @return array an array representation of a downtime
  */
@@ -517,22 +517,22 @@ function getDtDataFromWeb() {
     $dt ['DOWNTIME'] ['DESCRIPTION'] = $_REQUEST ['DESCRIPTION'];
     $dt ['DOWNTIME'] ['START_TIMESTAMP'] = $_REQUEST ['START_TIMESTAMP'];
     $dt ['DOWNTIME'] ['END_TIMESTAMP'] = $_REQUEST ['END_TIMESTAMP'];
-    
-    $dt ['DOWNTIME'] ['DEFINE_TZ_BY_UTC_OR_SITE'] = 'utc'; //default 
+
+    $dt ['DOWNTIME'] ['DEFINE_TZ_BY_UTC_OR_SITE'] = 'utc'; //default
     if(isset($_REQUEST ['DEFINE_TZ_BY_UTC_OR_SITE'])){
-       $dt ['DOWNTIME'] ['DEFINE_TZ_BY_UTC_OR_SITE'] = $_REQUEST ['DEFINE_TZ_BY_UTC_OR_SITE']; // 'utc' or 'site' 
-    } 
-    
+       $dt ['DOWNTIME'] ['DEFINE_TZ_BY_UTC_OR_SITE'] = $_REQUEST ['DEFINE_TZ_BY_UTC_OR_SITE']; // 'utc' or 'site'
+    }
+
     $dt ['IMPACTED_IDS'] = $_REQUEST ['IMPACTED_IDS'];
     if (! isset($_REQUEST ['IMPACTED_IDS'])){
         throw new Exception('Error - No endpoints or services selected, downtime must affect at least one endpoint');
     }
-    
+
     //Get the previous downtimes ID if we are doing an edit
     if(isset($_REQUEST['DOWNTIME_ID'])){
-        $dt['DOWNTIME']['EXISTINGID'] = $_REQUEST['DOWNTIME_ID']; 
+        $dt['DOWNTIME']['EXISTINGID'] = $_REQUEST['DOWNTIME_ID'];
     }
-    
+
     return $dt;
 }
 
@@ -548,7 +548,7 @@ function getDtDataFromWebOld() {
     $dt['DOWNTIME']['START_TIMESTAMP'] = $_REQUEST['START_TIMESTAMP'];
     $dt['DOWNTIME']['END_TIMESTAMP'] = $_REQUEST['END_TIMESTAMP'];
     if(!isset($_REQUEST['Impacted_SEs'])){
-        throw new Exception('Error - No service selected, downtime must affect at least one service'); 
+        throw new Exception('Error - No service selected, downtime must affect at least one service');
     }
     $dt['Impacted_SEs'] = $_REQUEST['Impacted_SEs'];
     if(isset($_REQUEST['ID'])) {
@@ -567,13 +567,13 @@ function getSpDataFromWeb() {
     if (isset($_REQUEST ['PROP'])){
         $sp ['SITEPROPERTIES'] ['PROP'] = $_REQUEST ['PROP'];
     }
-        
+
         if(isset($sp['SITEPROPERTIES']['NAME'])){
-        $sp['SITEPROPERTIES']['NAME'] = trim($sp['SITEPROPERTIES']['NAME']); 
+        $sp['SITEPROPERTIES']['NAME'] = trim($sp['SITEPROPERTIES']['NAME']);
     }
     if(isset($sp['SITEPROPERTIES']['VALUE'])){
-        $sp['SITEPROPERTIES']['VALUE'] = trim($sp['SITEPROPERTIES']['VALUE']); 
-    }        
+        $sp['SITEPROPERTIES']['VALUE'] = trim($sp['SITEPROPERTIES']['VALUE']);
+    }
     return $sp;
 }
 
@@ -588,31 +588,31 @@ function getSerPropDataFromWeb() {
         $sp ['SERVICEPROPERTIES'] ['PROP'] = trim($_REQUEST ['PROP']);
     }
     if(isset($sp['SERVICEPROPERTIES']['NAME'])){
-        $sp['SERVICEPROPERTIES']['NAME'] = trim($sp['SERVICEPROPERTIES']['NAME']); 
+        $sp['SERVICEPROPERTIES']['NAME'] = trim($sp['SERVICEPROPERTIES']['NAME']);
     }
     if(isset($sp['SERVICEPROPERTIES']['VALUE'])){
-         $sp['SERVICEPROPERTIES']['VALUE'] = trim($sp['SERVICEPROPERTIES']['VALUE']); 
-    }        
+         $sp['SERVICEPROPERTIES']['VALUE'] = trim($sp['SERVICEPROPERTIES']['VALUE']);
+    }
     return $sp;
 }
 
 /**
- * Gets the endpoint properties data passed by user 
+ * Gets the endpoint properties data passed by user
  */
 function getEndpointPropDataFromWeb() {
-    $sp = array(); 
+    $sp = array();
     if (isset($_REQUEST ['PROP'])){
         $sp ['ENDPOINTPROPERTIES'] ['PROP'] = trim($_REQUEST ['PROP']);
     }
     if(isset($_REQUEST ['ENDPOINTID'])){
-        $sp['ENDPOINTPROPERTIES']['ENDPOINTID'] = trim($_REQUEST ['ENDPOINTID']); 
+        $sp['ENDPOINTPROPERTIES']['ENDPOINTID'] = trim($_REQUEST ['ENDPOINTID']);
     }
     if(isset($_REQUEST ['KEYPAIRNAME'])){
-        $sp['ENDPOINTPROPERTIES']['NAME'] = trim($_REQUEST ['KEYPAIRNAME']); 
+        $sp['ENDPOINTPROPERTIES']['NAME'] = trim($_REQUEST ['KEYPAIRNAME']);
     }
     if(isset($_REQUEST ['KEYPAIRVALUE'])){
-         $sp['ENDPOINTPROPERTIES']['VALUE'] = trim($_REQUEST ['KEYPAIRVALUE']); 
-    }        
+         $sp['ENDPOINTPROPERTIES']['VALUE'] = trim($_REQUEST ['KEYPAIRVALUE']);
+    }
     return $sp;
 }
 
@@ -655,7 +655,7 @@ function getDateFormat() {
 
 /**
  * Gets the submitted post data for the addition or editing of a scope
- * 
+ *
  * @global array $_REQUEST array containg the post data
  * @return array
  */
@@ -665,13 +665,13 @@ function getScopeDataFromWeb() {
     if (array_key_exists('Id', $_REQUEST)){
         $scopeData ['Id'] = $_REQUEST ['Id'];
     }
-    
+
     return $scopeData;
 }
 
 /**
  * Gets the submitted post data for the addition or editing of a service type
- * 
+ *
  * @global array $_REQUEST array containg the post data
  * @return array $serviceTypeData an array containg the new site data
  */
@@ -681,6 +681,6 @@ function getSTDataFromWeb() {
     if (array_key_exists('ID', $_REQUEST)){
         $serviceTypeData ['ID'] = $_REQUEST ['ID'];
     }
-    
+
     return $serviceTypeData;
 }

--- a/htdocs/web_portal/index.php
+++ b/htdocs/web_portal/index.php
@@ -19,31 +19,31 @@
  * limitations under the License.
  *
  /*====================================================== */
-//phpinfo(); 
-//die(); 
+//phpinfo();
+//die();
 require_once __DIR__ . "/../../lib/Doctrine/bootstrap.php";
 require_once __DIR__.'/../../lib/Gocdb_Services/Factory.php';
-// Require GocContextPath which is used in most of the views scripts 
+// Require GocContextPath which is used in most of the views scripts
 require_once __DIR__.'/GocContextPath.php';
 
 // Set the timezone
 date_default_timezone_set("UTC");
 
 /**
- * Safely escape and return the data string (xss mitigation function). 
- * The string is esacped using htmlspecialchars.  
- * @see see https://www.owasp.org/index.php/PHP_Security_Cheat_Sheet  
+ * Safely escape and return the data string (xss mitigation function).
+ * The string is esacped using htmlspecialchars.
+ * @see see https://www.owasp.org/index.php/PHP_Security_Cheat_Sheet
  * @param string $data to encode
  * @param string $encoding
  * @return string
  */
 function xssafe($data,$encoding='UTF-8') {
    //return htmlspecialchars($data,ENT_QUOTES | ENT_HTML401,$encoding);
-    return htmlspecialchars($data); 
+    return htmlspecialchars($data);
 }
 /**
- * Safely escape then echo the given string (xss mitigation function).  
- * @see see https://www.owasp.org/index.php/PHP_Security_Cheat_Sheet  
+ * Safely escape then echo the given string (xss mitigation function).
+ * @see see https://www.owasp.org/index.php/PHP_Security_Cheat_Sheet
  * @param string $data to encode
  */
 function xecho($data) {
@@ -56,24 +56,24 @@ $Page_Type = Get_Page_Type();
 require_once __DIR__ . '/components/Get_User_Principle.php';
 
 /**
- * Dies if the request can't be authenticated. 
- * @param string $message If not specified, a default message is used. 
+ * Dies if the request can't be authenticated.
+ * @param string $message If not specified, a default message is used.
  */
 function rejectIfNotAuthenticated($message = null){
-    $authPrincipleStr = Get_User_Principle(); 
+    $authPrincipleStr = Get_User_Principle();
     if(empty($authPrincipleStr)){
-        // prob better to do a re-direct here to error page. 
+        // prob better to do a re-direct here to error page.
         if($message == null){
-            die('Access Denined, authentication failed - A valid user certificate was not found'); 
-            //or your EGI SSO user account is not associated with a valid certificate.'); 
+            die('Access Denined, authentication failed - A valid user certificate was not found');
+            //or your EGI SSO user account is not associated with a valid certificate.');
         } else {
-            die($message); 
+            die($message);
         }
-    }  
+    }
 }
-// Uncomment to invoke for any page (can instead do this selectively 
-// on per-page basis as below) 
-//rejectIfNotAuthenticated(); 
+// Uncomment to invoke for any page (can instead do this selectively
+// on per-page basis as below)
+//rejectIfNotAuthenticated();
 
 try {
     Draw_Page($Page_Type);
@@ -96,19 +96,19 @@ function Get_Page_Type() {
 
 /* Decides which type of page to draw based on the passed $Page_Type */
 function Draw_Page($Page_Type) {
-    
-    // Read only pages - these pages don't strictly require user authentication. 
-    // Therefore, to enable permit-all page viewing, comment out the call 
-    // to rejectIfNotAuthenticated() in the relevant case block. Note, some of 
-    // these pages will replace sensitive info such as telephone/email with 
-    // the string 'PROTECTED'   
+
+    // Read only pages - these pages don't strictly require user authentication.
+    // Therefore, to enable permit-all page viewing, comment out the call
+    // to rejectIfNotAuthenticated() in the relevant case block. Note, some of
+    // these pages will replace sensitive info such as telephone/email with
+    // the string 'PROTECTED'
     // ************************************************************************
     switch($Page_Type) {
         case "default" :
             //rejectIfNotAuthenticated();
             require_once __DIR__.'/controllers/start_page.php';
             startPage();
-            break; 
+            break;
         case "View_Service_Endpoint" :
             //rejectIfNotAuthenticated();
             require_once __DIR__ . '/controllers/service/view_service_endpoint.php';
@@ -190,183 +190,183 @@ function Draw_Page($Page_Type) {
     case "View_Role_Action_Mappings":
             //rejectIfNotAuthenticated();
         require_once __DIR__.'/controllers/political_role/view_role_action_mappings.php';
-        view_role_action_mappings(); 
+        view_role_action_mappings();
         break;
 
 
-        // CrUD Pages - These pages MUST have authentication enabled so  
-        // the calls to rejectIfNotAuthenticated() must be used. 
+        // CrUD Pages - These pages MUST have authentication enabled so
+        // the calls to rejectIfNotAuthenticated() must be used.
         // *********************************************************************
         case "Revoke_Role":
-            rejectIfNotAuthenticated(); 
+            rejectIfNotAuthenticated();
             require_once __DIR__.'/controllers/political_role/revoke_request.php';
             view_revoke_request();
             break;
         case "Accept_Role_Request":
-            rejectIfNotAuthenticated(); 
+            rejectIfNotAuthenticated();
             require_once __DIR__.'/controllers/political_role/accept_request.php';
             view_accept_request();
             break;
         case "Deny_Role_Request":
-            rejectIfNotAuthenticated(); 
+            rejectIfNotAuthenticated();
             require_once __DIR__.'/controllers/political_role/deny_request.php';
             view_deny_request();
             break;
         case "Role_Requests":
-            rejectIfNotAuthenticated(); 
+            rejectIfNotAuthenticated();
             require_once __DIR__.'/controllers/political_role/view_requests.php';
             view_requests();
             break;
         case "Request_Role":
-            rejectIfNotAuthenticated(); 
+            rejectIfNotAuthenticated();
             require_once __DIR__.'/controllers/political_role/request_role.php';
             request_role();
             break;
         case "Edit_Site":
-            rejectIfNotAuthenticated(); 
+            rejectIfNotAuthenticated();
             require_once __DIR__.'/controllers/site/edit_site.php';
             edit_site();
             break;
         case "Edit_Service":
-            rejectIfNotAuthenticated(); 
+            rejectIfNotAuthenticated();
             require_once __DIR__.'/controllers/service/edit_service.php';
             edit_service();
             break;
         case "SE_Downtimes":
-            rejectIfNotAuthenticated(); 
+            rejectIfNotAuthenticated();
             require_once __DIR__.'/controllers/service/se_downtimes.php';
             se_downtimes();
             break;
         case "Add_Service":
-            rejectIfNotAuthenticated(); 
+            rejectIfNotAuthenticated();
             require_once __DIR__.'/controllers/service/add_service.php';
             add_service();
             break;
         case "Add_Service_Endpoint":
-            rejectIfNotAuthenticated(); 
+            rejectIfNotAuthenticated();
             require_once __DIR__.'/controllers/service/add_service_endpoint.php';
             add_service_endpoint();
-            break;        	
+            break;
         case "Delete_Service":
-            rejectIfNotAuthenticated(); 
+            rejectIfNotAuthenticated();
             require_once __DIR__.'/controllers/service/delete_service.php';
             delete();
             break;
         case "Edit_User":
-            rejectIfNotAuthenticated(); 
+            rejectIfNotAuthenticated();
             require_once __DIR__.'/controllers/user/edit_user.php';
             edit_user();
             break;
         case "User":
-            rejectIfNotAuthenticated(); 
+            rejectIfNotAuthenticated();
             require_once __DIR__.'/controllers/user/view_user.php';
             view_user();
             break;
         case "Downtime":
-            rejectIfNotAuthenticated(); 
+            rejectIfNotAuthenticated();
             require_once __DIR__.'/controllers/downtime/view_downtime.php';
             view();
             break;
         case "My_Sites":
-            rejectIfNotAuthenticated(); 
+            rejectIfNotAuthenticated();
             require_once __DIR__.'/controllers/my_sites.php';
             my_sites();
             break;
         case "Edit_NGI":
-            rejectIfNotAuthenticated(); 
+            rejectIfNotAuthenticated();
             require_once __DIR__.'/controllers/ngi/edit_ngi.php';
             edit_ngi();
             break;
         case "Edit_Service_Group":
-            rejectIfNotAuthenticated(); 
+            rejectIfNotAuthenticated();
             require_once __DIR__.'/controllers/service_group/edit_service_group.php';
             edit_service_group();
             break;
         case "Add_Service_Group_SEs":
-            rejectIfNotAuthenticated(); 
+            rejectIfNotAuthenticated();
             require_once __DIR__.'/controllers/service_group/add_ses.php';
             add_ses();
             break;
         case "Search_SEs":
-            rejectIfNotAuthenticated(); 
+            rejectIfNotAuthenticated();
             require_once __DIR__.'/controllers/service_group/search_ses.php';
             search_ses();
             break;
         case "Remove_Service_Group_SEs":
-            rejectIfNotAuthenticated(); 
+            rejectIfNotAuthenticated();
             require_once __DIR__.'/controllers/service_group/remove_ses.php';
             remove_ses();
             break;
         case "Add_Site":
-            rejectIfNotAuthenticated(); 
+            rejectIfNotAuthenticated();
             require_once __DIR__.'/controllers/site/add_site.php';
             add_site();
             break;
         case "SGroup_Downtimes":
-            rejectIfNotAuthenticated(); 
+            rejectIfNotAuthenticated();
             require_once __DIR__.'/controllers/service_group/view_sgroup_downtimes.php';
             view_sgroup_downtimes();
             break;
         case "Add_Service_Group":
-            rejectIfNotAuthenticated(); 
+            rejectIfNotAuthenticated();
             require_once __DIR__.'/controllers/service_group/add_service_group.php';
             add_service_group();
             break;
         case "Site_Downtimes":
-            rejectIfNotAuthenticated(); 
+            rejectIfNotAuthenticated();
             require_once __DIR__.'/controllers/site/site_downtimes.php';
             site_downtimes();
             break;
         case "Register":
             rejectIfNotAuthenticated('Access denied - '
-                    . 'you need to be pre-authenticated before you can register a new account'); 
+                    . 'you need to be pre-authenticated before you can register a new account');
             require_once __DIR__.'/controllers/user/register.php';
             register();
             break;
         case "Add_Downtime":
-            rejectIfNotAuthenticated(); 
+            rejectIfNotAuthenticated();
             require_once __DIR__.'/controllers/downtime/add_downtime.php';
             //require_once __DIR__.'/controllers/downtime/add_downtime_old.php';
             add();
             break;
         case "Edit_Downtime":
-            rejectIfNotAuthenticated(); 
+            rejectIfNotAuthenticated();
             require_once __DIR__.'/controllers/downtime/edit_downtime.php';
             //require_once __DIR__.'/controllers/downtime/edit_downtime_old.php';
             edit();
             break;
         case "End_Downtime":
-            rejectIfNotAuthenticated(); 
+            rejectIfNotAuthenticated();
             require_once __DIR__.'/controllers/downtime/end_downtime.php';
             endDt();
             break;
         case "Downtime_view_endpoint_tree":
-            rejectIfNotAuthenticated(); 
+            rejectIfNotAuthenticated();
             require_once __DIR__.'/controllers/downtime/view_endpoint_tree.php';
             getServiceandEndpointList();
             break;
         case "Edit_Downtime_view_endpoint_tree":
-            rejectIfNotAuthenticated(); 
+            rejectIfNotAuthenticated();
             require_once __DIR__.'/controllers/downtime/view_endpoint_tree.php';
             editDowntimePopulateEndpointTree();
             break;
         case "Downtime_View_Services":
-            rejectIfNotAuthenticated(); 
+            rejectIfNotAuthenticated();
             require_once __DIR__.'/controllers/downtime/view_services.php';
             getSitesServices();
-            break; 
+            break;
         case "Delete_Site":
-            rejectIfNotAuthenticated(); 
+            rejectIfNotAuthenticated();
             require_once __DIR__.'/controllers/site/delete_site.php';
             delete();
             break;
         case "Delete_Downtime":
-            rejectIfNotAuthenticated(); 
+            rejectIfNotAuthenticated();
             require_once __DIR__.'/controllers/downtime/delete_downtime.php';
             delete();
             break;
         case "Downtimes_Overview":
-            rejectIfNotAuthenticated(); 
+            rejectIfNotAuthenticated();
             require_once __DIR__.'/controllers/downtime/downtimes_overview.php';
             view();
             break;
@@ -376,142 +376,142 @@ function Draw_Page($Page_Type) {
             view();
             break;
         case "Delete_Service_Group":
-            rejectIfNotAuthenticated(); 
+            rejectIfNotAuthenticated();
             require_once __DIR__.'/controllers/service_group/delete_service_group.php';
             delete();
             break;
         case "Delete_User":
-            rejectIfNotAuthenticated(); 
+            rejectIfNotAuthenticated();
             require_once __DIR__.'/controllers/user/delete_user.php';
             delete();
             break;
         case "Edit_Certification_Status":
-            rejectIfNotAuthenticated(); 
+            rejectIfNotAuthenticated();
             require_once __DIR__.'/controllers/site/edit_cert_status.php';
             edit();
             break;
         case "Retrieve_Account":
-            rejectIfNotAuthenticated(); 
+            rejectIfNotAuthenticated();
             require_once __DIR__.'/controllers/user/retrieve_account.php';
             retrieve();
             break;
         case "Remove_Project_NGIs":
-            rejectIfNotAuthenticated(); 
+            rejectIfNotAuthenticated();
             require_once __DIR__.'/controllers/project/remove_ngis.php';
             remove_ngis_project();
             break;
         case "Add_Project_NGIs":
-            rejectIfNotAuthenticated(); 
+            rejectIfNotAuthenticated();
             require_once __DIR__.'/controllers/project/add_ngis.php';
             add_ngis_to_project();
             break;
         case "Edit_Project":
-            rejectIfNotAuthenticated(); 
+            rejectIfNotAuthenticated();
             require_once __DIR__.'/controllers/project/edit_project.php';
             edit_project();
             break;
         case "Delete_Project":
-            rejectIfNotAuthenticated(); 
+            rejectIfNotAuthenticated();
             require_once __DIR__.'/controllers/project/delete_project.php';
             delete_project();
             break;
         case "Admin_Move_Site":
-            rejectIfNotAuthenticated(); 
+            rejectIfNotAuthenticated();
             require_once __DIR__.'/controllers/admin/move_site.php';
             move_site();
             break;
         case "Admin_Move_SEP":
-            rejectIfNotAuthenticated(); 
+            rejectIfNotAuthenticated();
             require_once __DIR__.'/controllers/admin/move_service_end_point.php';
             move_service_end_point();
             break;
         case "Admin_Service_Types":
-            rejectIfNotAuthenticated(); 
+            rejectIfNotAuthenticated();
             require_once __DIR__.'/controllers/admin/view_service_types.php';
             show_all();
             break;
         case "Admin_Service_Type":
-            rejectIfNotAuthenticated(); 
+            rejectIfNotAuthenticated();
             require_once __DIR__.'/controllers/admin/view_service_type.php';
             view_service_type();
             break;
         case "Admin_Edit_Service_Type":
-            rejectIfNotAuthenticated(); 
+            rejectIfNotAuthenticated();
             require_once __DIR__.'/controllers/admin/edit_service_type.php';
             edit_type();
             break;
         case "Admin_Add_Service_Type":
-            rejectIfNotAuthenticated(); 
+            rejectIfNotAuthenticated();
             require_once __DIR__.'/controllers/admin/add_service_type.php';
             add_type();
             break;
         case "Admin_Delete_Service_Type":
-            rejectIfNotAuthenticated(); 
+            rejectIfNotAuthenticated();
             require_once __DIR__.'/controllers/admin/delete_service_type.php';
             delete_service_type();
             break;
         case "Admin_Delete_Service_Type_Denied":
-            rejectIfNotAuthenticated(); 
+            rejectIfNotAuthenticated();
             require_once __DIR__.'/controllers/admin/delete_service_type_denied.php';
             deny_delete_type();
             break;
         case "Admin_Add_NGI":
-            rejectIfNotAuthenticated(); 
+            rejectIfNotAuthenticated();
             require_once __DIR__.'/controllers/admin/add_ngi.php';
             add_ngi();
             break;
         case "Admin_Users":
-            rejectIfNotAuthenticated(); 
+            rejectIfNotAuthenticated();
             require_once __DIR__.'/controllers/admin/users.php';
             show_users();
             break;
         case "Admin_Edit_User_DN":
-            rejectIfNotAuthenticated(); 
+            rejectIfNotAuthenticated();
             require_once __DIR__.'/controllers/admin/edit_user_dn.php';
             edit_dn();
             break;
 //        case "Admin_Change_User_Admin_Status":
-//            rejectIfNotAuthenticated(); 
+//            rejectIfNotAuthenticated();
 //            require_once __DIR__.'/controllers/admin/edit_user_isadmin.php';
 //            make_admin();
 //            break;
         case "Admin_Add_Project":
-            rejectIfNotAuthenticated(); 
+            rejectIfNotAuthenticated();
             require_once __DIR__.'/controllers/admin/add_project.php';
             add_project();
             break;
         case "Admin_Scopes":
-            rejectIfNotAuthenticated(); 
+            rejectIfNotAuthenticated();
             require_once __DIR__.'/controllers/admin/scopes.php';
             show_scopes();
             break;
         case "Admin_Remove_Scope":
-            rejectIfNotAuthenticated(); 
+            rejectIfNotAuthenticated();
             require_once __DIR__.'/controllers/admin/delete_scope.php';
             remove_scope();
             break;
         case "Admin_Add_Scope":
-            rejectIfNotAuthenticated(); 
+            rejectIfNotAuthenticated();
             require_once __DIR__.'/controllers/admin/add_scope.php';
             add_scope();
             break;
         case "Admin_Scope":
-            rejectIfNotAuthenticated(); 
+            rejectIfNotAuthenticated();
             require_once __DIR__.'/controllers/admin/scope.php';
             view_scope();
             break;
         case "Admin_Edit_Scope":
-            rejectIfNotAuthenticated(); 
+            rejectIfNotAuthenticated();
             require_once __DIR__.'/controllers/admin/edit_scope.php';
             edit_scope();
             break;
         case "Admin_Delete_NGI":
-            rejectIfNotAuthenticated(); 
+            rejectIfNotAuthenticated();
             require_once __DIR__.'/controllers/admin/delete_ngi.php';
             delete_ngi();
             break;
         case "User_Validate_DN_Change" :
-            rejectIfNotAuthenticated(); 
+            rejectIfNotAuthenticated();
             require_once __DIR__ . '/controllers/user/retrieve_account_user_validate.php';
             validate_dn_change ();
             break;
@@ -571,27 +571,27 @@ function Draw_Page($Page_Type) {
             delete ();
             break;
         case "Edit_Site_Property" :
-            rejectIfNotAuthenticated(); 
+            rejectIfNotAuthenticated();
             require_once __DIR__ . '/controllers/site/edit_site_property.php';
             edit_property ();
             break;
         case "Edit_Service_Property" :
-            rejectIfNotAuthenticated(); 
+            rejectIfNotAuthenticated();
             require_once __DIR__ . '/controllers/service/edit_service_property.php';
             edit_property ();
-            break;        	
+            break;
         case "Edit_Endpoint_Property" :
-            rejectIfNotAuthenticated(); 
+            rejectIfNotAuthenticated();
             require_once __DIR__ . '/controllers/service/edit_endpoint_property.php';
             edit_property ();
-            break;      
+            break;
         case "Add_Service_Group_Properties" :
             rejectIfNotAuthenticated();
             require_once __DIR__ . '/controllers/service_group/add_service_group_properties.php';
             add_service_group_properties ();
             break;
         case "Edit_Service_Group_Property" :
-            rejectIfNotAuthenticated(); 
+            rejectIfNotAuthenticated();
             require_once __DIR__ . '/controllers/service_group/edit_service_group_property.php';
             edit_property ();
             break;
@@ -601,18 +601,18 @@ function Draw_Page($Page_Type) {
             delete ();
             break;
         case "Delete_Service_Endpoint" :
-            rejectIfNotAuthenticated(); 
+            rejectIfNotAuthenticated();
             require_once __DIR__ . '/controllers/service/delete_service_endpoint.php';
             delete_endpoint();
             break;
         case "Edit_Service_Endpoint" :
-            rejectIfNotAuthenticated(); 
+            rejectIfNotAuthenticated();
             require_once __DIR__ . '/controllers/service/edit_service_endpoint.php';
             edit_endpoint();
-            break;                     
+            break;
         default:
-            // require auth by default 
-            rejectIfNotAuthenticated(); 
+            // require auth by default
+            rejectIfNotAuthenticated();
             require_once __DIR__.'/controllers/start_page.php';
             startPage();
             break;

--- a/htdocs/web_portal/static_php/standard_header.php
+++ b/htdocs/web_portal/static_php/standard_header.php
@@ -1,6 +1,6 @@
-<?php 
+<?php
 function get_standard_header($title = null) {
- 
+
     $header = '<!doctype html>
     <html>
         <head>

--- a/htdocs/web_portal/views/admin/add_ngi.php
+++ b/htdocs/web_portal/views/admin/add_ngi.php
@@ -3,33 +3,33 @@
     <br />
         When adding an NGI, please <b>also add a relevant image file</b> (usually a national flag)
         to web_portal/img/ngi/fullsize with the same name as the NGI and '.jpg' file
-        extension. A smaller copy with the same name should be placed in 
+        extension. A smaller copy with the same name should be placed in
         web_portal/img/ngi, this smaller image should not exceed width:28px, height:25px.
     <br />
     <br />
     <form class="inputForm" method="post" action="index.php?Page_Type=Admin_Add_NGI" name="addNGI">
-        
+
         <span class="input_name">Name
             <span class="input_syntax">(Unique name)</span>
         </span>
         <input type="text" value="" name="NAME" class="input_input_text">
-        
-        <span class="input_name">Management contact/mailing list 
+
+        <span class="input_name">Management contact/mailing list
             <span class="input_syntax">(valid email format)</span>
         </span>
         <input class="input_input_text" type="text" name="EMAIL" value="">
-        
+
         <span class="input_name">Helpdesk / Mailing list for GGUS tickets
             <span class="input_syntax">(valid email format)</span>
         </span>
         <input class="input_input_text" type="text" name="HELPDESK_EMAIL" value="">
-        
+
         <span class="input_name">ROD Mailing list
             <span class="input_syntax">(valid email format)</span>
         </span>
         <input class="input_input_text" type="text" name="ROD_EMAIL" value="">
-        
-        <span class="input_name">Security contact / mailing list 
+
+        <span class="input_name">Security contact / mailing list
             <span class="input_syntax">(valid email format)</span>
         </span>
         <input class="input_input_text" type="text" name="SECURITY_EMAIL" value="">
@@ -38,16 +38,16 @@
             <span class="input_syntax"></span>
         </span>
         <input class="input_input_text" type="text" name="GGUS_SU" value="">
-       
-        
+
+
         <br/>
         <br/>
         <!-- Scope Tags-->
-        <?php 
-        $parentObjectTypeLabel = 'Project'; 
+        <?php
+        $parentObjectTypeLabel = 'Project';
         require_once __DIR__ . '/../fragments/editScopesFragment.php';
         ?>
-        
+
         <br />
         <input type="submit" value="Add NGI" class="input_button">
     </form>
@@ -60,11 +60,11 @@
 
     $(document).ready(function () {
         var scopeJSON = JSON.parse('<?php echo($params["scopejson"]) ?>');
-        ScopeUtil.addScopeCheckBoxes(scopeJSON, 
+        ScopeUtil.addScopeCheckBoxes(scopeJSON,
             '#reservedScopeCheckBoxDIV',
-            '#reservedOptionalScopeCheckBoxDIV', 
+            '#reservedOptionalScopeCheckBoxDIV',
             '#reservedOptionalInhertiableScopeCheckBoxDIV',
-            '#optionalScopeCheckBoxDIV', 
+            '#optionalScopeCheckBoxDIV',
             true);
     });
-</script> 
+</script>

--- a/htdocs/web_portal/views/admin/added_ngi.php
+++ b/htdocs/web_portal/views/admin/added_ngi.php
@@ -2,7 +2,7 @@
     <h1 class="Success">Success</h1><br />
     <br />
     <a href="index.php?Page_Type=NGI&id=<?php echo $params['ID'] ?>">
-    <?php xecho($params['Name'])?> 
+    <?php xecho($params['Name'])?>
     </a> has been successfully added as a new NGI.
     <br />
     <br />
@@ -10,6 +10,6 @@
     to web_portal/img/ngi/fullsize with the name '<?php xecho($params['Name'])?>.jpg'.
     A smaller copy with the same name should be placed in web_portal/img/ngi,
     this smaller image should not exceed width:28px, height:25px.
-        
+
 </div>
 

--- a/htdocs/web_portal/views/admin/added_project.php
+++ b/htdocs/web_portal/views/admin/added_project.php
@@ -1,13 +1,13 @@
 <div class="rightPageContainer">
     <h1 class="Success">Success</h1><br />
-    
+
     <?php xecho($params['Name'])?> has been successfully added as a new project.
     <br />
     <br />
     <a href="index.php?Page_Type=Project&id=<?php echo $params['ID'] ?>">
      Click here</a> to view the <?php xecho($params['Name'])?> project and add NGIs
      to it.
-     
-        
+
+
 </div>
 

--- a/htdocs/web_portal/views/admin/added_scope.php
+++ b/htdocs/web_portal/views/admin/added_scope.php
@@ -1,12 +1,12 @@
 <div class="rightPageContainer">
     <h1 class="Success">Success</h1><br />
-    
+
     <?php xecho($params['Name'])?> has been successfully added as a new scope.
     <br />
     <br />
     <a href="index.php?Page_Type=Admin_Scope&id=<?php echo $params['ID'] ?>">
      Click here</a> to view the <?php xecho($params['Name'])?> scope.
-     
-        
+
+
 </div>
 

--- a/htdocs/web_portal/views/admin/added_service_type.php
+++ b/htdocs/web_portal/views/admin/added_service_type.php
@@ -1,14 +1,14 @@
 <div class="rightPageContainer">
     <h1 class="Success">Success</h1><br />
-    
+
     <?php xecho($params['Name'])?> has been successfully added as a new service
     type with the following description: "<?php xecho($params['Description'])?>".
     <br />
     <br />
     <a href="index.php?Page_Type=Admin_Service_Type&id=<?php echo $params['ID'] ?>">
      Click here</a> to view the <?php xecho($params['Name'])?> service type.
-     
-        
+
+
 </div>
 
 

--- a/htdocs/web_portal/views/admin/delete_ngi.php
+++ b/htdocs/web_portal/views/admin/delete_ngi.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 $ngi = $params['NGI'];
 $ngiName = $ngi->getName();
 $ngiId = $ngi->getId();
@@ -12,39 +12,39 @@ $sites = $params['Sites'];
         Are you sure you want to delete the NGI '
         <a href="index.php?Page_Type=NGI&id=<?php echo $ngiId;?>">
             <?php xecho($ngiName);?>
-        </a>'? Deleting NGIs is a functionality reserved for GOCDB administrators 
+        </a>'? Deleting NGIs is a functionality reserved for GOCDB administrators
         and should. be undertaken with caution.
     </p>
     <p>
         If you delete <?php xecho($ngiName); ?>, the following sites will be deleted as well:
-        <?php 
+        <?php
             foreach($sites as $site){
                 echo "<br />"
                     . "<a href=\"index.php?Page_Type=Site&id=" . $site->getId() ."\">"
                     .  xssafe($site->getName())
                     . "</a> ";
-            }	
+            }
         ?>
     </p>
     <p>
         As a consequence, the following services will be deleted as well:
-        <?php 
+        <?php
             foreach($services as $service){
                 echo "<br />"
                     . "<a href=\"index.php?Page_Type=Service&id=" . $service->getId() ."\">"
                     .  xssafe($service->getHostName()) . " (" . xssafe($service->getServiceType()->getName()) . ")"
                     . "</a> ";
-            }	
+            }
         ?>
     </p>
     <p>
-        Any down times associated with these services, and only these services, 
+        Any down times associated with these services, and only these services,
         will also be removed from GOCDB.
     </p>
     <p>
         Are you sure you wish to continue?
     </p>
-    
+
     <form class="inputForm" method="post" action="index.php?Page_Type=Admin_Delete_NGI&id=<?php echo $ngiId;?>" name="RemoveScope">
         <input class="input_input_hidden" type="hidden" name="UserConfirmed" value="true" />
         <input type="submit" value="Remove this NGI and all its associated sites and services from GOCDB" class="input_button">

--- a/htdocs/web_portal/views/admin/delete_scope_denied.php
+++ b/htdocs/web_portal/views/admin/delete_scope_denied.php
@@ -6,55 +6,55 @@
 
 <div class="rightPageContainer">
     <h1 class="Success">Scope In Use</h1><br />
-    The scope ' 
+    The scope '
     <a href="index.php?Page_Type=Admin_Scope&id=<?php echo $scopeId;?>">
         <?php xecho($params['Name']);?>
-    </a>' 
-    is currently in use. If you are absolutely sure you still want to delete it, 
+    </a>'
+    is currently in use. If you are absolutely sure you still want to delete it,
     a deletion button can be found at the bottom of the page.
     <br />
     <br />
     The following NGIs are currently tagged with this scope:
-    <?php 
+    <?php
         foreach($ngis as $ngi){
             echo "<br />"
                 . "<a href=\"index.php?Page_Type=NGI&id=" . $ngi->getId() ."\">"
                 .  xssafe($ngi->getName())
                 . "</a> ";
-        }	
+        }
     ?>
     <br />
     <br />
     The following sites are currently tagged with this scope:
-    <?php 
+    <?php
         foreach($sites as $site){
             echo "<br />"
                 . "<a href=\"index.php?Page_Type=Site&id=" . $site->getId() ."\">"
                 .  xssafe($site->getShortName())
                 . "</a> ";
-        }	
+        }
     ?>
     <br />
     <br />
     The following service groups are currently tagged with this scope:
-    <?php 
+    <?php
         foreach($sGroups as $sGroup){
             echo "<br />"
                 . "<a href=\"index.php?Page_Type=Service_Group&id=" . $sGroup->getId() ."\">"
                 .  xssafe($sGroup->getName())
                 . "</a> ";
-        }	
+        }
     ?>
     <br />
     <br />
     The following services are currently tagged with this scope:
-    <?php 
+    <?php
         foreach($sEndpoints as $sEndpoint){
             echo "<br />"
                 . "<a href=\"index.php?Page_Type=Service&id=" . $sEndpoint->getId() ."\">"
                 .  xssafe($sEndpoint->getHostName())
                 . "</a> ";
-        }	
+        }
     ?>
     <br />
     <br />

--- a/htdocs/web_portal/views/admin/delete_service_type_denied.php
+++ b/htdocs/web_portal/views/admin/delete_service_type_denied.php
@@ -2,21 +2,21 @@
 
 <div class="rightPageContainer">
     <h1 class="Success">Deletion Failed</h1><br />
-    The service type ' 
+    The service type '
     <a href="index.php?Page_Type=Admin_Service_Type&id=<?php echo $serviceType->getId();?>">
     <?php xecho($serviceType->getName());?>
-    </a>' 
+    </a>'
     can not be deleted as the following services are still of this type:
-    <?php 
+    <?php
         foreach($params['Services'] as $sep){
             echo "<br />"
                 . "<a href=\"index.php?Page_Type=Service&id=" . $sep->getId() ."\">"
                 .  xssafe($sep->getHostName())
                 . "</a> ";
-        }	
+        }
     ?>
     <br>
     <br>
-    These services will need their service type changing before the 
+    These services will need their service type changing before the
     service type can be deleted.
 </div>

--- a/htdocs/web_portal/views/admin/deleted_ngi.php
+++ b/htdocs/web_portal/views/admin/deleted_ngi.php
@@ -1,4 +1,4 @@
 <div class="rightPageContainer">
     <h1 class="Success">Deletion Successful</h1><br />
-    The NGI '<?php xecho($params['Name'])?>' and any associated sites and services have been successfully removed from GOCDB 
+    The NGI '<?php xecho($params['Name'])?>' and any associated sites and services have been successfully removed from GOCDB
 </div>

--- a/htdocs/web_portal/views/admin/deleted_scope.php
+++ b/htdocs/web_portal/views/admin/deleted_scope.php
@@ -1,4 +1,4 @@
 <div class="rightPageContainer">
     <h1 class="Success">Deletion Successful</h1><br />
-    The scope '<?php xecho($params['Name'])?>' has been successfully removed from GOCDB 
+    The scope '<?php xecho($params['Name'])?>' has been successfully removed from GOCDB
 </div>

--- a/htdocs/web_portal/views/admin/deleted_service_type.php
+++ b/htdocs/web_portal/views/admin/deleted_service_type.php
@@ -1,4 +1,4 @@
 <div class="rightPageContainer">
     <h1 class="Success">Deletion Successful</h1><br />
-    The service type '<?php xecho($params['Name'])?>' has been successfully removed from GOCDB 
+    The service type '<?php xecho($params['Name'])?>' has been successfully removed from GOCDB
 </div>

--- a/htdocs/web_portal/views/admin/edit_scope.php
+++ b/htdocs/web_portal/views/admin/edit_scope.php
@@ -6,7 +6,7 @@
         <input type="text" value="<?php xecho($params['Name']) ?>" name="Name" class="input_input_text">
         <span class="input_name">Description</span>
         <input type="text" value="<?php xecho($params['Description']) ?>" name="Description" class="input_input_text">
-        
+
         <br />
         <input class="input_input_hidden" type="hidden" name="Id" value="<?php echo $params['Id'] ?>" />
         <br />

--- a/htdocs/web_portal/views/admin/edit_service_type.php
+++ b/htdocs/web_portal/views/admin/edit_service_type.php
@@ -6,7 +6,7 @@
         <input type="text" value="<?php xecho($params['Name']) ?>" name="Name" class="input_input_text">
         <span class="input_name">Description</span>
         <input type="text" value="<?php xecho($params['Description']) ?>" name="Description" class="input_input_text">
-        
+
         <br />
         <input class="input_input_hidden" type="hidden" name="ID" value="<?php echo $params['ID'] ?>" />
         <br />

--- a/htdocs/web_portal/views/admin/edit_user_dn.php
+++ b/htdocs/web_portal/views/admin/edit_user_dn.php
@@ -2,7 +2,7 @@
     <h1>Update Certificate DN</h1>
     <br />
     <br />
-    The current certificate DN for 
+    The current certificate DN for
     <b><?php echo xssafe($params['Title']) ." ". xssafe($params['Forename']) ." ". xssafe($params['Surname']) ?></b>
     is:
     <br />

--- a/htdocs/web_portal/views/admin/edit_user_isadmin.php
+++ b/htdocs/web_portal/views/admin/edit_user_isadmin.php
@@ -9,14 +9,14 @@
     <br />
     <br />
     <script type="text/javascript" src="<?php echo \GocContextPath::getPath()?>javascript/confirm.js"></script>
-    
+
     <?php if($params['IsAdmin']): ?>
         <form class="inputForm" method="post" action="index.php?Page_Type=Admin_Change_User_Admin_Status" name="editisAdmin">
             <input class="input_input_hidden" type="hidden" name="IsAdmin" value="false" />
             <input class="input_input_hidden" type="hidden" name="ID" value="<?php echo $params['ID'] ?>" />
             <input type="submit" value="Remove <?php xecho($name) ?>'s GOCDB administrator status" class="input_button" onclick="return confirmSubmit()">
-        </form>    
-        
+        </form>
+
     <?php elseif(!$params['IsAdmin']): ?>
         <form class="inputForm" method="post" action="index.php?Page_Type=Admin_Change_User_Admin_Status" name="editisAdmin">
             <input class="input_input_hidden" type="hidden" name="IsAdmin" value="true" />

--- a/htdocs/web_portal/views/admin/edited_scope.php
+++ b/htdocs/web_portal/views/admin/edited_scope.php
@@ -2,9 +2,9 @@
     <h1 class="Success">Success</h1><br />
     <p>
        <a href="index.php?Page_Type=Admin_Scope&id=<?php echo $params['ID']?>">
-           <?php xecho($params['Name'])?> 
+           <?php xecho($params['Name'])?>
        </a> has been successfully edited as follows:
-    </p>    
+    </p>
     <p>
         Name: <?php xecho($params['Name'])?>
         <br />
@@ -13,7 +13,7 @@
     <p>
         <a href="index.php?Page_Type=Admin_Edit_Scope&id=<?php echo $params['ID']?>">
         Click here</a> to edit the <?php xecho($params['Name'])?> scope again.
-        
+
     </p>
 </div>
 

--- a/htdocs/web_portal/views/admin/edited_service_type.php
+++ b/htdocs/web_portal/views/admin/edited_service_type.php
@@ -2,7 +2,7 @@
     <h1 class="Success">Success</h1><br />
     <p>
        <a href="index.php?Page_Type=Admin_Service_Type&id=<?php echo $params['ID']?>"><?php xecho($params['Name'])?></a> has been successfully edited as follows:
-    </p>    
+    </p>
     <p>
         Name: <?php xecho($params['Name'])?>
         <br />
@@ -11,7 +11,7 @@
     <p>
         <a href="index.php?Page_Type=Admin_Edit_Service_Type&id=<?php echo $params['ID']?>">
         Click here</a> to edit the <?php xecho($params['Name'])?> service type again.
-        
+
     </p>
 </div>
 

--- a/htdocs/web_portal/views/admin/edited_user_dn.php
+++ b/htdocs/web_portal/views/admin/edited_user_dn.php
@@ -1,10 +1,10 @@
 <div class="rightPageContainer">
     <h1 class="Success">Success</h1><br />
-      
-    The certificate DN for 
+
+    The certificate DN for
     <a href="index.php?Page_Type=User&id=<?php echo $params['ID']?>">
-        <?php xecho($params['Name'])?> 
-    </a> has been successfully updated.   
+        <?php xecho($params['Name'])?>
+    </a> has been successfully updated.
 </div>
 
 

--- a/htdocs/web_portal/views/admin/edited_user_isadmin.php
+++ b/htdocs/web_portal/views/admin/edited_user_isadmin.php
@@ -1,10 +1,10 @@
 <div class="rightPageContainer">
     <h1 class="Success">Success</h1><br />
-    
+
     <a href="index.php?Page_Type=User&id=<?php echo $params['ID']?>">
-    <?php xecho($params['Name'])?>     
-    </a>  
-    is 
+    <?php xecho($params['Name'])?>
+    </a>
+    is
     <?php if($params['IsAdmin']){echo "now";}else{echo "no longer";} ?>
     a GOCDB administrator.
     <br>

--- a/htdocs/web_portal/views/admin/move_service_end_point.php
+++ b/htdocs/web_portal/views/admin/move_service_end_point.php
@@ -2,27 +2,27 @@
     <form name="Move_Service" action="index.php?Page_Type=Admin_Move_SEP" method="post" class="inputForm">
         <h1>Move Service</h1>
         <br />
-        
+
         <span class="input_name">New site for selected services</span>
         <select class="add_edit_form" name="NewSite">
             <?php
             foreach($params['Sites'] as $Site) {
                 echo "<option value=\"". $Site->getId() . "\">" . xssafe($Site->getShortName()). "</option>";
-            }	
+            }
             ?>
         </select>
-        
-        <span class="input_name">Please select the service(s) to be moved from 
+
+        <span class="input_name">Please select the service(s) to be moved from
             <?php xecho($params['OldSite'])?></span>
-        <select class="Downtime_Select" name="Services[]" size="20" 
+        <select class="Downtime_Select" name="Services[]" size="20"
          multiple id="Sites" style="margin-left: 0em; width: 38em;">
             <?php
                 foreach($params['Services'] as $sep) {
                 echo "<option value=\"". $sep->getId() . "\">" . xssafe($sep->getHostName()). "</option>";
-            }	
+            }
             ?>
         </select>
-        
+
         <br>
         <input class="input_button" type="submit" value="Move Service" />
     </form>

--- a/htdocs/web_portal/views/admin/move_service_end_point_select_old_site.php
+++ b/htdocs/web_portal/views/admin/move_service_end_point_select_old_site.php
@@ -2,16 +2,16 @@
      <form name="Move_Service" action="index.php?Page_Type=Admin_Move_SEP" method="post" class="inputForm">
         <h1>Move Service</h1>
         <br />
-        
+
         <span class="input_name">Please select the site from which you wish to move services</span>
         <select class="add_edit_form" name="OldSite">
             <?php
             foreach($params['Sites'] as $site) {
                 echo "<option value=\"". $site->getId() . "\">" . $site->getShortName(). "</option>";
-            }	
+            }
             ?>
         </select>
-        
+
         <input class="input_button" type="submit" value="Move service from this site" />
     </form>
 </div>

--- a/htdocs/web_portal/views/admin/move_site.php
+++ b/htdocs/web_portal/views/admin/move_site.php
@@ -2,27 +2,27 @@
     <form name="Move_Site" action="index.php?Page_Type=Admin_Move_Site" method="post" class="inputForm">
         <h1>Move Site</h1>
         <br />
-        
+
         <span class="input_name">New NGI for selected sites</span>
         <select class="add_edit_form" name="NewNGI">
             <?php
             foreach($params['Ngis'] as $NGI) {
                 echo "<option value=\"". $NGI->getId() . "\">" . xssafe($NGI->getName()). "</option>";
-            }	
+            }
             ?>
         </select>
-        
-        <span class="input_name">Please select the site(s) to be moved from 
+
+        <span class="input_name">Please select the site(s) to be moved from
             <?php xecho($params['OldNgi'])?></span>
-        <select class="Downtime_Select" name="Sites[]" size="20" 
+        <select class="Downtime_Select" name="Sites[]" size="20"
          multiple id="Sites" style="margin-left: 0em; width: 38em;">
             <?php
                 foreach($params['sites'] as $site) {
                 echo "<option value=\"". $site->getId() . "\">" . xssafe($site->getShortName()). "</option>";
-            }	
+            }
             ?>
         </select>
-        
+
         <br>
         <input class="input_button" type="submit" value="Move Site" />
     </form>

--- a/htdocs/web_portal/views/admin/move_site_select_old_ngi.php
+++ b/htdocs/web_portal/views/admin/move_site_select_old_ngi.php
@@ -2,16 +2,16 @@
      <form name="Move_Site" action="index.php?Page_Type=Admin_Move_Site" method="post" class="inputForm">
         <h1>Move Site</h1>
         <br />
-        
+
         <span class="input_name">Please select the NGI from which you wish to move sites</span>
         <select class="add_edit_form" name="OldNGI">
             <?php
             foreach($params['Ngis'] as $NGI) {
                 echo "<option value=\"". $NGI->getId() . "\">" . $NGI->getName(). "</option>";
-            }	
+            }
             ?>
         </select>
-        
+
         <input class="input_button" type="submit" value="Move Sites from this NGI" />
     </form>
 </div>

--- a/htdocs/web_portal/views/admin/moved_service_end_point.php
+++ b/htdocs/web_portal/views/admin/moved_service_end_point.php
@@ -1,16 +1,16 @@
 <div class="rightPageContainer">
     <h1 class="Success">Success</h1><br />
     <?php $Site = $params['NewSite'];?>
-    The following services have been moved to 
+    The following services have been moved to
     <a href="index.php?Page_Type=Site&id=<?php echo $Site->getId();?>">
     <?php xecho($Site->getShortName());?>
     </a>:
-    <?php 
+    <?php
         foreach($params['Services'] as $sep){
             echo "<br />"
                 . "<a href=\"index.php?Page_Type=Service&id=" . $sep->getId() ."\">"
                 .  xssafe($sep->getHostName())
                 . "</a> ";
-        }	
+        }
     ?>
 </div>

--- a/htdocs/web_portal/views/admin/moved_site.php
+++ b/htdocs/web_portal/views/admin/moved_site.php
@@ -1,16 +1,16 @@
 <div class="rightPageContainer">
     <h1 class="Success">Success</h1><br />
     <?php $NGI = $params['NewNGI'];?>
-    The following sites have been moved to 
+    The following sites have been moved to
     <a href="index.php?Page_Type=NGI&id=<?php echo $NGI->getId();?>">
     <?php xecho($NGI->getName());?>
     </a>:
-    <?php 
+    <?php
         foreach($params['sites'] as $site){
             echo "<br />"
                 . "<a href=\"index.php?Page_Type=Site&id=" . $site->getId() ."\">"
                 .  xssafe($site->getShortName())
                 . "</a> ";
-        }	
+        }
     ?>
 </div>

--- a/htdocs/web_portal/views/admin/scope.php
+++ b/htdocs/web_portal/views/admin/scope.php
@@ -16,23 +16,23 @@ $totalCount = $siteCount + $ngiCount + $serviceCount +$serviceGroupsCount;
 
 
 <div class="rightPageContainer">
-    
+
     <!--Headings-->
     <div style="float: left; width: 50em;">
         <h1 style="float: left; margin-left: 0em;">Scope: <?php echo $name?></h1>
         <span style="clear: both; float: left; padding-bottom: 0.4em;"><?php echo $description ?></span>
         <span style="clear: both; float: left; padding-bottom: 0.4em;">
             <?php if($totalCount>0):?>
-                In total, there are <?php if($totalCount==1){echo "is";}else{echo "are";}?> 
-                <?php if ($totalCount == 0){echo "no";} else{echo $totalCount;} ?> 
-                entit<?php if($totalCount != 1){echo "ies";}else{echo "y";}?> 
+                In total, there are <?php if($totalCount==1){echo "is";}else{echo "are";}?>
+                <?php if ($totalCount == 0){echo "no";} else{echo $totalCount;} ?>
+                entit<?php if($totalCount != 1){echo "ies";}else{echo "y";}?>
                 (<?php echo $ngiCount?> NGIs, <?php echo $siteCount?> sites, <?php echo $serviceGroupsCount?>
                 service groups, and <?php echo $serviceCount?> services) with this scope.
             <?php else: ?>
                 This scope is currently not used by any NGI, site, service group, or service.
             <?php endif; ?>
         </span>
-    
+
     </div>
 
     <!--Edit/Delete buttons-->
@@ -59,17 +59,17 @@ $totalCount = $siteCount + $ngiCount + $serviceCount +$serviceGroupsCount;
             </div>
         </div>
     <?php endif; ?>
-    
+
 
     <!--  NGIs -->
     <div class="tableContainer" style="width: 99.5%; float: left; margin-top: 3em; margin-right: 10px;">
         <span class="header" style="vertical-align:middle; float: left; padding-top: 0.9em; padding-left: 1em;">
             There <?php if($ngiCount==1){echo "is";}else{echo "are";}?> <?php if ($ngiCount == 0){echo "no";} else{echo $ngiCount;} ?> NGI<?php if($ngiCount != 1) echo "s"?> with this scope
         </span>
-<!--        
+<!--
         <img src="<?php echo \GocContextPath::getPath()?>img/NGI.png" height="25px" style="float: right; padding-right: 1em; padding-top: 0.5em; padding-bottom: 0.5em;" />
         -->
-        
+
         <?php if ($ngiCount != 0): ?>
             <table style="clear: both; width: 100%;">
                 <tr class="site_table_row_1">
@@ -88,7 +88,7 @@ $totalCount = $siteCount + $ngiCount + $serviceCount +$serviceGroupsCount;
                         <div style="background-color: inherit;">
                             <span style="vertical-align: middle;">
                                 <a href="index.php?Page_Type=NGI&id=<?php echo $ngi->getId() ?>">
-                                    <img class="flag" style="vertical-align: middle" src="<?php echo \GocContextPath::getPath()?>img/ngi/<?php echo $ngi->getName() ?>.jpg">                            
+                                    <img class="flag" style="vertical-align: middle" src="<?php echo \GocContextPath::getPath()?>img/ngi/<?php echo $ngi->getName() ?>.jpg">
                                     <span>&nbsp;&nbsp;</span><?php xecho($ngi->getName()); ?>
                                 </a>
                             </span>
@@ -104,7 +104,7 @@ $totalCount = $siteCount + $ngiCount + $serviceCount +$serviceGroupsCount;
             </table>
         <?php else: echo "<br><br>&nbsp &nbsp"; endif; ?>
     </div>
-    
+
     <!--  Sites -->
     <div class="listContainer">
         <span class="header listHeader">
@@ -159,7 +159,7 @@ $totalCount = $siteCount + $ngiCount + $serviceCount +$serviceGroupsCount;
                     <th class="site_table">Name</th>
                     <th class="site_table">Description</th>
                 </tr>
-                <?php           
+                <?php
                 $num = 2;
                 foreach($serviceGroups as $sGroup) {
                 ?>
@@ -180,14 +180,14 @@ $totalCount = $siteCount + $ngiCount + $serviceCount +$serviceGroupsCount;
                     </td>
 
                 </tr>
-                <?php  
+                <?php
                     if($num == 1) { $num = 2; } else { $num = 1; }
                     } // End of the foreach loop iterating over SEs
                 ?>
             </table>
         <?php endif; ?>
     </div>
-    
+
       <!--  Services - count and link -->
     <div class="listContainer">
         <span class="header listHeader">
@@ -206,5 +206,5 @@ $totalCount = $siteCount + $ngiCount + $serviceCount +$serviceGroupsCount;
             </table>
         <?php endif; ?>
     </div>
-    
+
 </div>

--- a/htdocs/web_portal/views/admin/scopes.php
+++ b/htdocs/web_portal/views/admin/scopes.php
@@ -21,7 +21,7 @@
         </div>
    <?php endif; ?>
 
-    <?php $numberOfScopes = sizeof($params['Scopes'])?>  
+    <?php $numberOfScopes = sizeof($params['Scopes'])?>
     <div class="listContainer">
         <span class="header listHeader">
             <?php echo $numberOfScopes ?> Scope<?php if($numberOfScopes) echo "s"?>
@@ -33,7 +33,7 @@
                     <th class="site_table">Remove</th>
                 <?php endif; ?>
             </tr>
-            <?php           
+            <?php
             $num = 2;
             if(sizeof($numberOfScopes > 0)) {
                 foreach($params['Scopes'] as $scope) {
@@ -42,7 +42,7 @@
                     <td class="site_table" style="width: 90%">
                         <div style="background-color: inherit;">
                             <span style="vertical-align: middle;">
-                                <a href="index.php?Page_Type=Admin_Scope&id=<?php echo $scope->getId() ?>">                            
+                                <a href="index.php?Page_Type=Admin_Scope&id=<?php echo $scope->getId() ?>">
                                     <?php xecho($scope->getName()); ?>
                                 </a>
                             </span>
@@ -54,10 +54,10 @@
                              <a onclick="return confirmSubmit()" href="index.php?Page_Type=Admin_Remove_Scope&id=<?php echo $scope->getId() ?>">
                                 <img src="<?php echo \GocContextPath::getPath()?>img/cross.png" height="22px" style="vertical-align: middle;" />
                             </a>
-                        </td> 
+                        </td>
                     <?php endif ?>
                 </tr>
-                <?php  
+                <?php
                     if($num == 1) { $num = 2; } else { $num = 1; }
                     } // End of the foreach loop iterating over scopes
             }

--- a/htdocs/web_portal/views/admin/users.php
+++ b/htdocs/web_portal/views/admin/users.php
@@ -1,4 +1,4 @@
-<?php $users = $params["Users"] ?> 
+<?php $users = $params["Users"] ?>
 <?php $numUsers = sizeof($users) ?>
 
 <div class="rightPageContainer">
@@ -12,7 +12,7 @@
         All users in GOCDB
         <br />
     </span>
-    
+
     <!-- Filter -->
     <div class="siteContainer">
         <form action="index.php?Page_Type=Admin_Users" method="GET" class="inline">
@@ -21,13 +21,13 @@
             <span class="header leftFloat">
                 Filter <a href="index.php?Page_Type=Admin_Users">&nbsp;&nbsp;(clear)</a>
             </span>
-        
+
             <br />
-            
+
             <div class="topMargin leftFloat siteFilter">
                 <span class="middle" style="margin-right: 0.4em">Forename: </span>
-                <input class="middle" style="width: 5.5em;" type="text" name="Forename" 
-                    <?php if(isset($params['Forename'])) 
+                <input class="middle" style="width: 5.5em;" type="text" name="Forename"
+                    <?php if(isset($params['Forename']))
                         xecho("value=".$params['Forename']);
                     ?>
                 />
@@ -35,8 +35,8 @@
 
             <div class="topMargin leftFloat siteFilter">
                 <span class="middle" style="margin-right: 0.4em">Surname: </span>
-                <input class="middle" style="width: 5.5em;" type="text" name="Surname" 
-                    <?php if(isset($params['Surname'])) 
+                <input class="middle" style="width: 5.5em;" type="text" name="Surname"
+                    <?php if(isset($params['Surname']))
                        xecho("value=".$params['Surname']);
                     ?>
                 />
@@ -47,27 +47,27 @@
                 <select name="IsAdmin" onchange="form.submit()">
                     <option value=""<?php if($params['IsAdmin'] == null) echo " selected" ?>>(all)</option>
                     <option value="true"<?php if($params['IsAdmin'] == true) echo " selected" ?>>Yes</option>
-                    <option value="false"<?php if($params['IsAdmin'] == false and !is_null($params['IsAdmin'])) echo " selected" ?>>No</option> 
+                    <option value="false"<?php if($params['IsAdmin'] == false and !is_null($params['IsAdmin'])) echo " selected" ?>>No</option>
                 </select>
             </div>
-            
+
             <div class="topMargin leftFloat siteFilter">
                 <span class="middle" style="margin-right: 0.4em">Certificate DN: </span>
-                <input class="middle" style="width: 11em;" type="text" name="DN" 
-                    <?php if(isset($params['DN'])) 
+                <input class="middle" style="width: 11em;" type="text" name="DN"
+                    <?php if(isset($params['DN']))
                         xecho("value=".$params['DN']);
                     ?>
                 />
             </div>
- 
-            
+
+
             <div class="topMargin leftFloat siteFilter">
                 <input class="middle" type="image" src="<?php echo \GocContextPath::getPath()?>img/enter.png" name="image" width="20" height="20">
             </div>
 
         </form>
     </div>
-    
+
     <!--  Users -->
     <div class="listContainer">
         <span class="header listHeader">
@@ -83,7 +83,7 @@
                     <th class="site_table">Certificate DN</th>
                     <th class="site_table">GOCDB<br>Admin.?</th>
                 </tr>
-                <?php           
+                <?php
                 $num = 2;
                 if($numUsers > 0) {
                 foreach($users as $user) {
@@ -108,7 +108,7 @@
                                 </a>
                             </span>
                         </div>
-                    </td>  
+                    </td>
 
                     <td class="site_table">
                         <!--<a href="index.php?Page_Type=Admin_Change_User_Admin_Status&id=<?php echo $user->getId() ?>">-->
@@ -130,20 +130,20 @@
                     </td>
 
                 </tr>
-                <?php  
+                <?php
                     if($num == 1) { $num = 2; } else { $num = 1; }
                     } // End of the foreach loop iterating over sites
                 }
                 ?>
             </table>
-            
+
             <div style="margin-right: 0.4em">
                 <br>
                 &nbsp; Click on a user's name to view more details, or to edit or
                 delete them. Click on their DN to update it.
                 <!-- Click on the tick or cross to promote them to or demote them from GOCDB admin status-->
             </div>
-                
+
         <?php endif; ?>
-    </div>      
+    </div>
 </div>

--- a/htdocs/web_portal/views/admin/view_service_type.php
+++ b/htdocs/web_portal/views/admin/view_service_type.php
@@ -9,7 +9,7 @@ $portalIsReadOnly = $params['portalIsReadOnly'];
 
 
 <div class="rightPageContainer">
-    
+
     <!--Headings-->
     <div style="float: left; width: 50em;">
         <h1 style="float: left; margin-left: 0em;">Service Type: <?php echo $name?></h1>
@@ -40,13 +40,13 @@ $portalIsReadOnly = $params['portalIsReadOnly'];
             </div>
         </div>
     <?php endif; ?>
-    
+
 
     <!--  Services -->
     <div class="listContainer" style="width: 99.5%; float: left; margin-top: 3em; margin-right: 10px;">
         <span class="header" style="vertical-align:middle; float: left; padding-top: 0.9em; padding-left: 1em;">
-            There <?php if ($SEsCount ==0) {echo 'are no services';} 
-                        elseif ($SEsCount==1) {echo 'is one service';} 
+            There <?php if ($SEsCount ==0) {echo 'are no services';}
+                        elseif ($SEsCount==1) {echo 'is one service';}
                         else {echo 'are ' . $SEsCount . ' services';}?>
             with <?php echo $name ?> service type<?php if ($SEsCount == 0) {echo '.';} else {echo ':';}?>
         </span>
@@ -59,7 +59,7 @@ $portalIsReadOnly = $params['portalIsReadOnly'];
                     <th class="site_table">Monitored</th>
                     <th class="site_table"><a href="index.php?Page_Type=Scope_Help">Scope(s)</a></th>
                 </tr>
-            
+
 
                 <?php $num = 2;
 

--- a/htdocs/web_portal/views/admin/view_service_types.php
+++ b/htdocs/web_portal/views/admin/view_service_types.php
@@ -8,7 +8,7 @@
             Click on the name of a service type to edit or delete it.
         </span>
     </div>
-   
+
     <!-- Only show add when not in read only mode-->
     <?php if(!$params['portalIsReadOnly']):?>
         <div style="float: right;">
@@ -22,7 +22,7 @@
         </div>
     <?php endif; ?>
 
-    <?php $numberOfServiceTypes = sizeof($params['ServiceTypes'])?>  
+    <?php $numberOfServiceTypes = sizeof($params['ServiceTypes'])?>
     <div class="listContainer">
         <span class="header listHeader">
             <?php echo $numberOfServiceTypes ?> Service Type<?php if($numberOfServiceTypes) echo "s"?>
@@ -32,7 +32,7 @@
                 <th class="site_table">Name</th>
                 <th class="site_table">Description</th>
             </tr>
-            <?php           
+            <?php
             $num = 2;
             if(sizeof($numberOfServiceTypes > 0)) {
                 foreach($params['ServiceTypes'] as $serviceType) {
@@ -41,18 +41,18 @@
                     <td class="site_table" style="width: 30%">
                         <div style="background-color: inherit;">
                             <span style="vertical-align: middle;">
-                                <a href="index.php?Page_Type=Admin_Service_Type&id=<?php echo $serviceType->getId() ?>">                            
+                                <a href="index.php?Page_Type=Admin_Service_Type&id=<?php echo $serviceType->getId() ?>">
                                     <?php xecho($serviceType->getName()); ?>
                                 </a>
                             </span>
                         </div>
                     </td>
-                    
+
                     <td class="site_table">
                         <?php xecho($serviceType->getDescription()); ?>
-                    </td> 
+                    </td>
                 </tr>
-                <?php  
+                <?php
                     if($num == 1) { $num = 2; } else { $num = 1; }
                     } // End of the foreach loop iterating over service types
             }

--- a/htdocs/web_portal/views/downtime/add_downtime.php
+++ b/htdocs/web_portal/views/downtime/add_downtime.php
@@ -1,16 +1,16 @@
-<!-- 
-@author James McCarthy 
+<!--
+@author James McCarthy
 
-DM: The downtime interface/logic needs to be reworked and tidied-up: 
-- It needs to allow services from multiple sites to be put into downtime 
+DM: The downtime interface/logic needs to be reworked and tidied-up:
+- It needs to allow services from multiple sites to be put into downtime
 (currently it only allows a single site to be selected which limits the
-selectable services to those only from that site). 
+selectable services to those only from that site).
 
-- There is almost certainly a more elegant way to pass down the UTC offset 
-(secs) and timezoneId label for each site (rather than using an AJAX call to query 
-for these values on site selection). This will be needed in order to cater for 
+- There is almost certainly a more elegant way to pass down the UTC offset
+(secs) and timezoneId label for each site (rather than using an AJAX call to query
+for these values on site selection). This will be needed in order to cater for
 multi-site selection. Perhaps pass down a set of DataTransferObjects or JSON string
-rather than the Site entities themselves, and specify tz, offset in the DTO/JSON. 
+rather than the Site entities themselves, and specify tz, offset in the DTO/JSON.
 
 -->
 
@@ -18,7 +18,7 @@ rather than the Site entities themselves, and specify tz, offset in the DTO/JSON
 
     <h1>Add Downtime</h1>
     <div>
-    <ul>    
+    <ul>
         <li>To be <strong>SCHEDULED</strong>, start must be <strong>24hrs</strong> in the future</li>
         <?php /*<li>Time in UTC since last page refresh <strong><?php xecho($params['nowUtc']);?></strong></li>*/ ?>
         <li>Time in UTC: <mark><label id="timeinUtcNowLabel"></label></mark></li>
@@ -41,86 +41,86 @@ rather than the Site entities themselves, and specify tz, offset in the DTO/JSON
         <div class="form-group" id="descriptionGroup">
             <label class="control-label" for="description">Description:</label>
             <div class="controls">
-                <input type="text" class="form-control" name="DESCRIPTION" id="description"> 
+                <input type="text" class="form-control" name="DESCRIPTION" id="description">
             </div>
-            <span id="descriptionError" class="label label-danger hidden"></span> 
+            <span id="descriptionError" class="label label-danger hidden"></span>
         </div>
 
         <br>
         <br>
-                
+
         <div class="alert alert-warning" role="alert">
           You may need to update your site's timezone from UTC to the required value for your site - this version of GOCDB uses
           a new timezone logic with new timezone labels taken from the 'Olsen' database. Where possible, the
-          old values have been copied over, but some legacy values including those starting 'Etc/' are not supported and so UTC 
+          old values have been copied over, but some legacy values including those starting 'Etc/' are not supported and so UTC
           is specified by default.
         </div>
 
 
-        
+
         <div class="form-group" id="timezoneSelectGroup">
             <!--If Site timezone is selected, the time will be converted and saved as UTC-->
             <label class="control-label">Enter Times In:</label>&nbsp;&nbsp;&nbsp;&nbsp;
-            <input type="radio" name="DEFINE_TZ_BY_UTC_OR_SITE" id="utcRadioButton" value="utc" checked>UTC&nbsp;&nbsp;&nbsp;&nbsp; 
-            <input type="radio" name="DEFINE_TZ_BY_UTC_OR_SITE" id="siteRadioButton" value="site">Site Timezone 
-            <input type="text" id="siteTimezoneText" value="UTC" placeholder="Updated on site selection" readonly> 
+            <input type="radio" name="DEFINE_TZ_BY_UTC_OR_SITE" id="utcRadioButton" value="utc" checked>UTC&nbsp;&nbsp;&nbsp;&nbsp;
+            <input type="radio" name="DEFINE_TZ_BY_UTC_OR_SITE" id="siteRadioButton" value="site">Site Timezone
+            <input type="text" id="siteTimezoneText" value="UTC" placeholder="Updated on site selection" readonly>
             &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<mark><label id="schedulingStatusLabel"></label></mark>
-        </div>    
+        </div>
 
 
-        
+
         <label for="startDate">Starts on:</label>
-        <mark><label id="startUtcLabel"></label></mark> 
+        <mark><label id="startUtcLabel"></label></mark>
         <div class="form-group" id="startDateGroup">
             <!-- Date Picker -->
             <div class="input-group date datePicker" id="startDate">
                 <input type='text' name="startDate" class="form-control"
-                    data-format="DD/MM/YYYY" id="startDateContent"/> 
+                    data-format="DD/MM/YYYY" id="startDateContent"/>
                 <span class="input-group-addon">
-                    <span class="glyphicon glyphicon-calendar" ></span> 
+                    <span class="glyphicon glyphicon-calendar" ></span>
                 </span>
             </div>
 
             <!-- Time Picker -->
             <div class="input-group date timePicker" id="startTime">
-                <input type='text' class="form-control" 
-                    id="startTimeContent"/> 
+                <input type='text' class="form-control"
+                    id="startTimeContent"/>
                 <span class="input-group-addon">
-                    <span class="glyphicon glyphicon-time" ></span> 
+                    <span class="glyphicon glyphicon-time" ></span>
                 </span>
             </div>
         </div>
         <div class="form-group"><span id="startError" class="label label-danger hidden"></span>&nbsp</div> <!-- Single space reserves a line for the label -->
-        
+
         <label for="endDate">Ends on:</label>
         <mark><label id="endUtcLabel"></label></mark>
         <div class="form-group" id="endDateGroup"">
             <!-- Date Picker -->
             <div class="input-group date datePicker" id="endDate">
                 <input type='text' class="form-control" data-format="DD/MM/YYYY"
-                    id="endDateContent" /> 
+                    id="endDateContent" />
                 <span class="input-group-addon">
-                    <span class="glyphicon glyphicon-calendar"></span> 
+                    <span class="glyphicon glyphicon-calendar"></span>
                 </span>
             </div>
 
             <!-- Time Picker -->
             <div class="input-group date timePicker" id="endTime">
-                <input type='text' class="form-control has-error" 
-                    id="endTimeContent" /> 
+                <input type='text' class="form-control has-error"
+                    id="endTimeContent" />
                 <span class="input-group-addon">
-                    <span class="glyphicon glyphicon-time"></span> 
+                    <span class="glyphicon glyphicon-time"></span>
                 </span>
             </div>
-        </div>		
+        </div>
         <div class="form-group"><span id="endError" class="label label-danger hidden"></span>&nbsp</div>  <!-- Single space reserves a line for the label -->
 
 
         <div>
-            
-             
+
+
         </div>
-        
+
 
         <div id="chooseSite" style="width: 50%; float: left; display: inline-block;">
         <?php
@@ -130,7 +130,7 @@ rather than the Site entities themselves, and specify tz, offset in the DTO/JSON
                 $site = $se->getParentSite();
                 $sites[] = $site;
             }
-            
+
             $sites = array_unique($sites);
             usort($sites, function($a, $b) {
                 return strcmp($a, $b);
@@ -153,9 +153,9 @@ rather than the Site entities themselves, and specify tz, offset in the DTO/JSON
 
                 <?php
                 foreach($sites as $site){
-                    $siteName = $site->getName(); 
-                    $ngiName = $site->getNgi()->getName(); 
-                    $label = xssafe($site."   (".$ngiName.")"); 
+                    $siteName = $site->getName();
+                    $ngiName = $site->getNgi()->getName();
+                    $label = xssafe($site."   (".$ngiName.")");
                     echo "<option value=\"{$site->getId()}\">$label</option>";
                 }
                 ?>
@@ -187,30 +187,30 @@ rather than the Site entities themselves, and specify tz, offset in the DTO/JSON
    /* global TARGETTIMEZONEOFFSETFROMUTCSECS: true */
    /* global M_START_UTC: true */
    /* global M_END_UTC: true */
-    
-   var TARGETTIMEZONEID = "UTC";  // e.g. Europe/London 
+
+   var TARGETTIMEZONEID = "UTC";  // e.g. Europe/London
    var TARGETTIMEZONEOFFSETFROMUTCSECS = 0; // e.g. 3600 if TARGETTIMEZONEID is ahead of UTC by 1hr
-   var M_START_UTC = null; 
-   var M_END_UTC = null; 
+   var M_START_UTC = null;
+   var M_END_UTC = null;
 
    $(document).ready(function() {
-        // configure date pickers 
+        // configure date pickers
         $('#startDate, #endDate').datetimepicker({
             format: 'DD/MM/YYYY',
 
             //pickTime:false,
             //startDate:getDate()     //Only show dates 48 in the past
         });
-        // configure time pickers 
+        // configure time pickers
         $('#startTime, #endTime').datetimepicker({
             format: 'HH:mm',
             //pickDate: false,
             //pickSeconds: false,
             //pick12HourFormat: false
         });
-   
-        // invoke ajax call to get selected sites timezoneId and offset (if 
-        // a site is specified in the URL bar) 
+
+        // invoke ajax call to get selected sites timezoneId and offset (if
+        // a site is specified in the URL bar)
         updateSiteTimezoneVars(getURLParameter('site'));
 
        // Add the jQuery form change event handlers
@@ -223,7 +223,7 @@ rather than the Site entities themselves, and specify tz, offset in the DTO/JSON
        });
 
        // The bootstrap datetimepickers don't fire the change event
-       // but they trigger a dp.change event instead so a separate 
+       // but they trigger a dp.change event instead so a separate
        // jQuery handler is needed.
        $('.date').on("dp.change", function(e) {
            updateStartEndTimesInUtc();
@@ -235,12 +235,12 @@ rather than the Site entities themselves, and specify tz, offset in the DTO/JSON
     });
 
     /**
-     * Get the start/end time strings and calculate the UTC equivalents using 
-     * the {@link TARGETTIMEZONEID} and {@link TARGETTIMEZONEOFFSETFROMUTCSECS} 
-     * values, then update the global vars {@link M_START_UTC} and {@link M_END_UTC}. 
-     * and the startTimestamp and endTimestamp form submission parameters.  
-     * Finally update the GUI labels.  
-     * 
+     * Get the start/end time strings and calculate the UTC equivalents using
+     * the {@link TARGETTIMEZONEID} and {@link TARGETTIMEZONEOFFSETFROMUTCSECS}
+     * values, then update the global vars {@link M_START_UTC} and {@link M_END_UTC}.
+     * and the startTimestamp and endTimestamp form submission parameters.
+     * Finally update the GUI labels.
+     *
      * @returns {null}
      */
     function updateStartEndTimesInUtc(){
@@ -248,112 +248,112 @@ rather than the Site entities themselves, and specify tz, offset in the DTO/JSON
         var sDate = $('#startDateContent').val();
         var eDate = $('#endDateContent').val();
         var sTime = $('#startTimeContent').val();
-        var eTime = $('#endTimeContent').val(); 
+        var eTime = $('#endTimeContent').val();
 
-        // calculate the start date time in UTC 
+        // calculate the start date time in UTC
         if(sDate && sTime){
             // First Parse the input string as UTC
             // (use moment.utc(), otherwise moment parses in current timezone)
-            var start = sDate +" "+sTime; 
+            var start = sDate +" "+sTime;
             var mStart = moment.utc(start, "DD-MM-YYYY, HH:mm"); // parse in utc
-            //console.log(mStart); 
-            // Then update utc time to time in target timezone; 
-            // if SiteTimezone RB is selected, subtract offset from time to 
-            // get time in specified tz 
-            if($('#siteRadioButton').is(':checked')){ 
-               mStart.subtract(TARGETTIMEZONEOFFSETFROMUTCSECS, 's'); 
+            //console.log(mStart);
+            // Then update utc time to time in target timezone;
+            // if SiteTimezone RB is selected, subtract offset from time to
+            // get time in specified tz
+            if($('#siteRadioButton').is(':checked')){
+               mStart.subtract(TARGETTIMEZONEOFFSETFROMUTCSECS, 's');
             }
-            M_START_UTC = mStart; 
-            //console.log(M_START_UTC.format("DD-MM-YYYY, HH:mm")); 
-            //console.log(M_START_UTC.format()); 
-            $('#startUtcLabel').text(M_START_UTC.format("DD/MM/YYYY HH:mm")+' UTC'); 
-            $('#startTimestamp').val(M_START_UTC.format("DD/MM/YYYY HH:mm")); 
+            M_START_UTC = mStart;
+            //console.log(M_START_UTC.format("DD-MM-YYYY, HH:mm"));
+            //console.log(M_START_UTC.format());
+            $('#startUtcLabel').text(M_START_UTC.format("DD/MM/YYYY HH:mm")+' UTC');
+            $('#startTimestamp').val(M_START_UTC.format("DD/MM/YYYY HH:mm"));
 
-            // refresh the SCHEDULED/UNSCHEDULED label  
-            refreshScheduledStatus();  
+            // refresh the SCHEDULED/UNSCHEDULED label
+            refreshScheduledStatus();
         }
-        // calculate the end date time in UTC 
+        // calculate the end date time in UTC
         if(eDate && eTime){
             // First Parse the input string as UTC
             // (use moment.utc(), otherwise moment parses in current timezone)
-            var end = eDate +" "+eTime;    
+            var end = eDate +" "+eTime;
             var mEnd = moment.utc(end, "DD-MM-YYYY, HH:mm"); // parse in utc
             //console.log(mEnd);
-            // Then update utc time to time in target timezone; 
-            // if SiteTimezone RB is selected, subtract offset from time to 
-            // get time in specified tz 
-            if($('#siteRadioButton').is(':checked')){  
-                mEnd.subtract(TARGETTIMEZONEOFFSETFROMUTCSECS, 's'); 
+            // Then update utc time to time in target timezone;
+            // if SiteTimezone RB is selected, subtract offset from time to
+            // get time in specified tz
+            if($('#siteRadioButton').is(':checked')){
+                mEnd.subtract(TARGETTIMEZONEOFFSETFROMUTCSECS, 's');
             }
-            M_END_UTC = mEnd; 
-            //console.log(M_END_UTC.format("DD-MM-YYYY, HH:mm")); 
-            //console.log(M_END_UTC.format()); 
-            $('#endUtcLabel').text(M_END_UTC.format("DD/MM/YYYY HH:mm")+' UTC'); 
-            $('#endTimestamp').val(M_END_UTC.format("DD/MM/YYYY HH:mm")); 
+            M_END_UTC = mEnd;
+            //console.log(M_END_UTC.format("DD-MM-YYYY, HH:mm"));
+            //console.log(M_END_UTC.format());
+            $('#endUtcLabel').text(M_END_UTC.format("DD/MM/YYYY HH:mm")+' UTC');
+            $('#endTimestamp').val(M_END_UTC.format("DD/MM/YYYY HH:mm"));
         }
    }
 
    /*
-    * Dynamically update the UTC time label and SCHEDULED/UNSCHEDULED labels. 
+    * Dynamically update the UTC time label and SCHEDULED/UNSCHEDULED labels.
     */
    setInterval(refreshScheduledStatus,5000);
-   setInterval(refreshCurrentUtcTimeLabel,1000); 
-  
+   setInterval(refreshCurrentUtcTimeLabel,1000);
+
    /**
-    * Update the UTC time label, executed every second. 
+    * Update the UTC time label, executed every second.
     * @returns {null}
     */
    function refreshCurrentUtcTimeLabel(){
-       var nowUtc = moment.utc(); 
-       $('#timeinUtcNowLabel').text(nowUtc.format("DD/MM/YYYY HH:mm:ss"));  
-   } 
+       var nowUtc = moment.utc();
+       $('#timeinUtcNowLabel').text(nowUtc.format("DD/MM/YYYY HH:mm:ss"));
+   }
 
    /**
-    * Update the SCHEDULED/UNSCHEDULED status label depending on 
-    * currently specified start/end time values, executed every 5 secs.   
+    * Update the SCHEDULED/UNSCHEDULED status label depending on
+    * currently specified start/end time values, executed every 5 secs.
     * @returns {null}
     */
    function refreshScheduledStatus(){
-        $('#schedulingStatusLabel').text(''); 
-        var nowUtc = moment.utc();    
-        var duration24hrs = moment.duration(24, 'hours'); 
+        $('#schedulingStatusLabel').text('');
+        var nowUtc = moment.utc();
+        var duration24hrs = moment.duration(24, 'hours');
         if(M_START_UTC){
             if( M_START_UTC > (nowUtc + duration24hrs)){
-                $('#schedulingStatusLabel').text('SCHEDULED'); 
+                $('#schedulingStatusLabel').text('SCHEDULED');
             } else {
-                $('#schedulingStatusLabel').text('UNSCHEDULED'); 
+                $('#schedulingStatusLabel').text('UNSCHEDULED');
             }
         }
-            
-        /*var sDate = $('#startDateContent').val();
-        var sTime = $('#startTimeContent').val(); 
-        console.log("sDate: ["+sDate+"] sTime: ["+sTime+"]"); 
 
-        // calculate the start date time in UTC 
+        /*var sDate = $('#startDateContent').val();
+        var sTime = $('#startTimeContent').val();
+        console.log("sDate: ["+sDate+"] sTime: ["+sTime+"]");
+
+        // calculate the start date time in UTC
         if(sDate && sTime){
             // First Parse the input string as UTC
             // (use moment.utc(), otherwise moment parses in current timezone)
-            var start = sDate +" "+sTime; 
+            var start = sDate +" "+sTime;
             var mStart = moment.utc(start, "DD-MM-YYYY, HH:mm"); // parse in utc
-            
-            // Is M_START_UTC >24hrs in future (SCHEDULED) or <24hrs (UNSCHEDULED) 
-            // this logic should go into a self-refresh loop. 
-            //console.log("mStart utc: "+mStart.format("DD/MM/YYYY HH:mm:ss")); 
 
-            // Then update utc time to time in target timezone; 
-            // if SiteTimezone RB is selected, subtract offset from time to 
-            // get time in specified tz 
-            if($('#siteRadioButton').is(':checked')){ 
-               mStart.subtract(TARGETTIMEZONEOFFSETFROMUTCSECS, 's'); 
+            // Is M_START_UTC >24hrs in future (SCHEDULED) or <24hrs (UNSCHEDULED)
+            // this logic should go into a self-refresh loop.
+            //console.log("mStart utc: "+mStart.format("DD/MM/YYYY HH:mm:ss"));
+
+            // Then update utc time to time in target timezone;
+            // if SiteTimezone RB is selected, subtract offset from time to
+            // get time in specified tz
+            if($('#siteRadioButton').is(':checked')){
+               mStart.subtract(TARGETTIMEZONEOFFSETFROMUTCSECS, 's');
             }
-            
-            $('#schedulingStatusLabel').text(''); 
-            var nowUtc = moment.utc();    
-            var duration24hrs = moment.duration(24, 'hours'); 
+
+            $('#schedulingStatusLabel').text('');
+            var nowUtc = moment.utc();
+            var duration24hrs = moment.duration(24, 'hours');
             if( mStart > (nowUtc + duration24hrs)){
-               $('#schedulingStatusLabel').text('SCHEDULED'); 
+               $('#schedulingStatusLabel').text('SCHEDULED');
             } else {
-               $('#schedulingStatusLabel').text('UNSCHEDULED'); 
+               $('#schedulingStatusLabel').text('UNSCHEDULED');
             }
         }*/
     }
@@ -362,7 +362,7 @@ rather than the Site entities themselves, and specify tz, offset in the DTO/JSON
         var epValid=false;
         var severityValid=false;
         var descriptionValid=false;
-        var datesValid = false; 
+        var datesValid = false;
 
         //----------Validate the Severity-------------//
         var severityStatus = $('#severity').val();
@@ -371,51 +371,51 @@ rather than the Site entities themselves, and specify tz, offset in the DTO/JSON
             $('#severityGroup').removeClass("has-error");
             $('#severityGroup').addClass("has-success");
             $('#severityError').addClass("hidden");
-            
+
         }else{
             severityValid=false;
-            $('#severityGroup').addClass("has-error");  
+            $('#severityGroup').addClass("has-error");
             $('#severityError').removeClass("hidden");
             //$("#severityError").text("Please choose a severity for this downtime.");
         }
-        
+
         //----------Validate the Description-------------//
         //var regEx = /^[A-Za-z0-9\s._(),:;/'\\]{0,4000}$/;    //This line may not appear valid in IDEs but it is
         var regEx = /^[^`'\";<>]{0,4000}$/;    //This line may not appear valid in IDEs but it is
         var description = $('#description').val();
         if(description && regEx.test(description) !== false){
             descriptionValid=true;
-            $("#descriptionError").addClass("hidden");    		
+            $("#descriptionError").addClass("hidden");
             $('#descriptionGroup').addClass("has-success");
-            
-        } else { 
+
+        } else {
             descriptionValid=false;
             $('#descriptionGroup').removeClass("has-success");
-            $('#descriptionGroup').addClass("has-error");  
+            $('#descriptionGroup').addClass("has-error");
             if(regEx.test(description) === false){
                 $("#descriptionError").removeClass("hidden");
-                $("#descriptionError").text("You have used an invalid character in this description");			    	
-            }	
+                $("#descriptionError").text("You have used an invalid character in this description");
+            }
         }
 
         //----------Validate the dates-------------//
-        //console.log('validate dates'); 
-        datesValid = validateUtcDates(); //validateDates(); 
-        
+        //console.log('validate dates');
+        datesValid = validateUtcDates(); //validateDates();
+
         //----------Validate the Endpoints-------------//
         //Get the selected options from the select services and endpoints list
-        
+
         //var selectedEPs = $('#Select_Services').val();
         //If this string contains an e then and endpoint has been selected
-        //if(selectedEPs != null){            
-        //	$(selectedEPs).each(function(index){    //Iterate over each selected option and check for e.        	
+        //if(selectedEPs != null){
+        //	$(selectedEPs).each(function(index){    //Iterate over each selected option and check for e.
         //   	if(this.indexOf('e') >= 0){
         //        	epValid = true;
         //    		$('#chooseSite').addClass("has-success");
-        //    		$('#chooseServices').addClass("has-success");                	
+        //    		$('#chooseServices').addClass("has-success");
         //    	}else{
         //        	$('#chooseSite').removeClass("has-success");
-        //    		$('#chooseServices').removeClass("has-success");                        	
+        //    		$('#chooseServices').removeClass("has-success");
         //    	}
         //	});
         //}else{
@@ -429,14 +429,14 @@ rather than the Site entities themselves, and specify tz, offset in the DTO/JSON
         if(selectedEPs){
             epValid = true;
             $('#chooseSite').addClass("has-success");
-            $('#chooseServices').addClass("has-success");                	
-            
+            $('#chooseServices').addClass("has-success");
+
         }else{
             epValid=false;
             $('#chooseSite').removeClass("has-success");
             $('#chooseServices').removeClass("has-success");
         }
-        
+
         //----------Set the Button based on validate status-------------//
 
         if(epValid && severityValid && descriptionValid && datesValid){
@@ -446,28 +446,28 @@ rather than the Site entities themselves, and specify tz, offset in the DTO/JSON
             $('#submitDowntime_btn').removeClass('btn btn-success');
             $('#submitDowntime_btn').addClass('btn btn-default');
             $('#submitDowntime_btn').prop('disabled', true);
-            
+
         }
-           
+
    }
 
     function validateUtcDates(){
-       var datesValid = false; 
+       var datesValid = false;
        if(M_END_UTC && M_START_UTC){
         //Check end is after start:
             var diff1 = moment.duration(M_END_UTC - M_START_UTC);
             //console.log(diff1);
-            var now = moment.utc();    
+            var now = moment.utc();
             var diff2 = moment.duration(now - M_START_UTC);
             //console.log(diff2);
-            //Downtime either ends before it begins or its start is over 48 hours ago 
-            if(diff1 <= 0 || diff2 > 172800000){  // if (diff2 > 2daysInMilliSecs) 
+            //Downtime either ends before it begins or its start is over 48 hours ago
+            if(diff1 <= 0 || diff2 > 172800000){  // if (diff2 > 2daysInMilliSecs)
                 $('#startDateGroup').removeClass("has-success");
                 $('#endDateGroup').removeClass("has-success");
                 if(diff1 <= 0){
                     $('#endError').removeClass("hidden");
                     $("#endError").text("A downtime cannot end before it begins.");
-                    $('#endDateGroup').addClass("has-error");                    
+                    $('#endDateGroup').addClass("has-error");
                 }else{
                     $('#startError').addClass("hidden");
                     $('#endDateGroup').removeClass("has-error");
@@ -475,65 +475,65 @@ rather than the Site entities themselves, and specify tz, offset in the DTO/JSON
                 if(diff2 > 172800000){
                     $('#startError').removeClass("hidden");
                     $("#startError").text("The start time of the downtime must be within the last 48 hrs");
-                    $('#startDateGroup').addClass("has-error");            		
+                    $('#startDateGroup').addClass("has-error");
                 }else{
-                    $('#startError').addClass("hidden");       
-                    $('#startDateGroup').removeClass("has-error");             
-                }             
+                    $('#startError').addClass("hidden");
+                    $('#startDateGroup').removeClass("has-error");
+                }
                 datesValid=false;
             }else{
                 datesValid=true;
                 $('#endError').addClass("hidden");
-                $('#startError').addClass("hidden");    
+                $('#startError').addClass("hidden");
                 $('#startDateGroup').addClass("has-success");
-                $('#endDateGroup').addClass("has-success");             
-            }    
-       } 
-       return datesValid; 
+                $('#endDateGroup').addClass("has-success");
+            }
+       }
+       return datesValid;
     }
-    
+
     function getSitesServices(){
         var siteId=$('#Select_Sites').val();
         if(siteId != null){ //If the user clicks on the box but not a specific row there will be no input, so catch that here
-            $('#chooseEndpoints').empty(); //Remove any previous content from the endpoints select list         	    	
+            $('#chooseEndpoints').empty(); //Remove any previous content from the endpoints select list
             $('#chooseServices').load('index.php?Page_Type=Downtime_view_endpoint_tree&site_id='+siteId,function( response, status, xhr ) {
                 if ( status == "success" ) {
                     validate();
                 }
             });
         }
-    }      
-
-    /**
-     * If a site is selected, get the site's timezone and update the 
-     * siteTimezoneText text input. 
-     * @returns {Null} 
-     */
-    function onSiteSelected(){
-        var siteId=$('#Select_Sites').val();
-        updateSiteTimezoneVars(siteId); 
     }
 
     /**
-     * Update the TARGETTIMEZONEID and TARGETTIMEZONEOFFSETFROMUTCSECS global 
-     * vars and update text area with the timezoneId label 
+     * If a site is selected, get the site's timezone and update the
+     * siteTimezoneText text input.
+     * @returns {Null}
+     */
+    function onSiteSelected(){
+        var siteId=$('#Select_Sites').val();
+        updateSiteTimezoneVars(siteId);
+    }
+
+    /**
+     * Update the TARGETTIMEZONEID and TARGETTIMEZONEOFFSETFROMUTCSECS global
+     * vars and update text area with the timezoneId label
      * @param {int} siteId
      * @returns {null}
      */
     function updateSiteTimezoneVars(siteId){
-        if(siteId){ 
-           // use ajax to get the selected site's timezone label and offset 
+        if(siteId){
+           // use ajax to get the selected site's timezone label and offset
            // and update display+vars
            //console.log('fetching selected site timezone label');
-           $.get('index.php', {Page_Type: 'Add_Downtime', siteid_timezone: siteId}, 
+           $.get('index.php', {Page_Type: 'Add_Downtime', siteid_timezone: siteId},
            function(data){
-              var jsonRsp = JSON.parse(data); 
-              // update global variables - used when calculating DT rules 
-              TARGETTIMEZONEID = jsonRsp[0]; 
-              TARGETTIMEZONEOFFSETFROMUTCSECS = jsonRsp[1]; //Returns the targetTimezone offset in seconds from UTC 
-              //console.log("updateSiteTimezoneVars, siteId: ["+siteId+"] TARGETTIMEZONEID: ["+TARGETTIMEZONEID+"] TARGETTIMEZONEOFFSETFROMUTCSECS: ["+TARGETTIMEZONEOFFSETFROMUTCSECS+"]"); 
-              $('#siteTimezoneText').val(TARGETTIMEZONEID); 
-           }); 
+              var jsonRsp = JSON.parse(data);
+              // update global variables - used when calculating DT rules
+              TARGETTIMEZONEID = jsonRsp[0];
+              TARGETTIMEZONEOFFSETFROMUTCSECS = jsonRsp[1]; //Returns the targetTimezone offset in seconds from UTC
+              //console.log("updateSiteTimezoneVars, siteId: ["+siteId+"] TARGETTIMEZONEID: ["+TARGETTIMEZONEID+"] TARGETTIMEZONEOFFSETFROMUTCSECS: ["+TARGETTIMEZONEOFFSETFROMUTCSECS+"]");
+              $('#siteTimezoneText').val(TARGETTIMEZONEID);
+           });
         }
     }
 
@@ -543,7 +543,7 @@ rather than the Site entities themselves, and specify tz, offset in the DTO/JSON
         var id = $('#Select_Services').children(":selected").attr("id");
         console.log(id);
         $('#'+id).prop('selected', true);	    //Set the service parent to be selected
-    }   
+    }
 
     //This function uses pure javascript to return the date - 2 days
     function getDate(){
@@ -554,10 +554,10 @@ rather than the Site entities themselves, and specify tz, offset in the DTO/JSON
            var yyyy = today.getFullYear();
            if(dd<10){
                dd='0'+dd
-           } 
+           }
            if(mm<10){
                mm='0'+mm
-           } 
+           }
 
            date = mm+'/'+dd+'/'+yyyy;
            return date;
@@ -567,11 +567,11 @@ rather than the Site entities themselves, and specify tz, offset in the DTO/JSON
         // see: http://stackoverflow.com/questions/11582512/how-to-get-url-parameters-with-javascript
         return decodeURIComponent((new RegExp('[?|&]' + name + '=' + '([^&;]+?)(&|#|;|$)').exec(location.search)||[,""])[1].replace(/\+/g, '%20'))||null
     }
-   
+
 
 
     /*function validateDates(){
-        var datesValid = false; 
+        var datesValid = false;
         var sDate = $('#startDateContent').val();
         var eDate = $('#endDateContent').val();
         var sTime = $('#startTimeContent').val();
@@ -579,31 +579,31 @@ rather than the Site entities themselves, and specify tz, offset in the DTO/JSON
 
         //Once all time and dates have been set validate to ensure date is not 48 hours in the past
         if(sDate && eDate && sTime  && eTime){
-            var startString = sDate +" "+sTime; 
-            var endString = eDate +" "+eTime;    
-            // moment parses the input string in current LOCAL timezone 
-            // This is what we want because we will be comparing time durations 
-            // against time now using 'moment()' which returns now in current timezone. 
-            var mStart = moment(startString, "DD-MM-YYYY, HH:mm");  
+            var startString = sDate +" "+sTime;
+            var endString = eDate +" "+eTime;
+            // moment parses the input string in current LOCAL timezone
+            // This is what we want because we will be comparing time durations
+            // against time now using 'moment()' which returns now in current timezone.
+            var mStart = moment(startString, "DD-MM-YYYY, HH:mm");
             var mEnd = moment(endString, "DD-MM-YYYY, HH:mm");
-            
+
             //$('#startTimestamp').val(startString);
             //$('#endTimestamp').val(endString);
-            
+
             //Check end is after start:
             var diff1 = moment.duration(mEnd - mStart);
             //console.log(diff1);
-            var now = moment();    
+            var now = moment();
             var diff2 = moment.duration(now - mStart);
             //console.log(diff2);
-            //Downtime either ends before it begins or its start is over 48 hours ago 
-            if(diff1 <= 0 || diff2 > 172800000){  // if (diff2 > 2daysInMilliSecs) 
+            //Downtime either ends before it begins or its start is over 48 hours ago
+            if(diff1 <= 0 || diff2 > 172800000){  // if (diff2 > 2daysInMilliSecs)
                 $('#startDateGroup').removeClass("has-success");
                 $('#endDateGroup').removeClass("has-success");
                 if(diff1 <= 0){
                     $('#endError').removeClass("hidden");
                     $("#endError").text("A downtime cannot end before it begins.");
-                    $('#endDateGroup').addClass("has-error");                    
+                    $('#endDateGroup').addClass("has-error");
                 }else{
                     $('#startError').addClass("hidden");
                     $('#endDateGroup').removeClass("has-error");
@@ -611,24 +611,24 @@ rather than the Site entities themselves, and specify tz, offset in the DTO/JSON
                 if(diff2 > 172800000){
                     $('#startError').removeClass("hidden");
                     $("#startError").text("The start time of the downtime must be within the last 48 hrs");
-                    $('#startDateGroup').addClass("has-error");            		
+                    $('#startDateGroup').addClass("has-error");
                 }else{
-                    $('#startError').addClass("hidden");       
-                    $('#startDateGroup').removeClass("has-error");             
-                }             
+                    $('#startError').addClass("hidden");
+                    $('#startDateGroup').removeClass("has-error");
+                }
                 datesValid=false;
             }else{
                 datesValid=true;
                 $('#endError').addClass("hidden");
-                $('#startError').addClass("hidden");    
+                $('#startError').addClass("hidden");
                 $('#startDateGroup').addClass("has-success");
-                $('#endDateGroup').addClass("has-success");             
-                                            
+                $('#endDateGroup').addClass("has-success");
+
             }
         }
-        return datesValid; 
+        return datesValid;
     }*/
-    
+
 </script>
 
 

--- a/htdocs/web_portal/views/downtime/confirm_add_downtime.php
+++ b/htdocs/web_portal/views/downtime/confirm_add_downtime.php
@@ -8,12 +8,12 @@ $endpoints = $params['Impacted_Endpoints'];
 if(isset($params['isEdit'])){
     $edit = true;
 }else{
-    $edit = false;    
+    $edit = false;
 }
 
 ?>
 <div class="rightPageContainer">
-    <h1 class="Success">Confirm 
+    <h1 class="Success">Confirm
     <?php if($edit){
         echo "Edit";
     }?>
@@ -24,46 +24,46 @@ if(isset($params['isEdit'])){
     <li><b>Description: </b><?php xecho($params['DOWNTIME']['DESCRIPTION'])?></li>
     <?php /*<li><b>Times defined in: </b><?php xecho($params['DOWNTIME']['DEFINE_TZ_BY_UTC_OR_SITE'])?> timezone</li> */ ?>
     <li><b>Starting (UTC): </b>
-    <?php 
+    <?php
         //$startStamp = $params['DOWNTIME']['START_TIMESTAMP'];
         //$timestamp = new DateTime("@$startStamp"); //Little PHP magic to create date object directly from timestamp
         //echo date_format($timestamp, 'l jS \of F Y \a\t\: h:i A');
         xecho($params['DOWNTIME']['START_TIMESTAMP']);
     ?>
     </li>
-    <li><b>Ending (UTC): </b>    
+    <li><b>Ending (UTC): </b>
     <?php
         //$endStamp = $params['DOWNTIME']['END_TIMESTAMP'];
         //$timestamp = new DateTime("@$endStamp"); //Little PHP magic to create date object directly from timestamp
-        //echo date_format($timestamp, 'l jS \of F Y \a\t\: h:i A'); 	    
+        //echo date_format($timestamp, 'l jS \of F Y \a\t\: h:i A');
         xecho($params['DOWNTIME']['END_TIMESTAMP']);
-    ?></li>    
-    <?php 
+    ?></li>
+    <?php
     if(count($services > 1)){
-        echo "<li><b>Affecting Services:</b>";	
+        echo "<li><b>Affecting Services:</b>";
     }else{
         echo "<li><b>Affecting Service:</b>";
-    }   	
-    ?>     
+    }
+    ?>
         <ul>
-        <?php 
+        <?php
         foreach($services as $id){
             $service = \Factory::getServiceService()->getService($id);
-            $safeHostName = xssafe($service->getHostname());  
+            $safeHostName = xssafe($service->getHostname());
             echo "<li>" . $safeHostName . "</li>";
             }
         ?>
         </ul>
     </li>
-    <?php 
+    <?php
     if(count($endpoints > 1)){
-        echo "<li><b>Affecting Endpoints:</b>";	
+        echo "<li><b>Affecting Endpoints:</b>";
     }else{
         echo "<li><b>Affecting Endpoint:</b>";
-    }   	
-    ?>     
+    }
+    ?>
         <ul>
-        <?php 
+        <?php
         foreach($endpoints as $id){
             $endpoint = \Factory::getServiceService()->getEndpoint($id);
             if($endpoint->getName() != ''){
@@ -79,19 +79,19 @@ if(isset($params['isEdit'])){
     </ul>
     <!-- Echo out a page type of edit or add downtime depending on type.  -->
     <?php if(!$edit):?>
-    <form name="Add_Downtime" action="index.php?Page_Type=Add_Downtime" 
-          method="post" class="inputForm" id="Downtime_Form" name=Downtime_Form 
+    <form name="Add_Downtime" action="index.php?Page_Type=Add_Downtime"
+          method="post" class="inputForm" id="Downtime_Form" name=Downtime_Form
           onsubmit="document.getElementById('confirmSubmitBtn').disabled=true">
     <?php else:?>
-    <form name="Add_Downtime" action="index.php?Page_Type=Edit_Downtime" 
-          method="post" class="inputForm" id="Downtime_Form" name=Downtime_Form 
+    <form name="Add_Downtime" action="index.php?Page_Type=Edit_Downtime"
+          method="post" class="inputForm" id="Downtime_Form" name=Downtime_Form
           onsubmit="document.getElementById('confirmSubmitBtn').disabled=true">
     <?php endif;?>
-        <?php $confirmed = true;?> 	
-        <input class="input_input_text" type="hidden" name="CONFIRMED" value="<?php echo $confirmed;?>" />        
+        <?php $confirmed = true;?>
+        <input class="input_input_text" type="hidden" name="CONFIRMED" value="<?php echo $confirmed;?>" />
          <!-- json_encode caters for UTF-8 chars -->
         <input class="input_input_text" type="hidden" name="newValues" value="<?php xecho(json_encode($params));?>" />
-        
+
         <?php if(!$edit):?>
         <input id="confirmSubmitBtn" type="submit" value="Add downtime to GocDB" class="input_button"  >
         <?php else:?>

--- a/htdocs/web_portal/views/downtime/custom_json_encode.php
+++ b/htdocs/web_portal/views/downtime/custom_json_encode.php
@@ -1,8 +1,8 @@
 <?php
-function __json_encode( $data ) {           
+function __json_encode( $data ) {
     if( is_array($data) || is_object($data) ) {
         $islist = is_array($data) && ( empty($data) || array_keys($data) === range(0,count($data)-1) );
-       
+
         if( $islist ) {
             $json = '[' . implode(',', array_map('__json_encode', $data) ) . ']';
         } else {
@@ -20,35 +20,35 @@ function __json_encode( $data ) {
         $len    = strlen($string);
         # Convert UTF-8 to Hexadecimal Codepoints.
         for( $i = 0; $i < $len; $i++ ) {
-           
+
             $char = $string[$i];
             $c1 = ord($char);
-           
+
             # Single byte;
             if( $c1 <128 ) {
                 $json .= ($c1 > 31) ? $char : sprintf("\\u%04x", $c1);
                 continue;
             }
-           
+
             # Double byte
             $c2 = ord($string[++$i]);
             if ( ($c1 & 32) === 0 ) {
                 $json .= sprintf("\\u%04x", ($c1 - 192) * 64 + $c2 - 128);
                 continue;
             }
-           
+
             # Triple
             $c3 = ord($string[++$i]);
             if( ($c1 & 16) === 0 ) {
                 $json .= sprintf("\\u%04x", (($c1 - 224) <<12) + (($c2 - 128) << 6) + ($c3 - 128));
                 continue;
             }
-               
+
             # Quadruple
             $c4 = ord($string[++$i]);
             if( ($c1 & 8 ) === 0 ) {
                 $u = (($c1 & 15) << 2) + (($c2>>4) & 3) - 1;
-           
+
                 $w1 = (54<<10) + ($u<<6) + (($c2 & 15) << 2) + (($c3>>4) & 3);
                 $w2 = (55<<10) + (($c3 & 15)<<6) + ($c4-128);
                 $json .= sprintf("\\u%04x\\u%04x", $w1, $w2);
@@ -59,4 +59,4 @@ function __json_encode( $data ) {
         $json = strtolower(var_export( $data, true ));
     }
     return $json;
-} 
+}

--- a/htdocs/web_portal/views/downtime/downtime_edit_view_nested_endpoints_list.php
+++ b/htdocs/web_portal/views/downtime/downtime_edit_view_nested_endpoints_list.php
@@ -3,7 +3,7 @@ $services = $params['services'];
 $dt = $params['downtime'];
 $configService = \Factory::getConfigService();
 
-//Get the affected services and store the ids in an array. 
+//Get the affected services and store the ids in an array.
 $affectedServiceIds = array();
 foreach($dt->getServices() as $affectedService){
     $affectedServiceIds[] = $affectedService->getId();
@@ -18,28 +18,28 @@ foreach($dt->getEndpointLocations() as $affectedEndpoints){
 ?>
 
 
-<!-- Dynamically create a select list from a sites services 
+<!-- Dynamically create a select list from a sites services
  AND SELECT ONLY THOSE SERVICES AND ENDPOINTS THAT ARE AFFECTED AS DEFINED IN THE DOWNTIME -->
-<label> Select Affected Services</label> 
-<select name="IMPACTED_IDS[]" id="Select_Services" size="10" 
-        class="form-control" onclick="" 
-        style="width:99%; margin-left:1%" 
+<label> Select Affected Services</label>
+<select name="IMPACTED_IDS[]" id="Select_Services" size="10"
+        class="form-control" onclick=""
+        style="width:99%; margin-left:1%"
         onChange="selectServicesEndpoint()" multiple>
-<?php 
+<?php
     foreach($services as $service){
         $count=0;
-        
+
         // Set the html 'SELECTED' attribute on the <option> only if this service was affected.
         if(in_array($service->getId(), $affectedServiceIds)){
             $selected = 'SELECTED';
         }else{
             $selected = '';
         }
-        echo "<option value=\"s" . $service->getId() . "\" id=\"" . $service->getId() . "\" ".$selected.">"; 
-                xecho('('.$service->getServiceType()->getName().') '); 
-                xecho($service->getHostName());  
+        echo "<option value=\"s" . $service->getId() . "\" id=\"" . $service->getId() . "\" ".$selected.">";
+                xecho('('.$service->getServiceType()->getName().') ');
+                xecho($service->getHostName());
                 echo("</option>");
-        
+
         foreach($service->getEndpointLocations() as $endpoint){
                     if(in_array($endpoint->getId(), $affectedEndpointIds)){
                         $selected = 'SELECTED';
@@ -51,11 +51,11 @@ foreach($dt->getEndpointLocations() as $affectedEndpoints){
             }else{
                 $name = xssafe($endpoint->getName());
             }
-            //Option styling doesn't work well cross browser so just use 4 spaces to indent the branch            
+            //Option styling doesn't work well cross browser so just use 4 spaces to indent the branch
             echo "<option id=\"".$service->getId()."\" value=\"e" . $endpoint->getId() . "\" ".$selected.">&nbsp&nbsp&nbsp&nbsp-" . $name . "</option>";
             $count++;
         }
-        
+
     }
-?>	
+?>
 </select>

--- a/htdocs/web_portal/views/downtime/downtimes_calendar.php
+++ b/htdocs/web_portal/views/downtime/downtimes_calendar.php
@@ -521,7 +521,7 @@
         //get the time from the page controller, and turn it into a moment
         var time = moment(<?php if($params['date'] != null){ echo( "\"". $params['date'] . "\", \"YYYY-MM-DD\"");}?>);
         var view = "<?php if($params['view'] != null){ echo($params['view']);}?>";
-        
+
         moment.locale('en', {
             week: { dow: 1 } // Monday is the first day of the week in the datetimepicker
         });

--- a/htdocs/web_portal/views/downtime/downtimes_overview.php
+++ b/htdocs/web_portal/views/downtime/downtimes_overview.php
@@ -10,14 +10,14 @@ $td2 = '</td>';
 
 <!---
 This page will show two tables, one of active downtimes and one of downtimes coming between 1-4 weeks. The user
-can select the time period for planned downtimes to show. Extra information is shown by expanding a sub table 
-from the main downtimes table. This table is shown and hidden by creating dynamically named tables and using 
-javascript to show and hide these tables. 
+can select the time period for planned downtimes to show. Extra information is shown by expanding a sub table
+from the main downtimes table. This table is shown and hidden by creating dynamically named tables and using
+javascript to show and hide these tables.
 --->
 <div class="rightPageContainer">
     <script type="text/javascript" src="<?php echo \GocContextPath::getPath()?>javascript/confirm.js"></script>
     <script type="text/javascript" src="<?php echo \GocContextPath::getPath()?>javascript/showHide.js"></script>
-        
+
     <div style="overflow: hidden;">
         <div style="float: left;">
             <img src="<?php echo \GocContextPath::getPath()?>img/down_arrow.png" class="pageLogo" />
@@ -44,14 +44,14 @@ javascript to show and hide these tables.
                     <th class="site_table">Classification</th>
                     <th class="site_table">Services Affected</th>
                     <th class="site_table">Start</th>
-                    <th class="site_table">End</th>                    
+                    <th class="site_table">End</th>
                 </tr>
-                
-                <?php 
+
+                <?php
                 $count = 0;
-                foreach($dtActive as $dt){ 
-                    echo '<tr class="site_table_row_2">';                
-                                        
+                foreach($dtActive as $dt){
+                    echo '<tr class="site_table_row_2">';
+
                     $affectedServices = $dt->getServices();
                     $affectedEPs = count($affectedServices);
                     $parentSite = $affectedServices->first()->getParentSite();
@@ -79,7 +79,7 @@ javascript to show and hide these tables.
                     echo $td1 . xssafe($dt->getClassification()) .  $td2;
                     echo $td1 . $affectedEPs . ' of ' . $siteTotalEPs .  $td2;
                     echo $td1 . $dt->getStartDate()->format(DATE_FORMAT) .  $td2;
-                    echo $td1 . $dt->getEndDate()->format(DATE_FORMAT) .  $td2;                             
+                    echo $td1 . $dt->getEndDate()->format(DATE_FORMAT) .  $td2;
                     //There is dynamic creation of table ids here which are used to show and hide the extra services info
                     //when clicked. This sub table by default is hidden
                     echo '</tr>';
@@ -91,42 +91,42 @@ javascript to show and hide these tables.
                     echo '<th class="site_table">Hostname</th>';
                     echo '<th class="site_table">Production</th>';
                     echo '<th class="site_table">Monitored</th>';
-                    
+
                     foreach($dt->getServices() as $se){
-                        echo '<tr class="site_table_row_2">';            			
+                        echo '<tr class="site_table_row_2">';
                         $sID = $se->getParentSite()->getId();
                         echo $td1 . '<a href="index.php?Page_Type=Site&id='.$sID.'"/>'.xssafe($se->getParentSite()->getName()).'</a>'.$td2;
                         echo $td1 . '<a href="index.php?Page_Type=Service&id='.$se->getId().'"/>'.xssafe($se->getHostName()).'</a>'.$td2;
                         echo $td1 . (($se->getProduction()) ? 'Yes' : 'No') . $td2;
-                        echo $td1 . (($se->getMonitored()) ? 'Yes' : 'No') . $td2;            			
-                        echo '</tr>';            			
+                        echo $td1 . (($se->getMonitored()) ? 'Yes' : 'No') . $td2;
+                        echo '</tr>';
                     }
-                    
+
 
                     echo '</table>';
                     echo '</td></tr>';
                     $count++;
                 }
-                
-                ?>           
+
+                ?>
             </table>
         </div>
-        
-        
+
+
         <!--  Imminent Downtimes -->
         <div class="listContainer" style="width: 99.5%; float: left; margin-top: 3em; margin-right: 10px;">
             <span class="header" style="vertical-align:middle; float: left; padding-top: 0.9em; padding-left: 1em;">Downtimes Schedules for the next week(s)</span>
             <img src="<?php echo \GocContextPath::getPath()?>img/service.png" class="decoration"/>
-           
-           <div class="topMargin rightFloat clearRight">            
+
+           <div class="topMargin rightFloat clearRight">
            <form action="index.php?Page_Type=Downtimes_Overview" method="GET" class="inline">
             <input type="hidden" name="Page_Type" value="Downtimes_Overview" />
 
-                <select name="timePeriod" onchange="form.submit()">                                        
+                <select name="timePeriod" onchange="form.submit()">
                     <?php for($i=1; $i<5; $i++){ ?>
                         <option value="<?php echo $i ?>"<?php if($timePeriod == $i){echo " selected";} ?>><?php echo $i." weeks"?></option>
                     <?php }?>
-                    
+
                 </select>
             </form>
             </div>
@@ -138,14 +138,14 @@ javascript to show and hide these tables.
                     <th class="site_table">Classification</th>
                     <th class="site_table">Services Affected</th>
                     <th class="site_table">Start</th>
-                    <th class="site_table">End</th>                    
+                    <th class="site_table">End</th>
                 </tr>
-                
-                <?php 
+
+                <?php
                 $count = 0;
-                foreach($dtImmenent as $dt){ 
-                    echo '<tr class="site_table_row_2">';                
-                    
+                foreach($dtImmenent as $dt){
+                    echo '<tr class="site_table_row_2">';
+
                     $affectedServices = $dt->getServices();
                     $affectedEPs = count($affectedServices);
                     $parentSite = $affectedServices->first()->getParentSite();
@@ -173,7 +173,7 @@ javascript to show and hide these tables.
                     echo $td1 . xssafe($dt->getClassification()) .  $td2;
                     echo $td1 . $affectedEPs . ' of ' . $siteTotalEPs .  $td2;
                     echo $td1 . $dt->getStartDate()->format(DATE_FORMAT) .  $td2;
-                    echo $td1 . $dt->getEndDate()->format(DATE_FORMAT) .  $td2;                             
+                    echo $td1 . $dt->getEndDate()->format(DATE_FORMAT) .  $td2;
                     //There is dynamic creation of table ids here which are used to show and hide the extra services info
                     //when clicked. This sub table by default is hidden
                     echo '</tr>';
@@ -185,26 +185,26 @@ javascript to show and hide these tables.
                     echo '<th class="site_table">Hostname</th>';
                     echo '<th class="site_table">Production</th>';
                     echo '<th class="site_table">Monitored</th>';
-                    
+
                     foreach($dt->getServices() as $se){
-                        echo '<tr class="site_table_row_2">';            			
+                        echo '<tr class="site_table_row_2">';
                         $sID = $se->getParentSite()->getId();
                         echo $td1 . '<a href="index.php?Page_Type=Site&id='.$sID.'"/>'.xssafe($se->getParentSite()->getName()).'</a>'.$td2;
-                        echo $td1 . '<a href="index.php?Page_Type=Service&id='.$se->getId().'"/>'.xssafe($se->getHostName()).'</a>'.$td2; 
+                        echo $td1 . '<a href="index.php?Page_Type=Service&id='.$se->getId().'"/>'.xssafe($se->getHostName()).'</a>'.$td2;
                         echo $td1 . (($se->getProduction()) ? 'Yes' : 'No') . $td2;
-                        echo $td1 . (($se->getMonitored()) ? 'Yes' : 'No') . $td2;            			
-                        echo '</tr>';            			
+                        echo $td1 . (($se->getMonitored()) ? 'Yes' : 'No') . $td2;
+                        echo '</tr>';
                     }
-                    
+
 
                     echo '</table>';
                     echo '</td></tr>';
                     $count++;
                 }
-                
-                ?>           
+
+                ?>
             </table>
         </div>
-        
+
     </div>
 </div>

--- a/htdocs/web_portal/views/downtime/edit_downtime.php
+++ b/htdocs/web_portal/views/downtime/edit_downtime.php
@@ -12,13 +12,13 @@ foreach($downtime->getServices() as $service){
 }
 
 if(count($affectedSites == 1)){
-   $siteTimezoneId = $affectedSites[0]->getTimezoneId();  
+   $siteTimezoneId = $affectedSites[0]->getTimezoneId();
 } else {
-   $siteTimezoneId = 'UTC';  
+   $siteTimezoneId = 'UTC';
 }
 
-$nowInTargetTz = new \DateTime(null, new \DateTimeZone($siteTimezoneId)); 
-$offsetInSecsFromUtc = $nowInTargetTz->getOffset(); 
+$nowInTargetTz = new \DateTime(null, new \DateTimeZone($siteTimezoneId));
+$offsetInSecsFromUtc = $nowInTargetTz->getOffset();
 
 foreach($downtime->getEndpointLocations() as $endpoints){
     $affectedEndpoints[] = $endpoints;
@@ -36,10 +36,10 @@ foreach($downtime->getEndpointLocations() as $endpoints){
         <?php /*<li>Time in UTC since last page refresh <strong><?php xecho($params['nowUtc']);?></strong></li>*/ ?>
         <li>Time in UTC: <label id="timeinUtcNowLabel"></label></li>
     </ul>
-    <?php 
+    <?php
 //     echo $downtime->getId().'<br>';
-//     echo( $startDate->format('Y-m-d H:i:s').'<br>' ); 
-//     echo( $endDate->format('Y-m-d H:i:s') ); 
+//     echo( $startDate->format('Y-m-d H:i:s').'<br>' );
+//     echo( $endDate->format('Y-m-d H:i:s') );
 //     ?>
     <br>
 
@@ -64,7 +64,7 @@ foreach($downtime->getEndpointLocations() as $endpoints){
             <div class="controls">
                 <input type="text" class="form-control" name="DESCRIPTION" id="description"  value="<?php xecho($downtime->getDescription());?>">
             </div>
-            <span id="descriptionError" class="label label-danger hidden"></span> 
+            <span id="descriptionError" class="label label-danger hidden"></span>
         </div>
 
         <br>
@@ -73,7 +73,7 @@ foreach($downtime->getEndpointLocations() as $endpoints){
         <div class="alert alert-warning" role="alert">
           You may need to update your site's timezone from UTC to the required value for your site - this version of GOCDB uses
           a new timezone logic with new timezone labels taken from the 'Olsen' database. Where possible, the
-          old values have been copied over, but some legacy values including those starting 'Etc/' are not supported and so UTC 
+          old values have been copied over, but some legacy values including those starting 'Etc/' are not supported and so UTC
           is specified by default.
         </div>
 
@@ -81,14 +81,14 @@ foreach($downtime->getEndpointLocations() as $endpoints){
         <div class="form-group" id="timezoneSelectGroup">
             <label class="control-label">Enter Times In:</label>&nbsp;&nbsp;&nbsp;&nbsp;
             <input type="radio" name="DEFINE_TZ_BY_UTC_OR_SITE" id="utcRadioButton" value="utc" checked>UTC&nbsp;&nbsp;&nbsp;&nbsp;
-            <input type="radio" name="DEFINE_TZ_BY_UTC_OR_SITE" id="siteRadioButton" value="site">Site Timezone 
+            <input type="radio" name="DEFINE_TZ_BY_UTC_OR_SITE" id="siteRadioButton" value="site">Site Timezone
             <input type="text" id="siteTimezoneText" placeholder="Updated on site selection" readonly>
             &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<label id="schedulingStatusLabel"></label>
-        </div>    
+        </div>
 
-        
+
         <label for="startDate">Starts on:</label>
-        <mark><label id="startUtcLabel"></label></mark> 
+        <mark><label id="startUtcLabel"></label></mark>
         <div class="form-group" id="startDateGroup">
             <!-- Date Picker -->
             <div class="input-group date datePicker" id="startDate">
@@ -100,13 +100,13 @@ foreach($downtime->getEndpointLocations() as $endpoints){
 
             <!-- Time Picker -->
             <div class="input-group date timePicker" id="startTime">
-                <input type='text' class="form-control" 
+                <input type='text' class="form-control"
                     id="startTimeContent" /> <span class="input-group-addon"><span
                     class="glyphicon glyphicon-time"></span> </span>
             </div>
         </div>
         <div class="form-group"><span id="startError" class="label label-danger hidden"></span>&nbsp</div> <!-- Single space reserves a line for the label -->
-        
+
         <label for="endDate">Ends on:</label>
         <mark><label id="endUtcLabel"></label></mark>
         <div class="form-group" id="endDateGroup">
@@ -120,13 +120,13 @@ foreach($downtime->getEndpointLocations() as $endpoints){
 
             <!-- Time Picker -->
             <div class="input-group date timePicker" id="endTime">
-                <input type='text' class="form-control has-error" 
+                <input type='text' class="form-control has-error"
                     id="endTimeContent" /> <span class="input-group-addon"><span
                     class="glyphicon glyphicon-time"></span> </span>
-                    
+
             </div>
-        </div>		
-                
+        </div>
+
         <div class="form-group"><span id="endError" class="label label-danger hidden"></span>&nbsp</div>  <!-- Single space reserves a line for the label -->
 
         <div id="chooseSite" style="width: 50%; float: left; display: inline-block;">
@@ -137,7 +137,7 @@ foreach($downtime->getEndpointLocations() as $endpoints){
             //    $site = $se->getParentSite();
             //    $sites[] = $site;
             //}
-            
+
             $sites = array_unique($affectedSites);
             usort($sites, function($a, $b) {
                 return strcmp($a, $b);
@@ -160,7 +160,7 @@ foreach($downtime->getEndpointLocations() as $endpoints){
 
                 <?php
                 foreach($sites as $site){
-                    $sName = xssafe($site); 
+                    $sName = xssafe($site);
                     echo "<option value=\"{$site->getId()}\" SELECTED>$sName</option>";
                 }
                 ?>
@@ -192,20 +192,20 @@ foreach($downtime->getEndpointLocations() as $endpoints){
    /* global TARGETTIMEZONEID: true */
    /* global TARGETTIMEZONEOFFSETFROMUTCSECS: true */
    /* global M_START_UTC: true */
-   /* global M_END_UTC: true */ 
-   
-   var TARGETTIMEZONEID = "UTC";  // e.g. Europe/London 
+   /* global M_END_UTC: true */
+
+   var TARGETTIMEZONEID = "UTC";  // e.g. Europe/London
    var TARGETTIMEZONEOFFSETFROMUTCSECS = 0; // e.g. 3600 if TARGETTIMEZONEID is ahead of UTC by 1hr
-   var M_START_UTC = null; 
-   var M_END_UTC = null; 
-   var M_START_UTC_PRE_EDIT = null; 
-   var M_END_UTC_PRE_EDIT = null; 
+   var M_START_UTC = null;
+   var M_END_UTC = null;
+   var M_START_UTC_PRE_EDIT = null;
+   var M_END_UTC_PRE_EDIT = null;
 
    $(document).ready(function() {
-        TARGETTIMEZONEID =  "<?php xecho($siteTimezoneId); ?>";  
-        TARGETTIMEZONEOFFSETFROMUTCSECS = <?php echo($offsetInSecsFromUtc); ?>; 
-        $('#siteTimezoneText').val(TARGETTIMEZONEID); 
-        
+        TARGETTIMEZONEID =  "<?php xecho($siteTimezoneId); ?>";
+        TARGETTIMEZONEOFFSETFROMUTCSECS = <?php echo($offsetInSecsFromUtc); ?>;
+        $('#siteTimezoneText').val(TARGETTIMEZONEID);
+
         //Setup datetimepicker
        $('#startDate, #endDate').datetimepicker({
            format: 'DD/MM/YYYY',
@@ -229,13 +229,13 @@ foreach($downtime->getEndpointLocations() as $endpoints){
         $('#startTime').data("DateTimePicker").date("<?php echo date_format($startDate,"H:i"); ?>");
         $('#endTime').data("DateTimePicker").date("<?php echo date_format($endDate,"H:i"); ?>");
 
-        // By default select the original affected services and endpoints  
+        // By default select the original affected services and endpoints
         loadSitesServicesAndEndpoints();
 
-        // Calculate the start end times in UTC/site timezone 
-        updateStartEndTimesInUtc(); 
-  
-        // Run through the validate and set edit downtime submit button to enabled or not.  
+        // Calculate the start end times in UTC/site timezone
+        updateStartEndTimesInUtc();
+
+        // Run through the validate and set edit downtime submit button to enabled or not.
         validate();
 
        // Add the jQuery form change event handlers
@@ -248,27 +248,27 @@ foreach($downtime->getEndpointLocations() as $endpoints){
        });
 
        // The bootstrap datetimepickers don't fire the change event
-       // but they trigger a dp.change event instead so a separate 
+       // but they trigger a dp.change event instead so a separate
        // jQuery handler is needed.
        $('.date').on("dp.change", function(e) {
            updateStartEndTimesInUtc();
            validate();
        });
 
-        // Store the start/end times before the user starts to modify (are 
-        // used when validating the new duration which can only be shorter) 
-        M_START_UTC_PRE_EDIT = M_START_UTC; 
-        M_END_UTC_PRE_EDIT = M_END_UTC; 
-        
+        // Store the start/end times before the user starts to modify (are
+        // used when validating the new duration which can only be shorter)
+        M_START_UTC_PRE_EDIT = M_START_UTC;
+        M_END_UTC_PRE_EDIT = M_END_UTC;
+
     });
 
 
-   
+
    function validate(){
         var epValid=false;
         var severityValid=false;
         var descriptionValid=false;
-        var datesValid=false; 
+        var datesValid=false;
 
         //----------Validate the Severity-------------//
         var severityStatus = $('#severity').val();
@@ -277,32 +277,32 @@ foreach($downtime->getEndpointLocations() as $endpoints){
             $('#severityGroup').removeClass("has-error");
             $('#severityGroup').addClass("has-success");
             $('#severityError').addClass("hidden");
-            
+
         }else{
             severityValid=false;
-            $('#severityGroup').addClass("has-error");  
+            $('#severityGroup').addClass("has-error");
             $('#severityError').removeClass("hidden");
             $("#severityError").text("Please choose a severity for this downtime.");
         }
-        
+
         //----------Validate the Description-------------//
         //var regEx = /^[-A-Za-z0-9\s._(),:;/'\\]{0,4000}$/;    //This line may not appear valid in IDEs but it is
-        var regEx = /^[^`'\";<>]{0,4000}$/;  
+        var regEx = /^[^`'\";<>]{0,4000}$/;
         var description = $('#description').val();
 
         if(description && regEx.test(description) !== false){
             descriptionValid=true;
-            $("#descriptionError").addClass("hidden");    		
+            $("#descriptionError").addClass("hidden");
             $('#descriptionGroup').addClass("has-success");
-            
+
         }else { //if(description != ''){
             descriptionValid=false;
             $('#descriptionGroup').removeClass("has-success");
-            $('#descriptionGroup').addClass("has-error");  
+            $('#descriptionGroup').addClass("has-error");
             if(regEx.test(description) === false){
                 $("#descriptionError").removeClass("hidden");
-                $("#descriptionError").text("You have used an invalid character in this description");			    	
-            }	
+                $("#descriptionError").text("You have used an invalid character in this description");
+            }
         }
 //        else if(description == ''){   //If field is empty then show no errors or colours
 //    		$("#descriptionError").addClass("hidden");
@@ -310,23 +310,23 @@ foreach($downtime->getEndpointLocations() as $endpoints){
 //    		$("#descriptionGroup").removeClass("has-error");
 //    	}
 
-        //console.log('validating dates'); 
-        datesValid = validateUtcDates(); //validateDates(); 	
-        
+        //console.log('validating dates');
+        datesValid = validateUtcDates(); //validateDates();
+
         //----------Validate the Endpoints-------------//
         //Get the selected options from the select services and endpoints list
-        
+
         //var selectedEPs = $('#Select_Services').val();
         //If this string contains an e then and endpoint has been selected
-        //if(selectedEPs != null){            
-        //	$(selectedEPs).each(function(index){    //Iterate over each selected option and check for e.        	
+        //if(selectedEPs != null){
+        //	$(selectedEPs).each(function(index){    //Iterate over each selected option and check for e.
         //   	if(this.indexOf('e') >= 0){
         //        	epValid = true;
         //    		$('#chooseSite').addClass("has-success");
-        //    		$('#chooseServices').addClass("has-success");                	
+        //    		$('#chooseServices').addClass("has-success");
         //    	}else{
         //        	$('#chooseSite').removeClass("has-success");
-        //    		$('#chooseServices').removeClass("has-success");                        	
+        //    		$('#chooseServices').removeClass("has-success");
         //    	}
         //	});
         //}else{
@@ -340,14 +340,14 @@ foreach($downtime->getEndpointLocations() as $endpoints){
         if(selectedEPs){
             epValid = true;
             $('#chooseSite').addClass("has-success");
-            $('#chooseServices').addClass("has-success");                	
-            
+            $('#chooseServices').addClass("has-success");
+
         }else{
             epValid=false;
             $('#chooseSite').removeClass("has-success");
             $('#chooseServices').removeClass("has-success");
         }
-        
+
         //----------Set the Button based on validate status-------------//
 
         if(epValid && severityValid && descriptionValid && datesValid){
@@ -361,35 +361,35 @@ foreach($downtime->getEndpointLocations() as $endpoints){
    }
 
 
-    
+
     /**
-     * Load the affected services and endpoints of the original downtime (before edit). 
-     * This loads an html <select> list that displays all of the site's 
-     * services and all of their endpoints, and HIGHLIGHTS ONLY THE SERVICES AND 
-     * ENDPOINTS THAT ARE AFFECTED BY THE CURRENT DOWNTIME. 
+     * Load the affected services and endpoints of the original downtime (before edit).
+     * This loads an html <select> list that displays all of the site's
+     * services and all of their endpoints, and HIGHLIGHTS ONLY THE SERVICES AND
+     * ENDPOINTS THAT ARE AFFECTED BY THE CURRENT DOWNTIME.
      * The services and endpoints that are affected by the current downtime can
      * be subsequently re-selected for update.
-     * Note, only the services and endpoints belonging to the original site can 
-     * be udpated, and at least one service must be selected.   
-     * 
+     * Note, only the services and endpoints belonging to the original site can
+     * be udpated, and at least one service must be selected.
+     *
      * @returns {undefined}
      */
     function loadSitesServicesAndEndpoints(){
         var dtId = <?php echo $downtime->getId();?>;
-        var siteId=$('#Select_Sites').val();    	    	
-        
-        $('#chooseServices').empty(); //Remove any previous content from the endpoints select list         	    	
-        // The Page_Type handler for 'Edit_Downtime_view_endpoint_tree' in the front controller loads the 
+        var siteId=$('#Select_Sites').val();
+
+        $('#chooseServices').empty(); //Remove any previous content from the endpoints select list
+        // The Page_Type handler for 'Edit_Downtime_view_endpoint_tree' in the front controller loads the
         // following view: 'views/downtime/downtime_edit_view_nested_endpoints_list.php'
-        // loading the downtime and the site. 
+        // loading the downtime and the site.
         $('#chooseServices').load('index.php?Page_Type=Edit_Downtime_view_endpoint_tree&dt_id='+dtId+'&site_id='+siteId,
           function( response, status, xhr ) {
               if ( status == "success" ) {
                     validate();
                   }
         });
-        
-    }      
+
+    }
 
     //This function will select all of a services endpoints when the user clicks just the service option in the list
     function selectServicesEndpoint(){
@@ -397,17 +397,17 @@ foreach($downtime->getEndpointLocations() as $endpoints){
         var id = $('#Select_Services').children(":selected").attr("id");
         console.log(id);
         $('#'+id).prop('selected', true);	    //Set the service parent to be selected
-        
-    }   
+
+    }
 
 
     /**
-     * Get the start/end time strings and calculate the UTC equivalents using 
-     * the {@link TARGETTIMEZONEID} and {@link TARGETTIMEZONEOFFSETFROMUTCSECS} 
-     * values, then update the global vars {@link M_START_UTC} and {@link M_END_UTC}. 
-     * and the startTimestamp and endTimestamp form submission parameters.  
-     * Finally update the GUI labels.  
-     * 
+     * Get the start/end time strings and calculate the UTC equivalents using
+     * the {@link TARGETTIMEZONEID} and {@link TARGETTIMEZONEOFFSETFROMUTCSECS}
+     * values, then update the global vars {@link M_START_UTC} and {@link M_END_UTC}.
+     * and the startTimestamp and endTimestamp form submission parameters.
+     * Finally update the GUI labels.
+     *
      * @returns {null}
      */
     function updateStartEndTimesInUtc(){
@@ -415,109 +415,109 @@ foreach($downtime->getEndpointLocations() as $endpoints){
         var sDate = $('#startDateContent').val();
         var eDate = $('#endDateContent').val();
         var sTime = $('#startTimeContent').val();
-        var eTime = $('#endTimeContent').val(); 
-        
-        // calculate the start date time in UTC 
+        var eTime = $('#endTimeContent').val();
+
+        // calculate the start date time in UTC
         if(sDate && sTime){
             // First Parse the input string as UTC
             // (use moment.utc(), otherwise moment parses in current timezone)
-            var start = sDate +" "+sTime; 
+            var start = sDate +" "+sTime;
             var mStart = moment.utc(start, "DD-MM-YYYY, HH:mm"); // parse in utc
-            //console.log(mStart); 
-            // Then update utc time to time in target timezone; 
-            // if SiteTimezone RB is selected, subtract offset from time to 
-            // get time in specified tz 
-            if($('#siteRadioButton').is(':checked')){ 
-               mStart.subtract(TARGETTIMEZONEOFFSETFROMUTCSECS, 's'); 
+            //console.log(mStart);
+            // Then update utc time to time in target timezone;
+            // if SiteTimezone RB is selected, subtract offset from time to
+            // get time in specified tz
+            if($('#siteRadioButton').is(':checked')){
+               mStart.subtract(TARGETTIMEZONEOFFSETFROMUTCSECS, 's');
             }
-            M_START_UTC = mStart; 
-            //console.log(M_START_UTC.format("DD-MM-YYYY, HH:mm")); 
-            //console.log(M_START_UTC.format()); 
-            $('#startUtcLabel').text(M_START_UTC.format("DD/MM/YYYY HH:mm")+' UTC'); 
-            $('#startTimestamp').val(M_START_UTC.format("DD/MM/YYYY HH:mm")); 
+            M_START_UTC = mStart;
+            //console.log(M_START_UTC.format("DD-MM-YYYY, HH:mm"));
+            //console.log(M_START_UTC.format());
+            $('#startUtcLabel').text(M_START_UTC.format("DD/MM/YYYY HH:mm")+' UTC');
+            $('#startTimestamp').val(M_START_UTC.format("DD/MM/YYYY HH:mm"));
 
-            // refresh the SCHEDULED/UNSCHEDULED label  
-            refreshScheduledStatus();  
+            // refresh the SCHEDULED/UNSCHEDULED label
+            refreshScheduledStatus();
         }
-        // calculate the end date time in UTC 
+        // calculate the end date time in UTC
         if(eDate && eTime){
             // First Parse the input string as UTC
             // (use moment.utc(), otherwise moment parses in current timezone)
-            var end = eDate +" "+eTime;    
+            var end = eDate +" "+eTime;
             var mEnd = moment.utc(end, "DD-MM-YYYY, HH:mm"); // parse in utc
             //console.log(mEnd);
-            // Then update utc time to time in target timezone; 
-            // if SiteTimezone RB is selected, subtract offset from time to 
-            // get time in specified tz 
-            if($('#siteRadioButton').is(':checked')){  
-                mEnd.subtract(TARGETTIMEZONEOFFSETFROMUTCSECS, 's'); 
+            // Then update utc time to time in target timezone;
+            // if SiteTimezone RB is selected, subtract offset from time to
+            // get time in specified tz
+            if($('#siteRadioButton').is(':checked')){
+                mEnd.subtract(TARGETTIMEZONEOFFSETFROMUTCSECS, 's');
             }
-            M_END_UTC = mEnd; 
-            //console.log(M_END_UTC.format("DD-MM-YYYY, HH:mm")); 
-            //console.log(M_END_UTC.format()); 
-            $('#endUtcLabel').text(M_END_UTC.format("DD/MM/YYYY HH:mm")+' UTC'); 
-            $('#endTimestamp').val(M_END_UTC.format("DD/MM/YYYY HH:mm")); 
+            M_END_UTC = mEnd;
+            //console.log(M_END_UTC.format("DD-MM-YYYY, HH:mm"));
+            //console.log(M_END_UTC.format());
+            $('#endUtcLabel').text(M_END_UTC.format("DD/MM/YYYY HH:mm")+' UTC');
+            $('#endTimestamp').val(M_END_UTC.format("DD/MM/YYYY HH:mm"));
         }
    }
 
    /*
-    * Dynamically update the UTC time label and SCHEDULED/UNSCHEDULED labels. 
+    * Dynamically update the UTC time label and SCHEDULED/UNSCHEDULED labels.
     */
    setInterval(refreshScheduledStatus,5000);
-   setInterval(refreshCurrentUtcTimeLabel,1000); 
-  
+   setInterval(refreshCurrentUtcTimeLabel,1000);
+
    /**
-    * Update the UTC time label, executed every second. 
+    * Update the UTC time label, executed every second.
     * @returns {null}
     */
    function refreshCurrentUtcTimeLabel(){
-       var nowUtc = moment.utc(); 
-       $('#timeinUtcNowLabel').text(nowUtc.format("DD/MM/YYYY HH:mm:ss"));  
-   } 
+       var nowUtc = moment.utc();
+       $('#timeinUtcNowLabel').text(nowUtc.format("DD/MM/YYYY HH:mm:ss"));
+   }
 
    /**
-    * Update the SCHEDULED/UNSCHEDULED status label depending on 
-    * currently specified start/end time values, executed every 5 secs.   
+    * Update the SCHEDULED/UNSCHEDULED status label depending on
+    * currently specified start/end time values, executed every 5 secs.
     * @returns {null}
     */
    function refreshScheduledStatus(){
-       $('#schedulingStatusLabel').text(''); 
-        var nowUtc = moment.utc();    
-        var duration24hrs = moment.duration(24, 'hours'); 
+       $('#schedulingStatusLabel').text('');
+        var nowUtc = moment.utc();
+        var duration24hrs = moment.duration(24, 'hours');
         if(M_START_UTC){
             if( M_START_UTC > (nowUtc + duration24hrs)){
-               $('#schedulingStatusLabel').text('SCHEDULED'); 
+               $('#schedulingStatusLabel').text('SCHEDULED');
             } else {
-               $('#schedulingStatusLabel').text('UNSCHEDULED'); 
+               $('#schedulingStatusLabel').text('UNSCHEDULED');
             }
         }
-        
+
         /*var sDate = $('#startDateContent').val();
         var sTime = $('#startTimeContent').val();
 
-        // calculate the start date time in UTC 
+        // calculate the start date time in UTC
         if(sDate && sTime){
             // First Parse the input string as UTC
             // (use moment.utc(), otherwise moment parses in current timezone)
-            var start = sDate +" "+sTime; 
+            var start = sDate +" "+sTime;
             var mStart = moment.utc(start, "DD-MM-YYYY, HH:mm"); // parse in utc
-            // this logic should go into a self-refresh loop. 
-            
-            // Then update utc time to time in target timezone; 
-            // if SiteTimezone RB is selected, subtract offset from time to 
-            // get time in specified tz 
-            if($('#siteRadioButton').is(':checked')){ 
-               mStart.subtract(TARGETTIMEZONEOFFSETFROMUTCSECS, 's'); 
+            // this logic should go into a self-refresh loop.
+
+            // Then update utc time to time in target timezone;
+            // if SiteTimezone RB is selected, subtract offset from time to
+            // get time in specified tz
+            if($('#siteRadioButton').is(':checked')){
+               mStart.subtract(TARGETTIMEZONEOFFSETFROMUTCSECS, 's');
             }
-             
+
             //if(mStart){    // if mStart is not null
-                $('#schedulingStatusLabel').text(''); 
-                var nowUtc = moment.utc();    
-                var duration24hrs = moment.duration(24, 'hours'); 
+                $('#schedulingStatusLabel').text('');
+                var nowUtc = moment.utc();
+                var duration24hrs = moment.duration(24, 'hours');
                 if( mStart > (nowUtc + duration24hrs)){
-                   $('#schedulingStatusLabel').text('SCHEDULED'); 
+                   $('#schedulingStatusLabel').text('SCHEDULED');
                 } else {
-                   $('#schedulingStatusLabel').text('UNSCHEDULED'); 
+                   $('#schedulingStatusLabel').text('UNSCHEDULED');
                 }
             //}
         }*/
@@ -528,30 +528,30 @@ foreach($downtime->getEndpointLocations() as $endpoints){
        if(M_END_UTC && M_START_UTC){
             var newDuration = moment.duration(M_END_UTC - M_START_UTC);
             var startDuration = moment.duration(now - M_START_UTC);
-            var now = moment.utc();    
+            var now = moment.utc();
 
             if(M_END_UTC_PRE_EDIT && M_START_UTC_PRE_EDIT){
-                var originalDuration = moment.duration(M_END_UTC_PRE_EDIT - M_START_UTC_PRE_EDIT); 
+                var originalDuration = moment.duration(M_END_UTC_PRE_EDIT - M_START_UTC_PRE_EDIT);
                 if(newDuration > originalDuration){
                     $('#startDateGroup').removeClass("has-success");
                     $('#endDateGroup').removeClass("has-success");
                     $('#endError').removeClass("hidden");
                     $("#endError").text("Downtime durations can't be extended, add a new DT to extend.");
-                    $('#endDateGroup').addClass("has-error");  
-                    $('#startDateGroup').addClass("has-error");  
-                    return false; 
+                    $('#endDateGroup').addClass("has-error");
+                    $('#startDateGroup').addClass("has-error");
+                    return false;
                 }
             }
-            
+
             //console.log(diff2);
-            //Downtime either ends before it begins or its start is over 48 hours ago 
-            if(newDuration <= 0 || startDuration > 172800000){  // if (diff2 > 2daysInMilliSecs) 
+            //Downtime either ends before it begins or its start is over 48 hours ago
+            if(newDuration <= 0 || startDuration > 172800000){  // if (diff2 > 2daysInMilliSecs)
                 $('#startDateGroup').removeClass("has-success");
                 $('#endDateGroup').removeClass("has-success");
                 if(newDuration <= 0){
                     $('#endError').removeClass("hidden");
                     $("#endError").text("A downtime cannot end before it begins.");
-                    $('#endDateGroup').addClass("has-error");                    
+                    $('#endDateGroup').addClass("has-error");
                 }else{
                     $('#startError').addClass("hidden");
                     $('#endDateGroup').removeClass("has-error");
@@ -559,22 +559,22 @@ foreach($downtime->getEndpointLocations() as $endpoints){
                 if(startDuration > 172800000){
                     $('#startError').removeClass("hidden");
                     $("#startError").text("The start time of the downtime must be within the last 48 hrs");
-                    $('#startDateGroup').addClass("has-error");            		
+                    $('#startDateGroup').addClass("has-error");
                 }else{
-                    $('#startError').addClass("hidden");       
-                    $('#startDateGroup').removeClass("has-error");             
-                }             
+                    $('#startError').addClass("hidden");
+                    $('#startDateGroup').removeClass("has-error");
+                }
                 return false;
             }
 
-            // ok, dates seem valid 
+            // ok, dates seem valid
             $('#endError').addClass("hidden");
-            $('#startError').addClass("hidden");    
+            $('#startError').addClass("hidden");
             $('#startDateGroup').addClass("has-success");
-            $('#endDateGroup').addClass("has-success");             
-            return true; 
-       } 
-       return false; 
+            $('#endDateGroup').addClass("has-success");
+            return true;
+       }
+       return false;
     }
 
     //This function uses pure javascript to return the date - 2 days
@@ -586,10 +586,10 @@ foreach($downtime->getEndpointLocations() as $endpoints){
            var yyyy = today.getFullYear();
            if(dd<10){
                dd='0'+dd
-           } 
+           }
            if(mm<10){
                mm='0'+mm
-           } 
+           }
 
            date = mm+'/'+dd+'/'+yyyy;
            return date;
@@ -597,7 +597,7 @@ foreach($downtime->getEndpointLocations() as $endpoints){
 
 
     /*function validateDates(){
-        var datesValid = false; 
+        var datesValid = false;
         //----------Validate the Dates-------------//
         var sDate = $('#startDateContent').val();
         var eDate = $('#endDateContent').val();
@@ -606,27 +606,27 @@ foreach($downtime->getEndpointLocations() as $endpoints){
 
         //Once all time and dates have been set validate to ensure date is not 48 hours in the past
         if(sDate != '' && eDate != '' && sTime != '' && eTime != ''){
-            var start = sDate +" "+sTime; 
-            var end = eDate +" "+eTime;    
+            var start = sDate +" "+sTime;
+            var end = eDate +" "+eTime;
             var mStart = moment(start, "DD-MM-YYYY, HH:mm");
             var mEnd = moment(end, "DD-MM-YYYY, HH:mm");
             $('#startTimestamp').val(start);
             $('#endTimestamp').val(end);
-            
+
             //Check end is after start:
             var diff1 = moment.duration(mEnd - mStart);
             //console.log(diff1);
-            var now = moment();    
+            var now = moment();
             var diff2 = moment.duration(now - mStart);
             //console.log(diff2);
-            //Downtime either ends before it begins or its start is over 48 hours ago 
+            //Downtime either ends before it begins or its start is over 48 hours ago
             if(diff1 <= 0 || diff2 > 172800000){
                 $('#startDateGroup').removeClass("has-success");
                 $('#endDateGroup').removeClass("has-success");
                 if(diff1 <= 0){
                     $('#endError').removeClass("hidden");
                     $("#endError").text("A downtime cannot end before it begins.");
-                    $('#endDateGroup').addClass("has-error");                    
+                    $('#endDateGroup').addClass("has-error");
                 }else{
                     $('#startError').addClass("hidden");
                     $('#endDateGroup').removeClass("has-error");
@@ -634,24 +634,24 @@ foreach($downtime->getEndpointLocations() as $endpoints){
                 if(diff2 > 172800000){
                     $('#startError').removeClass("hidden");
                     $("#startError").text("The start time of the downtime must be within the last 48 hrs");
-                    $('#startDateGroup').addClass("has-error");            		
+                    $('#startDateGroup').addClass("has-error");
                 }else{
-                    $('#startError').addClass("hidden");       
-                    $('#startDateGroup').removeClass("has-error");             
-                }             
+                    $('#startError').addClass("hidden");
+                    $('#startDateGroup').removeClass("has-error");
+                }
                 datesValid=false;
             }else{
                 datesValid=true;
                 $('#endError').addClass("hidden");
-                $('#startError').addClass("hidden");    
+                $('#startError').addClass("hidden");
                 $('#startDateGroup').addClass("has-success");
-                $('#endDateGroup').addClass("has-success");             
-                                            
+                $('#endDateGroup').addClass("has-success");
+
             }
         }else{
             datesValid=false;
         }
-        return datesValid; 
+        return datesValid;
     }*/
 </script>
 

--- a/htdocs/web_portal/views/downtime/view_downtime.php
+++ b/htdocs/web_portal/views/downtime/view_downtime.php
@@ -129,7 +129,7 @@ $dt = $params['downtime'];
         <div class="listContainer" style="width: 99.5%; float: left; margin-top: 3em; margin-right: 10px;">
             <span class="header" style="vertical-align:middle; float: left; padding-top: 0.9em; padding-left: 1em;">
                 Affected Services&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-                <input type="checkbox" id="affectedEndpointsCheckBox" /> &nbsp;Show Affected Child Endpoints 
+                <input type="checkbox" id="affectedEndpointsCheckBox" /> &nbsp;Show Affected Child Endpoints
             </span>
             <img src="<?php echo \GocContextPath::getPath()?>img/service.png" height="25px" style="float: right; padding-right: 1em; padding-top: 0.5em; padding-bottom: 0.5em;" />
             <table style="clear: both; width: 100%;">
@@ -144,11 +144,11 @@ $dt = $params['downtime'];
                 $num = 2;
                 foreach($dt->getServices() as $se) {
                     $alreadyRenderedSE = array();
-                                    
+
                     if(in_array($se->getId(), $alreadyRenderedSE)){
-                        continue; 
+                        continue;
                     } else {
-                        $alreadyRenderedSE[] = $se->getId(); 
+                        $alreadyRenderedSE[] = $se->getId();
                     }
                 ?>
 
@@ -183,50 +183,50 @@ $dt = $params['downtime'];
                     <?php xecho($se->getScopeNamesAsString()); ?>
                     </td>
                 </tr>
-                <!--&rdsh; --> 
+                <!--&rdsh; -->
                 <tr class="affectedendpointsrow site_table_row_<?php echo $num ?>">
                     <td class="site_table" colspan="4" style="padding-left:5em">
                         <table class="site_table" style="width: 100%; border: solid #D5D5D5 thin">
                             <tr>
-                                <th class="site_table">Affected Endpoints</th> 
-                                <th class="site_table">Url</th> 
-                                <th class="site_table">Interface Name</th> 
+                                <th class="site_table">Affected Endpoints</th>
+                                <th class="site_table">Url</th>
+                                <th class="site_table">Interface Name</th>
                             </tr>
-                            <?php 
+                            <?php
                             foreach($se->getEndpointLocations() as $el){
-                                echo '<tr>'; 
+                                echo '<tr>';
                                 if(in_array($el, $dt->getEndpointLocations()->toArray())){
-                                    echo '<td>&check; <a href="index.php?Page_Type=View_Service_Endpoint&id=' . $el->getId() . '">'.xssafe($el->getName()).'</a></td>'; 
-                                    echo '<td>'.xssafe($el->getUrl()).'</td>'; 
-                                    echo '<td>'.xssafe($el->getInterfaceName()).'</td>'; 
+                                    echo '<td>&check; <a href="index.php?Page_Type=View_Service_Endpoint&id=' . $el->getId() . '">'.xssafe($el->getName()).'</a></td>';
+                                    echo '<td>'.xssafe($el->getUrl()).'</td>';
+                                    echo '<td>'.xssafe($el->getInterfaceName()).'</td>';
                                 } else {
-                                    echo '<td><span style=\'color: grey\'>&cross; <a href="index.php?Page_Type=View_Service_Endpoint&id='.$el->getId().'">'.xssafe($el->getName()).'</span></td>'; 
-                                    echo "<td><span style='color: grey'>".xssafe($el->getUrl()).'</span></td>'; 
-                                    echo "<td><span style='color: grey'>".xssafe($el->getInterfaceName()).'</span></td>'; 
+                                    echo '<td><span style=\'color: grey\'>&cross; <a href="index.php?Page_Type=View_Service_Endpoint&id='.$el->getId().'">'.xssafe($el->getName()).'</span></td>';
+                                    echo "<td><span style='color: grey'>".xssafe($el->getUrl()).'</span></td>';
+                                    echo "<td><span style='color: grey'>".xssafe($el->getInterfaceName()).'</span></td>';
                                 }
-                                echo '</tr>'; 
+                                echo '</tr>';
                             }
                             ?>
-                        </table>    
-                    </td>    
-                </tr> 
-                
+                        </table>
+                    </td>
+                </tr>
+
                 <?php
                     if($num == 1) { $num = 2; } else { $num = 1; }
                 } // End of the foreach loop iterating over SEs
                 ?>
             </table>
         </div>
-       
+
     </div>
 </div>
 
 <script>
 $(document).ready(function(){
-    // hide all nested affected endpoints by default  
-    $(".affectedendpointsrow").hide(); 
-    
-    // toggle hide/show affected endpoints on click 
+    // hide all nested affected endpoints by default
+    $(".affectedendpointsrow").hide();
+
+    // toggle hide/show affected endpoints on click
     $("#affectedEndpointsCheckBox").click(function(){
         $(".affectedendpointsrow").toggle();
     });

--- a/htdocs/web_portal/views/downtime/view_nested_endpoints_list.php
+++ b/htdocs/web_portal/views/downtime/view_nested_endpoints_list.php
@@ -4,9 +4,9 @@ $configService = \Factory::getConfigService();
 
 ?>
 <!-- Dynamically create a select list from a sites services -->
-<label> Select Affected Services+Endpoints (Ctrl+click to select)</label> 
+<label> Select Affected Services+Endpoints (Ctrl+click to select)</label>
 <select name="IMPACTED_IDS[]" id="Select_Services" size="10" class="form-control" onclick="" style="width:99%; margin-left:1%" onChange="selectServicesEndpoint()" multiple>
-<?php 
+<?php
     foreach($services as $service){
         $count=0;
         echo "<option value=\"s" . $service->getId() . "\" id=\"" . $service->getId() . "\" SELECTED>" . '('.xssafe($service->getServiceType()->getName()).') '.xssafe($service->getHostName()) . "</option>";
@@ -16,11 +16,11 @@ $configService = \Factory::getConfigService();
             }else{
                 $name = xssafe($endpoint->getName());
             }
-            //Option styling doesn't work well cross browser so just use 4 spaces to indent the branch            
+            //Option styling doesn't work well cross browser so just use 4 spaces to indent the branch
             echo "<option id=\"".$service->getId()."\" value=\"e" . $endpoint->getId() . "\" SELECTED>&nbsp&nbsp&nbsp&nbsp-" . $name . "</option>";
             $count++;
         }
-        
+
     }
-?>	
+?>
 </select>

--- a/htdocs/web_portal/views/error.php
+++ b/htdocs/web_portal/views/error.php
@@ -2,12 +2,12 @@
     <h1>Error</h1>
     <br />
     <?php
-        
+
     if(strpos($params, 'DOCSVN.SERV_KEYPAIRS') || strpos($params, 'DOCSVN.SITE_KEYPAIRS')){
         echo "A key value pair already exists with this keyname and keyvalue.";
     }else{
         xecho($params);
     }
-    
+
     ?>
 </div>

--- a/htdocs/web_portal/views/fragments/editScopesFragment.php
+++ b/htdocs/web_portal/views/fragments/editScopesFragment.php
@@ -1,31 +1,31 @@
 <!-- Scope Tags-->
-<?php 
+<?php
 if(!isset($parentObjectTypeLabel)){
-   $parentObjectTypeLabel = "Object";  
+   $parentObjectTypeLabel = "Object";
 }
 ?>
 <div class="h4">Scope Tags</div>
 <br>
 <div id="allscopeCheckBoxDIV">
-    <span class="input_name">&check; Optional Tags 
+    <span class="input_name">&check; Optional Tags
         <span class="input_syntax" >(At least <?php echo $params['numberOfScopesRequired'] ?> optional tags must be selected)</span>
     </span>
-    <div id="optionalScopeCheckBoxDIV"></div> 
+    <div id="optionalScopeCheckBoxDIV"></div>
     <br/>
 
     <span class="input_name">&check; Reserved Tags Inheritable from Parent <?php echo $parentObjectTypeLabel;?></span>
-    <div id="reservedOptionalInhertiableScopeCheckBoxDIV"></div> 
-    <br/> 
-
-    <span class="input_name">&check; Reserved Tags Directly Assigned 
-        <span class="input_syntax" >(WARNING - If deselected you will not be able to reselect the tag - it will be moved to the 'Protected Reserved Tags' list)</span>
-    </span>
-    <div id="reservedOptionalScopeCheckBoxDIV"></div> 
+    <div id="reservedOptionalInhertiableScopeCheckBoxDIV"></div>
     <br/>
 
-    <span class="input_name">&cross; Protected Reserved Tags 
+    <span class="input_name">&check; Reserved Tags Directly Assigned
+        <span class="input_syntax" >(WARNING - If deselected you will not be able to reselect the tag - it will be moved to the 'Protected Reserved Tags' list)</span>
+    </span>
+    <div id="reservedOptionalScopeCheckBoxDIV"></div>
+    <br/>
+
+    <span class="input_name">&cross; Protected Reserved Tags
         <span class="input_syntax" >(Can only be assigned on request)</span>
     </span>
-    <div id="reservedScopeCheckBoxDIV"></div> 
+    <div id="reservedScopeCheckBoxDIV"></div>
     <br/>
 </div>

--- a/htdocs/web_portal/views/fragments/viewRoleActionsTable.php
+++ b/htdocs/web_portal/views/fragments/viewRoleActionsTable.php
@@ -1,17 +1,17 @@
-<div class="listContainer"> 
-    <!-- if there are many records, then set table height to sensible value with 
+<div class="listContainer">
+    <!-- if there are many records, then set table height to sensible value with
     horizontal and vertical overflow -->
     <?php if (sizeof($params['RoleActionRecords']) > 5){ ?>
     <div style="height: 500px; overflow: auto;">
-    <?php } else { ?>    
-    <!-- if there are fewer records, don't bother setting height and still allow 
-    horizontal overflow -->    
+    <?php } else { ?>
+    <!-- if there are fewer records, don't bother setting height and still allow
+    horizontal overflow -->
     <div style="overflow: auto;">
-    <?php } ?>    
+    <?php } ?>
 
         <span class="header listHeader">
             Role Request Log (Only shown if you have the necessary permissions)
-        </span> 
+        </span>
         <table class="table table-striped table-condensed" id="roleActionTable">
             <thead>
                 <tr>
@@ -34,10 +34,10 @@
                             <td>
                                 <a href="index.php?Page_Type=User&id=<?php echo $ra->getRoleUserId(); ?>">
                                     <?php xecho($ra->getRoleUserPrinciple()); ?>
-                                </a>    
+                                </a>
                             </td>
                             <td>
-                                <?php echo($ra->getActionDate()->format('Y-m-d H:i:s')); ?> 
+                                <?php echo($ra->getActionDate()->format('Y-m-d H:i:s')); ?>
                             </td>
                             <td>
                                 <?php xecho($ra->getRolePreStatus()); ?>
@@ -48,17 +48,17 @@
                             <td>
                                 <a href="index.php?Page_Type=User&id=<?php echo $ra->getUpdatedByUserId(); ?>">
                                     <?php xecho($ra->getUpdatedByUserPrinciple()); ?>
-                                </a>     
+                                </a>
                             </td>
-                        </tr>     
+                        </tr>
                         <?php
-                    } // End of the foreach loop iterating over RoleActions 
+                    } // End of the foreach loop iterating over RoleActions
                 ?>
             </tbody>
         </table>
- 
+
     <?php if (sizeof($params['RoleActionRecords']) > 5): ?>
     </div>
-    <?php endif; ?>     
+    <?php endif; ?>
 </div>
 

--- a/htdocs/web_portal/views/my_sites.php
+++ b/htdocs/web_portal/views/my_sites.php
@@ -10,7 +10,7 @@
             Sites and groups from your roles
         </span>
     </div>
-    
+
     <!-- NGIs and Sites from My Roles -->
     <div style="float: left; width: 100%; margin-top: 2em;">
         <!--  Sites -->
@@ -19,7 +19,7 @@
             <img src="<?php echo \GocContextPath::getPath()?>img/site.png" class="titleIcon"/>
             <table style="clear: both; width: 100%; table-layout: fixed;">
                 <?php if(!empty($params['sites_from_roles'])) {
-                        $num = 1; 
+                        $num = 1;
                         foreach($params['sites_from_roles'] as $site) { ?>
                         <tr class="site_table_row_<?php echo $num ?>">
                             <td class="site_table">
@@ -27,18 +27,18 @@
                             </td>
                         </tr>
                         <?php if($num == 1) { $num = 2; } else { $num = 1; } } ?>
-                    
+
                 <?php }?>
             </table>
         </div>
-        
+
         <!--  NGIs -->
         <div class="tableContainer" style="width: 42%; float: right;" >
             <span class="header" style="vertical-align:middle; float: left; padding-top: 0.9em; padding-left: 1em;">NGIs From Your Roles</span>
             <img src="<?php echo \GocContextPath::getPath()?>img/ngi.png" class="titleIcon"/>
             <table style="clear: both; width: 100%; table-layout: fixed;">
                 <?php if(!empty($params['ngis_from_roles'])) {
-                        $num = 1; 
+                        $num = 1;
                         foreach($params['ngis_from_roles'] as $ngi) { ?>
                         <tr class="site_table_row_<?php echo $num ?>">
                             <td class="site_table">
@@ -46,12 +46,12 @@
                             </td>
                         </tr>
                         <?php if($num == 1) { $num = 2; } else { $num = 1; } } ?>
-                    
+
                 <?php } ?>
             </table>
         </div>
     </div>
-    
+
     <!-- Service Groups and projects from My Roles -->
     <div style="float: left; width: 100%; margin-top: 2em;">
         <!--  Service Groups -->
@@ -60,7 +60,7 @@
             <img src="<?php echo \GocContextPath::getPath()?>img/virtualSite.png" class="titleIcon"/>
             <table style="clear: both; width: 100%; table-layout: fixed;">
                 <?php if(!empty($params['sgroups_from_roles'])) {
-                        $num = 1; 
+                        $num = 1;
                         foreach($params['sgroups_from_roles'] as $sg) { ?>
                         <tr class="site_table_row_<?php echo $num ?>">
                             <td class="site_table">
@@ -68,18 +68,18 @@
                             </td>
                         </tr>
                         <?php if($num == 1) { $num = 2; } else { $num = 1; } } ?>
-                    
+
                 <?php }?>
             </table>
         </div>
-    
+
         <!--  Projects -->
         <div class="tableContainer" style="width: 42%; float: right;" >
             <span class="header" style="vertical-align:middle; float: left; padding-top: 0.9em; padding-left: 1em;">Projects From Your Roles</span>
             <img src="<?php echo \GocContextPath::getPath()?>img/project.png" class="titleIcon"/>
             <table style="clear: both; width: 100%; table-layout: fixed;">
                 <?php if(!empty($params['projects_from_roles'])) {
-                        $num = 1; 
+                        $num = 1;
                         foreach($params['projects_from_roles'] as $project) { ?>
                         <tr class="site_table_row_<?php echo $num ?>">
                             <td class="site_table">
@@ -87,7 +87,7 @@
                             </td>
                         </tr>
                         <?php if($num == 1) { $num = 2; } else { $num = 1; } } ?>
-                    
+
                 <?php } ?>
             </table>
         </div>

--- a/htdocs/web_portal/views/ngi/edit_ngi.php
+++ b/htdocs/web_portal/views/ngi/edit_ngi.php
@@ -1,17 +1,17 @@
 <div class="rightPageContainer">
     <form name="Update_Group" action="index.php?Page_Type=Edit_NGI" method="post" class="inputForm">
-        
+
         <h1><?php xecho($params['ngi']->getName()) ?></h1>
         <br />
-        
+
         <span class="input_name">
-            Management contact/mailing list 
+            Management contact/mailing list
             <span class="input_syntax">
                 (valid email format)
             </span>
         </span>
         <input class="input_input_text" type="text" name="EMAIL" value="<?php xecho($params['ngi']->getEmail()); ?>">
-        
+
         <span class="input_name">
             Helpdesk / Mailing list for GGUS tickets
             <span class="input_syntax">
@@ -19,7 +19,7 @@
             </span>
         </span>
         <input class="input_input_text" type="text" name="HELPDESK_EMAIL" value="<?php xecho($params['ngi']->getHelpdeskEmail()); ?>">
-        
+
         <span class="input_name">
             ROD Mailing list
             <span class="input_syntax">
@@ -27,9 +27,9 @@
             </span>
         </span>
         <input class="input_input_text" type="text" name="ROD_EMAIL" value="<?php xecho($params['ngi']->getRodEmail()); ?>">
-        
+
         <span class="input_name">
-            Security contact / mailing list 
+            Security contact / mailing list
             <span class="input_syntax">
                 (valid email format)
             </span>
@@ -37,7 +37,7 @@
         <input class="input_input_text" type="text" name="SECURITY_EMAIL" value="<?php xecho($params['ngi']->getSecurityEmail()); ?>">
 
         <span class="input_name">
-            GGUS Support Unit 
+            GGUS Support Unit
             <span class="input_syntax">
             </span>
         </span>
@@ -47,7 +47,7 @@
         <span class="input_name">Scope(s)
             <span class="input_syntax">(Select at least <?php xecho($params['numberOfScopesRequired'])?>)</span>
         </span>
-        <div style="margin-left: 2em">    
+        <div style="margin-left: 2em">
         <?php foreach ($params['scopes'] as $scopeArray){ ?>
             <br />
             <input type="checkbox" name="SCOPE_IDS[]" value="<?php echo $scopeArray['scope']->getId();?>"<?php if($scopeArray['applied']){echo ' checked="checked"';}?>>
@@ -59,13 +59,13 @@
 
         <br/>
         <br/>
-        
+
         <!-- Scope Tags-->
-        <?php 
-        $parentObjectTypeLabel = 'Project'; 
+        <?php
+        $parentObjectTypeLabel = 'Project';
         require_once __DIR__ . '/../fragments/editScopesFragment.php';
         ?>
-            
+
         <input class="input_input_hidden" type="hidden" name="ID" value="<?php echo $params['ngi']->getId(); ?>">
         <br />
         <input class="input_button" type="submit" value="Update NGI">
@@ -78,11 +78,11 @@
 
     $(document).ready(function () {
         var scopeJSON = JSON.parse('<?php echo($params["scopejson"]) ?>');
-        ScopeUtil.addScopeCheckBoxes(scopeJSON, 
+        ScopeUtil.addScopeCheckBoxes(scopeJSON,
         '#reservedScopeCheckBoxDIV',
-        '#reservedOptionalScopeCheckBoxDIV', 
+        '#reservedOptionalScopeCheckBoxDIV',
         '#reservedOptionalInhertiableScopeCheckBoxDIV',
-        '#optionalScopeCheckBoxDIV', 
+        '#optionalScopeCheckBoxDIV',
         true);
     });
-</script> 
+</script>

--- a/htdocs/web_portal/views/ngi/view_ngi.php
+++ b/htdocs/web_portal/views/ngi/view_ngi.php
@@ -20,7 +20,7 @@
             <?php if($params['UserIsAdmin']):?>
                 <div style="float: right; margin-left: 2em; text-align:center;">
                     <script type="text/javascript" src="<?php echo \GocContextPath::getPath()?>javascript/confirm.js"></script>
-                    <a onclick="return confirmSubmit()" 
+                    <a onclick="return confirmSubmit()"
                        href="index.php?Page_Type=Admin_Delete_NGI&id=<?php echo $params['ngi']->getId() ?>">
                         <img src="<?php echo \GocContextPath::getPath()?>img/cross.png" height="25px" />
                         <br />
@@ -93,14 +93,14 @@
                     </tr>
                 </table>
         </div>
-        
+
         <!-- Project memberships (Top right) -->
         <div class="tableContainer" style="width: 42%; float: right;" >
             <span class="header" style="vertical-align:middle; float: left; padding-top: 0.9em; padding-left: 1em;">Project memberships</span>
             <img src="<?php echo \GocContextPath::getPath()?>img/project.png" class="titleIcon"/>
             <table style="clear: both; width: 100%; table-layout: fixed;">
                 <?php if(!empty($params['Projects'])) {
-                        $num = 1; 
+                        $num = 1;
                         foreach($params['Projects'] as $project) { ?>
                         <tr class="site_table_row_<?php echo $num ?>">
                             <td class="site_table">
@@ -108,11 +108,11 @@
                             </td>
                         </tr>
                         <?php if($num == 1) { $num = 2; } else { $num = 1; } } ?>
-                    
+
                 <?php } ?>
             </table>
         </div>
-       
+
         <!-- Scopes (bottom right) -->
         <div class="tableContainer" style="width: 42%; float: right; margin-top: 1.6em" >
             <span class="header" style="vertical-align:middle; float: left; padding-top: 0.9em; padding-left: 1em; word-wrap: normal">
@@ -124,11 +124,11 @@
                             <td class="site_table" >
                                 <textarea readonly="true" style="width: 100%; height: 60px;"><?php xecho($params['ngi']->getScopeNamesAsString()); ?></textarea>
                             </td>
-                            
+
                         </tr>
             </table>
         </div>
-        
+
     </div>
 
 
@@ -136,10 +136,10 @@
     <div class="listContainer">
         <span class="header listHeader">
             <?php echo sizeof($params['ngi']->getSites()) ?> Site<?php if(sizeof($params['ngi']->getSites()) != 1) echo "s"?>
-        (Note, Scope values marked with (x) indicate the parent NGI does not share that scope) 
+        (Note, Scope values marked with (x) indicate the parent NGI does not share that scope)
         </span>
         <img src="<?php echo \GocContextPath::getPath()?>img/site.png" class="decoration" />
-    
+
         <table id="sitesTable" class="table table-striped table-condensed tablesorter" >
         <thead>
         <tr>
@@ -151,11 +151,11 @@
         </thead>
         <tbody>
 <!--            <tr class="site_table">
-              <td colspan="4"> 
-                  Note, Scope values marked with (x) indicate the parent NGI does not share that scope 
+              <td colspan="4">
+                  Note, Scope values marked with (x) indicate the parent NGI does not share that scope
               </td>
             </tr>-->
-        
+
             <?php
             //$num = 2;
             if(sizeof($params['ngi']->getSites()) > 0) {
@@ -181,7 +181,7 @@
                                  <?php
                                  $count = 0;
                                  $numScopes = sizeof($scopes);
-                                 $scopeString = ''; 
+                                 $scopeString = '';
                                  foreach ($scopes as $scopeName => $sharedWithParent) {
                                      if ($sharedWithParent) {
                                          $scopeString .= $scopeName;
@@ -191,11 +191,11 @@
                                      if (++$count != $numScopes) {
                                          $scopeString .= ", ";
                                      }
-                                 } ?>   
+                                 } ?>
                           <textarea readonly="true" style="height: 25px;"><?php xecho($scopeString); ?></textarea>
                     </td>
 
-                    
+
                 </tr>
                 <?php
                     //if($num == 1) { $num = 2; } else { $num = 1; }
@@ -209,7 +209,7 @@
     <!--  Users and Roles -->
     <div class="listContainer">
         <span class="header listHeader">
-           Users (Click on name to manage roles) 
+           Users (Click on name to manage roles)
         </span>
         <img src="<?php echo \GocContextPath::getPath()?>img/user.png" class="decoration" />
 
@@ -263,31 +263,31 @@
 
     <!-- Show RoleActionRecords if user has permissions over this NGI -->
     <?php if ($params['ShowEdit']){
-        require_once __DIR__ . '/../fragments/viewRoleActionsTable.php'; 
+        require_once __DIR__ . '/../fragments/viewRoleActionsTable.php';
     } ?>
-    
+
 
 </div>
 
 <script>
-    $(document).ready(function() 
+    $(document).ready(function()
     {
 
-    $("#sitesTable").tablesorter(); 
-    $("#usersTable").tablesorter(); 
-    // sort on first and second table cols only 
-//	$("#sitesTable").tablesorter({ 
-//	    // pass the headers argument and assing a object 
-//	    headers: { 
-//		// assign the third column (we start counting zero) 
-//		2: { 
-//		    sorter: false 
-//		}, 
-//		3: { 
-//		    sorter: false 
+    $("#sitesTable").tablesorter();
+    $("#usersTable").tablesorter();
+    // sort on first and second table cols only
+//	$("#sitesTable").tablesorter({
+//	    // pass the headers argument and assing a object
+//	    headers: {
+//		// assign the third column (we start counting zero)
+//		2: {
+//		    sorter: false
+//		},
+//		3: {
+//		    sorter: false
 //		}
-//	    } 
-//	}); 
-    
-    }); 
+//	    }
+//	});
+
+    });
 </script>

--- a/htdocs/web_portal/views/ngi/view_ngis.php
+++ b/htdocs/web_portal/views/ngi/view_ngis.php
@@ -13,7 +13,7 @@
             <a style="float: left; padding-top: 0.3em;" href="http://www.egi.eu/about/glossary/glossary_N.html">What is an NGI?</a>
         </span>
     </div>
-    
+
     <!-- Filter -->
     <div class="siteContainer">
         <form action="index.php?Page_Type=NGIs" method="GET" class="inline">
@@ -22,26 +22,26 @@
         <span class="header leftFloat">
         Filter <a href="index.php?Page_Type=NGIs">&nbsp;&nbsp;(clear)</a>
         </span>
-        <br />      
+        <br />
 
         <div class="topMargin leftFloat siteFilter">
         <span class=""><a href="index.php?Page_Type=Scope_Help">Scopes:</a> </span>
         <select id="scopeSelect" multiple="multiple" name="mscope[]" style="width: 200px">
             <?php foreach ($params['scopes'] as $scope) { ?>
-            <option value="<?php xecho($scope->getName()); ?>" 
+            <option value="<?php xecho($scope->getName()); ?>"
                 <?php if(in_array($scope->getName(), $params['selectedScopes'])){ echo ' selected';}?> >
                 <?php xecho($scope->getName()); ?>
             </option>
             <?php } ?>
         </select>
         </div>
-        
+
         <div class="topMargin leftFloat siteFilter">
         <input type="submit" value="Filter NGIs">
         </div>
         </form>
     </div>
-    
+
     <!--  NGIs -->
     <div class="listContainer">
         <span class="header listHeader">
@@ -58,30 +58,30 @@
             </tr>
         </thead>
         <tbody>
-            <?php           
+            <?php
             $num = 2;
             if(sizeof($params['ngis'] > 0)) {
                 foreach($params['ngis'] as $ngi) {
                 ?>
                 <tr>
                     <td style="width: 10%">
-            <img class="flag" style="vertical-align: middle" src="<?php echo \GocContextPath::getPath()?>img/ngi/<?php echo $ngi->getName() ?>.jpg">                            
+            <img class="flag" style="vertical-align: middle" src="<?php echo \GocContextPath::getPath()?>img/ngi/<?php echo $ngi->getName() ?>.jpg">
             </td>
             <td>
             <a href="index.php?Page_Type=NGI&id=<?php echo $ngi->getId() ?>">
                 <?php xecho($ngi->getName()); ?>
             </a>
                     </td>
-                    
+
                     <td class="site_table">
                         <?php echo $ngi->getEmail(); ?>
-                    </td> 
-                    
+                    </td>
+
                     <td class="site_table">
                          <textarea readonly="true" style="height: 25px;"><?php xecho($ngi->getScopeNamesAsString()); ?></textarea>
                     </td>
                 </tr>
-                <?php  
+                <?php
                     //if($num == 1) { $num = 2; } else { $num = 1; }
                     } // End of the foreach loop iterating over sites
             }
@@ -102,23 +102,23 @@
 <script type="text/javascript" src="<?php GocContextPath::getPath()?>javascript/jquery.multiple.select.js"></script>
 
 <script>
-    $(document).ready(function() 
+    $(document).ready(function()
     {
 
-    // sort on first and second table cols only 
-    $("#selectedNgisTable").tablesorter({ 
-        // pass the headers argument and assing a object 
-        headers: { 
-        // assign the third column (we start counting zero) 
-        0: { 
-            sorter: false 
+    // sort on first and second table cols only
+    $("#selectedNgisTable").tablesorter({
+        // pass the headers argument and assing a object
+        headers: {
+        // assign the third column (we start counting zero)
+        0: {
+            sorter: false
         }
-        } 
-    }); 
-    
+        }
+    });
+
     $('#scopeSelect').multipleSelect({
         filter: true,
             placeholder: "NGI Scopes"
         });
-    }); 
+    });
 </script>

--- a/htdocs/web_portal/views/political_role/new_request.php
+++ b/htdocs/web_portal/views/political_role/new_request.php
@@ -1,6 +1,6 @@
 <div class="rightPageContainer">
     <h1>Success</h1>
     <br />
-    Role requested - View your pending role requests on the <a href="index.php?Page_Type=Role_Requests">Manage Roles</a> page. 
+    Role requested - View your pending role requests on the <a href="index.php?Page_Type=Role_Requests">Manage Roles</a> page.
     <br />
 </div>

--- a/htdocs/web_portal/views/political_role/request_role.php
+++ b/htdocs/web_portal/views/political_role/request_role.php
@@ -11,13 +11,13 @@
         </span><br/>
     </div>
 
-    <form   style="clear: both; float: left; margin-top: 1em;" 
-            action="index.php?Page_Type=Request_Role" method="post" class="inputForm">    
-        <select name="Role_Name_Value">        
+    <form   style="clear: both; float: left; margin-top: 1em;"
+            action="index.php?Page_Type=Request_Role" method="post" class="inputForm">
+        <select name="Role_Name_Value">
         <?php foreach($params['roles'] as $roleName) { ?>
             <option value="<?php xecho($roleName) ?>"><?php xecho($roleName) ?></option>
         <?php } ?>
-        </select> : [RoleTypeName] 
+        </select> : [RoleTypeName]
         <br/><br/>
         <input type="hidden" name="Object_ID" value="<?php echo $params['objectId'] ?>"/>
         <input type="submit" />

--- a/htdocs/web_portal/views/political_role/role_revoked.php
+++ b/htdocs/web_portal/views/political_role/role_revoked.php
@@ -1,6 +1,6 @@
 <div class="rightPageContainer">
     <h1>Success</h1>
-    Role revoked 
+    Role revoked
     <br>
     <a href="index.php?Page_Type=Role_Requests">Back to Manage Role Requests</a>
 </div>

--- a/htdocs/web_portal/views/political_role/role_self_revoked.php
+++ b/htdocs/web_portal/views/political_role/role_self_revoked.php
@@ -1,6 +1,6 @@
 <div class="rightPageContainer">
     <h1>Success</h1>
-    Role self revoked 
+    Role self revoked
     <br>
     <a href="index.php?Page_Type=Role_Requests">Back to Manage Role Requests</a>
 </div>

--- a/htdocs/web_portal/views/political_role/view_requests.php
+++ b/htdocs/web_portal/views/political_role/view_requests.php
@@ -25,19 +25,19 @@
             <form action="index.php?Page_Type=Request_Role" method="post" style="clear: both; padding-top: 1em; padding-bottom: 1em;">
                 <select name="id">
                     <option>-- Please Select --</option>
-                    <?php foreach($params['entities'] as $entity) {  
+                    <?php foreach($params['entities'] as $entity) {
                         if(!empty($entity['Object_ID'])) {
-                            $entName = xssafe($entity['Name']); 
+                            $entName = xssafe($entity['Name']);
                             echo "<option value=\"{$entity['Object_ID']}\">{$entName}</option>";
                         } else {
-                            $entName = xssafe($entity['Name']); 
-                            // eudat customisations: 
+                            $entName = xssafe($entity['Name']);
+                            // eudat customisations:
                             /*if($entName == 'NGIs'){
-                               $entName = 'EUDAT';  
+                               $entName = 'EUDAT';
                             } else if($entName == 'Projects'){
-                               $entName = 'Admin Domain';  
+                               $entName = 'Admin Domain';
                             } else {
-                                $entName = 'Site'; 
+                                $entName = 'Site';
                             } */
                             echo "<option class=\"sectionTitle\">{$entName}</option>";
                         }
@@ -50,14 +50,14 @@
         <li>Newly requested roles will be queued for approval.</li>
         <li>See the <a href="index.php?Page_Type=View_Role_Action_Mappings">role action mappings</a> page to see which permissions are granted by different roles.</li>
         </ul>
-        
+
         </div>
     <?php endif; ?>
-        
+
     <!-- Roles you've requested awaiting approval-->
     <div style="float: left; width: 100%; margin-top: 2em;">
         <h3>
-              My role requests awaiting approval 
+              My role requests awaiting approval
         </h3>
 
         <div class="listContainer" style="margin-top: 0em">
@@ -74,58 +74,58 @@
                         <th class="site_table">Delete My Request</th>
                     <?php endif; ?>
                 </tr>
-                <?php           
+                <?php
                 $num = 2;
                 if(sizeof($params['myRequests'] > 0)) {
                 foreach($params['myRequests'] as $request) {
-                ?> 
+                ?>
                 <tr class="site_table_row_<?php echo $num ?>">
                     <td class="site_table" style="width: 50%">
-                       <?php xecho($request->getRoleType()->getName())/*.' ['.$request->getId().']'*/?> 
-                    </td> 
+                       <?php xecho($request->getRoleType()->getName())/*.' ['.$request->getId().']'*/?>
+                    </td>
                     <td class="site_table">
-                       <?php 
+                       <?php
                          $entityId = $request->getOwnedEntity()->getId();
-                         $entityName = xssafe($request->getOwnedEntity()->getName());  
+                         $entityName = xssafe($request->getOwnedEntity()->getName());
                          if($request->getOwnedEntity() instanceof \ServiceGroup){
                              $entityViewLinkName = 'Service_Group';
                          } elseif($request->getOwnedEntity() instanceof \Site){
-                             $entityViewLinkName = 'Site'; 
+                             $entityViewLinkName = 'Site';
                          } elseif($request->getOwnedEntity() instanceof \NGI){
-                             $entityViewLinkName = 'NGI'; 
+                             $entityViewLinkName = 'NGI';
                          } elseif($request->getOwnedEntity() instanceof \Project){
-                             $entityViewLinkName = 'Project'; 
+                             $entityViewLinkName = 'Project';
                          }
-                         echo  " <a href='index.php?Page_Type=$entityViewLinkName&id=$entityId'>$entityName [$entityViewLinkName]</a>"; 
-                  
-                       ?> 
+                         echo  " <a href='index.php?Page_Type=$entityViewLinkName&id=$entityId'>$entityName [$entityViewLinkName]</a>";
+
+                       ?>
                     </td>
                     <!-- Do not show delete request when portal is read only -->
                     <?php if(!$params['portalIsReadOnly']):?>
                         <td class="site_table">
-                            <form action="index.php?Page_Type=Revoke_Role" method="post"> 
-                                <!--<a href="index.php?Page_Type=Revoke_Role&id=<?php echo $request->getId()?>" onclick="return confirmSubmit()"> Delete </a>--> 
-                                <input type="hidden" name="id" value="<?php echo $request->getId()?>" /> 
+                            <form action="index.php?Page_Type=Revoke_Role" method="post">
+                                <!--<a href="index.php?Page_Type=Revoke_Role&id=<?php echo $request->getId()?>" onclick="return confirmSubmit()"> Delete </a>-->
+                                <input type="hidden" name="id" value="<?php echo $request->getId()?>" />
                                 <input type="submit" value="Delete" class="btn btn-sm btn-danger" onclick="return confirmSubmit()">
-                            </form>    
+                            </form>
                         </td>
                     <?php endif; ?>
-                </tr> 
-                <?php  
+                </tr>
+                <?php
                     if($num == 1) { $num = 2; } else { $num = 1; }
                     } // End of the foreach loop iterating over roles
                 }
                 ?>
             </table>
-            
+
     </div>
-    
+
     <!-- Roles you can approve -->
     <div style="float: left; width: 100%; margin-top: 2em;">
         <h3>
-              Other role requests that you can approve 
+              Other role requests that you can approve
         </h3>
-        
+
         <!--  Sites -->
         <div class="listContainer" style="margin-top: 0em">
             <span class="header listHeader">
@@ -142,43 +142,43 @@
                         <th class="site_table">Approval</th>
                     <?php endif; ?>
                 </tr>
-                <?php           
+                <?php
                 $num = 2;
                 if(sizeof($params['allRequests'] > 0)) {
                 foreach($params['allRequests'] as $request) {
                 ?>
                 <tr class="site_table_row_<?php echo $num ?>">
                     <td class="site_table">
-                       <?php 
-                         $requestingUser = $request->getUser();  
-                         $requestingUserId = $requestingUser->getId(); 
-                         $surname = xssafe($requestingUser->getSurname()); 
-                         $forename = xssafe($requestingUser->getForename()); 
+                       <?php
+                         $requestingUser = $request->getUser();
+                         $requestingUserId = $requestingUser->getId();
+                         $surname = xssafe($requestingUser->getSurname());
+                         $forename = xssafe($requestingUser->getForename());
                          echo "<a href='index.php?Page_Type=User&id=$requestingUserId'>$forename $surname</a>";
-                        ?> 
-                       
-                    </td> 
+                        ?>
+
+                    </td>
                     <td class="site_table" style="width: 40%">
-                        <?php 
-                         xecho($request->getRoleType()->getName())/*.' ['.$request->getId().']'*/; 
+                        <?php
+                         xecho($request->getRoleType()->getName())/*.' ['.$request->getId().']'*/;
                         ?>
                     </td>
                     <td class="site_table" >
-                        <?php 
+                        <?php
                          $entityId = $request->getOwnedEntity()->getId();
-                         $entityName = xssafe($request->getOwnedEntity()->getName());  
+                         $entityName = xssafe($request->getOwnedEntity()->getName());
                          if($request->getOwnedEntity() instanceof \ServiceGroup){
                              $entityClassName = 'Service_Group';
                          } elseif($request->getOwnedEntity() instanceof \Site){
-                             $entityClassName = 'Site'; 
+                             $entityClassName = 'Site';
                          } elseif($request->getOwnedEntity() instanceof \NGI){
-                             $entityClassName = 'NGI'; 
+                             $entityClassName = 'NGI';
                          } elseif($request->getOwnedEntity() instanceof \Project){
-                             $entityClassName = 'Project'; 
+                             $entityClassName = 'Project';
                          }
-                         echo  " <a href='index.php?Page_Type=$entityClassName&id=$entityId'>$entityName [$entityClassName]</a>"; 
+                         echo  " <a href='index.php?Page_Type=$entityClassName&id=$entityId'>$entityName [$entityClassName]</a>";
                         ?>
-                    </td> 
+                    </td>
                     <td class="site_table">
                         <!-- Do not show forms when portal is read only -->
                         <?php if (!$params['portalIsReadOnly']): ?>
@@ -190,14 +190,14 @@
                             </form>
                             <form action="index.php?Page_Type=Deny_Role_Request" method="post" class="form-inline"  style="float:left;" >
                                 <input type="hidden" name="id" value="<?php echo $request->getId() ?>"/>
-                                <input type="submit" value="Deny" onclick="return confirmSubmit()" class="btn btn-sm btn-danger" 
+                                <input type="submit" value="Deny" onclick="return confirmSubmit()" class="btn btn-sm btn-danger"
                                        title="Roles allowing Deny: <?php $denyRoles = $request->getDecoratorObject(); xecho($denyRoles['deny']); ?>"/>
                             </form>
                         <?php endif; ?>
                     </td>
-                    
+
                 </tr>
-                <?php  
+                <?php
                     if($num == 1) { $num = 2; } else { $num = 1; }
                     } // End of the foreach loop iterating over roles
                 }

--- a/htdocs/web_portal/views/political_role/view_role_action_mappings.php
+++ b/htdocs/web_portal/views/political_role/view_role_action_mappings.php
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
---> 
+-->
 
 <div class="rightPageContainer">
     <div style="float: left; text-align: center;">
@@ -28,35 +28,35 @@
         <li>A Role enables Actions on target objects (often, the target is the same as the domain object).</li>
         <li>Some Roles allow actions over different targets. </li>
         <li>The Role-Action mapping matrix is shown below.</li>
-        </ol> 
+        </ol>
     </span>
     </div>
     <?php /*
-    <div class="listContainer"> 
+    <div class="listContainer">
     <div style="float: left;">
-        <?php 
+        <?php
          $allActionsOverByRoleType = $params['allActionsOverByRoleType'];
          foreach($allActionsOverByRoleType as $actionsOverByRoleType => $actionsOverArray){
-         echo $actionsOverByRoleType.'<br>'; 
+         echo $actionsOverByRoleType.'<br>';
          foreach($actionsOverArray as $actionsOver){
-             echo $actionsOver[0].' '.$actionsOver[1].'<br>'; 
+             echo $actionsOver[0].' '.$actionsOver[1].'<br>';
          }
          }
         ?>
     </div>
     </div>
      */ ?>
-        
-    <div class="listContainer"> 
+
+    <div class="listContainer">
     <div>
 
         <?php
         $roleTypeActionTarget_byObjectType = $params['roleTypeActionTarget_byObjectType'];
-        $inc = 0; 
+        $inc = 0;
         foreach ($roleTypeActionTarget_byObjectType as $over => $roleActionTargetArray) {
-        ++$inc; 
+        ++$inc;
         ?>
-        <h3><?php echo $over; ?> Roles</h3> 
+        <h3><?php echo $over; ?> Roles</h3>
             <table id="roleActionMapTable<?php echo($inc)?>" class="table table-striped table-condensed tablesorter">
             <thead>
                 <tr>
@@ -71,7 +71,7 @@
                 <td><?php echo $roleActionTarget[0] ?></td>
                 <td><?php echo $roleActionTarget[1] ?></td>
                 <td><?php echo $roleActionTarget[2] ?></td>
-                </tr>	
+                </tr>
             <?php } ?>
             </tbody>
             </table>
@@ -80,18 +80,18 @@
     </div>
 
     </div>
- 
+
 </div>
 
 <script>
-   $(document).ready(function() 
-    { 
-        $("#roleActionMapTable1").tablesorter(); 
-     $("#roleActionMapTable2").tablesorter(); 
-      $("#roleActionMapTable3").tablesorter(); 
-       $("#roleActionMapTable4").tablesorter(); 
-    } 
-);  
-</script>    
-    
+   $(document).ready(function()
+    {
+        $("#roleActionMapTable1").tablesorter();
+     $("#roleActionMapTable2").tablesorter();
+      $("#roleActionMapTable3").tablesorter();
+       $("#roleActionMapTable4").tablesorter();
+    }
+);
+</script>
+
 

--- a/htdocs/web_portal/views/project/add_ngis.php
+++ b/htdocs/web_portal/views/project/add_ngis.php
@@ -13,14 +13,14 @@
                 <!--  Services -->
                 <form class="inputForm" method="post" action="index.php?Page_Type=Add_Project_NGIs" name="addNGIs">
                     <span class="input_name">
-                        Please select the NGIs you wish to add to the 
+                        Please select the NGIs you wish to add to the
                         <?php xecho($params['Name'])?> project.
                     </span>
                     <select class="Downtime_Select" name="NGIs[]" size="20"  multiple id="NGIs" style="margin-left: 0em; width: 38em;">
                         <?php
                         foreach($params['NGIs'] as $ngi) {
                             echo "<option value=\"". $ngi->getId() . "\">"; xecho($ngi->getName()); echo "</option>";
-                        }	
+                        }
                         ?>
                     </select>
                     <br />
@@ -28,12 +28,12 @@
                     <input class="input_button" type="submit" value="Add selected NGIs">
                 </form>
             <?php else: ?>
-                There are either no NGIs in GOCDB or they are all a member of this project already.              
-            <?php endif; ?>                
-      
+                There are either no NGIs in GOCDB or they are all a member of this project already.
+            <?php endif; ?>
+
             <br />
             <br />
-            Return to 
+            Return to
             <a href="index.php?Page_Type=Project&id=<?php echo $params['ID'] ?>">
                  <?php xecho($params['Name']) ?>
             </a>

--- a/htdocs/web_portal/views/project/added_ngis.php
+++ b/htdocs/web_portal/views/project/added_ngis.php
@@ -4,12 +4,12 @@
     <a href="index.php?Page_Type=Project&id=<?php echo $params['ID']?>">
     <?php echo $params['Name'];?>
     </a> project:
-    <?php 
+    <?php
         foreach($params['NGIs'] as $ngi){
             echo "<br />"
                 . "<a href=\"index.php?Page_Type=NGI&id=" . $ngi->getId() ."\">"
                 .  $ngi->getName()
                 . "</a> ";
-        }	
+        }
     ?>
 </div>

--- a/htdocs/web_portal/views/project/deleted_project.php
+++ b/htdocs/web_portal/views/project/deleted_project.php
@@ -1,4 +1,4 @@
 <div class="rightPageContainer">
     <h1 class="Success">Deletion Successful</h1><br />
-    The project '<?php xecho($params['Name'])?>' has been successfully removed from GOCDB 
+    The project '<?php xecho($params['Name'])?>' has been successfully removed from GOCDB
 </div>

--- a/htdocs/web_portal/views/project/edit_project.php
+++ b/htdocs/web_portal/views/project/edit_project.php
@@ -7,7 +7,7 @@
         <input type="text" value="<?php xecho($params['Name']) ?>" name="Name" class="input_input_text">
         <span class="input_name">Description</span>
         <input type="text" value="<?php xecho($params['Description']) ?>" name="Description" class="input_input_text">
-        
+
         <br />
         <input class="input_input_hidden" type="hidden" name="ID" value="<?php echo $params['ID'] ?>" />
         <br />

--- a/htdocs/web_portal/views/project/edited_project.php
+++ b/htdocs/web_portal/views/project/edited_project.php
@@ -3,7 +3,7 @@
     <p>
        The <a href="index.php?Page_Type=Project&id=<?php echo $params['ID']?>">
            <?php xecho($params['Name'])?></a> project has been successfully edited as follows:
-    </p>    
+    </p>
     <p>
         Name: <?php xecho($params['Name'])?>
         <br />
@@ -12,7 +12,7 @@
     <p>
         <a href="index.php?Page_Type=Edit_Project&id=<?php echo $params['ID']?>">
         Click here</a> to edit the <?php xecho($params['Name'])?> project again.
-        
+
     </p>
 </div>
 

--- a/htdocs/web_portal/views/project/remove_ngis.php
+++ b/htdocs/web_portal/views/project/remove_ngis.php
@@ -12,14 +12,14 @@
             <!--  Services -->
             <form class="inputForm" method="post" action="index.php?Page_Type=Remove_Project_NGIs" name="removeNGIs">
                 <span class="input_name">
-                    Please select the NGIs you wish to remove from the 
+                    Please select the NGIs you wish to remove from the
                     <?php xecho($params['Name'])?> project.
                 </span>
                 <select class="Downtime_Select" name="NGIs[]" size="20"  multiple id="NGIs" style="margin-left: 0em; width: 38em;">
                     <?php
                     foreach($params['NGIs'] as $ngi) {
                         echo "<option value=\"". $ngi->getId() . "\">"; xecho($ngi->getName()); echo "</option>";
-                    }	
+                    }
                     ?>
                 </select>
                 <br />
@@ -28,7 +28,7 @@
             </form>
             <br/>
             <br/>
-            Return to 
+            Return to
             <a href="index.php?Page_Type=Project&id=<?php echo $params['ID'] ?>">
                  <?php xecho($params['Name']) ?>
             </a>

--- a/htdocs/web_portal/views/project/removed_ngis.php
+++ b/htdocs/web_portal/views/project/removed_ngis.php
@@ -1,6 +1,6 @@
 <div class="rightPageContainer">
     <h1 class="Success">Success</h1><br />
-    The selected NGIs have been successfully removed from the 
+    The selected NGIs have been successfully removed from the
     <a href="index.php?Page_Type=Project&id=<?php echo $params['ID']?>">
     <?php xecho($params['Name']);?>
     </a> project

--- a/htdocs/web_portal/views/project/view_all.php
+++ b/htdocs/web_portal/views/project/view_all.php
@@ -16,14 +16,14 @@
             </a>
         </span>
     </div>
-    
+
     <!--  Projects -->
     <div class="listContainer">
         <span class="header listHeader">
             <?php echo sizeof($params['Projects']) ?> Project<?php if(sizeof($params['Projects']) != 1) echo "s"?>
         </span>
         <img src="<?php echo \GocContextPath::getPath()?>img/grid.png" class="decoration" />
-    
+
         <table id="selectedProjTable" class="table table-striped table-condensed tablesorter">
         <thead>
             <tr>
@@ -31,7 +31,7 @@
                 <th>Description</th>
             </tr>
         </thead>
-            <?php           
+            <?php
             //$num = 2;
             foreach($params['Projects'] as $project) {
             ?>
@@ -41,13 +41,13 @@
             <?php xecho($project->getName()); ?>
             </a>
                 </td>
-                    
+
                 <td>
                     <?php xecho($project->getDescription()); ?>
                 </td>
-                
+
             </tr>
-            <?php  
+            <?php
                 //if($num == 1) { $num = 2; } else { $num = 1; }
                 } // End of the foreach loop iterating over Projs
             ?>

--- a/htdocs/web_portal/views/project/view_project.php
+++ b/htdocs/web_portal/views/project/view_project.php
@@ -5,7 +5,7 @@
 <!--    <div style="float: left;">
         <img src="<?php echo \GocContextPath::getPath()?>img/project.png" class="pageLogo" />
     </div>-->
-    
+
     <div style="float: left;">
         <h1 style="float: left; margin-left: 0em;">
                 Project: <?php xecho($params['Name'])?>
@@ -45,9 +45,9 @@
     <div class="tableContainer" style="width: 99.5%; float: left; margin-top: 3em; margin-right: 10px;">
         <span class="header" style="vertical-align:middle; float: left; padding-top: 0.9em; padding-left: 1em;">
             This project <?php if ($ngiCount == 0){echo "has no";} else{echo "consists of " . $ngiCount;} ?> NGI<?php if($ngiCount != 1) echo "s"?>
-        </span>   
+        </span>
         <img src="<?php echo \GocContextPath::getPath()?>img/ngi.png" height="25px" style="float: right; padding-right: 1em; padding-top: 0.5em; padding-bottom: 0.5em;" />
-        
+
         <?php if ($ngiCount != 0): ?>
             <table id="ngisTable" class="table table-striped table-condensed tablesorter">
         <thead>
@@ -64,7 +64,7 @@
                 ?>
                 <tr>
             <td>
-            <img class="flag" src="<?php echo \GocContextPath::getPath()?>img/ngi/<?php xecho($ngi->getName()) ?>.jpg">                            
+            <img class="flag" src="<?php echo \GocContextPath::getPath()?>img/ngi/<?php xecho($ngi->getName()) ?>.jpg">
             </td>
                     <td>
             <a href="index.php?Page_Type=NGI&id=<?php echo $ngi->getId() ?>">
@@ -79,7 +79,7 @@
                 ?>
         </tbody>
             </table>
-    
+
         <?php else: echo "<br><br>&nbsp &nbsp"; endif; ?>
         <!-- Don't show link in read only mode -->
         <?php if(!$params['portalIsReadOnly']):?>
@@ -92,8 +92,8 @@
                     </span>
                 </a>
             <?php } ?>
-        
-            <?php if ($ngiCount > 0): ?> 
+
+            <?php if ($ngiCount > 0): ?>
                 <!-- Remove NGI Link -->
                 <?php if($params['ShowEdit']){?>
                     <a href="index.php?Page_Type=Remove_Project_NGIs&id=<?php echo $params['ID'];?>">
@@ -107,7 +107,7 @@
         <?php endif; ?>
     </div>
 
-    
+
     <!-- Roles -->
     <div class="tableContainer" style="width: 99.5%; float: left; margin-top: 3em; margin-right: 10px;">
         <span class="header" style="vertical-align:middle; float: left; padding-top: 0.9em; padding-left: 1em;">
@@ -115,7 +115,7 @@
         </span>
         <img src="<?php echo \GocContextPath::getPath()?>img/people.png" height="25px" style="float: right; padding-right: 1em; padding-top: 0.5em; padding-bottom: 0.5em;" />
         <?php if (sizeof($params['Roles'])>0): ?>
-    
+
             <table id="usersTable" class="table table-striped table-condensed tablesorter">
         <thead>
             <tr>
@@ -194,7 +194,7 @@
                     <td>
                         <?php xecho($site->getCertificationStatus()->getName()) ?>
                     </td>
-                    
+
                     <td>
                         <a href="index.php?Page_Type=NGI&id=<?php echo $site->getNGI()->getId() ?>">
                             <?php xecho($site->getNGI()->getName()) ?>
@@ -205,7 +205,7 @@
                         <?php xecho($site->getInfrastructure()->getName()) ?>
                     </td>
                 </tr>
-                <?php 
+                <?php
         //if($num == 1) { $num = 2; } else { $num = 1; }
         }?>
             </table>
@@ -213,40 +213,40 @@
 
     <!-- Show RoleActionRecords if user has permissions over this object -->
     <?php if ($params['ShowEdit']){
-        require_once __DIR__ . '/../fragments/viewRoleActionsTable.php'; 
+        require_once __DIR__ . '/../fragments/viewRoleActionsTable.php';
     } ?>
-            
+
     </div>
 
 <script>
-    $(document).ready(function() 
+    $(document).ready(function()
     {
 
-    $("#sitesTable").tablesorter(); 
+    $("#sitesTable").tablesorter();
 
-    // sort on first and second table cols only 
-    $("#ngisTable").tablesorter({ 
-        // pass the headers argument and assing a object 
-        headers: { 
-        // assign the third column (we start counting zero) 
-        0: { 
-            sorter: false 
-        }, 
-        2: { 
-            sorter: false 
+    // sort on first and second table cols only
+    $("#ngisTable").tablesorter({
+        // pass the headers argument and assing a object
+        headers: {
+        // assign the third column (we start counting zero)
+        0: {
+            sorter: false
+        },
+        2: {
+            sorter: false
         }
-        } 
-    }); 
+        }
+    });
 
-    $("#usersTable").tablesorter({ 
-        // pass the headers argument and assing a object 
-        headers: { 
-        // assign the third column (we start counting zero) 
-        0: { 
-            sorter: false 
+    $("#usersTable").tablesorter({
+        // pass the headers argument and assing a object
+        headers: {
+        // assign the third column (we start counting zero)
+        0: {
+            sorter: false
         }
-        } 
-    }); 
-    
-    }); 
+        }
+    });
+
+    });
 </script>

--- a/htdocs/web_portal/views/scope_help.php
+++ b/htdocs/web_portal/views/scope_help.php
@@ -6,66 +6,66 @@
         <h2>What are scope tags?</h2>
         <ul>
             <li>
-                Scope tags are used to selectively tag Services, ServiceGroups, 
+                Scope tags are used to selectively tag Services, ServiceGroups,
                 Sites and NGIs so that API queries and users of the UI can filter for
-                objects that define the required set of tags. 
+                objects that define the required set of tags.
             </li>
             <li>
-                The available tags are controlled by the GOCDB admins, allowing 
-                users to select relevant tags from the list. New tags can 
-                be requested if required.  
+                The available tags are controlled by the GOCDB admins, allowing
+                users to select relevant tags from the list. New tags can
+                be requested if required.
             </li>
             <li>
-                In EGI, scope tags are used to categorise resources, 
-                e.g. a Site could be tagged with the 'EGI' and 'ProjX' tags 
+                In EGI, scope tags are used to categorise resources,
+                e.g. a Site could be tagged with the 'EGI' and 'ProjX' tags
                 while a single 'Local' tag can be used to declare that
-                this site does not provide any resources to EGI or ProjX. 
+                this site does not provide any resources to EGI or ProjX.
             </li>
             <li>
-                Scope tags should not be confused with projects. Projects 
+                Scope tags should not be confused with projects. Projects
                 provide a means to cascade roles/permissions over
-                child resources (NGIs, Sites, Services) grouped under the project. 
-                Scope tags have no effect on permissions. 
+                child resources (NGIs, Sites, Services) grouped under the project.
+                Scope tags have no effect on permissions.
             </li>
-            
+
         </ul>
         <h2>What are Reserved tags?</h2>
         <ul>
-            <li>Some tags may be 'Reserved' which means they are protected - they are used to restrict tag usage 
+            <li>Some tags may be 'Reserved' which means they are protected - they are used to restrict tag usage
             and prevent non-authorised sites/services from using tags not intended for them.</li>
-            <li>Reserved tags are initially assigned to resources by the gocdb-admins, and can then be optionially 
+            <li>Reserved tags are initially assigned to resources by the gocdb-admins, and can then be optionially
               inherited by child resources (tags can be initially assigned to NGIs, Sites, Services and ServiceGroups).</li>
-            <li>When creating a new child resource (e.g. a child Site or child Service), 
+            <li>When creating a new child resource (e.g. a child Site or child Service),
               the scopes that are assigned to the parent are automatically inherited and assigned to the child.</li>
             <li>Reserved tags assigned to a resource are optional and can be de-selected if required.</li>
-            <li>Users can reapply Reserved tags to a resource ONLY if the tag can be 
+            <li>Users can reapply Reserved tags to a resource ONLY if the tag can be
               inherited from the parent Scoped Entity (parents include NGIs/Sites).</li>
             <li>For Sites: If a Reserved tag is removed from a Site, then the same tag is also removed
-              from all the child Services - a Service can't have a reserved tag that 
+              from all the child Services - a Service can't have a reserved tag that
               is not supported by its parent Site.</li>
-            <li>For NGIs: If a Reserved tag is removed from an NGI, then the same tag is NOT 
+            <li>For NGIs: If a Reserved tag is removed from an NGI, then the same tag is NOT
               removed from all the child Sites - this is intentionally different from the Site->Service relationship.</li>
         </ul>
         <h2>How are scope tags used in the API?</h2>
-        The following are some examples of scope tags in use in PI 
-        queries: 
+        The following are some examples of scope tags in use in PI
+        queries:
         <ul>
             <li>
                 <pre>?method=get_site&scope=EGI</pre>
-                (Fetch all sites tagged as 'EGI') 
-            </li>   
+                (Fetch all sites tagged as 'EGI')
+            </li>
             <li>
                 <pre>?method=get_site&scope=EGI,ProjX&scope_match=all</pre>
-                (Fetch all sites tagged with <b>both</b> 'EGI' and ProjX) 
-            </li> 
+                (Fetch all sites tagged with <b>both</b> 'EGI' and ProjX)
+            </li>
             <li>
                 <pre>?method=get_site&scope=EGI,ProjX&scope_match=any</pre>
-                (Fetch all sites tagged with <b>either</b> 'EGI' or ProjX) 
-            </li> 
+                (Fetch all sites tagged with <b>either</b> 'EGI' or ProjX)
+            </li>
              <li>
                 <pre>?method=get_site&scope=</pre>
-                (Fetch <b>all sites</b> regardless of scope tags) 
-            </li> 
+                (Fetch <b>all sites</b> regardless of scope tags)
+            </li>
         </ul>
     </div>
 
@@ -80,7 +80,7 @@
                         <th>Reserved?</th>
                     </tr>
                 </thead>
-                
+
                <?php foreach($params['optionalScopes'] as $scope){ ?>
                 <tr>
                     <td><?php xecho($scope->getName());?></td>
@@ -88,7 +88,7 @@
                     <td>&cross;</td>
                 </tr>
                <?php } ?>
-                
+
                <?php foreach($params['reservedScopes'] as $scope){ ?>
                 <tr>
                     <td><?php xecho($scope->getName());?></td>
@@ -96,37 +96,37 @@
                     <td>&check;</td>
                 </tr>
                <?php } ?>
-                
+
             </table>
         </div>
     </div>
-  
 
-    
+
+
     <div>
         <h2>What does having the EGI scope applied mean?</h2>
         <ul>
             <li>
                 If a site, service, service group, or NGI is scoped as ‘EGI’ then it
-                will be exposed to the central operational tools for monitoring and 
-                will appear in the operations portal. 
+                will be exposed to the central operational tools for monitoring and
+                will appear in the operations portal.
             </li>
             <li>
-                The 'EGI' scope not being selected for a given object makes the 
+                The 'EGI' scope not being selected for a given object makes the
                 object invisible to EGI and the central operation tools (it will not
-                show in the central dashboard and it will not be monitored 
-                centrally). This can be useful if you wish to hide certain parts of 
+                show in the central dashboard and it will not be monitored
+                centrally). This can be useful if you wish to hide certain parts of
                 your infrastructure from EGI but still have the information stored
-                and accessed from the same GOCDB instance. In this case you should 
+                and accessed from the same GOCDB instance. In this case you should
                 use the 'Local' scope tag.
             </li>
             <li>
                 Note that scoping a site / service endpoint as EGI does not override
                 the production status or certification status fields. For example if
                 a site is not marked as production it won't be monitored centrally
-                even if it's marked as visible to EGI. 
-            </li> 
+                even if it's marked as visible to EGI.
+            </li>
         </ul>
     </div>
-    
+
 </div>

--- a/htdocs/web_portal/views/search_results.php
+++ b/htdocs/web_portal/views/search_results.php
@@ -10,10 +10,10 @@
             <ul>
                 <li>Searching sites, services and users</li>
                 <li>Please note, these search results are case-insensitive unlike the API parameters which must be case-sensitive</li>
-            </ul>    
+            </ul>
         </span>
     </div>
-    
+
     <!--  NGI Results -->
     <?php if(sizeof($params['ngiResults']) > 0) { ?>
         <div class="listContainer" style="width: 97%;">
@@ -23,7 +23,7 @@
                     NGIs
                 </h3>
             </div>
-        
+
             <table id="ngisTable" class="table table-striped table-condensed tablesorter">
         <thead>
             <tr>
@@ -32,7 +32,7 @@
             </tr>
         </thead>
         <tbody>
-                <?php           
+                <?php
                 $num = 2;
                 foreach($params['ngiResults'] as $ngi) {
                 ?>
@@ -43,12 +43,12 @@
                 &nbsp;&nbsp;&nbsp;<?php xecho($ngi->getName()); ?>
             </a>
                     </td>
-                        
+
                     <td>
                         <?php xecho($ngi->getDescription()); ?>
                     </td>
                 </tr>
-                <?php  
+                <?php
                     //if($num == 1) { $num = 2; } else { $num = 1; }
                     } // End of the foreach loop iterating over users
                 ?>
@@ -56,7 +56,7 @@
             </table>
         </div>
     <?php } // end of "if NGIs is > 0"?>
-    
+
     <!--  Site Results -->
     <?php if(sizeof($params['siteResults']) > 0) { ?>
         <div class="listContainer" style="width: 97%;">
@@ -66,7 +66,7 @@
                     Sites
                 </h3>
             </div>
-        
+
             <table id="sitesTable" class="table table-striped table-condensed tablesorter">
         <thead>
                 <tr>
@@ -75,7 +75,7 @@
                 </tr>
         </thead>
         <tbody>
-                <?php           
+                <?php
                 $num = 2;
                 if(sizeof($params['siteResults'] > 0)) {
                 foreach($params['siteResults'] as $site) {
@@ -86,12 +86,12 @@
                 <?php xecho($site->getShortName()); ?>
             </a>
                     </td>
-                        
+
                     <td>
                         <?php xecho($site->getOfficialName()); ?>
                     </td>
                 </tr>
-                <?php  
+                <?php
                     //if($num == 1) { $num = 2; } else { $num = 1; }
                     } // End of the foreach loop iterating over sites
                 }
@@ -100,7 +100,7 @@
             </table>
         </div>
     <?php } // end of "if sites is > 0"?>
-    
+
     <!--  Service results -->
     <?php if(sizeof($params['serviceResults']) > 0) { ?>
         <div class="listContainer" style="width: 97%;">
@@ -119,7 +119,7 @@
                 </tr>
         </thead>
         <tbody>
-                <?php           
+                <?php
                 $num = 2;
                 foreach($params['serviceResults'] as $ser) {
                 ?>
@@ -129,24 +129,24 @@
                 <?php xecho($ser->getHostName()); ?>
             </a>
                     </td>
-                        
+
                     <td>
                         <?php xecho($ser->getServiceType()->getName()); ?>
                     </td>
-                    
+
                     <td>
                         <?php xecho($ser->getDescription()); ?>
                     </td>
                 </tr>
-                <?php  
+                <?php
                     //if($num == 1) { $num = 2; } else { $num = 1; }
-                    } // End of the foreach loop iterating over services 
+                    } // End of the foreach loop iterating over services
                 ?>
         </tbody>
             </table>
         </div>
     <?php } // end of "if services is > 0"?>
-    
+
     <!--  User Results -->
     <?php if(sizeof($params['userResults']) > 0) { ?>
         <div class="listContainer" style="width: 97%;">
@@ -165,7 +165,7 @@
                     </tr>
             </thead>
             <tbody>
-                    <?php           
+                    <?php
                     $num = 2;
                     foreach($params['userResults'] as $user) {
                     ?>
@@ -175,12 +175,12 @@
                 <?php xecho($user->getFullName()); ?>
                 </a>
                         </td>
-                            
+
                         <td>
                             <?php if($params['authenticated']){ xecho($user->getEmail()); } else {echo 'PROTECTED - Authentication required'; } ?>
                         </td>
                     </tr>
-                    <?php  
+                    <?php
                         if($num == 1) { $num = 2; } else { $num = 1; }
                         } // End of the foreach loop iterating over users
                     ?>
@@ -189,7 +189,7 @@
             <?php } else {echo 'PROTECTED'; } ?>
         </div>
     <?php } // end of "if users is > 0"?>
-    
+
     <?php if(sizeof($params['siteResults']) == 0 && sizeof($params['serviceResults']) == 0 && sizeof($params['userResults']) == 0 && sizeof($params['ngiResults'] == 0))  { ?>
         <div class="listContainer" style="padding: 0.5em; width: 97%;">
             <span style="float: left;">No results found</span>
@@ -198,12 +198,12 @@
 </div>
 
 <script>
-   $(document).ready(function() 
-    { 
-    $("#ngisTable").tablesorter(); 
-    $("#sitesTable").tablesorter(); 
-    $("#servicesTable").tablesorter(); 
-    $("#usersTable").tablesorter(); 
-    });  
-</script>  
+   $(document).ready(function()
+    {
+    $("#ngisTable").tablesorter();
+    $("#sitesTable").tablesorter();
+    $("#servicesTable").tablesorter();
+    $("#usersTable").tablesorter();
+    });
+</script>
 

--- a/htdocs/web_portal/views/service/add_endpoint_properties_confirmation.php
+++ b/htdocs/web_portal/views/service/add_endpoint_properties_confirmation.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 $propertyArray = $params['proparr'];
 $parent = $params['endpoint'];
 $addPropertiesPage = "Add_Endpoint_Properties";

--- a/htdocs/web_portal/views/service/add_service.php
+++ b/htdocs/web_portal/views/service/add_service.php
@@ -43,14 +43,14 @@ $serviceTypes = $params['serviceTypes'];
         </span>
         <input class="input_input_text" type="text" name="HOSTNAME" />
 
-        <span class="input_name">Host IP 
+        <span class="input_name">Host IP
             <span class="input_syntax" >a.b.c.d</span>
         </span>
         <input class="input_input_text" type="text" name="HOST_IP" />
 
-        <span class="input_name">Host IPv6 
+        <span class="input_name">Host IPv6
             <span class="input_syntax" >(0000:0000:0000:0000:0000:0000:0000:0000[/int]) (optional [/int] range)</span>
-        </span>    	
+        </span>
         <input class="input_input_text" type="text" name="HOST_IP_V6" />
 
         <span class="input_name">Host DN
@@ -98,8 +98,8 @@ $serviceTypes = $params['serviceTypes'];
 
 
         <!-- Scope Tags-->
-        <?php 
-        $parentObjectTypeLabel = 'Site'; 
+        <?php
+        $parentObjectTypeLabel = 'Site';
         require_once __DIR__ . '/../fragments/editScopesFragment.php';
         ?>
 
@@ -114,25 +114,25 @@ $serviceTypes = $params['serviceTypes'];
 
     $(document).ready(function () {
 
-        //console.log('defalutVal: '+$('#ngiSelectPullDown').val());  
+        //console.log('defalutVal: '+$('#ngiSelectPullDown').val());
         var entityId = $('#siteSelectPullDown').val();
-        ScopeUtil.queryForJsonScopesAddScopeCheckBoxes('Add_Service', entityId, 
-          '#reservedScopeCheckBoxDIV', 
-          '#reservedOptionalScopeCheckBoxDIV', 
+        ScopeUtil.queryForJsonScopesAddScopeCheckBoxes('Add_Service', entityId,
+          '#reservedScopeCheckBoxDIV',
+          '#reservedOptionalScopeCheckBoxDIV',
           '#reservedOptionalInhertiableScopeCheckBoxDIV',
-          '#optionalScopeCheckBoxDIV', 
+          '#optionalScopeCheckBoxDIV',
           true);
 
         $('#siteSelectPullDown').change(function () {
-            //console.log($('#ngiSelectPullDown').val());  
+            //console.log($('#ngiSelectPullDown').val());
             var entityId = $('#siteSelectPullDown').val();
-            ScopeUtil.queryForJsonScopesAddScopeCheckBoxes('Add_Service', entityId, 
+            ScopeUtil.queryForJsonScopesAddScopeCheckBoxes('Add_Service', entityId,
               '#reservedScopeCheckBoxDIV',
-              '#reservedOptionalScopeCheckBoxDIV', 
+              '#reservedOptionalScopeCheckBoxDIV',
               '#reservedOptionalInhertiableScopeCheckBoxDIV',
-              '#optionalScopeCheckBoxDIV', 
+              '#optionalScopeCheckBoxDIV',
               true);
         });
 
     });
-</script>   
+</script>

--- a/htdocs/web_portal/views/service/add_service_endpoint.php
+++ b/htdocs/web_portal/views/service/add_service_endpoint.php
@@ -4,19 +4,19 @@ $serviceTypes = $params['serviceTypes'];
 $serviceType = $params['serviceType'];
 ?>
 <div class="rightPageContainer">
-    <form action="index.php?Page_Type=Add_Service_Endpoint" method="post" 
+    <form action="index.php?Page_Type=Add_Service_Endpoint" method="post"
           id="Add_Service_Endpoint" name="Add_Service_Endpoint"> <!-- class="inputForm"-->
 
-        <h1>Add Endpoint</h1>    		
+        <h1>Add Endpoint</h1>
          <a href="index.php?Page_Type=Service&id=<?php echo $service->getId();?>">
             &LeftArrow;View Parent Service</a>
         <br />
         <br />
         <ul>
-            <li>A single Service may define optional Endpoint objects.</li> 
-            <li>Endpoints model network locations for different service-functionalities 
+            <li>A single Service may define optional Endpoint objects.</li>
+            <li>Endpoints model network locations for different service-functionalities
                 that can't be described by the main ServiceType and URL alone.</li>
-            <li>When declaring a Service Downtime, different Endpoints can be 
+            <li>When declaring a Service Downtime, different Endpoints can be
                 selectively put into downtime.</li>
         </ul>
         <br/>
@@ -24,22 +24,22 @@ $serviceType = $params['serviceType'];
         <div class="form-group">
             <label class="control-label">*Endpoint Name</label>
             <br/>
-            <input class="form-control" style="width: 50%; display: inline;" type="text" 
+            <input class="form-control" style="width: 50%; display: inline;" type="text"
                    name="ENDPOINTNAME" id="ENDPOINTNAME" />
         </div>
 
         <div class="form-group">
             <label class="control-label">Description</label>
             <br/>
-            <input class="form-control"  style="width: 50%; display: inline;" type="text" 
+            <input class="form-control"  style="width: 50%; display: inline;" type="text"
                    name="DESCRIPTION" id="DESCRIPTION" />
-        </div> 
+        </div>
 
-        
+
         <div class="form-group">
-            <label class="control-label">*Endpoint URL</label>           
+            <label class="control-label">*Endpoint URL</label>
             <br/>
-            <input class="form-control" style="width: 50%; display: inline;" type="text" 
+            <input class="form-control" style="width: 50%; display: inline;" type="text"
                    name="ENDPOINTURL" id="ENDPOINTURL" />
         </div>
 
@@ -49,27 +49,27 @@ $serviceType = $params['serviceType'];
                 <span class="text-muted">
                     (Often same value as parent service type as pre-selected in the pull-down)
                 </span>
-            </label> 
+            </label>
             <br/>
-            <input class="form-control" style="width: 40%; float: left;" type="text" 
-                   id="ENDPOINTINTERFACENAME" name="ENDPOINTINTERFACENAME" 
+            <input class="form-control" style="width: 40%; float: left;" type="text"
+                   id="ENDPOINTINTERFACENAME" name="ENDPOINTINTERFACENAME"
                    value="<?php echo $serviceType; ?>" />
             <select  name="serviceType" id="selectInterfaceName" class="form-control"
-                     style="width: 40%; float: left; " 
+                     style="width: 40%; float: left; "
                      onchange="updateServiceTypeFromSelection();" >
                      <?php foreach($serviceTypes as $type) { ?>
                         <option value="<?php echo $type->getName() ?>"
                             <?php if($service->getServiceType() == $type){echo " selected=\"selected\"";}?>>
                                 <?php echo $type->getName() ?>
                         </option>
-                    <?php } ?> 
+                    <?php } ?>
             </select>
             <br/>
             <br/>
-            <label for="ENDPOINTINTERFACENAME" class="error"></label> 
+            <label for="ENDPOINTINTERFACENAME" class="error"></label>
         </div>
 
-        
+
         <input type="hidden" name ="SERVICE" value="<?php echo $service->getId();?>" />
         <br/>
         <input class="btn btn-default" type="submit" value="Add Service Endpoint" />
@@ -82,22 +82,22 @@ $serviceType = $params['serviceType'];
         debug: false,
         success: "valid"
     });
-   
-    $.validator.addMethod("validateDescription", function(value){ 
-        var regEx = /^[A-Za-z0-9\s._:-]{0,255}$/;   
-        return regEx.test(value);  
-    }, "Invalid description."); 
-   
+
+    $.validator.addMethod("validateDescription", function(value){
+        var regEx = /^[A-Za-z0-9\s._:-]{0,255}$/;
+        return regEx.test(value);
+    }, "Invalid description.");
+
     $.validator.addMethod("validateInterfaceName", function(value) {
-        var regEx = /^[A-Za-z0-9\s._:-]{0,255}$/;   
-        return regEx.test(value); 
-    }, 'Invalid Interface Name.'); 
+        var regEx = /^[A-Za-z0-9\s._:-]{0,255}$/;
+        return regEx.test(value);
+    }, 'Invalid Interface Name.');
 
     $.validator.addMethod("validateMyUrl", function(value) {
          var regEx = /^([a-z])+:\/\/(((([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(%[\da-f]{2})|[!\$&'\(\)\*\+,;=]|:)*@)?(((\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5])\.(\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5])\.(\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5])\.(\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5]))|((([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])))\.)+(([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])))\.?)(:\d*)?)(\/((([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(%[\da-f]{2})|[!\$&'\(\)\*\+,;=]|:|@)+(\/(([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(%[\da-f]{2})|[!\$&'\(\)\*\+,;=]|:|@)*)*)?)?(\?((([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(%[\da-f]{2})|[!\$&'\(\)\*\+,;=]|:|@)|[\uE000-\uF8FF]|\/|\?)*)?(\#((([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(%[\da-f]{2})|[!\$&'\(\)\*\+,;=]|:|@)|\/|\?)*)?$/i;
-         return regEx.test(value); 
+         return regEx.test(value);
     }, "Invalid endpoint URI.")
-    
+
     $("#Add_Service_Endpoint").validate({
         rules: {
             ENDPOINTNAME: {
@@ -114,7 +114,7 @@ $serviceType = $params['serviceType'];
             },
             DESCRIPTION: {
                 validateDescription: "",
-                required: false 
+                required: false
             }
         }
     });
@@ -122,52 +122,52 @@ $serviceType = $params['serviceType'];
     function updateServiceTypeFromSelection() {
         $('#ENDPOINTINTERFACENAME').val($('#selectInterfaceName').val());
         //http://stackoverflow.com/questions/1479255/how-to-manually-trigger-validation-with-jquery-validate
-        //$("#Edit_Service_Endpoint").valid(); // to validate the whole form  
-        //$('#ENDPOINTINTERFACENAME').valid(); // to validate just the element (but doc says you need to call validate() on form first)  
+        //$("#Edit_Service_Endpoint").valid(); // to validate the whole form
+        //$('#ENDPOINTINTERFACENAME').valid(); // to validate just the element (but doc says you need to call validate() on form first)
         $( "#Add_Service_Endpoint" ).validate().element( "#ENDPOINTINTERFACENAME" );
     }
 
-    
+
     /*function updateServiceTypeFromSelection(){
-       $('#ENDPOINTINTERFACENAME').val($('#selectInterfaceName').val());  
+       $('#ENDPOINTINTERFACENAME').val($('#selectInterfaceName').val());
     }
 
     function enableSubmit(){
        if(validateEndpointName() & validateEndpointUrl() & validateInterfaceName()){
-           return true; 
+           return true;
        } else {
-           alert('Invalid input'); 
-           return false; 
+           alert('Invalid input');
+           return false;
        }
     }
 
     function validateInterfaceName(){
-       var intefaceName =  $('#ENDPOINTINTERFACENAME').val(); 
-       var regEx = /^[A-Za-z0-9\s._:-]{0,255}$/;    
-       var valid = 'false'; 
+       var intefaceName =  $('#ENDPOINTINTERFACENAME').val();
+       var regEx = /^[A-Za-z0-9\s._:-]{0,255}$/;
+       var valid = 'false';
          if(intefaceName === ''){ //If field is empty then show no errors or colours
-             valid = 'empty'; 
+             valid = 'empty';
          } else {
             if(regEx.test(intefaceName) === false){
-              valid = 'false'; 	
+              valid = 'false';
             } else {
-                valid = 'true'; 
+                valid = 'true';
             }
          }
 
          if(valid === 'false' || valid === 'empty') {
             $('#interfaceNameGroup').removeClass("has-success");
-            $('#interfaceNameGroup').addClass("has-error");  
+            $('#interfaceNameGroup').addClass("has-error");
             $("#interfaceNameError").removeClass("hidden");
-            $("#interfaceNameError").text("Invalid"); 
-            return false; 
+            $("#interfaceNameError").text("Invalid");
+            return false;
          } else if(valid === 'true'){
-            $("#interfaceNameError").addClass("hidden");    		
-            $('#interfaceNameGroup').addClass("has-success"); 
-            return true; 
+            $("#interfaceNameError").addClass("hidden");
+            $('#interfaceNameGroup').addClass("has-success");
+            return true;
          }
     }
-    
+
 
     function validateEndpointUrl(){
        var endpointURL = $('#ENDPOINTURL').val();
@@ -175,55 +175,54 @@ $serviceType = $params['serviceType'];
        // http://stackoverflow.com/questions/1303872/trying-to-validate-url-using-javascript
        //var regEx = /^(https?|ftp):\/\/(((([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(%[\da-f]{2})|[!\$&'\(\)\*\+,;=]|:)*@)?(((\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5])\.(\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5])\.(\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5])\.(\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5]))|((([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])))\.)+(([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])))\.?)(:\d*)?)(\/((([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(%[\da-f]{2})|[!\$&'\(\)\*\+,;=]|:|@)+(\/(([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(%[\da-f]{2})|[!\$&'\(\)\*\+,;=]|:|@)*)*)?)?(\?((([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(%[\da-f]{2})|[!\$&'\(\)\*\+,;=]|:|@)|[\uE000-\uF8FF]|\/|\?)*)?(\#((([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(%[\da-f]{2})|[!\$&'\(\)\*\+,;=]|:|@)|\/|\?)*)?$/i;
        var regEx = /^[a-z]+:\/\/(((([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(%[\da-f]{2})|[!\$&'\(\)\*\+,;=]|:)*@)?(((\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5])\.(\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5])\.(\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5])\.(\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5]))|((([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])))\.)+(([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])))\.?)(:\d*)?)(\/((([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(%[\da-f]{2})|[!\$&'\(\)\*\+,;=]|:|@)+(\/(([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(%[\da-f]{2})|[!\$&'\(\)\*\+,;=]|:|@)*)*)?)?(\?((([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(%[\da-f]{2})|[!\$&'\(\)\*\+,;=]|:|@)|[\uE000-\uF8FF]|\/|\?)*)?(\#((([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(%[\da-f]{2})|[!\$&'\(\)\*\+,;=]|:|@)|\/|\?)*)?$/i;
-       var valid = 'false'; 
+       var valid = 'false';
        if(endpointURL === ''){
-          valid = 'empty';  
+          valid = 'empty';
        } else {
           if(regEx.test(endpointURL) === false){
-              valid = 'false'; 	
+              valid = 'false';
             } else {
-                valid = 'true'; 
-            } 
+                valid = 'true';
+            }
        }
-       
+
         if(valid === 'false') {
             $('#endpointUrlGroup').removeClass("has-success");
-            $('#endpointUrlGroup').addClass("has-error");  
+            $('#endpointUrlGroup').addClass("has-error");
             $("#endpointUrlError").removeClass("hidden");
-            $("#endpointUrlError").text("Invalid URL"); 
-            return false; 
+            $("#endpointUrlError").text("Invalid URL");
+            return false;
          } else if(valid === 'true' || valid === 'empty'){
-            $("#endpointUrlError").addClass("hidden");    		
-            $('#endpointUrlGroup').addClass("has-success"); 
-            return true; 
+            $("#endpointUrlError").addClass("hidden");
+            $('#endpointUrlGroup').addClass("has-success");
+            return true;
          }
     }
 
     function validateEndpointName(){
          var endpointName = $('#ENDPOINTNAME').val();
-         var regEx = /^[A-Za-z0-9\s._:]{0,255}$/;    
-         var valid = 'false'; 
+         var regEx = /^[A-Za-z0-9\s._:]{0,255}$/;
+         var valid = 'false';
          if(endpointName === ''){ //If field is empty then show no errors or colours
-             valid = 'empty'; 
+             valid = 'empty';
          } else {
             if(regEx.test(endpointName) === false){
-              valid = 'false'; 	
+              valid = 'false';
             } else {
-                valid = 'true'; 
+                valid = 'true';
             }
          }
 
           if(valid === 'false' || valid === 'empty') {
             $('#endpointNameGroup').removeClass("has-success");
-            $('#endpointNameGroup').addClass("has-error");  
+            $('#endpointNameGroup').addClass("has-error");
             $("#endpointNameError").removeClass("hidden");
-            $("#endpointNameError").text("Invalid"); 
-            return false; 
+            $("#endpointNameError").text("Invalid");
+            return false;
          } else if(valid === 'true'){
-            $("#endpointNameError").addClass("hidden");    		
-            $('#endpointNameGroup').addClass("has-success"); 
-            return true; 
+            $("#endpointNameError").addClass("hidden");
+            $('#endpointNameGroup').addClass("has-success");
+            return true;
          }
     }*/
 </script>
-  

--- a/htdocs/web_portal/views/service/add_service_properties_confirmation.php
+++ b/htdocs/web_portal/views/service/add_service_properties_confirmation.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 $propertyArray = $params['proparr'];
 $parent = $params['service'];
 $addPropertiesPage = "Add_Service_Properties";

--- a/htdocs/web_portal/views/service/delete_service_endpoint.php
+++ b/htdocs/web_portal/views/service/delete_service_endpoint.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 $endpoint = $params['endpoint'];
 $service = $params['service'];
 ?>
@@ -7,14 +7,14 @@ $service = $params['service'];
     <h1 class="Success">Delete Endpoint</h1><br/>
     <p>
     Are you sure you want to delete:<br/><br/>
-    Endponit Name: <b><?php xecho($endpoint->getName());?><br/></b> 
+    Endponit Name: <b><?php xecho($endpoint->getName());?><br/></b>
     Endpoint URL: <b><?php xecho($endpoint->getUrl());?><br/></b>
     Interface Name: <b><?php xecho($endpoint->getInterfaceName());?><br/></b>
     </p>
     <p>
         Are you sure you wish to continue?
     </p>
-    
+
     <form class="inputForm" method="post" action="index.php?Page_Type=Delete_Service_Endpoint&endpointid=<?php echo $endpoint->getId();?>&serviceid=<?php echo $service->getId();?>" name="RemoveServiceEndpoint">
         <input class="input_input_hidden" type="hidden" name="UserConfirmed" value="true" />
         <input type="submit" value="Remove this endpoint from GOCDB" class="input_button">

--- a/htdocs/web_portal/views/service/deleted_service_endpoint.php
+++ b/htdocs/web_portal/views/service/deleted_service_endpoint.php
@@ -1,18 +1,18 @@
-<?php 
+<?php
 $endpoint = $params['endpoint'];
 $service = $params['service'];
 ?>
 <div class="rightPageContainer">
-    <h1 class="Success">Deletion Successful</h1><br />	
+    <h1 class="Success">Deletion Successful</h1><br />
     <p>
-    Endponit Name: <b><?php xecho($endpoint->getName());?><br/></b> 
+    Endponit Name: <b><?php xecho($endpoint->getName());?><br/></b>
     Endpoint URL: <b><?php xecho($endpoint->getUrl());?><br/></b>
     Interface Name: <b><?php xecho($endpoint->getInterfaceName());?><br/></b>
     </p>
     <p>
     Has been successfully removed from service <?php xecho($service->getHostName());?><br/>
     <a href="index.php?Page_Type=Service&id=<?php echo $service->getId();?>">
-    View service</a>	 
+    View service</a>
     </p>
 
 </div>

--- a/htdocs/web_portal/views/service/edit_endpoint_property.php
+++ b/htdocs/web_portal/views/service/edit_endpoint_property.php
@@ -1,20 +1,20 @@
 <?php
 $service = $params['service'];
-$endpoint = $params['endpoint']; 
+$endpoint = $params['endpoint'];
 $prop = $params['prop'];
 ?>
 <div class="rightPageContainer">
     <form name="Edit_Endpoint_Property" action="index.php?Page_Type=Edit_Endpoint_Property" method="post" class="inputForm" id="Endpoint_Property_Form" name="Edit_Endpoint_Property_Form">
 
-        <h1>Edit Endpoint Property</h1>    		
+        <h1>Edit Endpoint Property</h1>
         <br />
 
         <span class="input_name">
-            Property Name            
+            Property Name
         </span>
         <input class="input_input_text" type="text" name="KEYPAIRNAME" value="<?php xecho($prop->getKeyName());?>" />
         <span class="input_name">
-            Property Value            
+            Property Value
         </span>
         <input class="input_input_text" type="text" name="KEYPAIRVALUE" value="<?php xecho($prop->getKeyValue());?>"/>
         <input class="input_input_text" type="hidden" name ="ENDPOINTID" value="<?php echo $endpoint->getId();?>" />

--- a/htdocs/web_portal/views/service/edit_service.php
+++ b/htdocs/web_portal/views/service/edit_service.php
@@ -46,7 +46,7 @@ $siteName = $service->getParentSite()->getName();
         <span class="input_name">
             Host IP
             <span class="input_syntax" >
-                a.b.c.d 
+                a.b.c.d
             </span>
         </span>
         <input class="input_input_text" type="text" name="HOST_IP" value="<?php xecho($service->getIpAddress()) ?>" />
@@ -127,18 +127,18 @@ $siteName = $service->getParentSite()->getName();
         <br>
 
         <!-- Scope Tags-->
-        <?php 
-        $parentObjectTypeLabel = 'Site'; 
+        <?php
+        $parentObjectTypeLabel = 'Site';
         require_once __DIR__ . '/../fragments/editScopesFragment.php';
         ?>
 
         <br>
-        
+
         <div class="alert alert-warning" role="alert">
             Note, rather than setting scope tags individually for each service, you can update
-            the scopes of every service when editing the parent Site 
-            (options such as 'Inherit Site scopes' and 'Override Service scopes with Site scopes' 
-            are provided for your convenience) 
+            the scopes of every service when editing the parent Site
+            (options such as 'Inherit Site scopes' and 'Override Service scopes with Site scopes'
+            are provided for your convenience)
         </div>
 
         <input class="input_input_hidden" type="hidden" value="<?php echo $service->getId() ?>" name="ID">
@@ -152,11 +152,11 @@ $siteName = $service->getParentSite()->getName();
 
     $(document).ready(function () {
         var scopeJSON = JSON.parse('<?php echo($params["scopejson"]) ?>');
-        ScopeUtil.addScopeCheckBoxes(scopeJSON, 
+        ScopeUtil.addScopeCheckBoxes(scopeJSON,
         '#reservedScopeCheckBoxDIV',
-        '#reservedOptionalScopeCheckBoxDIV', 
+        '#reservedOptionalScopeCheckBoxDIV',
         '#reservedOptionalInhertiableScopeCheckBoxDIV',
-        '#optionalScopeCheckBoxDIV', 
+        '#optionalScopeCheckBoxDIV',
         true);
     });
-</script>  
+</script>

--- a/htdocs/web_portal/views/service/edit_service_endpoint.php
+++ b/htdocs/web_portal/views/service/edit_service_endpoint.php
@@ -5,12 +5,12 @@ $configService = \Factory::getConfigService();
 $serviceTypes = $params['serviceTypes'];
 ?>
 
-  <div class="rightPageContainer">  
+  <div class="rightPageContainer">
 
-    <form action="index.php?Page_Type=Edit_Service_Endpoint" method="post" 
+    <form action="index.php?Page_Type=Edit_Service_Endpoint" method="post"
            id="Edit_Service_Endpoint" name="Edit_Service_Endpoint">
 
-        <h1>Edit Endpoint</h1>    		
+        <h1>Edit Endpoint</h1>
         <a href="index.php?Page_Type=Service&id=<?php echo $service->getId();?>">
             &LeftArrow;View Parent Service</a>
         <br/>
@@ -19,10 +19,10 @@ $serviceTypes = $params['serviceTypes'];
         <br />
         <br />
         <ul>
-            <li>A single Service may define optional Endpoint objects.</li> 
-            <li>Endpoints model network locations for different service-functionalities 
+            <li>A single Service may define optional Endpoint objects.</li>
+            <li>Endpoints model network locations for different service-functionalities
                 that can't be described by the main ServiceType and URL alone.</li>
-            <li>When declaring a Service Downtime, different Endpoints can be 
+            <li>When declaring a Service Downtime, different Endpoints can be
                 selectively put into downtime.</li>
         </ul>
         <br/>
@@ -30,24 +30,24 @@ $serviceTypes = $params['serviceTypes'];
         <div class="form-group">
             <label class="control-label">*Endpoint Name</label>
             <br/>
-            <input class="form-control" style="width: 50%; display: inline;" type="text" 
-                   name="ENDPOINTNAME" id="ENDPOINTNAME" 
+            <input class="form-control" style="width: 50%; display: inline;" type="text"
+                   name="ENDPOINTNAME" id="ENDPOINTNAME"
                    value="<?php xecho($endpoint->getName()) ?>" />
         </div>
 
         <div class="form-group">
             <label class="control-label">Description</label>
             <br/>
-            <input class="form-control"  style="width: 50%; display: inline;" type="text" 
-                   name="DESCRIPTION" id="DESCRIPTION" 
+            <input class="form-control"  style="width: 50%; display: inline;" type="text"
+                   name="DESCRIPTION" id="DESCRIPTION"
                    value="<?php xecho($endpoint->getDescription()); ?>"/>
-        </div> 
+        </div>
 
         <div class="form-group">
-            <label class="control-label">*Endpoint URL</label>           
+            <label class="control-label">*Endpoint URL</label>
             <br/>
-            <input class="form-control" style="width: 50%; display: inline;" type="text" 
-                   name="ENDPOINTURL" id="ENDPOINTURL" 
+            <input class="form-control" style="width: 50%; display: inline;" type="text"
+                   name="ENDPOINTURL" id="ENDPOINTURL"
                    value="<?php xecho($endpoint->getUrl()) ?>" />
         </div>
 
@@ -57,29 +57,29 @@ $serviceTypes = $params['serviceTypes'];
                 <span class="text-muted">
                     (Often same value as *Parent Service Type* as pre-selected in the pull-down)
                 </span>
-            </label> 
+            </label>
             <br/>
-            <input class="form-control" style="width: 40%; float: left;" type="text" 
-                   id="ENDPOINTINTERFACENAME" name="ENDPOINTINTERFACENAME" 
+            <input class="form-control" style="width: 40%; float: left;" type="text"
+                   id="ENDPOINTINTERFACENAME" name="ENDPOINTINTERFACENAME"
                    value="<?php echo( $endpoint->getInterfaceName()); ?>" />
             <select  name="serviceType" id="selectInterfaceName" class="form-control"
-                     style="width: 40%; float: left; " 
+                     style="width: 40%; float: left; "
                      onchange="updateServiceTypeFromSelection();" >
                      <?php foreach($serviceTypes as $type) { ?>
                         <option value="<?php echo($type->getName()) ?>"
                             <?php if($service->getServiceType() == $type){echo " selected=\"selected\"";}?>>
                                 <?php echo($type->getName()) ?>
                         </option>
-                    <?php } ?> 
+                    <?php } ?>
             </select>
             <br/>
             <br/>
-            <label for="ENDPOINTINTERFACENAME" class="error"></label> 
+            <label for="ENDPOINTINTERFACENAME" class="error"></label>
         </div>
-        
+
         <input type="hidden" name ="SERVICE" value="<?php echo $service->getId(); ?>" />
         <input type="hidden" name ="ENDPOINTID" value="<?php echo $endpoint->getId(); ?>" />
-        <br/> 
+        <br/>
         <input class="btn btn-default" type="submit" value="Edit Endpoint" />
     </form>
 </div>
@@ -90,22 +90,22 @@ $serviceTypes = $params['serviceTypes'];
         debug: false,
         success: "valid"
     });
-   
-    $.validator.addMethod("validateDescription", function(value){ 
-        var regEx = /^[A-Za-z0-9\s._:-]{0,255}$/;   
-        return regEx.test(value);  
-    }, "Invalid description."); 
-   
+
+    $.validator.addMethod("validateDescription", function(value){
+        var regEx = /^[A-Za-z0-9\s._:-]{0,255}$/;
+        return regEx.test(value);
+    }, "Invalid description.");
+
     $.validator.addMethod("validateInterfaceName", function(value) {
-        var regEx = /^[A-Za-z0-9\s._:-]{0,255}$/;   
-        return regEx.test(value); 
-    }, 'Invalid Interface Name.'); 
+        var regEx = /^[A-Za-z0-9\s._:-]{0,255}$/;
+        return regEx.test(value);
+    }, 'Invalid Interface Name.');
 
     $.validator.addMethod("validateMyUrl", function(value) {
          var regEx = /^([a-z])+:\/\/(((([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(%[\da-f]{2})|[!\$&'\(\)\*\+,;=]|:)*@)?(((\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5])\.(\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5])\.(\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5])\.(\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5]))|((([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])))\.)+(([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])))\.?)(:\d*)?)(\/((([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(%[\da-f]{2})|[!\$&'\(\)\*\+,;=]|:|@)+(\/(([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(%[\da-f]{2})|[!\$&'\(\)\*\+,;=]|:|@)*)*)?)?(\?((([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(%[\da-f]{2})|[!\$&'\(\)\*\+,;=]|:|@)|[\uE000-\uF8FF]|\/|\?)*)?(\#((([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(%[\da-f]{2})|[!\$&'\(\)\*\+,;=]|:|@)|\/|\?)*)?$/i;
-         return regEx.test(value); 
+         return regEx.test(value);
     }, "Invalid endpoint URI.")
-    
+
     $("#Edit_Service_Endpoint").validate({
         rules: {
             ENDPOINTNAME: {
@@ -122,7 +122,7 @@ $serviceTypes = $params['serviceTypes'];
             },
             DESCRIPTION: {
                 validateDescription: "",
-                required: false 
+                required: false
             }
         }
     });
@@ -130,8 +130,8 @@ $serviceTypes = $params['serviceTypes'];
     function updateServiceTypeFromSelection() {
         $('#ENDPOINTINTERFACENAME').val($('#selectInterfaceName').val());
         //http://stackoverflow.com/questions/1479255/how-to-manually-trigger-validation-with-jquery-validate
-        //$("#Edit_Service_Endpoint").valid(); // to validate the whole form  
-        //$('#ENDPOINTINTERFACENAME').valid(); // to validate just the element (but doc says you need to call validate() on form first)  
+        //$("#Edit_Service_Endpoint").valid(); // to validate the whole form
+        //$('#ENDPOINTINTERFACENAME').valid(); // to validate just the element (but doc says you need to call validate() on form first)
         $( "#Edit_Service_Endpoint" ).validate().element( "#ENDPOINTINTERFACENAME" );
     }
 </script>

--- a/htdocs/web_portal/views/service/edit_service_property.php
+++ b/htdocs/web_portal/views/service/edit_service_property.php
@@ -5,15 +5,15 @@ $prop = $params['prop'];
 <div class="rightPageContainer">
     <form name="Edit_Service_Property" action="index.php?Page_Type=Edit_Service_Property" method="post" class="inputForm" id="Service_Property_Form" name="Edit_Site_Property_Form">
 
-        <h1>Edit Service Property</h1>    		
+        <h1>Edit Service Property</h1>
         <br />
 
         <span class="input_name">
-            Property Name            
+            Property Name
         </span>
         <input class="input_input_text" type="text" name="KEYPAIRNAME" value="<?php xecho($prop->getKeyName());?>" />
         <span class="input_name">
-            Property Value            
+            Property Value
         </span>
         <input class="input_input_text" type="text" name="KEYPAIRVALUE" value="<?php xecho($prop->getKeyValue());?>"/>
         <input class="input_input_text" type="hidden" name ="SERVICE" value="<?php echo $service->getId();?>" />

--- a/htdocs/web_portal/views/service/endpoint_property_updated.php
+++ b/htdocs/web_portal/views/service/endpoint_property_updated.php
@@ -1,6 +1,6 @@
 <div class="rightPageContainer">
     <h1 class="Success">Success</h1>
-    Endpoint Property updated.<br />    
+    Endpoint Property updated.<br />
     <a href="index.php?Page_Type=View_Service_Endpoint&id=<?php echo $params['endpointid']; ?>">
     View endpoint</a>
 </div>

--- a/htdocs/web_portal/views/service/se_downtimes.php
+++ b/htdocs/web_portal/views/service/se_downtimes.php
@@ -4,14 +4,14 @@
             <h1 style="float: left; margin-left: 0em; padding-bottom: 0.3em;">
                 Downtimes for Service:
                 <br/>
-                <a  style="font-family: inherit; font-size: inherit; font-weight: inherit; text-decoration: underline; padding-bottom: inherit; " 
+                <a  style="font-family: inherit; font-size: inherit; font-weight: inherit; text-decoration: underline; padding-bottom: inherit; "
                     href="index.php?Page_Type=Service&id=<?php echo $params['se']->getId()?>">
-                    <?php xecho($params['se']->getServiceType()->getName()) ?> - 
+                    <?php xecho($params['se']->getServiceType()->getName()) ?> -
                     <?php xecho($params['se']->getHostName())?>
                 </a>
             </h1>
         </div>
-        
+
         <!--  Downtimes -->
         <div class="listContainer">
             <span class="header" style="vertical-align:middle; float: left; padding-top: 0.9em; padding-left: 1em;">All Downtimes (Year-Month-Day Time in UTC)</span>
@@ -28,14 +28,14 @@
             <?php
             foreach($params['downtimes'] as $downtime) {
             ?>
-            
+
             <tr>
             <td>
                 <a style="padding-right: 1em;" href="index.php?Page_Type=Downtime&id=<?php echo $downtime->getId() ?>">
                     <?php echo $downtime->getDescription() ?>
                 </a>
             </td>
-            
+
             <td style="width: 20%"><?php echo $downtime->getStartDate()->format('Y-m-d H:i'/*$downtime::DATE_FORMAT*/); ?></td>
             <td style="width: 20%"><?php echo $downtime->getEndDate()->format('Y-m-d H:i'/*$downtime::DATE_FORMAT*/); ?></td>
             </tr>
@@ -53,4 +53,4 @@
     $("#allServiceDowntimesTable").tablesorter();
     }
     );
-</script> 
+</script>

--- a/htdocs/web_portal/views/service/service_property_updated.php
+++ b/htdocs/web_portal/views/service/service_property_updated.php
@@ -1,6 +1,6 @@
 <div class="rightPageContainer">
     <h1 class="Success">Success</h1>
-    Service Property updated.<br />    
+    Service Property updated.<br />
     <a href="index.php?Page_Type=Service&id=<?php echo $params['serviceid']; ?>">
     View service</a>
 </div>

--- a/htdocs/web_portal/views/service/view_all.php
+++ b/htdocs/web_portal/views/service/view_all.php
@@ -4,20 +4,20 @@
     </div>
     <div style="float: left;">
         <h1 style="float: left; margin-left: 0em;">
-                Services 
+                Services
         </h1>
         <span style="clear: both; float: left; padding-bottom: 0.4em;">All Services in GOCDB</span>
     </div>
-    
+
     <!-- Filter -->
     <div class="siteContainer">
         <form action="index.php?Page_Type=Services" method="GET" class="inline">
             <input type="hidden" name="Page_Type" value="Services" />
-            
+
             <span class="header leftFloat">
                 Filter <a href="index.php?Page_Type=Services">&nbsp;&nbsp;(clear)</a>
             </span>
-            
+
             <div class="topMargin leftFloat clearLeft siteFilter">
                 <span>Service Type: </span>
                 <select id="serviceTypeSelect" name="serviceType"  multiple="multiple">
@@ -27,8 +27,8 @@
                     <?php foreach($params['serviceTypes'] as $serviceType) { ?>
                         <option value="<?php xecho($serviceType->getName()); ?>"<?php if($params['selectedServiceType'] == $serviceType->getName()) echo " selected"?>>
                 <?php xecho($serviceType->getName()); ?>
-            </option> 
-                    <?php  } ?>   
+            </option>
+                    <?php  } ?>
 <!--		</datalist>	-->
                 </select>
 
@@ -36,28 +36,28 @@
 
         <!--<button id="uncheckAllSeTypeBtn" onclick="return false;">&laquo;Any</button>-->
             </div>
-            
+
             <div class="topMargin leftFloat siteFilter">
                 <span>NGI:</span>
-                <select name="ngi">                                        
+                <select name="ngi">
                     <option value="">(all)</option>
                     <?php foreach ($params['ngis'] as $ngi){ ?>
                         <option value="<?php xecho($ngi->getName())?>"<?php if($params['selectedNgi'] == $ngi->getName()){echo " selected";} ?>><?php xecho($ngi->getName())?></option>
                     <?php }?>
-                    
+
                 </select>
             </div>
-            <?php 
+            <?php
             //Clean off % from searchTerm
             if(isset($params['searchTerm'])){
                 $params['searchTerm'] = str_replace('%', '', $params['searchTerm']);
-            } 
+            }
             ?>
             <div class="topMargin leftFloat clearLeft siteFilter">
                 <span>Search for text in Hostname or Service Description: </span>
                 <input type="text" name="searchTerm" style="width: 400px" <?php if(isset($params['searchTerm'])) echo "value=\"{$params['searchTerm']}\"";?>/>
             </div>
-            
+
             <div class="topMargin leftFloat clearLeft siteFilter">
             <span>Production Service: </span>
                 <select name="production">
@@ -66,7 +66,7 @@
                     <option value="FALSE"<?php if($params['selectedProduction'] == "FALSE") echo " selected" ?>>N</option>
                 </select>
             </div>
-            
+
         <div class="topMargin leftFloat siteFilter">
                 <span class="">Monitored Service: </span>
                 <select name="monitored">
@@ -88,13 +88,13 @@
                     <?php  } ?>
                 </select>
             </div>
-        
-        
+
+
         <div class="topMargin leftFloat siteFilter">
         <span class=""><a href="index.php?Page_Type=Scope_Help">Service Scopes:</a> </span>
         <select id="scopeSelect" multiple="multiple" name="mscope[]" style="width: 200px">
             <?php foreach ($params['scopes'] as $scope) { ?>
-            <option value="<?php xecho($scope->getName()); ?>" 
+            <option value="<?php xecho($scope->getName()); ?>"
                 <?php if(in_array($scope->getName(), $params['selectedScopes'])){ echo ' selected';}?> >
                 <?php xecho($scope->getName()); ?>
             </option>
@@ -115,11 +115,11 @@
         </div>
 
 
-            
-            
 
 
-            
+
+
+
 
         <div class="topMargin leftFloat clearLeft siteFilter">
         <span class="">Service Extension Name:</span>
@@ -128,28 +128,28 @@
             <?php foreach ($params['servKeyNames'] as $servExtensions) { ?>
                 <option value="<?php xecho($servExtensions); ?>"<?php if ($params['selectedServKeyNames'] == $servExtensions) echo " selected" ?>>
                 <?php xecho($servExtensions); ?>
-                </option> 
-            <?php } ?>                  
+                </option>
+            <?php } ?>
                 </select>
-        </div> 
+        </div>
 
 
         <div class="topMargin leftFloat siteFilter siteFilter">
         <span class="middle" style="margin-right: 0.4em">Extension Value: </span>
-        <input class="middle" type="text" name="servKeyValue" 
+        <input class="middle" type="text" name="servKeyValue"
             <?php if (isset($params['selectedServKeyValue'])) echo "value=\"{$params['selectedServKeyValue']}\""; ?>/>
         </div>
 
 
         <div class="topMargin leftFloat clearLeft siteFilter">
         <span class="">Include Closed Sites: </span>
-        <input type="checkbox" value=""<?php if ($params['showClosed'] == true) echo " checked=checked" ?> name="showClosed" /> 
+        <input type="checkbox" value=""<?php if ($params['showClosed'] == true) echo " checked=checked" ?> name="showClosed" />
         <input type="submit" value="Filter Services">
         </div>
-            
+
         </form>
     </div>
-    
+
     <!--  Services -->
     <div class="listContainer">
         <span class="header listHeader">
@@ -175,7 +175,7 @@
         <?php
         if (count($params['services']) > 0) {
             foreach ($params['services'] as $se) {
-            ?>	
+            ?>
             <tr>
                 <td>
                 <a href="index.php?Page_Type=Service&id=<?php echo $se->getId() ?>">
@@ -211,7 +211,7 @@
                 <textarea readonly="true" style="height: 25px;"><?php xecho($se->getScopeNamesAsString()); ?></textarea>
                 </td>
 
-            </tr> 	
+            </tr>
             <?php
             }
         }
@@ -233,9 +233,9 @@
             </a>
             <a href="<?php echo $params['lastLink'] ?>">
                 <img class="nav" src="<?php echo \GocContextPath::getPath()?>img/last.png" />
-            </a>  
-        </div>    
-        
+            </a>
+        </div>
+
     </div>
     <br>&nbsp;
     <br>&nbsp;
@@ -250,26 +250,26 @@
 <script type="text/javascript" src="<?php GocContextPath::getPath()?>javascript/jquery.multiple.select.js"></script>
 
 <script>
-    $(document).ready(function() 
+    $(document).ready(function()
     {
 
-    //$("#selectedSETable").tablesorter(); 
+    //$("#selectedSETable").tablesorter();
 
-    // sort on first and second table cols only 
-    $("#selectedSETable").tablesorter({ 
-        // pass the headers argument and assing a object 
-        headers: { 
-        // assign the third column (we start counting zero) 
-        2: { 
-            sorter: false 
-        }, 
-        3: { 
-            sorter: false 
+    // sort on first and second table cols only
+    $("#selectedSETable").tablesorter({
+        // pass the headers argument and assing a object
+        headers: {
+        // assign the third column (we start counting zero)
+        2: {
+            sorter: false
+        },
+        3: {
+            sorter: false
         }
-        } 
-    }); 
-    
-     
+        }
+    });
+
+
     $('#scopeSelect').multipleSelect({
         filter: true,
             placeholder: "Service Scopes"
@@ -278,11 +278,11 @@
     $('#serviceTypeSelect').multipleSelect({
         filter: true,
         single: true,
-            placeholder: "Service Types" 
+            placeholder: "Service Types"
         });
 //	$("#uncheckAllSeTypeBtn").click(function() {
 //            $("#serviceTypeSelect").multipleSelect("uncheckAll");
 //        });
-    }); 
+    });
 </script>
- 
+

--- a/htdocs/web_portal/views/service/view_service.php
+++ b/htdocs/web_portal/views/service/view_service.php
@@ -51,45 +51,45 @@ $configService = \Factory::getConfigService();
             <table style="clear: both; width: 100%;">
                 <tr class="site_table_row_1">
                     <td class="site_table">Host name</td><td class="site_table">
-                        <?php if ($params['authenticated']) { 
-                            xecho($se->getHostName()); 
+                        <?php if ($params['authenticated']) {
+                            xecho($se->getHostName());
                         } else echo('PROTECTED - Auth required'); ?>
                     </td>
                 </tr>
                 <tr class="site_table_row_2">
                     <td class="site_table">IP Address</td><td class="site_table">
-                        <?php if ($params['authenticated']) { 
-                          xecho($se->getIpAddress());  
+                        <?php if ($params['authenticated']) {
+                          xecho($se->getIpAddress());
                         }else echo('PROTECED - Auth required');  ?>
                     </td>
                 </tr>
                 <tr class="site_table_row_1">
                     <td class="site_table">IP v6 Address</td><td class="site_table">
-                        <?php if ($params['authenticated']) { 
-                            xecho($se->getIpV6Address()); 
+                        <?php if ($params['authenticated']) {
+                            xecho($se->getIpV6Address());
                         } else echo('PROTECED - Auth required'); ?>
                     </td>
-                </tr>	
+                </tr>
                 <tr class="site_table_row_2">
                     <td class="site_table">Operating System</td><td class="site_table">
-                        <?php if ($params['authenticated']) { 
-                            xecho($se->getOperatingSystem()); 
+                        <?php if ($params['authenticated']) {
+                            xecho($se->getOperatingSystem());
                         } else echo('PROTECTED - Auth required'); ?>
                     </td>
                 </tr>
                 <tr class="site_table_row_1">
                     <td class="site_table">Architecture</td><td class="site_table">
-                        <?php if ($params['authenticated']) { 
-                            xecho($se->getArchitecture()); 
+                        <?php if ($params['authenticated']) {
+                            xecho($se->getArchitecture());
                         } else echo('PROTECTED - Auth required'); ?>
                     </td>
                 </tr>
                 <tr class="site_table_row_2">
                     <td class="site_table">Contact E-Mail</td><td class="site_table">
-                    <?php if (!$params['authenticated']) : ?> 
-                            PROTECTED - Auth required 
+                    <?php if (!$params['authenticated']) : ?>
+                            PROTECTED - Auth required
                     <?php endif; ?>
-                    <?php if ($params['authenticated']) : ?> 
+                    <?php if ($params['authenticated']) : ?>
                             <?php xecho($se->getEmail()) ?>
                     <?php endif; ?>
                     </td>
@@ -106,8 +106,8 @@ $configService = \Factory::getConfigService();
                 <tr class="site_table_row_1">
                     <td class="site_table" style="width: 5em;">Host DN</td><td class="site_table">
                         <div style="word-wrap: break-word;">
-                                <?php if ($params['authenticated']) { 
-                                    xecho($se->getDn()) ; 
+                                <?php if ($params['authenticated']) {
+                                    xecho($se->getDn()) ;
                                 } else echo('PROTECTED - Auth required'); ?>
                         </div>
                     </td>
@@ -139,11 +139,11 @@ $configService = \Factory::getConfigService();
                                 $scopeString .= ", ";
                             }
                         }
-                        ?>  
+                        ?>
                     <td class="site_table">
                         <a href="index.php?Page_Type=Scope_Help" style="word-wrap: normal"
                             title="Note, Scope(x) indicates the parent Site does not share this scope">
-                            Scope Tags 
+                            Scope Tags
                         </a>
                     </td>
                     <td class="site_table">
@@ -248,16 +248,16 @@ $configService = \Factory::getConfigService();
             </table>
         </div>
     </div>
-    
+
      <!-- Service Endpoints -->
     <div class="tableContainer" style="width: 99.5%; float: left; margin-top: 3em; margin-right: 10px;">
         <span class="header" style="vertical-align:middle; float: left; padding-top: 0.9em; padding-left: 1em;">
-            Service Endpoints 
-            <a href="#" id="serviceEndpointLink" data-toggle="tooltip" data-placement="right" 
-                title="A Service may define optional Endpoint objects which 
-                model network locations for different service-functionalities 
+            Service Endpoints
+            <a href="#" id="serviceEndpointLink" data-toggle="tooltip" data-placement="right"
+                title="A Service may define optional Endpoint objects which
+                model network locations for different service-functionalities
                 that can't be described by the main ServiceType and URL alone.">(endpoints?)</a>
-        </span>        
+        </span>
         <img src="<?php echo \GocContextPath::getPath()?>img/serviceEndpoint.png" class="titleIcon"/>
         <table style="clear: both; width: 100%;">
             <tr class="site_table_row_1">
@@ -265,24 +265,24 @@ $configService = \Factory::getConfigService();
                 <th class="site_table">URL</th>
                 <th class="site_table">Interface Name</th>
                 <?php if(!$params['portalIsReadOnly'] && $params['ShowEdit']): ?>
-                    <th class="site_table" >Edit</th>  
-                    <th class="site_table" >Remove</th>  
-                <?php endif; ?>              
+                    <th class="site_table" >Edit</th>
+                    <th class="site_table" >Remove</th>
+                <?php endif; ?>
             </tr>
             <?php
             $num = 2;
             foreach($se->getEndpointLocations() as $endpoint) {
                 ?>
-                                
+
                 <tr class="site_table_row_<?php echo $num ?>">
                     <td style="width: 30%;"class="site_table">
                         <a href="index.php?Page_Type=View_Service_Endpoint&id=<?php echo $endpoint->getId() ?>">
                             <?php xecho($endpoint->getName()) ?>
-                        </a> 
+                        </a>
                     </td>
                     <td style="width: 30%;"class="site_table"><?php echo($endpoint->getUrl()); ?></td>
                     <td style="width: 30%;"class="site_table"><?php xecho($endpoint->getInterfaceName()); ?></td>
-                    <?php if(!$params['portalIsReadOnly'] && $params['ShowEdit']): ?>	                
+                    <?php if(!$params['portalIsReadOnly'] && $params['ShowEdit']): ?>
                         <td style="width: 10%;"align = "center"class="site_table">
                                 <a href="index.php?Page_Type=Edit_Service_Endpoint&endpointid=<?php echo $endpoint->getId();?>&serviceid=<?php echo $seId;?>">
                                     <img height="25px" src="<?php echo \GocContextPath::getPath()?>img/pencil.png"/>
@@ -294,7 +294,7 @@ $configService = \Factory::getConfigService();
                             </a>
                         </td>
                     <?php endif; ?>
-                        
+
                 </tr>
                 <?php
                 if($num == 1) { $num = 2; } else { $num = 1; }
@@ -312,9 +312,9 @@ $configService = \Factory::getConfigService();
             </a>
         <?php endif; ?>
     </div>
-    
-   
-    
+
+
+
     <!--  Service Properties -->
     <?php
     $parent = $params['se'];
@@ -324,13 +324,13 @@ $configService = \Factory::getConfigService();
 
     require_once __DIR__ . '/../fragments/viewPropertiesTable.php';
     ?>
-    
+
     <!--  Downtimes -->
     <div class="listContainer rounded" style="width: 99.5%; float: left; margin-top: 3em; margin-right: 10px;">
         <span class="header" style="vertical-align:middle; float: left; padding-top: 0.9em; padding-left: 1em;">Recent Downtimes</span>
         <a href="index.php?Page_Type=SE_Downtimes&id=<?php echo $se->getId(); ?>" style="vertical-align:middle; float: left; padding-top: 1.3em; padding-left: 1em; font-size: 0.8em;">(View all Downtimes)</a>
         <img src="<?php echo \GocContextPath::getPath()?>img/down_arrow.png" height="25px" style="float: right; padding-right: 1em; padding-top: 0.5em; padding-bottom: 0.5em;" />
-    
+
         <table id="downtimesTable"  class="table table-striped table-condensed tablesorter">
         <thead>
             <tr>
@@ -360,7 +360,7 @@ $configService = \Factory::getConfigService();
             ?>
         </tbody>
         </table>
-    
+
         <!--  only show this link if we're in read / write mode -->
         <?php if(!$params['portalIsReadOnly'] && $params['ShowEdit']): ?>
             <!-- Add new Downtime Link -->
@@ -372,32 +372,31 @@ $configService = \Factory::getConfigService();
             </a>
         <?php endif; ?>
     </div>
-    
+
 </div>
 
  <script type="text/javascript">
     $(document).ready(function() {
         $('#serviceEndpointLink').tooltip();
-        $('#extensionsLink').tooltip(); 
+        $('#extensionsLink').tooltip();
 
-        $('#downtimesTable').tablesorter(); 
-    // sort on first and second table cols only 
-        $("#serviceExtensionPropsTable").tablesorter({ 
-        // pass the headers argument and assing a object 
-        headers: { 
-            // assign the third column (we start counting zero) 
-            2: { 
-                // disable it by setting the property sorter to false 
-                sorter: false 
-            }, 
-            3: { 
-                // disable it by setting the property sorter to false 
-                sorter: false 
-            } 
-        } 
+        $('#downtimesTable').tablesorter();
+    // sort on first and second table cols only
+        $("#serviceExtensionPropsTable").tablesorter({
+        // pass the headers argument and assing a object
+        headers: {
+            // assign the third column (we start counting zero)
+            2: {
+                // disable it by setting the property sorter to false
+                sorter: false
+            },
+            3: {
+                // disable it by setting the property sorter to false
+                sorter: false
+            }
+        }
         });
 
-    } 
-);  
-</script>  
-    
+    }
+);
+</script>

--- a/htdocs/web_portal/views/service/view_service_endpoint.php
+++ b/htdocs/web_portal/views/service/view_service_endpoint.php
@@ -14,7 +14,7 @@ $seId = $se->getId();
     <div style="float: left; width: 50em;">
         <h1 style="float: left; margin-left: 0em;"><?php xecho('Service Endpoint: ' . $endpoint->getName()) ?> </h1>
         <span style="clear: both; float: left; padding-bottom: 0.4em;">
-        Description: <?php xecho($endpoint->getDescription()) ?> 
+        Description: <?php xecho($endpoint->getDescription()) ?>
         </span>
     </div>
 
@@ -33,7 +33,7 @@ $seId = $se->getId();
         </div>
         <div style="float: right;">
             <script type="text/javascript" src="<?php echo \GocContextPath::getPath() ?>javascript/confirm.js"></script>
-            <a onclick="return confirmSubmit()" 
+            <a onclick="return confirmSubmit()"
                href="index.php?Page_Type=Delete_Service_Endpoint&endpointid=<?php echo $endpoint->getId(); ?>&serviceid=<?php echo $seId; ?>">
             <img src="<?php echo \GocContextPath::getPath() ?>img/cross.png" height="25px" style="float: right; margin-right: 0.4em;" />
             <br />
@@ -87,9 +87,9 @@ $seId = $se->getId();
         </div>
     </div>
 
-    <div style="float: left; width: 100%; margin-top: 2em;"> 
-    More (GLUE2) attributes can be added on request - please contact gocdb developers.  
-    </div>                 
+    <div style="float: left; width: 100%; margin-top: 2em;">
+    More (GLUE2) attributes can be added on request - please contact gocdb developers.
+    </div>
 
     <!-- Extension Properties -->
     <?php
@@ -105,17 +105,17 @@ $seId = $se->getId();
     <script type="text/javascript">
     $(document).ready(function () {
 
-        // sort on first and second table cols only 
+        // sort on first and second table cols only
         $("#endpointExtensionPropsTable").tablesorter({
         // pass the headers argument and passing a object
         headers: {
-            // assign the third column (we start counting zero) 
+            // assign the third column (we start counting zero)
             2: {
-            // disable it by setting the property sorter to false 
+            // disable it by setting the property sorter to false
             sorter: false
             },
             3: {
-            // disable it by setting the property sorter to false 
+            // disable it by setting the property sorter to false
             sorter: false
             }
         }
@@ -123,4 +123,4 @@ $seId = $se->getId();
 
     }
     );
-    </script>  
+    </script>

--- a/htdocs/web_portal/views/service_group/add_new_se_to_service_group.php
+++ b/htdocs/web_portal/views/service_group/add_new_se_to_service_group.php
@@ -3,24 +3,24 @@
         <h1>Add New Services to Service Group</h1>
         <br />
         <span>
-            Please note: Adding a new service to a service group ties the 
+            Please note: Adding a new service to a service group ties the
             new service to the group.
             <br />
-            If the service group is deleted then the service 
+            If the service group is deleted then the service
             will also be deleted.
             <br />
             Modifications to the service can only be performed by
             users who hold a role over the creating service group.
         </span>
-        
+
         <br /><br />
-        
+
         <input type="hidden" name="vSiteId" value="<?php echo $params['vSite']['COBJECTID'] ?>">
         <input type="hidden" name="gridId" value="<?php echo $params['gridId'] ?>">
-        
+
         <span class="input_name">Hosting Service Group</span>
         <input class="input_input_text" type="text" name="" value="<?php echo $params['vSite']['NAME'] ?>" disabled="disabled" />
-        
+
         <span class="input_name">Service Type</span>
         <select class="add_edit_form" name="Service_Type">
             <?php
@@ -29,77 +29,77 @@
             }
             ?>
         </select>
-        
+
         <span class="input_name">
             Service URL
             <span class="input_syntax" >(Alphanumeric and $-_.+!*'(),:)</span>
         </span>
         <input class="input_input_text" type="text" name="EndpointURL" value="" />
-        
+
         <span class="input_name">Host name *
             <span class="input_syntax" >(valid FQDN format)</span>
         </span>
         <input class="input_input_text" type="text" name="HOSTNAME" />
-        
+
         <span class="input_name">Host IP
             <span class="input_syntax" >(a.b.c.d)</span>
         </span>
         <input class="input_input_text" type="text" name="HOST_IP" />
-        
+
         <span class="input_name">Host DN
             <span class="input_syntax" >(/C=.../OU=.../...)</span>
         </span>
         <input class="input_input_text" type="text" name="HOST_DN" />
-        
-        <span class="input_name">Description 
+
+        <span class="input_name">Description
             <span class="input_syntax" >(Alphanumeric and basic punctuation)</span>
         </span>
         <input class="input_input_text" type="text" name="DESCRIPTION" />
-        
-        <span class="input_name">Host Operating System 
+
+        <span class="input_name">Host Operating System
             <span class="input_syntax" >(Alphanumeric and basic punctuation)</span>
         </span>
         <input class="input_input_text" type="text" name="HOST_OS" />
-        
+
         <span class="input_name">Host Architecture
             <span class="input_syntax" >(Alphanumeric and basic punctuation)</span>
         </span>
         <input class="input_input_text" type="text" name="HOST_ARCH" />
-        
+
         <span class="input_name">Is it a beta service (formerly PPS service)?</span>
         <select class="add_edit_form" name="HOST_BETA">
             <option value="N">N</option>
             <option value="Y">Y</option>
         </select>
-        
+
         <span class="input_name">Is this service in production?</span>
         <select class="add_edit_form" name="PRODUCTION_LEVEL">
             <option value="N">N</option>
             <option value="Y">Y</option>
         </select>
-            
+
         <span class="input_name">Is this service monitored?</span>
         <select class="add_edit_form" name="IS_MONITORED">
             <option value="N">N</option>
             <option value="Y">Y</option>
         </select>
-        
+
         <br />
-        
+
         <div style="display: inline; float: none;">
             <span class="input_name" style="">
-               Is this service visible to EGI? 
+               Is this service visible to EGI?
                <a href=""index.php?Page_Type=Scope_Help"">
                    (Help)
                </a>
             </span>
             <input class="add_edit_form" style="width: auto; display: inline;" type="checkbox" name="egi_data" value="" checked="checked"/>
         </div>
-        
+
         <div style="display: inline; float: none;">
-            
+
         </div>
-        
+
         <br />
         <input class="input_button" type="submit" value="Execute" />
     </form>

--- a/htdocs/web_portal/views/service_group/add_service_group.php
+++ b/htdocs/web_portal/views/service_group/add_service_group.php
@@ -31,11 +31,11 @@
         <br>
         <br>
         <!-- Scope Tags-->
-        <?php 
-        $parentObjectTypeLabel = ''; 
+        <?php
+        $parentObjectTypeLabel = '';
         require_once __DIR__ . '/../fragments/editScopesFragment.php';
         ?>
-          
+
 
         <input class="input_button" type="submit" value="Add Service Group" />
     </form>
@@ -46,11 +46,11 @@
 
     $(document).ready(function () {
         var scopeJSON = JSON.parse('<?php echo($params["scopejson"]) ?>');
-        ScopeUtil.addScopeCheckBoxes(scopeJSON, 
-          '#reservedScopeCheckBoxDIV', 
-          '#reservedOptionalScopeCheckBoxDIV', 
+        ScopeUtil.addScopeCheckBoxes(scopeJSON,
+          '#reservedScopeCheckBoxDIV',
+          '#reservedOptionalScopeCheckBoxDIV',
           '#reservedOptionalInhertiableScopeCheckBoxDIV',
-          '#optionalScopeCheckBoxDIV', 
+          '#optionalScopeCheckBoxDIV',
           true);
     });
-</script>  
+</script>

--- a/htdocs/web_portal/views/service_group/add_service_group_properties_confirmation.php
+++ b/htdocs/web_portal/views/service_group/add_service_group_properties_confirmation.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 $propertyArray = $params['proparr'];
 $parent = $params['serviceGroup'];
 $addPropertiesPage = "Add_Service_Group_Properties";

--- a/htdocs/web_portal/views/service_group/add_ses.php
+++ b/htdocs/web_portal/views/service_group/add_ses.php
@@ -20,9 +20,9 @@
                 </a>
             </span>
         </div>
-        
+
         <?php require_once __DIR__.'/add_ses_body.php';?>
-    
+
         <?php if($params['siteLessServices']) { ?>
         <div class="leftFloat topMargin2 leftMargin">
             <a href="index.php?Page_Type=Add_New_SE_To_Service_Group&id=<?php echo $params['sg']->getId() ?>">
@@ -33,7 +33,7 @@
             </a>
         </div>
         <?php } ?>
-    
+
     <form id="sesToAdd" action="index.php?Page_Type=Add_Service_Group_SEs" method="POST" class="empty" style="margin-top: 1em; float: left;">
         <input class="input_button leftFloat topMargin2" type="submit" value="Add SEs to Service Group"  />
         <input type="hidden" name="id" value="<?php echo $params['sg']->getId(); ?>" />

--- a/htdocs/web_portal/views/service_group/add_ses_body.php
+++ b/htdocs/web_portal/views/service_group/add_ses_body.php
@@ -7,14 +7,14 @@
         </span>
         <img src="<?php echo \GocContextPath::getPath()?>img/grid.png" class="decoration" />
         <form action="javascript:void(0);">
-            <input  class="input_input_text vSiteSearch" type="text" 
-                    name="Search" value="Search" onclick="clearText()" 
+            <input  class="input_input_text vSiteSearch" type="text"
+                    name="Search" value="Search" onclick="clearText()"
                     id='filter' />
-            <input  class="input_button vSiteSearchButton" type="submit" 
+            <input  class="input_button vSiteSearchButton" type="submit"
                     value="Search" onclick="startSearch()" />
         </form>
-        
-        
+
+
         <div class="vSiteSearchResultContainer" id="resultsContainer">
         <span class="header listHeader vSite1emBottomMargin">
             Results:
@@ -30,7 +30,7 @@
         </table>
         </div>
     </div>
-    
+
     <!--  Selected Services -->
     <div class="listContainer">
         <span class="header listHeader">

--- a/htdocs/web_portal/views/service_group/deleted_service_group_properties.php
+++ b/htdocs/web_portal/views/service_group/deleted_service_group_properties.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 $propertyArray = $params['propArr'];
 $serviceGroup = $params['serviceGroup'];
 ?>

--- a/htdocs/web_portal/views/service_group/edit_service_group.php
+++ b/htdocs/web_portal/views/service_group/edit_service_group.php
@@ -16,12 +16,12 @@ $sg = $params['serviceGroup'];
 
         <br/>
         <br/>
-        
+
         <!-- Scope Tags-->
-        <?php 
-        $parentObjectTypeLabel = ''; 
+        <?php
+        $parentObjectTypeLabel = '';
         require_once __DIR__ . '/../fragments/editScopesFragment.php';
-        ?> 
+        ?>
 
         <input class="input_input_hidden" type="hidden" name="objectId" value="<?php echo $sg->getId(); ?>" />
         <br />
@@ -34,11 +34,11 @@ $sg = $params['serviceGroup'];
 
     $(document).ready(function () {
         var scopeJSON = JSON.parse('<?php echo($params["scopejson"]) ?>');
-        ScopeUtil.addScopeCheckBoxes(scopeJSON, 
-          '#reservedScopeCheckBoxDIV', 
-          '#reservedOptionalScopeCheckBoxDIV', 
+        ScopeUtil.addScopeCheckBoxes(scopeJSON,
+          '#reservedScopeCheckBoxDIV',
+          '#reservedOptionalScopeCheckBoxDIV',
           '#reservedOptionalInhertiableScopeCheckBoxDIV',
-          '#optionalScopeCheckBoxDIV', 
+          '#optionalScopeCheckBoxDIV',
           true);
     });
-</script> 
+</script>

--- a/htdocs/web_portal/views/service_group/edit_service_group_property.php
+++ b/htdocs/web_portal/views/service_group/edit_service_group_property.php
@@ -5,15 +5,15 @@ $prop = $params['prop'];
 <div class="rightPageContainer">
     <form name="Edit_Service_Group_Property" action="index.php?Page_Type=Edit_Service_Group_Property" method="post" class="inputForm" id="Service_Group_Property_Form">
 
-        <h1>Edit Service Group Property</h1>    		
+        <h1>Edit Service Group Property</h1>
         <br />
 
         <span class="input_name">
-            Property Name            
+            Property Name
         </span>
         <input class="input_input_text" type="text" name="KEYPAIRNAME" value="<?php xecho($prop->getKeyName());?>" />
         <span class="input_name">
-            Property Value            
+            Property Value
         </span>
         <input class="input_input_text" type="text" name="KEYPAIRVALUE" value="<?php xecho($prop->getKeyValue());?>"/>
         <input class="input_input_text" type="hidden" name ="SERVICEGROUP" value="<?php echo $serviceGroup->getId();?>" />

--- a/htdocs/web_portal/views/service_group/remove_ses.php
+++ b/htdocs/web_portal/views/service_group/remove_ses.php
@@ -1,5 +1,5 @@
 <?php
-$sg = $params['sg']; 
+$sg = $params['sg'];
 ?>
 <div class="rightPageContainer">
     <script language="JavaScript" src="<?php echo \GocContextPath::getPath()?>javascript/service_group/remove_se_from_vsite.js"></script>
@@ -23,13 +23,13 @@ $sg = $params['sg'];
                 </a>
             </span>
         </div>
-        
+
         <span class="vSiteNotice">Please ensure the service administrators are aware of your modifications.</span>
-        
+
         <!--  Services -->
         <div class="listContainer">
             <span class="header listHeader">
-                Services 
+                Services
             </span>
             <img src="<?php echo \GocContextPath::getPath()?>img/grid.png" class="decoration" />
             <table class="vSiteResults" id="selectedSETable">
@@ -39,25 +39,25 @@ $sg = $params['sg'];
                     <th class="site_table">Description</th>
                     <th class="site_table">Hosting Site</th>
                 </tr>
-                <?php           
+                <?php
                 $num = 2;
-                
+
                 foreach($sg->getServices() as $se) {
                     if($se->getScopes()->first()->getName() == 'Local') {
-                        $style = "style=\"background-color: #A3D7A3;\""; 
+                        $style = "style=\"background-color: #A3D7A3;\"";
                     }
                     else{
                         $style = "";
                     }
-                        
+
                 ?>
                 <tr class="site_table_row_<?php echo $num ?>"<?php echo $style; ?> id="<?php echo $se->getId(); ?>Row">
                     <td>
                         <a href="#" onclick="removeSe(<?php echo $se->getId() ?>, <?php echo $sg->getId() ?>, <?php if(is_null($se->getParentSite())) { echo "true"; } else { echo "false"; }?>)">
-                           Remove 
+                           Remove
                         </a>
                     </td>
-                        
+
                     <td class="site_table">
                         <div style="background-color: inherit;">
                             <img src="<?php echo \GocContextPath::getPath()?>img/server.png" height="25px" style="vertical-align: middle; padding-right: 1em;" />
@@ -65,7 +65,7 @@ $sg = $params['sg'];
                                 <a href="index.php?Page_Type=Service&id=<?php echo $se->getId() ?>">
                                     <?php
                                         xecho($se->getServiceType()->getName());
-                                        echo " - "; 
+                                        echo " - ";
                                         xecho($se->getHostName());
                                     ?>
                                 </a>
@@ -81,14 +81,14 @@ $sg = $params['sg'];
                         </a>
                     </td>
                 </tr>
-                <?php  
+                <?php
                     if($num == 1) { $num = 2; } else { $num = 1; }
                     } // End of the foreach loop iterating over SEs
                 ?>
             </table>
         </div>
         <span class="leftFloat topMargin">
-            Return to 
+            Return to
             <a href="index.php?Page_Type=Service_Group&id=<?php echo $sg->getId() ?>">
                  <?php xecho($sg->getName()) ?>
             </a>

--- a/htdocs/web_portal/views/service_group/service_group_property_updated.php
+++ b/htdocs/web_portal/views/service_group/service_group_property_updated.php
@@ -1,6 +1,6 @@
 <div class="rightPageContainer">
     <h1 class="Success">Success</h1>
-    Service Group Property updated.<br />    
+    Service Group Property updated.<br />
     <a href="index.php?Page_Type=Service_Group&id=<?php echo $params['serviceGroupId']; ?>">
     View service group</a>
 </div>

--- a/htdocs/web_portal/views/service_group/view_all.php
+++ b/htdocs/web_portal/views/service_group/view_all.php
@@ -16,7 +16,7 @@
         </span>
         <!-- <span style="clear: both; float: left;">Intentionally Blank</span>  -->
     </div>
-    
+
     <!-- Filter -->
     <div class="siteContainer">
         <form action="index.php?Page_Type=Service_Groups" method="GET" class="inline">
@@ -25,18 +25,18 @@
         <span class="header leftFloat">
         Filter <a href="index.php?Page_Type=Service_Groups">&nbsp;&nbsp;(clear)</a>
         </span>
-        
+
         <div class="topMargin leftFloat siteFilter clearLeft">
         <span class=""><a href="index.php?Page_Type=Scope_Help">Scopes:</a> </span>
         <select id="scopeSelect" multiple="multiple" name="mscope[]" style="width: 200px">
             <?php foreach ($params['scopes'] as $scope) { ?>
-            <option value="<?php xecho($scope->getName()); ?>" 
+            <option value="<?php xecho($scope->getName()); ?>"
                 <?php if(in_array($scope->getName(), $params['selectedScopes'])){ echo ' selected';}?> >
                 <?php xecho($scope->getName()); ?>
             </option>
             <?php } ?>
         </select>
-        </div>                 
+        </div>
 
         <div class="topMargin leftFloat siteFilter">
         <span class="">Extension Name:</span>
@@ -46,16 +46,16 @@
                 <option value="<?php echo $extensions; ?>"
             <?php if ($params['selectedExtKeyName'] == $extensions){ echo " selected";} ?>>
                 <?php echo $extensions; ?>
-            </option> 
-            <?php } ?>                  
+            </option>
+            <?php } ?>
                 </select>
-        </div> 
+        </div>
 
             <div class="topMargin leftFloat siteFilter">
                     <span class="middle" style="margin-right: 0.4em">Extension Value: </span>
-                    <input class="middle" type="text" name="selectedExtKeyValue" 
+                    <input class="middle" type="text" name="selectedExtKeyValue"
             <?php if (isset($params['selectedExtKeyValue'])){ echo "value=\"{$params['selectedExtKeyValue']}\""; } ?>/>
-            </div>        	
+            </div>
 
         <div class="topMargin leftFloat siteFilter clearLeft">
         <input type="submit" value="Filter ServiceGroups">
@@ -78,7 +78,7 @@
             </tr>
         </thead>
         <tbody>
-            <?php           
+            <?php
             //$num = 2;
             foreach($params['sGroups'] as $sGroup) {
             ?>
@@ -88,16 +88,16 @@
             <?php xecho($sGroup->getName()); ?>
             </a>
                 </td>
-                    
+
                 <td>
                     <?php xecho($sGroup->getDescription()); ?>
                 </td>
-                
+
                 <td>
            <textarea readonly="true" style="height: 25px;"><?php xecho($sGroup->getScopeNamesAsString()); ?></textarea>
                 </td>
             </tr>
-            <?php  
+            <?php
                 //if($num == 1) { $num = 2; } else { $num = 1; }
                 } // End of the foreach loop iterating over SEs
             ?>
@@ -117,13 +117,13 @@
 <script type="text/javascript" src="<?php GocContextPath::getPath()?>javascript/jquery.multiple.select.js"></script>
 
 <script>
-    $(document).ready(function() 
+    $(document).ready(function()
     {
-    $("#selectedSgTable").tablesorter(); 
-    
+    $("#selectedSgTable").tablesorter();
+
     $('#scopeSelect').multipleSelect({
         filter: true,
             placeholder: "SG Scopes"
         });
-    }); 
+    });
 </script>

--- a/htdocs/web_portal/views/service_group/view_sgroup.php
+++ b/htdocs/web_portal/views/service_group/view_sgroup.php
@@ -65,10 +65,10 @@ $extensionProperties = $params['sGroup']->getServiceGroupProperties();
                         }
                         ?></td>
                 </tr>
-                <?php 
-                if($params['sGroup']->getScopes() != null && $params['sGroup']->getScopes()->first() != null && 
-                        $params['sGroup']->getScopes()->first()->getName() == "Local") { 
-                    $style = " style=\"background-color: #A3D7A3;\""; } else { $style = ""; } 
+                <?php
+                if($params['sGroup']->getScopes() != null && $params['sGroup']->getScopes()->first() != null &&
+                        $params['sGroup']->getScopes()->first()->getName() == "Local") {
+                    $style = " style=\"background-color: #A3D7A3;\""; } else { $style = ""; }
                 ?>
                 <tr class="site_table_row_2" <?php echo $style ?>>
                     <td class="site_table">
@@ -152,7 +152,7 @@ $extensionProperties = $params['sGroup']->getServiceGroupProperties();
             } // End of the foreach loop iterating over SEs
             ?>
         </table>
-    
+
         <!--  only show this link if we're in read / write mode -->
         <?php if(!$params['portalIsReadOnly'] && $params['ShowEdit']): ?>
             <!-- Add new Service Link -->
@@ -197,10 +197,10 @@ $extensionProperties = $params['sGroup']->getServiceGroupProperties();
                     </div>
                 </td>
                 <td class="site_table">
-                    <?php 
-                    if($params['authenticated']) { 
-                       xecho($role->getRoleType()->getName()) ; 
-                    } else {echo 'PROTECTED'; } 
+                    <?php
+                    if($params['authenticated']) {
+                       xecho($role->getRoleType()->getName()) ;
+                    } else {echo 'PROTECTED'; }
                     ?>
                 </td>
             </tr>
@@ -265,26 +265,26 @@ $extensionProperties = $params['sGroup']->getServiceGroupProperties();
 
     <!-- Show RoleActionRecords if user has permissions over this object -->
     <?php if ($params['ShowEdit']){
-        require_once __DIR__ . '/../fragments/viewRoleActionsTable.php'; 
+        require_once __DIR__ . '/../fragments/viewRoleActionsTable.php';
     } ?>
-        
+
 </div>
 
 
     <script type="text/javascript">
     $(document).ready(function () {
 
-        // sort on first and second table cols only 
+        // sort on first and second table cols only
         $("#sgExtensionPropsTable").tablesorter({
-        // pass the headers argument and assing a object 
+        // pass the headers argument and assing a object
         headers: {
-            // assign the third column (we start counting zero) 
+            // assign the third column (we start counting zero)
             2: {
-            // disable it by setting the property sorter to false 
+            // disable it by setting the property sorter to false
             sorter: false
             },
             3: {
-            // disable it by setting the property sorter to false 
+            // disable it by setting the property sorter to false
             sorter: false
             }
         }
@@ -292,4 +292,4 @@ $extensionProperties = $params['sGroup']->getServiceGroupProperties();
 
     }
     );
-    </script>  
+    </script>

--- a/htdocs/web_portal/views/service_group/view_sgroup_downtimes.php
+++ b/htdocs/web_portal/views/service_group/view_sgroup_downtimes.php
@@ -2,14 +2,14 @@
     <div style="overflow: hidden">
         <div style="float: left;">
             <h1 style="float: left; margin-left: 0em;">
-                Downtimes for 
-                <a  style="font-family: inherit; font-size: inherit; font-weight: inherit; text-decoration: underline; padding-bottom: inherit; " 
+                Downtimes for
+                <a  style="font-family: inherit; font-size: inherit; font-weight: inherit; text-decoration: underline; padding-bottom: inherit; "
                     href="index.php?Page_Type=Service_Group&id=<?php echo $params['sGroup']->getId(); ?>">
                     <?php xecho($params['sGroup']->getName())?>
                 </a>
             </h1>
         </div>
-        
+
         <!--  Downtimes -->
         <div class="listContainer">
             <span class="header" style="vertical-align:middle; float: left; padding-top: 0.9em; padding-left: 1em;">All Downtimes (Year-Month-Day Time in UTC)</span>
@@ -27,7 +27,7 @@
                     //$num = 2;
                     foreach($params['downtimes'] as $d) {
                 ?>
-                
+
                 <tr>
                     <td>
                         <a style="padding-right: 1em;" href="index.php?Page_Type=Downtime&id=<?php echo $d->getId() ?>">
@@ -37,7 +37,7 @@
                     <td style="width: 20%"><?php echo $d->getStartDate()->format('Y-m-d H:i'/*$d::DATE_FORMAT*/); ?></td>
                     <td style="width: 20%"><?php echo $d->getStartDate()->format('Y-m-d H:i'/*$d::DATE_FORMAT*/); ?></td>
                 </tr>
-                <?php 
+                <?php
                     //if($num == 1) { $num = 2; } else { $num = 1; }
                 }
                 ?>
@@ -53,4 +53,4 @@
     $("#allSgDowntimesTable").tablesorter();
     }
     );
-</script> 
+</script>

--- a/htdocs/web_portal/views/site/add_site.php
+++ b/htdocs/web_portal/views/site/add_site.php
@@ -58,55 +58,55 @@
         <input class="input_input_text" type="text"name="DOMAIN"value="" />
 
         <span class="input_name">
-            Short Name * 
+            Short Name *
             <span class="input_syntax" >(Alphanumeric, dot dash and underscore)</span>
         </span>
         <input class="input_input_text" type="text" name="SHORT_NAME" />
 
         <span class="input_name">
-            Official Name 
+            Official Name
             <span class="input_syntax" >(Alphanumeric and basic punctuation)</span>
         </span>
         <input class="input_input_text" type="text" name="OFFICIAL_NAME" />
 
         <span class="input_name">
-            Home URL 
+            Home URL
             <span class="input_syntax" >(http(s)://url_format)</span>
         </span>
         <input class="input_input_text" type="text" name="HOME_URL" />
 
         <span class="input_name">
-            GIIS URL 
+            GIIS URL
             <span class="input_syntax" >(ldap://giis_url_format)</span>
         </span>
         <input class="input_input_text" type="text" name="GIIS_URL" />
 
         <span class="input_name">
-            IP Range 
+            IP Range
             <span class="input_syntax" >(a.b.c.d/e.f.g.h)</span>
         </span>
         <input class="input_input_text" type="text" name="IP_RANGE" />
 
         <span class="input_name">
-            IPv6 Range 
+            IPv6 Range
             <span class="input_syntax" >(0000:0000:0000:0000:0000:0000:0000:0000[/int]) (optional [/int] range)</span>
-        </span>        
-        <input class="input_input_text" type="text" name="IP_V6_RANGE" />        
+        </span>
+        <input class="input_input_text" type="text" name="IP_V6_RANGE" />
 
         <span class="input_name">
-            Location 
+            Location
             <span class="input_syntax" >(Alphanumeric and basic punctuation)</span>
         </span>
         <input class="input_input_text" type="text" name="LOCATION" />
 
         <span class="input_name">
-            Latitude 
+            Latitude
             <span class="input_syntax" >(-90 <= number <= 90)</span>
         </span>
         <input class="input_input_text" type="text" name="LATITUDE" />
 
         <span class="input_name">
-            Longitude 
+            Longitude
             <span class="input_syntax" >(-180 <= number <= 180)</span>
         </span>
         <input class="input_input_text" type="text" name="LONGITUDE" />
@@ -118,7 +118,7 @@
         <input class="input_input_text" type="text" name="DESCRIPTION" />
 
         <span class="input_name">
-            E-Mail * 
+            E-Mail *
             <span class="input_syntax" >(valid email format)</span>
         </span>
         <input class="input_input_text" type="text" name="EMAIL" />
@@ -130,7 +130,7 @@
         <input class="input_input_text" type="text" name="CONTACTTEL" />
 
         <span class="input_name">
-            Emergency Telephone Number 
+            Emergency Telephone Number
             <span class="input_syntax" >(optional + at the start, numbers, dots spaces or dashes, multiple comma separated numbers allowed)</span>
         </span>
         <input class="input_input_text" type="text" name="EMERGENCYTEL" />
@@ -162,8 +162,8 @@
         <br>
         <br>
         <!-- Scope Tags-->
-        <?php 
-        $parentObjectTypeLabel = 'NGI'; 
+        <?php
+        $parentObjectTypeLabel = 'NGI';
         require_once __DIR__ . '/../fragments/editScopesFragment.php';
         ?>
 
@@ -177,24 +177,24 @@
 <script type="text/javascript">
     $(document).ready(function () {
         var entityId = $('#ngiSelectPullDown').val();
-        //console.log(ajaxText); 
-        ScopeUtil.queryForJsonScopesAddScopeCheckBoxes('Add_Site', entityId, 
+        //console.log(ajaxText);
+        ScopeUtil.queryForJsonScopesAddScopeCheckBoxes('Add_Site', entityId,
           '#reservedScopeCheckBoxDIV',
-          '#reservedOptionalScopeCheckBoxDIV', 
+          '#reservedOptionalScopeCheckBoxDIV',
           '#reservedOptionalInhertiableScopeCheckBoxDIV',
-          '#optionalScopeCheckBoxDIV', 
+          '#optionalScopeCheckBoxDIV',
           true);
 
         $('#ngiSelectPullDown').change(function () {
             var entityId = $('#ngiSelectPullDown').val();
-            ScopeUtil.queryForJsonScopesAddScopeCheckBoxes('Add_Site', entityId, 
-              '#reservedScopeCheckBoxDIV', 
-              '#reservedOptionalScopeCheckBoxDIV', 
+            ScopeUtil.queryForJsonScopesAddScopeCheckBoxes('Add_Site', entityId,
+              '#reservedScopeCheckBoxDIV',
+              '#reservedOptionalScopeCheckBoxDIV',
               '#reservedOptionalInhertiableScopeCheckBoxDIV',
-              '#optionalScopeCheckBoxDIV', 
+              '#optionalScopeCheckBoxDIV',
               true);
         });
 
     });
 
-</script>    
+</script>

--- a/htdocs/web_portal/views/site/add_site_properties_confirmation.php
+++ b/htdocs/web_portal/views/site/add_site_properties_confirmation.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 $propertyArray = $params['proparr'];
 $parent = $params['site'];
 $addPropertiesPage = "Add_Site_Properties";

--- a/htdocs/web_portal/views/site/add_site_property.php
+++ b/htdocs/web_portal/views/site/add_site_property.php
@@ -4,15 +4,15 @@ $site = $params['site'];
 <div class="rightPageContainer">
     <form name="Add_Site_Property" action="index.php?Page_Type=Add_Site_Property" method="post" class="inputForm" id="Site_Property_Form" name="Site_Property_Form">
 
-        <h1>Add Site Property</h1>    		
+        <h1>Add Site Property</h1>
         <br />
 
         <span class="input_name">
-            Property Name            
+            Property Name
         </span>
         <input class="input_input_text" type="text" name="KEYPAIRNAME" />
         <span class="input_name">
-            Property Value            
+            Property Value
         </span>
         <input class="input_input_text" type="text" name="KEYPAIRVALUE" />
         <input class="input_input_text" type="hidden" name ="SITE" value="<?php echo $site->getId();?>" />

--- a/htdocs/web_portal/views/site/delete_site.php
+++ b/htdocs/web_portal/views/site/delete_site.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 $site = $params['Site'];
 $siteName = $site->getName();
 $siteId = $site->getId();
@@ -15,23 +15,23 @@ $services = $params['Services']
     </p>
     <p>
         If you delete this site, the following services will be deleted as well:
-        <?php 
+        <?php
             foreach($services as $service){
                 echo "<br />"
                     . "<a href=\"index.php?Page_Type=Service&id=" . $service->getId() ."\">"
                     .  $service->getHostName() . " (" . $service->getServiceType()->getName() . ")"
                     . "</a> ";
-            }	
+            }
         ?>
     </p>
     <p>
-        Any down times associated with these services, and only these services, 
+        Any down times associated with these services, and only these services,
         will also be removed from GOCDB.
     </p>
     <p>
         Are you sure you wish to continue?
     </p>
-    
+
     <form class="inputForm" method="post" action="index.php?Page_Type=Delete_Site&id=<?php echo $siteId;?>" name="RemoveScope">
         <input class="input_input_hidden" type="hidden" name="UserConfirmed" value="true" />
         <input type="submit" value="Remove this site and all its associated services from GOCDB" class="input_button">

--- a/htdocs/web_portal/views/site/deleted_site.php
+++ b/htdocs/web_portal/views/site/deleted_site.php
@@ -1,4 +1,4 @@
 <div class="rightPageContainer">
     <h1 class="Success">Deletion Successful</h1><br />
-    The site '<?php echo $params['Name']?>' and any associated services have been successfully removed from GOCDB 
+    The site '<?php echo $params['Name']?>' and any associated services have been successfully removed from GOCDB
 </div>

--- a/htdocs/web_portal/views/site/deleted_site_properties.php
+++ b/htdocs/web_portal/views/site/deleted_site_properties.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 $propertyArray = $params['propArr'];
 $site = $params['site'];
 ?>

--- a/htdocs/web_portal/views/site/edit_site.php
+++ b/htdocs/web_portal/views/site/edit_site.php
@@ -9,7 +9,7 @@ $siteScopes = $site->getScopes();
         <h1>Edit Site</h1>
         <br />
 
-        <!-- Countries -->    	
+        <!-- Countries -->
         <span class="input_name">Country</span>
         <select class="add_edit_form" name="Country">
             <?php foreach ($params['countries'] as $country) { ?>
@@ -43,7 +43,7 @@ $siteScopes = $site->getScopes();
         <input class="input_input_text" type="text" name="DOMAIN" value="<?php xecho($site->getDomain()) ?>" />
 
         <!-- Short Name -->
-        <span class="input_name">Short Name * 
+        <span class="input_name">Short Name *
             <span class="input_syntax" >
                 (Alphanumeric, dot dash and underscore)
             </span>
@@ -51,7 +51,7 @@ $siteScopes = $site->getScopes();
         <input class="input_input_text" type="text" name="SHORT_NAME" value="<?php xecho($site->getShortName()) ?>" />
 
         <!--  Official Name -->
-        <span class="input_name">Official Name 
+        <span class="input_name">Official Name
             <span class="input_syntax" >
                 (Alphanumeric and basic punctuation)
             </span>
@@ -60,7 +60,7 @@ $siteScopes = $site->getScopes();
 
         <!-- URL -->
         <span class="input_name">
-            Home URL 
+            Home URL
             <span class="input_syntax" >
                 (http(s)://url_format)
             </span>
@@ -85,11 +85,11 @@ $siteScopes = $site->getScopes();
         </span>
         <input class="input_input_text" type="text" name="IP_RANGE" value="<?php xecho($site->getIpRange()) ?>" />
 
-        <!-- IP v6 Range -->        
+        <!-- IP v6 Range -->
         <span class="input_name">
             IPv6 Range
             <span class="input_syntax" >(0000:0000:0000:0000:0000:0000:0000:0000[/int]) (optional [/int] range)</span>
-        </span>        
+        </span>
         <input class="input_input_text" type="text" name="IP_V6_RANGE" value="<?php xecho($site->getIpV6Range()) ?>" />
 
         <!-- Location -->
@@ -103,7 +103,7 @@ $siteScopes = $site->getScopes();
 
         <!-- Latitude -->
         <span class="input_name">
-            Latitude    
+            Latitude
             <span class="input_syntax" >(-90 <= number <= 90)</span>
         </span>
         <input class="input_input_text" type="text" name="LATITUDE" value="<?php xecho($site->getLatitude()) ?>" />
@@ -126,7 +126,7 @@ $siteScopes = $site->getScopes();
 
         <!-- E-Mail -->
         <span class="input_name">
-            E-Mail * 
+            E-Mail *
             <span class="input_syntax" >
                 (valid email format)
             </span>
@@ -142,7 +142,7 @@ $siteScopes = $site->getScopes();
         </span>
         <input class="input_input_text" type="text" name="CONTACTTEL" value="<?php xecho($site->getTelephone()) ?>" />
 
-        <!-- Emergency Telephone Number -->    
+        <!-- Emergency Telephone Number -->
         <span class="input_name">
             Emergency Telephone Number
             <span class="input_syntax" >
@@ -178,7 +178,7 @@ $siteScopes = $site->getScopes();
         </span>
         <input class="input_input_text" type="text" name="EMERGENCYEMAIL" value="<?php xecho($site->getAlarmEmail()) ?>" />
 
-        <!-- Helpdesk email -->        
+        <!-- Helpdesk email -->
         <span class="input_name">
             Helpdesk E-Mail
             <span class="input_syntax" >
@@ -190,16 +190,16 @@ $siteScopes = $site->getScopes();
 
         <br>
         <br>
-        
+
         <!-- Scope Tags-->
-        <?php 
-        $parentObjectTypeLabel = 'NGI'; 
+        <?php
+        $parentObjectTypeLabel = 'NGI';
         require_once __DIR__ . '/../fragments/editScopesFragment.php';
         ?>
-        
+
 
         <br>
-        
+
         <span class="input_name">
             Action to Take For All Child Service Scopes
         </span>
@@ -223,11 +223,11 @@ $siteScopes = $site->getScopes();
 
     $(document).ready(function () {
         var scopeJSON = JSON.parse('<?php echo($params["scopejson"]) ?>');
-        ScopeUtil.addScopeCheckBoxes(scopeJSON, 
-        '#reservedScopeCheckBoxDIV', 
-        '#reservedOptionalScopeCheckBoxDIV', 
-        '#reservedOptionalInhertiableScopeCheckBoxDIV', 
-        '#optionalScopeCheckBoxDIV', 
+        ScopeUtil.addScopeCheckBoxes(scopeJSON,
+        '#reservedScopeCheckBoxDIV',
+        '#reservedOptionalScopeCheckBoxDIV',
+        '#reservedOptionalInhertiableScopeCheckBoxDIV',
+        '#optionalScopeCheckBoxDIV',
         true);
     });
-</script>    
+</script>

--- a/htdocs/web_portal/views/site/edit_site_property.php
+++ b/htdocs/web_portal/views/site/edit_site_property.php
@@ -5,15 +5,15 @@ $prop = $params['prop'];
 <div class="rightPageContainer">
     <form name="Edit_Site_Property" action="index.php?Page_Type=Edit_Site_Property" method="post" class="inputForm" id="Site_Property_Form" name="Edit_Site_Property_Form">
 
-        <h1>Edit Site Property</h1>    		
+        <h1>Edit Site Property</h1>
         <br />
 
         <span class="input_name">
-            Property Name            
+            Property Name
         </span>
         <input class="input_input_text" type="text" name="KEYPAIRNAME" value="<?php xecho($prop->getKeyName());?>" />
         <span class="input_name">
-            Property Value            
+            Property Value
         </span>
         <input class="input_input_text" type="text" name="KEYPAIRVALUE" value="<?php xecho($prop->getKeyValue());?>"/>
         <input class="input_input_text" type="hidden" name ="SITE" value="<?php echo($site->getId());?>" />

--- a/htdocs/web_portal/views/site/site_downtimes.php
+++ b/htdocs/web_portal/views/site/site_downtimes.php
@@ -61,4 +61,4 @@ $downtimes = $params['downtimes'];
     $("#allSiteDowntimesTable").tablesorter();
     }
     );
-</script> 
+</script>

--- a/htdocs/web_portal/views/site/site_property_updated.php
+++ b/htdocs/web_portal/views/site/site_property_updated.php
@@ -1,6 +1,6 @@
 <div class="rightPageContainer">
     <h1 class="Success">Success</h1>
-    Site Property updated.<br />    
+    Site Property updated.<br />
     <a href="index.php?Page_Type=Site&id=<?php echo $params['siteid']; ?>">
     View site</a>
 </div>

--- a/htdocs/web_portal/views/site/view_all.php
+++ b/htdocs/web_portal/views/site/view_all.php
@@ -26,7 +26,7 @@
                 <option value="<?php xecho($ngi->getName()); ?>"
             <?php if ($params['selectedNgi'] == $ngi->getName()){ echo " selected";} ?>>
                 <?php xecho($ngi->getName()); ?>
-            </option> 
+            </option>
             <?php } ?>
                 </select>
         </div>
@@ -39,8 +39,8 @@
                 <option value="<?php xecho($certStatus->getName()); ?>"
             <?php if ($params['selectedCertStatus'] == $certStatus->getName()){ echo " selected";} ?> >
                 <?php xecho($certStatus->getName()); ?>
-            </option> 
-            <?php } ?>   
+            </option>
+            <?php } ?>
                 </select>
         </div>
 
@@ -52,8 +52,8 @@
                 <option value="<?php xecho($prodStatus->getName()); ?>"
             <?php if ($params['selectedProdStatus'] == $prodStatus->getName()){ echo " selected";} ?>>
                 <?php xecho($prodStatus->getName()); ?>
-            </option> 
-            <?php } ?>   
+            </option>
+            <?php } ?>
                 </select>
         </div>
 
@@ -61,7 +61,7 @@
         <span class=""><a href="index.php?Page_Type=Scope_Help">Site Scopes:</a> </span>
         <select id="scopeSelect" multiple="multiple" name="mscope[]" style="width: 200px">
             <?php foreach ($params['scopes'] as $scope) { ?>
-            <option value="<?php xecho($scope->getName()); ?>" 
+            <option value="<?php xecho($scope->getName()); ?>"
                 <?php if(in_array($scope->getName(), $params['selectedScopes'])){ echo ' selected';}?> >
                 <?php xecho($scope->getName()); ?>
             </option>
@@ -91,21 +91,21 @@
                 <option value="<?php echo $siteExtensions; ?>"
             <?php if ($params['selectedSiteKeyNames'] == $siteExtensions) echo " selected" ?>>
                 <?php echo $siteExtensions; ?>
-            </option> 
-            <?php } ?>                  
+            </option>
+            <?php } ?>
                 </select>
-        </div> 
+        </div>
 
         <div class="topMargin leftFloat siteFilter">
             <span class="middle" style="margin-right: 0.4em">Extension Value: </span>
-            <input class="middle" type="text" name="selectedSiteKeyValue" 
+            <input class="middle" type="text" name="selectedSiteKeyValue"
             <?php if (isset($params['selectedSiteKeyValue'])) echo "value=\"{$params['selectedSiteKeyValue']}\""; ?>/>
-            </div>  
-        
-        
+            </div>
+
+
         <div class="topMargin leftFloat siteFilter clearLeft">
         <span class="">Include Closed Sites: </span>
-        <input type="checkbox" value=""<?php if ($params['showClosed'] == true){ echo " checked=checked";} ?> name="showClosed"> 
+        <input type="checkbox" value=""<?php if ($params['showClosed'] == true){ echo " checked=checked";} ?> name="showClosed">
         <input type="submit" value="Filter Sites">
         </div>
         </form>
@@ -117,7 +117,7 @@
         <?php echo sizeof($params['sites']) ?> Site<?php if (sizeof($params['sites']) != 1) echo "s" ?>
         </span>
         <img src="<?php echo \GocContextPath::getPath() ?>img/grid.png" class="decoration" />
-    
+
         <table id="selectedSiteTable" class="table table-striped table-condensed tablesorter">
         <thead>
             <tr>
@@ -133,7 +133,7 @@
         //$num = 2;
         if (sizeof($params['sites'] > 0)) {
         foreach ($params['sites'] as $site) {
-            
+
 //		    $scopeC = count($site->getScopes());
 //		    $style = ""; //Set no style as the default
 //		    if ($scopeC != 0) {
@@ -175,7 +175,7 @@
         } // End of the foreach loop iterating over sites
         }
         ?>
-        </tbody>	    
+        </tbody>
         </table>
     </div>
     <br>&nbsp;
@@ -192,21 +192,21 @@
 <script type="text/javascript" src="<?php GocContextPath::getPath()?>javascript/jquery.multiple.select.js"></script>
 
 <script>
-    $(document).ready(function() 
+    $(document).ready(function()
     {
-        $("#selectedSiteTable").tablesorter(); 
+        $("#selectedSiteTable").tablesorter();
 
-    // sort on first and second table cols only 
-//	$("#selectedSiteTable").tablesorter({ 
-//	    // pass the headers argument and assing a object 
-//	    headers: { 
-//		// assign the third column (we start counting zero) 
-//		4: { 
-//		    sorter: false 
+    // sort on first and second table cols only
+//	$("#selectedSiteTable").tablesorter({
+//	    // pass the headers argument and assing a object
+//	    headers: {
+//		// assign the third column (we start counting zero)
+//		4: {
+//		    sorter: false
 //		}
-//	    } 
-//	}); 
-    
+//	    }
+//	});
+
     $('#scopeSelect').multipleSelect({
         filter: true,
             placeholder: "Site Scopes"

--- a/htdocs/web_portal/views/site/view_site.php
+++ b/htdocs/web_portal/views/site/view_site.php
@@ -57,7 +57,7 @@ $extensionProperties = $site->getSiteProperties();
             <?php if ($params['authenticated']) { ?>
                 <a href="mailto:<?php xecho($site->getEmail()) ?>">
                 <?php xecho($site->getEmail()) ?>
-                </a> 
+                </a>
             <?php } else echo('PROTECTED - Auth Required'); ?>
             </td>
         </tr>
@@ -143,7 +143,7 @@ $extensionProperties = $site->getSiteProperties();
                 <?php if (!$portalIsReadOnly): ?>
                 <a href="index.php?Page_Type=Edit_Certification_Status&id=<?php echo($site->getId()) ?>">Change</a>
                 <?php endif; ?>
-            <?php } else echo('PROTECTED - Auth Required'); ?>    
+            <?php } else echo('PROTECTED - Auth Required'); ?>
                     </td>
                 </tr>
 
@@ -162,9 +162,9 @@ $extensionProperties = $site->getSiteProperties();
                 $scopeString .= ", ";
                 }
             }
-            ?> 
+            ?>
                     <td class="site_table">
-                        <a href="index.php?Page_Type=Scope_Help" style="word-wrap: normal" 
+                        <a href="index.php?Page_Type=Scope_Help" style="word-wrap: normal"
                            title="Note, Scope(x) indicates the parent NGI does not share this scope">
                             Scope Tags
                         </a>
@@ -203,7 +203,7 @@ $extensionProperties = $site->getSiteProperties();
                 xecho($site->getGiisUrl());
             } else
                 echo('PROTECTED - Auth Required');
-            ?> 
+            ?>
                     </td>
                 </tr>
                 <tr class="site_table_row_1">
@@ -227,7 +227,7 @@ $extensionProperties = $site->getSiteProperties();
                 echo('PROTECTED - Auth Required');
             ?>
                     </td>
-                </tr>                 
+                </tr>
                 <tr class="site_table_row_1">
                     <td class="site_table">Domain</td>
                     <td class="site_table">
@@ -323,7 +323,7 @@ $extensionProperties = $site->getSiteProperties();
         Services (Note, Service scope values marked with (x) indicate the Site does not share that scope)
     </span>
         <img src="<?php echo \GocContextPath::getPath() ?>img/service.png" height="25px" style="float: right; padding-right: 1em; padding-top: 0.5em; padding-bottom: 0.5em;" />
-    
+
         <table id="servicesTable" class="table table-striped table-condensed tablesorter">
         <thead>
             <tr>
@@ -400,7 +400,7 @@ $extensionProperties = $site->getSiteProperties();
                 $scopeString .= ", ";
             }
             }
-            ?>   
+            ?>
             <textarea readonly="true" style="height: 25px;"><?php xecho($scopeString); ?></textarea>
             </td>
             </tr>
@@ -411,14 +411,14 @@ $extensionProperties = $site->getSiteProperties();
         </tbody>
         </table>
 
-    
+
     <!--  only show this link if we're in read / write mode -->
     <?php if (!$portalIsReadOnly && $params['ShowEdit']) : ?>
         <!-- Add new Service Link -->
         <a href="index.php?Page_Type=Add_Service&siteId=<?php echo($site->getId()); ?>">
             <img src="<?php echo \GocContextPath::getPath() ?>img/add.png" height="50px" style="float: left; padding-top: 0.9em; padding-left: 1.2em; padding-bottom: 0.9em;"/>
             <span class="header" style="vertical-align:middle; float: left; padding-top: 1.1em; padding-left: 1em; padding-bottom: 0.9em;">
-            Add Service 
+            Add Service
             </span>
         </a>
     <?php endif; ?>
@@ -429,7 +429,7 @@ $extensionProperties = $site->getSiteProperties();
     <div class="tableContainer" style="width: 99.5%; float: left; margin-top: 3em; margin-right: 10px;">
         <span class="header" style="vertical-align:middle; float: left; padding-top: 0.9em; padding-left: 1em;">Users (Click on name to manage roles)</span>
         <img src="<?php echo \GocContextPath::getPath() ?>img/people.png" height="25px" style="float: right; padding-right: 1em; padding-top: 0.5em; padding-bottom: 0.5em;" />
-    
+
         <table id="siteUsersTable" class="table table-striped table-condensed tablesorter">
         <thead>
             <tr>
@@ -493,7 +493,7 @@ $extensionProperties = $site->getSiteProperties();
         <span class="header" style="vertical-align:middle; float: left; padding-top: 0.9em; padding-left: 1em;">Recent Downtimes Affecting <?php xecho($site->getShortName()) ?>'s SEs </span>
         <a href="index.php?Page_Type=Site_Downtimes&id=<?php echo($site->getId()); ?>" style="vertical-align:middle; float: left; padding-top: 1.3em; padding-left: 1em; font-size: 0.8em;">(View all Downtimes)</a>
         <img src="<?php echo \GocContextPath::getPath() ?>img/down_arrow.png" height="25px" style="float: right; padding-right: 1em; padding-top: 0.5em; padding-bottom: 0.5em;" />
-    
+
         <table id="siteDowntimesTable" class="table table-striped table-condensed tablesorter">
         <thead>
         <tr>
@@ -521,7 +521,7 @@ $extensionProperties = $site->getSiteProperties();
         }
         ?>
         </table>
-    
+
         <!--  only show this link if we're in read / write mode -->
     <?php if (!$portalIsReadOnly && $params['ShowEdit']): ?>
         <!-- Add new Downtime Link -->
@@ -544,38 +544,38 @@ $extensionProperties = $site->getSiteProperties();
 </div>
 
 <script>
-   $(document).ready(function() 
-    { 
-    $("#siteDowntimesTable").tablesorter(); 
-    $("#siteUsersTable").tablesorter(); 
-    
-       $("#servicesTable").tablesorter( { 
-        // pass the headers argument and assing a object 
-        headers: { 
-        // assign the third column (we start counting zero) 
-        2: { 
-            sorter: false 
-        }, 
-        3: { 
-            sorter: false 
-        } 
-        } 
-    }); 
+   $(document).ready(function()
+    {
+    $("#siteDowntimesTable").tablesorter();
+    $("#siteUsersTable").tablesorter();
 
-    // sort on first and second table cols only 
-        $("#siteExtensionPropsTable").tablesorter({ 
-        // pass the headers argument and assing a object 
-        headers: { 
-            // assign the third column (we start counting zero) 
-            2: { 
-                // disable it by setting the property sorter to false 
-                sorter: false 
-            }, 
-            3: { 
-                // disable it by setting the property sorter to false 
-                sorter: false 
-            } 
-        } 
+       $("#servicesTable").tablesorter( {
+        // pass the headers argument and assing a object
+        headers: {
+        // assign the third column (we start counting zero)
+        2: {
+            sorter: false
+        },
+        3: {
+            sorter: false
+        }
+        }
+    });
+
+    // sort on first and second table cols only
+        $("#siteExtensionPropsTable").tablesorter({
+        // pass the headers argument and assing a object
+        headers: {
+            // assign the third column (we start counting zero)
+            2: {
+                // disable it by setting the property sorter to false
+                sorter: false
+            },
+            3: {
+                // disable it by setting the property sorter to false
+                sorter: false
+            }
+        }
     });
 
     //register handler for the select/deselect all properties checkbox
@@ -583,8 +583,8 @@ $extensionProperties = $site->getSiteProperties();
         $(".propCheckBox").prop('checked', $(this).prop("checked"));
     });
 
-    } 
+    }
 );
 
 
-</script>  
+</script>

--- a/htdocs/web_portal/views/start_page.php
+++ b/htdocs/web_portal/views/start_page.php
@@ -5,7 +5,7 @@
     topology and resources information.
 
 
-    <br/><br/>   
+    <br/><br/>
     <h2 class="startPage">What information is stored here?</h2>
     <br />
 
@@ -16,31 +16,31 @@
     <li class="no_border">Resources and services, including maintenance plans for these resources</li>
     <li class="no_border">Participating people, and their roles within EGI operations</li>
     </ul>
-   Data are provided and updated by participating 
+   Data are provided and updated by participating
    NGIs, and are presented through this web portal.<br/><br/>
-   
-        Please note: 
+
+        Please note:
         <ul>
           <li>It is a "catch-all" service. This means it is centrally hosted on behalf of all NGIs.</li>
           <li>If an organisation deploys and uses their own system or a local GOCDB installation, their data won't appear here.</li>
-        </ul>  
-   
+        </ul>
+
     </div>
     <?php if(sizeof($params['roles']) > 0) { ?>
         <div class="alert alert-warning" style="width: 98%; margin-bottom:1%; float: left;">
-                <span class="glyphicon glyphicon-asterisk"></span>   <b>Notification:</b> You have pending role requests - <a href="index.php?Page_Type=Role_Requests">Manage Roles</a>                   
+                <span class="glyphicon glyphicon-asterisk"></span>   <b>Notification:</b> You have pending role requests - <a href="index.php?Page_Type=Role_Requests">Manage Roles</a>
         </div>
     <?php } ?>
-    
+
     <!-- map Block -->
-    <?php if($params['showMap']): ?> 
+    <?php if($params['showMap']): ?>
         <script type="text/javascript" src="https://maps.googleapis.com/maps/api/js?sensor=false&key=<?php echo $params['googleAPIKey'];?>">
         </script>
         <!--This script provides the marker clustering functionality comment out the cluster line in googleSiteMap.js and this script to disable it-->
         <!--<script type="text/javascript" src="<?php echo \GocContextPath::getPath()?>javascript/googleMapClusterer.js">
         </script>-->
         <script type="text/javascript" src="<?php echo \GocContextPath::getPath()?>javascript/googleSiteMap.js">
-        </script> 
+        </script>
         <div style="display:inline-block;  ">
             <div id="GoogleMap" style="width:840px;height:400px;"></div>
         </div>

--- a/htdocs/web_portal/views/user/edit_user.php
+++ b/htdocs/web_portal/views/user/edit_user.php
@@ -16,34 +16,34 @@
                 } else {
                   echo '<option value="'.$title.'">'.$title.'</option>';
                 }
-            } 
+            }
         ?>
         </select>
-        
+
         <span class="input_name">
-            Forename * 
+            Forename *
             <span class="input_syntax" >(unaccentuated letters, spaces, dashes and quotes)</span>
         </span>
         <input class="input_input_text" type="text" name="FORENAME" value="<?php xecho($params['user']->getForename()); ?>" />
-        
+
         <span class="input_name">
-            Surname * 
+            Surname *
             <span class="input_syntax" >(unaccentuated letters, spaces, dashes and quotes)</span>
         </span>
         <input class="input_input_text" type="text" name="SURNAME" value="<?php xecho($params['user']->getSurname()); ?>"/>
-        
+
         <span class="input_name">
             E-Mail *
             <span class="input_syntax" >(valid e-mail format)</span>
         </span>
         <input class="input_input_text" type="text" name="EMAIL" value="<?php xecho($params['user']->getEmail()); ?>"/>
-        
+
         <span class="input_name">
             Telephone Number
             <span class="input_syntax" >(numbers, optional +, dots spaces or dashes)</span>
         </span>
         <input class="input_input_text" type="text" name="TELEPHONE" value="<?php echo $params['user']->getTelephone(); ?>"/>
-        
+
         <input class="input_input_hidden" type="hidden" value="<?php echo $params['user']->getId() ?>" name="OBJECTID">
         <br />
         <input class="input_button" type="submit" value="Update User" />

--- a/htdocs/web_portal/views/user/register.php
+++ b/htdocs/web_portal/views/user/register.php
@@ -4,10 +4,10 @@
         <h1>Register</h1>
         <br />
         Register Unique Identity: <b> <?php echo($params['dn']); ?> </b>
-        <br/> 
-        <br/> 
+        <br/>
+        <br/>
 
-        
+
     <div class="alert alert-warning" role="alert">
             <h3>Terms and Conditions of Account Registration</h3>
             <ul>
@@ -42,7 +42,7 @@
                 echo '<br>';
             }
             ?>
-        </div> 
+        </div>
         <br>
 
         <span class="input_name">

--- a/htdocs/web_portal/views/user/retrieve_account_accepted.php
+++ b/htdocs/web_portal/views/user/retrieve_account_accepted.php
@@ -1,6 +1,6 @@
 <div class="rightPageContainer">
     <h1 class="Success">Success</h1>
-    Your request to retrieve an old account has been accepted. An e-mail has 
-    been sent to the address registered with your account. Please follow the 
+    Your request to retrieve an old account has been accepted. An e-mail has
+    been sent to the address registered with your account. Please follow the
     instructions contained within it to complete your account retrieval. <br />
 </div>

--- a/htdocs/web_portal/views/user/view_user.php
+++ b/htdocs/web_portal/views/user/view_user.php
@@ -91,11 +91,11 @@
                     <td class="site_table">EGI SSO Username</td>
                     <td class="site_table">
                         <div style="word-wrap: break-word;">
-                            <?php 
+                            <?php
                             //if($params['user']->getusername1() != null){
-                            //    echo  'Should this be shown? - TBC'; //$params['user']->getusername1(); 
+                            //    echo  'Should this be shown? - TBC'; //$params['user']->getusername1();
                             //} else {
-                            //    echo 'Not known'; 
+                            //    echo 'Not known';
                             //}
                             ?>
                         </div>
@@ -116,7 +116,7 @@
     </div>
 
 
-    
+
     <div class="listContainer">
         <b>Authentication Attributes:</b>
         <br>
@@ -141,7 +141,7 @@
     <?php foreach($params['projectNamesIds'] as $projId => $projName){ ?>
     <div class="listContainer" style="width: 99.5%; float: left; margin-top: 1em; margin-right: 10px;">
         <span class="header" style="vertical-align:middle; float: left; padding-top: 0.9em; padding-left: 1em;">
-        Roles in Project 
+        Roles in Project
         <a href="index.php?Page_Type=Project&id=<?php echo $projId ?>">
         [<?php xecho($projName) ?>]
         </a>
@@ -160,8 +160,8 @@
             <?php
             $num = 2;
             foreach($params['role_ProjIds'] as $role_ProjIds ) { // foreach role
-        $role = $role_ProjIds[0]; 
-        $projIds = $role_ProjIds[1]; 
+        $role = $role_ProjIds[0];
+        $projIds = $role_ProjIds[1];
 
         if(in_array($projId, $projIds)){ // if projId in array
             ?>
@@ -203,18 +203,18 @@
                 </td>
                 <td class="site_table">
                     <?php if(!$params['portalIsReadOnly'] && $role->getDecoratorObject() != null):?>
-                        <form action="index.php?Page_Type=Revoke_Role" method="post"> 
-                            <input type="hidden" name="id" value="<?php echo $role->getId()?>" /> 
-                            <input id="revokeButton" type="submit" value="Revoke" class="btn btn-sm btn-danger" onclick="return confirmSubmit()" 
+                        <form action="index.php?Page_Type=Revoke_Role" method="post">
+                            <input type="hidden" name="id" value="<?php echo $role->getId()?>" />
+                            <input id="revokeButton" type="submit" value="Revoke" class="btn btn-sm btn-danger" onclick="return confirmSubmit()"
                                    title="Your roles allowing revoke: <?php xecho($role->getDecoratorObject()); ?>" >
-                        </form> 
+                        </form>
                     <?php endif;?>
                 </td>
-                    
+
             </tr>
             <?php
               if($num == 1) { $num = 2; } else { $num = 1; }
-          
+
           } // if projId in array
         } // foreach role
             ?>
@@ -227,7 +227,7 @@
     <!-- Roles NOT in Project, e.g. ServiceGroup roles -->
     <div class="listContainer" style="width: 99.5%; float: left; margin-top: 3em; margin-right: 10px;">
         <span class="header" style="vertical-align:middle; float: left; padding-top: 0.9em; padding-left: 1em;">
-        Project Agnostic Roles (Selected roles may be over objects with no ancestor Project, e.g. ServiceGroups) 
+        Project Agnostic Roles (Selected roles may be over objects with no ancestor Project, e.g. ServiceGroups)
     </span>
         <img src="<?php echo \GocContextPath::getPath()?>img/people.png" height="25px" style="float: right; padding-right: 1em; padding-top: 0.5em; padding-bottom: 0.5em;" />
 
@@ -243,8 +243,8 @@
             <?php
             $num = 2;
             foreach($params['role_ProjIds'] as $role_ProjIds ) { // foreach role
-        $role = $role_ProjIds[0]; 
-        $projIds = $role_ProjIds[1]; 
+        $role = $role_ProjIds[0];
+        $projIds = $role_ProjIds[1];
 
         if(count($projIds) == 0){ // role with no owning proj
             ?>
@@ -286,18 +286,18 @@
                 </td>
                 <td class="site_table">
                     <?php if(!$params['portalIsReadOnly'] && $role->getDecoratorObject() != null):?>
-                        <form action="index.php?Page_Type=Revoke_Role" method="post"> 
-                            <input type="hidden" name="id" value="<?php echo $role->getId()?>" /> 
-                            <input id="revokeButton" type="submit" value="Revoke" class="btn btn-sm btn-danger" onclick="return confirmSubmit()" 
+                        <form action="index.php?Page_Type=Revoke_Role" method="post">
+                            <input type="hidden" name="id" value="<?php echo $role->getId()?>" />
+                            <input id="revokeButton" type="submit" value="Revoke" class="btn btn-sm btn-danger" onclick="return confirmSubmit()"
                                    title="Your roles allowing revoke: <?php xecho($role->getDecoratorObject()); ?>" >
-                        </form> 
+                        </form>
                     <?php endif;?>
                 </td>
-                    
+
             </tr>
             <?php
               if($num == 1) { $num = 2; } else { $num = 1; }
-          
+
           } // end role with no owning proj
         } // end foreach role
             ?>
@@ -308,6 +308,6 @@
 
  <script type="text/javascript">
     //$(document).ready(function() {
-    //    $('#revokeButton').tooltip(); 
-    //}); 
+    //    $('#revokeButton').tooltip();
+    //});
 </script>

--- a/lib/Authentication/AuthProviders/GOCDBAuthProvider.php
+++ b/lib/Authentication/AuthProviders/GOCDBAuthProvider.php
@@ -5,109 +5,109 @@ include_once __DIR__.'/../_autoload.php';
 
 
 /**
- * The GOCDB Authentication provider.  
- * Supports X509AuthenticationToken and SimpleSamlPhpAuthToken tokens. 
+ * The GOCDB Authentication provider.
+ * Supports X509AuthenticationToken and SimpleSamlPhpAuthToken tokens.
  *
- * @author David Meredith 
+ * @author David Meredith
  */
 class GOCDBAuthProvider implements IAuthenticationProvider {
-    
+
     public function authenticate(IAuthentication $auth){
         if($auth == null){
-            throw new BadCredentialsException(null, 'Bad credentials - null given'); 
+            throw new BadCredentialsException(null, 'Bad credentials - null given');
         }
         if(!$this->supports($auth)){
             //throw new BadCredentialsException(null, 'Bad credentials - unsupported token');
-            // the implementation may return null if it is unable to support 
+            // the implementation may return null if it is unable to support
             // authentication of the passed Authentication object
-            return null; 
+            return null;
         }
-        // If a un/pw token is given, then we have to use the username to  
+        // If a un/pw token is given, then we have to use the username to
         // load a user from the DB and then compare the hashed password against
-        // the hashed pw stored in the DB. Only then can we authenticate.   
+        // the hashed pw stored in the DB. Only then can we authenticate.
         //if($auth instanceof UsernamePasswordAuthenticationToken){
-        //    return $this->authenticateAgainstDB($auth); 
+        //    return $this->authenticateAgainstDB($auth);
         //}
 
-        // If not un/pw token, get the principle string which authenitcates our user 
-        // and perform any extra authentication logic, e.g. compare principle to 
-        // an authenitcated user list (not needed in this AuthProvider) 
-        $authPrincipleStr = $auth->getPrinciple() ;  
+        // If not un/pw token, get the principle string which authenitcates our user
+        // and perform any extra authentication logic, e.g. compare principle to
+        // an authenitcated user list (not needed in this AuthProvider)
+        $authPrincipleStr = $auth->getPrinciple() ;
         if($authPrincipleStr == null || $authPrincipleStr == ''){
             throw new AuthenticationException(null, 'Principle string could not be extracted from token ['.  get_class($auth).']');
         }
-        $roles = array();  
+        $roles = array();
         if($auth instanceof X509AuthenticationToken){
-            $roles[] = 'ROLE_CERTOWNER';    
+            $roles[] = 'ROLE_CERTOWNER';
         }
         else if($auth instanceof SimpleSamlPhpAuthToken){
-            $roles[] = 'ROLE_SAMLUSER'; 
-        } 
-        $auth->setAuthorities($roles); 
-        return $auth; 
+            $roles[] = 'ROLE_SAMLUSER';
+        }
+        $auth->setAuthorities($roles);
+        return $auth;
     }
 
     /**
-     * TODO - If a un/pw token is given, then we have to use the username to  
+     * TODO - If a un/pw token is given, then we have to use the username to
      * load a user from the DB and then compare the hashed password against
-     * the hashed pw stored in the DB. Only then can we authenticate.   
-     */ 
-    private function authenticateAgainstDB($auth){    
-        // Perform Authentication: 
-        // You may need to customize this logic. In Spring this is absracted 
-        // using different ProviderManager implementations that must support:   
-        // 'authenticate(IAuthentication)throws AuthenticationException' 
-        try { 
-            $username = $auth->getPrinciple(); 
-            // Spring way...(if $auth.principle was previously updated to be a IUserDetails) 
-            //if($username instanceof IUserDetails) $username = $username->getUsername(); 
-           
+     * the hashed pw stored in the DB. Only then can we authenticate.
+     */
+    private function authenticateAgainstDB($auth){
+        // Perform Authentication:
+        // You may need to customize this logic. In Spring this is absracted
+        // using different ProviderManager implementations that must support:
+        // 'authenticate(IAuthentication)throws AuthenticationException'
+        try {
+            $username = $auth->getPrinciple();
+            // Spring way...(if $auth.principle was previously updated to be a IUserDetails)
+            //if($username instanceof IUserDetails) $username = $username->getUsername();
+
             // Now attempt to load the user's details from the DB
-            $userDetails = ApplicationSecurityConfigService::getUserDetailsService()->loadUserByUsername($username);  
+            $userDetails = ApplicationSecurityConfigService::getUserDetailsService()->loadUserByUsername($username);
         } catch(UsernameNotFoundException $ex){
-            // if auth->getPrinciple is not null, then this could be a 
-            // new user without a recognised DN ! so throwing an AuthException 
-            // would be wrong - TODO! 
-            throw new AuthenticationException($ex, 'Username not found');  
+            // if auth->getPrinciple is not null, then this could be a
+            // new user without a recognised DN ! so throwing an AuthException
+            // would be wrong - TODO!
+            throw new AuthenticationException($ex, 'Username not found');
         }
-        // Auth is usually done by comparing principle and password value equality  
-        // between the returned $userDetails object and the given $auth token.  
-        // Note, getPassword() never returns null, even for auth mechanisms that 
-        // don't use a password in which case an empty string is returned. This 
-        // allows the same auth logic across different mechanisms (e.g. x509).  
-        if($userDetails->getUsername() == $auth->getPrinciple() && 
+        // Auth is usually done by comparing principle and password value equality
+        // between the returned $userDetails object and the given $auth token.
+        // Note, getPassword() never returns null, even for auth mechanisms that
+        // don't use a password in which case an empty string is returned. This
+        // allows the same auth logic across different mechanisms (e.g. x509).
+        if($userDetails->getUsername() == $auth->getPrinciple() &&
                 $userDetails->getPassword() == $auth->getCredentials()){
-          
-           // Spring way...(most spring auth providers update (re-set) the $auth->principle 
-           // to be a IUserDetails implementation, e.g.  
-           //$auth->setPrinciple($userDetails);  
-            
+
+           // Spring way...(most spring auth providers update (re-set) the $auth->principle
+           // to be a IUserDetails implementation, e.g.
+           //$auth->setPrinciple($userDetails);
+
            //$auth->setDetails($userDetails);
            // set UserDetails as Doctrine 'User' entity or null
            $auth->setDetails($userDetails->getGOCDBCustomVal());
-           $auth->setAuthorities($userDetails->getAuthorities()); 
-           return $auth; 
+           $auth->setAuthorities($userDetails->getAuthorities());
+           return $auth;
         }
-        // We didn't manage to authenticate the user, so throw exception 
-        throw new AuthenticationException(null, 'Authentication failed');  
+        // We didn't manage to authenticate the user, so throw exception
+        throw new AuthenticationException(null, 'Authentication failed');
     }
 
 
     public function supports(IAuthentication $auth){
         if($auth != null){
-            return true; 
+            return true;
         }
         // You can limit support to specific token types:
         /*if($auth instanceof X509AuthenticationToken){
-            return true; 
+            return true;
         }
         if($auth instanceof SimpleSamlPhpAuthToken){
-            return true; 
+            return true;
         }
         return false; */
     }
 
-    
+
 }
 
 ?>

--- a/lib/Authentication/AuthProviders/SampleAuthProvider.php
+++ b/lib/Authentication/AuthProviders/SampleAuthProvider.php
@@ -1,58 +1,58 @@
 <?php
 namespace org\gocdb\security\authentication;
 include_once __DIR__.'/../_autoload.php';
-//require_once __DIR__.'/../IAuthenticationProvider.php'; 
-//require_once __DIR__.'/../IAuthentication.php'; 
+//require_once __DIR__.'/../IAuthenticationProvider.php';
+//require_once __DIR__.'/../IAuthentication.php';
 //require_once __DIR__.'/../Exceptions/AuthenticationException.php';
-//require_once __DIR__.'/../Exceptions/BadCredentialsException.php'; 
-//require_once __DIR__.'/../IUserDetails.php'; 
-//require_once __DIR__.'/../ApplicationSecurityConfigService.php'; 
-//require_once __DIR__.'/../AuthTokens/UsernamePasswordAuthenticationToken.php'; 
+//require_once __DIR__.'/../Exceptions/BadCredentialsException.php';
+//require_once __DIR__.'/../IUserDetails.php';
+//require_once __DIR__.'/../ApplicationSecurityConfigService.php';
+//require_once __DIR__.'/../AuthTokens/UsernamePasswordAuthenticationToken.php';
 //require_once __DIR__.'/../UserDetails/GOCDBUserDetails.php';
 
 
 /**
  * Sample IAuthenticationProvider implementation that will authenticate any user
  * whose username and password are the same. It assigns a single role to every user
- * (ROLE_REGISTERED_USER). 
+ * (ROLE_REGISTERED_USER).
  * <p>
- * It requires a <code>UsernamePasswordAuthenticationToken</code> as the given IAuth token. 
+ * It requires a <code>UsernamePasswordAuthenticationToken</code> as the given IAuth token.
  *
- * @author David Meredith 
+ * @author David Meredith
  */
 class SampleAuthProvider implements IAuthenticationProvider{
 
     public function authenticate(IAuthentication $auth) {
         if($auth == null){
-            throw new BadCredentialsException(null, 'Bad credentials - null given'); 
-        }        
-        if(!($auth instanceof UsernamePasswordAuthenticationToken)){
-            throw new BadCredentialsException(null, 'Bad credentials - expected UsernamePasswordAuthenticationToken'); 
+            throw new BadCredentialsException(null, 'Bad credentials - null given');
         }
-        
-        // Normally we would use a IUserDetailsService implementation here to 
-        // lookup our given user against the local credential store, we don't 
-        // need to as we are simply authenticating users if un==pw. 
+        if(!($auth instanceof UsernamePasswordAuthenticationToken)){
+            throw new BadCredentialsException(null, 'Bad credentials - expected UsernamePasswordAuthenticationToken');
+        }
 
-        if($auth->getPrinciple() != null && 
+        // Normally we would use a IUserDetailsService implementation here to
+        // lookup our given user against the local credential store, we don't
+        // need to as we are simply authenticating users if un==pw.
+
+        if($auth->getPrinciple() != null &&
                 $auth->getPrinciple() == $auth->getCredentials()){
-            $roles = array(); 
-            $roles[] = 'ROLE_REGISTERED_USER'; 
+            $roles = array();
+            $roles[] = 'ROLE_REGISTERED_USER';
             $auth->setAuthorities($roles);
             $userDetails = new GOCDBUserDetails($auth->getPrinciple(), true, $roles, 'customVal2', '');
-            $auth->setDetails($userDetails); 
-            return $auth; 
+            $auth->setDetails($userDetails);
+            return $auth;
         }
 
-        // We didn't manage to authenticate the user, so throw exception 
-        throw new AuthenticationException(null, 'Authentication failed');  
+        // We didn't manage to authenticate the user, so throw exception
+        throw new AuthenticationException(null, 'Authentication failed');
     }
 
     public function supports(IAuthentication $auth){
         if($auth instanceof UsernamePasswordAuthenticationToken){
-            return true; 
+            return true;
         }
-        return false; 
+        return false;
     }
 }
 

--- a/lib/Authentication/AuthTokens/ShibAuthToken.php
+++ b/lib/Authentication/AuthTokens/ShibAuthToken.php
@@ -1,6 +1,6 @@
 <?php
 namespace org\gocdb\security\authentication;
-require_once __DIR__.'/../IAuthentication.php'; 
+require_once __DIR__.'/../IAuthentication.php';
 
 /*
  * Copyright (C) 2015 STFC
@@ -16,57 +16,57 @@ require_once __DIR__.'/../IAuthentication.php';
  */
 
 /**
- * AuthToken for use with ShibSP. 
+ * AuthToken for use with ShibSP.
  * <p>
- * Requires installation/config of ShibSP before use. 
- * You will almost certainly need to modify this class to request the necessary 
- * SAML attribute from the IdP that is used as the principle string. 
+ * Requires installation/config of ShibSP before use.
+ * You will almost certainly need to modify this class to request the necessary
+ * SAML attribute from the IdP that is used as the principle string.
  * <p>
- * The token is stateless because it relies on the ShibSP session and simply 
- * reads the attributes stored in the ShibSP session. 
+ * The token is stateless because it relies on the ShibSP session and simply
+ * reads the attributes stored in the ShibSP session.
  *
- * @see IAuthentication 
- * @author David Meredith 
+ * @see IAuthentication
+ * @author David Meredith
  */
 class ShibAuthToken implements IAuthentication {
-    
+
     private $userDetails = null;
     private $authorities = array();
-    private $principal;  
+    private $principal;
 
       public function __construct() {
-       $this->getAttributesInitToken();   
+       $this->getAttributesInitToken();
     }
 
     /**
      * {@see IAuthentication::eraseCredentials()}
-     */ 
+     */
     public function eraseCredentials() {
-        
+
     }
 
     /**
-     * {@see IAuthentication::getAuthorities()} 
+     * {@see IAuthentication::getAuthorities()}
      */
     public function getAuthorities() {
-       return $this->authorities;  
+       return $this->authorities;
     }
 
     /**
      * {@see IAuthentication::getCredentials()}
-     * @return string An empty string as passwords are not used by this token. 
+     * @return string An empty string as passwords are not used by this token.
      */
     public function getCredentials() {
-        return ""; // none used in this token, handled by SSO/SAML 
+        return ""; // none used in this token, handled by SSO/SAML
     }
 
     /**
-     * A custom object used to store additional user details.  
-     * Allows non-security related user information (such as email addresses, 
-     * telephone numbers etc) to be stored in a convenient location. 
+     * A custom object used to store additional user details.
+     * Allows non-security related user information (such as email addresses,
+     * telephone numbers etc) to be stored in a convenient location.
      * {@see IAuthentication::getDetails()}
-     * 
-     * @return Object or null if not used 
+     *
+     * @return Object or null if not used
      */
     public function getDetails() {
         return $this->userDetails;
@@ -74,27 +74,27 @@ class ShibAuthToken implements IAuthentication {
 
     /**
      * {@see IAuthentication::getPrinciple()}
-     * @return string unique principle string of user  
+     * @return string unique principle string of user
      */
     public function getPrinciple() {
-       return $this->principal;  
+       return $this->principal;
     }
 
     private function getAttributesInitToken(){
-        $hostname = gethostname(); // gocdb-test.esc.rl.ac.uk, goc.egi.eu 
-        // specify location of the Shib Logout handler 
+        $hostname = gethostname(); // gocdb-test.esc.rl.ac.uk, goc.egi.eu
+        // specify location of the Shib Logout handler
         \Factory::$properties['LOGOUTURL'] = 'https://'.$hostname.'/Shibboleth.sso/Logout';
         $idp = isset($_SERVER['Shib-Identity-Provider']) ? $_SERVER['Shib-Identity-Provider'] : '';
-        if ($idp == 'https://unity.eudat-aai.fz-juelich.de:8443/saml-idp/metadata' 
+        if ($idp == 'https://unity.eudat-aai.fz-juelich.de:8443/saml-idp/metadata'
                 &&  $_SERVER['distinguishedName'] != null){
             $this->principal = $_SERVER['distinguishedName'];
             $this->userDetails = array('AuthenticationRealm' => array('EUDAT_SSO_IDP'));
-            return; 
-        } else if($idp == 'https://idp.ebi.ac.uk/idp/shibboleth' 
+            return;
+        } else if($idp == 'https://idp.ebi.ac.uk/idp/shibboleth'
                 &&  $_SERVER['eppn'] != null){
             $this->principal = hash('sha256', $_SERVER['eppn']);
             $this->userDetails = array('AuthenticationRealm' => array('UK_ACCESS_FED'));
-            return; 
+            return;
         }
         else if($idp == 'https://aai.egi.eu/proxy/saml2/idp/metadata.php'){
             if( empty($_SERVER['epuid'])){// || empty($_SERVER['displayName']) ){
@@ -119,19 +119,19 @@ class ShibAuthToken implements IAuthentication {
 
 
 //        else {
-//            die('Now go configure this AuthToken file ['.__FILE__.']');   
+//            die('Now go configure this AuthToken file ['.__FILE__.']');
 //        }
-        // if we have not set the principle/userDetails, re-direct to our Discovery Service 
+        // if we have not set the principle/userDetails, re-direct to our Discovery Service
         $target = urlencode("https://" . $hostname . "/portal/");
         header("Location: https://" . $hostname . "/Shibboleth.sso/Login?target=" . $target);
         die();
     }
 
     /**
-     * {@see IAuthentication::setAuthorities($authorities)} 
+     * {@see IAuthentication::setAuthorities($authorities)}
      */
     public function setAuthorities($authorities) {
-       $this->authorities = $authorities;  
+       $this->authorities = $authorities;
     }
 
     /**
@@ -141,28 +141,28 @@ class ShibAuthToken implements IAuthentication {
     public function setDetails($userDetails) {
         $this->userDetails = $userDetails;
     }
- 
+
     /**
      * {@see IAuthentication::validate()}
      */
     public function validate() {
-        
+
     }
 
     /**
      * {@see IAuthentication::isPreAuthenticating()}
      */
     public static function isPreAuthenticating() {
-        return true;         
+        return true;
     }
 
     /**
-     * Returns true, this token reads the ShibSP session attributes and so 
-     * does not need to be stateful itself. 
-     * {@see IAuthentication::isStateless()} 
+     * Returns true, this token reads the ShibSP session attributes and so
+     * does not need to be stateful itself.
+     * {@see IAuthentication::isStateless()}
      */
     public static function isStateless() {
-        return true;         
+        return true;
     }
 
 }

--- a/lib/Authentication/AuthTokens/SimpleSamlPhpAuthToken.php
+++ b/lib/Authentication/AuthTokens/SimpleSamlPhpAuthToken.php
@@ -1,6 +1,6 @@
 <?php
 namespace org\gocdb\security\authentication;
-require_once __DIR__.'/../IAuthentication.php'; 
+require_once __DIR__.'/../IAuthentication.php';
 
 /*
  * Copyright (C) 2012 STFC
@@ -16,37 +16,37 @@ require_once __DIR__.'/../IAuthentication.php';
  */
 
 /**
- * AuthToken that supports SAML2. 
+ * AuthToken that supports SAML2.
  * <p>
- * Requires installation of SimpleSamlPhp lib before use. 
- * You will almost certainly need to modify this class to request the necessary 
- * SAML attribute from the IdP that is used as the principle string. 
+ * Requires installation of SimpleSamlPhp lib before use.
+ * You will almost certainly need to modify this class to request the necessary
+ * SAML attribute from the IdP that is used as the principle string.
  * <p>
- * The token is stateless because it relies on the SSPhp session and simply 
- * reads the attributes stored in the SSPhp session. 
+ * The token is stateless because it relies on the SSPhp session and simply
+ * reads the attributes stored in the SSPhp session.
  *
- * @see IAuthentication 
- * @author David Meredith 
+ * @see IAuthentication
+ * @author David Meredith
  */
 class SimpleSamlPhpAuthToken implements IAuthentication {
- 
+
     private $userDetails = null;
     private $authorities = array();
-    private $principal; 
-  
+    private $principal;
+
     /*
-     * Implementation note:  
-     * There is a bug with SimpleSamlPhp in that it throws an exception if 
-     * an IdP does not return a NameID in the Subject (of a response). 
+     * Implementation note:
+     * There is a bug with SimpleSamlPhp in that it throws an exception if
+     * an IdP does not return a NameID in the Subject (of a response).
      * "Missing saml:NameID or saml:EncryptedID in saml:Subject".
-     * 
-     * IdpS only have to set a NameID in the Subject if it supports the Browser Single Logout 
-     * Profile, otherwise its optional (although recommended). I have therefore reported this to 
-     * the SSPhp project and have used the following hack to get around this issue:  
+     *
+     * IdpS only have to set a NameID in the Subject if it supports the Browser Single Logout
+     * Profile, otherwise its optional (although recommended). I have therefore reported this to
+     * the SSPhp project and have used the following hack to get around this issue:
      * https://github.com/simplesamlphp/simplesamlphp/issues/143
      */
-/*    
-// '/var/simplesamlphp/vendor/simplesamlphp/saml2/src/SAML2/Assertion.php'   
+/*
+// '/var/simplesamlphp/vendor/simplesamlphp/saml2/src/SAML2/Assertion.php'
 // DMHack: orignal:
 //        if (empty($nameId)) {
 //            throw new Exception('Missing <saml:NameID> or <saml:EncryptedID> in <saml:Subject>.');
@@ -81,38 +81,38 @@ class SimpleSamlPhpAuthToken implements IAuthentication {
  */
 
     public function __construct() {
-       $this->getAttributesInitToken();   
+       $this->getAttributesInitToken();
     }
 
     /**
      * {@see IAuthentication::eraseCredentials()}
-     */ 
+     */
     public function eraseCredentials() {
-        
+
     }
 
     /**
-     * {@see IAuthentication::getAuthorities()} 
+     * {@see IAuthentication::getAuthorities()}
      */
     public function getAuthorities() {
-       return $this->authorities;  
+       return $this->authorities;
     }
 
     /**
      * {@see IAuthentication::getCredentials()}
-     * @return string An empty string as passwords are not used by this token. 
+     * @return string An empty string as passwords are not used by this token.
      */
     public function getCredentials() {
-        return ""; // none used in this token, handled by SSO/SAML 
+        return ""; // none used in this token, handled by SSO/SAML
     }
 
     /**
-     * A custom object used to store additional user details.  
-     * Allows non-security related user information (such as email addresses, 
-     * telephone numbers etc) to be stored in a convenient location. 
+     * A custom object used to store additional user details.
+     * Allows non-security related user information (such as email addresses,
+     * telephone numbers etc) to be stored in a convenient location.
      * {@see IAuthentication::getDetails()}
-     * 
-     * @return Object or null if not used 
+     *
+     * @return Object or null if not used
      */
     public function getDetails() {
         return $this->userDetails;
@@ -120,10 +120,10 @@ class SimpleSamlPhpAuthToken implements IAuthentication {
 
     /**
      * {@see IAuthentication::getPrinciple()}
-     * @return string unique principle string of user  
+     * @return string unique principle string of user
      */
     public function getPrinciple() {
-       return $this->principal;  
+       return $this->principal;
     }
 
     private function getAttributesInitToken(){
@@ -134,7 +134,7 @@ class SimpleSamlPhpAuthToken implements IAuthentication {
         $attributes = $auth->getAttributes();
         if (!empty($attributes)) {
             $idp = $auth->getAuthData('saml:sp:IdP');
-            if($idp == 'https://www.egi.eu/idp/shibboleth'){ // EGI IdP 
+            if($idp == 'https://www.egi.eu/idp/shibboleth'){ // EGI IdP
                 $nameID = $auth->getAuthData('saml:sp:NameID');
                 $this->principal = $nameID['Value'];
                 $this->userDetails = array('AuthenticationRealm' => array('EGI_SSO_IDP'));
@@ -145,13 +145,13 @@ class SimpleSamlPhpAuthToken implements IAuthentication {
                 //    $this->userDetails = array('AuthenticationRealm' => array('EGI_SSO_IDP'));
                 //}
                 // iterate the attributes and store in the userDetails
-                // Each attribute name can be used as an index into $attributes to obtain the value. 
+                // Each attribute name can be used as an index into $attributes to obtain the value.
                 // Every attribute value is an array - a single-valued attribute is an array of a single element.
                 foreach($attributes as $key => $valArray){
-                   $this->userDetails[$key] = $valArray;  
+                   $this->userDetails[$key] = $valArray;
                 }
             }
-            // EUDAT IdP 
+            // EUDAT IdP
             else if($idp == 'https://unity.eudat-aai.fz-juelich.de:8443/saml-idp/metadata'){
                 // For EUDAT federated id:
                 //$dnAttribute = $attributes['urn:oid:2.5.4.49'][0];
@@ -161,20 +161,20 @@ class SimpleSamlPhpAuthToken implements IAuthentication {
                 $this->principal = $nameID['Value'];
                 $this->userDetails = array('AuthenticationRealm' => array('EUDAT_SSO_IDP'));
                 // iterate the attributes and store in the userDetails
-                // Each attribute name can be used as an index into $attributes to obtain the value. 
+                // Each attribute name can be used as an index into $attributes to obtain the value.
                 // Every attribute value is an array - a single-valued attribute is an array of a single element.
                 foreach($attributes as $key => $valArray){
-                   $this->userDetails[$key] = $valArray;  
+                   $this->userDetails[$key] = $valArray;
                 }
             }
         }
     }
 
     /**
-     * {@see IAuthentication::setAuthorities($authorities)} 
+     * {@see IAuthentication::setAuthorities($authorities)}
      */
     public function setAuthorities($authorities) {
-       $this->authorities = $authorities;  
+       $this->authorities = $authorities;
     }
 
     /**
@@ -184,28 +184,28 @@ class SimpleSamlPhpAuthToken implements IAuthentication {
     public function setDetails($userDetails) {
         $this->userDetails = $userDetails;
     }
- 
+
     /**
      * {@see IAuthentication::validate()}
      */
     public function validate() {
-        
+
     }
 
     /**
      * {@see IAuthentication::isPreAuthenticating()}
      */
     public static function isPreAuthenticating() {
-        return true;         
+        return true;
     }
 
     /**
-     * Returns true, this token reads the SSPhp session attributes and so 
-     * does not need to be stateful itself.  
-     * {@see IAuthentication::isStateless()} 
+     * Returns true, this token reads the SSPhp session attributes and so
+     * does not need to be stateful itself.
+     * {@see IAuthentication::isStateless()}
      */
     public static function isStateless() {
-        return true;         
+        return true;
     }
 
 }

--- a/lib/Authentication/AuthTokens/UsernamePasswordAuthenticationToken.php
+++ b/lib/Authentication/AuthTokens/UsernamePasswordAuthenticationToken.php
@@ -1,68 +1,68 @@
 <?php
 namespace org\gocdb\security\authentication;
-require_once __DIR__.'/../IAuthentication.php'; 
+require_once __DIR__.'/../IAuthentication.php';
 
 /**
  * Description of UsernamePasswordAuthenticationToken
  *
- * @author David Meredith 
+ * @author David Meredith
  */
 class UsernamePasswordAuthenticationToken implements IAuthentication {
-    private $userDetails; 
-    private $username; 
-    private $password; 
-    private $authorities; 
-    private $initialUsername; 
-    
+    private $userDetails;
+    private $username;
+    private $password;
+    private $authorities;
+    private $initialUsername;
+
     public function __construct($username, $password) {
-        $this->username = $username; 
-        $this->initialUsername = $username; 
-        $this->password = $password; 
+        $this->username = $username;
+        $this->initialUsername = $username;
+        $this->password = $password;
     }
-    
+
     public static function isStateless() {
         return false;
-    } 
+    }
 
     public static function isPreAuthenticating() {
-        return false;   
+        return false;
     }
-    
+
     public function getCredentials() {
-      return $this->password;     
+      return $this->password;
     }
 
     public function getDetails() {
-      return $this->userDetails;   
+      return $this->userDetails;
     }
 
     public function getPrinciple() {
-       return $this->username;  
+       return $this->username;
     }
     public function setPrinciple($username){
-        $this->username = $username; 
+        $this->username = $username;
     }
 
     public function setDetails($userDetails) {
-        $this->userDetails = $userDetails; 
+        $this->userDetails = $userDetails;
     }
 
     public function eraseCredentials() {
-        $this->password = null; 
+        $this->password = null;
     }
 
     public function getAuthorities(){
-       return $this->authorities;          
+       return $this->authorities;
     }
 
     public function setAuthorities($authorities) {
-        $this->authorities = $authorities; 
+        $this->authorities = $authorities;
     }
 
     public function validate(){
        if($this->getPrinciple() != $this->initialUsername){
-           throw new AuthenticationException('Invalid state, principle does not equal initial username'); 
-       } 
+           throw new AuthenticationException('Invalid state, principle does not equal initial username');
+       }
     }
 }
 

--- a/lib/Authentication/AuthTokens/X509AuthenticationToken.php
+++ b/lib/Authentication/AuthTokens/X509AuthenticationToken.php
@@ -7,10 +7,10 @@ require_once __DIR__ . '/../IAuthentication.php';
 //use Monolog\Handler\StreamHandler;
 
 /**
- * An implementation of <code>IAuthentication</code> for use with X509 certificates. 
+ * An implementation of <code>IAuthentication</code> for use with X509 certificates.
  *
  * @see IAuthentication
- * @author David Meredith 
+ * @author David Meredith
  */
 class X509AuthenticationToken implements IAuthentication {
 
@@ -18,34 +18,34 @@ class X509AuthenticationToken implements IAuthentication {
     private $authorities = array();
     private $initialDN = null;
     /** @var \Psr\Log\LoggerInterface logger methods */
-    //private $logger; 
+    //private $logger;
 
     public function __construct() {
-        // create logger 
+        // create logger
         //$this->logger = new Logger('X509AuthenticationTokenLogger');
         //$this->logger->pushHandler(new StreamHandler(__DIR__.'/../../../gocdb.log', Logger::DEBUG));
-        
+
         $this->initialDN = $this->getDN();
-        $this->userDetails = array('AuthenticationRealm' => array('IGTF')); 
+        $this->userDetails = array('AuthenticationRealm' => array('IGTF'));
     }
 
     /**
-     * {@see IAuthentication::isStateless()} 
+     * {@see IAuthentication::isStateless()}
      */
     public static function isStateless() {
         return true;
-    } 
+    }
 
     /**
-     * {@see IAuthentication::isPreAuthenticating()} 
+     * {@see IAuthentication::isPreAuthenticating()}
      */
     public static function isPreAuthenticating() {
-        return true;   
+        return true;
     }
 
     /**
      * {@see IAuthentication::getCredentials()}
-     * @return string An empty string as passwords are not used in X509. 
+     * @return string An empty string as passwords are not used in X509.
      */
     public function getCredentials() {
         return "";
@@ -53,38 +53,38 @@ class X509AuthenticationToken implements IAuthentication {
 
     /**
      * {@see IAuthentication::eraseCredentials()}
-     * Does nothing, passwords not ussed in X509. 
+     * Does nothing, passwords not ussed in X509.
      */
     public function eraseCredentials() {
         // do nothing, password not used for X509
     }
 
     /**
-     * Return the user's DN string from the client's certificate stored in their 
-     * browser. The DN is fetched once and cached on object creation. Subsequent 
-     * invocations return the cached value.  
-     * {@see IAuthentication::getPrinciple()) 
-     * 
-     * @return String Certifiate DN. 
-     * @throws \RuntimeException if DN can't be extracted. 
+     * Return the user's DN string from the client's certificate stored in their
+     * browser. The DN is fetched once and cached on object creation. Subsequent
+     * invocations return the cached value.
+     * {@see IAuthentication::getPrinciple())
+     *
+     * @return String Certifiate DN.
+     * @throws \RuntimeException if DN can't be extracted.
      */
     public function getPrinciple() {
         return $this->initialDN;
     }
 
     /**
-     * {@see IAuthentication::validate()} 
+     * {@see IAuthentication::validate()}
      * @throws AuthenticationException if validation fails
      */
     public function validate() {
-        // if current DN is not the same as intial DN, if not raise hue and cry ! 
+        // if current DN is not the same as intial DN, if not raise hue and cry !
         if (strcmp($this->initialDN, $this->getDN()) != 0) {
             throw new AuthenticationException(null, 'Invalid state, DN is now different');
         }
     }
 
     private function getDN() {
-        //$this->logger->addDebug('getDN()'); 
+        //$this->logger->addDebug('getDN()');
         if (isset($_SERVER['SSL_CLIENT_CERT'])) {
             $Raw_Client_Certificate = $_SERVER['SSL_CLIENT_CERT'];
             if (isset($Raw_Client_Certificate)) {
@@ -92,18 +92,18 @@ class X509AuthenticationToken implements IAuthentication {
                 $User_DN = $Plain_Client_Cerfificate['name'];
                 if (isset($User_DN)) {
                     // Check that the dn does not contain a backslash - utf8 chars
-                    // can exist in DN strings but this is not allowed in the 
-                    // Grid world. The openssl_x509_parse method will replace 
-                    // utf-8 chars with a backslashed hex code, thus we must 
-                    // reject here. 
-                    $pos = strpos($User_DN, "\\"); 
+                    // can exist in DN strings but this is not allowed in the
+                    // Grid world. The openssl_x509_parse method will replace
+                    // utf-8 chars with a backslashed hex code, thus we must
+                    // reject here.
+                    $pos = strpos($User_DN, "\\");
                     if($pos !== FALSE){
                         die('Your certificate DN appears to contain an invalid '
                             . 'character which is not allowed in the Grid World, '
-                                . 'please contact your Certification Authority / Cert Issuer and report this: '. 
-                                $User_DN); 
+                                . 'please contact your Certification Authority / Cert Issuer and report this: '.
+                                $User_DN);
                     }
-                   
+
                     // harmonise "email" field that can be different depending on version of SSL
                     $dn = str_replace("emailAddress=", "Email=", $User_DN);
                     if ($dn != null && $dn != '') {
@@ -115,12 +115,12 @@ class X509AuthenticationToken implements IAuthentication {
     }
 
     /**
-     * A custom object used to store additional user details.  
-     * Allows non-security related user information (such as email addresses, 
-     * telephone numbers etc) to be stored in a convenient location. 
+     * A custom object used to store additional user details.
+     * Allows non-security related user information (such as email addresses,
+     * telephone numbers etc) to be stored in a convenient location.
      * {@see IAuthentication::getDetails()}
-     * 
-     * @return Object or null if not used 
+     *
+     * @return Object or null if not used
      */
     public function getDetails() {
         return $this->userDetails;
@@ -136,14 +136,14 @@ class X509AuthenticationToken implements IAuthentication {
 
     /**
      * {@see IAuthentication::getAuthorities()}
-     * @return array 
+     * @return array
      */
     public function getAuthorities() {
         return $this->authorities;
     }
 
     /**
-     * {@see IAuthentication::setAuthorities($authorities)} 
+     * {@see IAuthentication::setAuthorities($authorities)}
      * @param array $authorities
      */
     public function setAuthorities($authorities) {

--- a/lib/Authentication/Exceptions/AuthenticationException.php
+++ b/lib/Authentication/Exceptions/AuthenticationException.php
@@ -5,13 +5,13 @@ namespace org\gocdb\security\authentication;
 /**
  * Description of AuthenticationException
  *
- * @author David Meredith 
+ * @author David Meredith
  */
 class AuthenticationException extends \Exception {
 
     private $errorDetail = '';
     private $priorException = null;
-   
+
 
     /**
      * Note, the $priorException replicates the final getPrevious()
@@ -23,8 +23,8 @@ class AuthenticationException extends \Exception {
      */
      public function __construct(\Exception $priorException=null, $errorDetail=''){
         $this->errorDetail = $errorDetail;
-        $this->priorException = $priorException; 
-        parent::__construct($errorDetail); 
+        $this->priorException = $priorException;
+        parent::__construct($errorDetail);
      }
 
 
@@ -38,17 +38,17 @@ class AuthenticationException extends \Exception {
 
     /**
      * Get the nested causal exception (if any). Note, this replicates the final
-     * getPrevious() method that was added in PHP 5.3 (adding our own method 
+     * getPrevious() method that was added in PHP 5.3 (adding our own method
      * enables exception nesting in PHP 5.0+).
-     * @see http://www.php.net/manual/en/language.exceptions.extending.php 
-     * @return Exception 
+     * @see http://www.php.net/manual/en/language.exceptions.extending.php
+     * @return Exception
      */
     public function getPriorException(){
         // dont call this method getPrevious as in php5.3+ because this
         // method is final and we want this to run in 5 and 5.3+
         return $this->priorException;
     }
-    
+
 }
 
 ?>

--- a/lib/Authentication/Exceptions/BadCredentialsException.php
+++ b/lib/Authentication/Exceptions/BadCredentialsException.php
@@ -1,20 +1,20 @@
 <?php
 namespace org\gocdb\security\authentication;
 
-require_once __DIR__.'/AuthenticationException.php'; 
+require_once __DIR__.'/AuthenticationException.php';
 /**
- * Thrown if an authentication request is rejected because the credentials are invalid. 
+ * Thrown if an authentication request is rejected because the credentials are invalid.
  *
- * @author David Meredith 
+ * @author David Meredith
  */
 class BadCredentialsException extends AuthenticationException {
-    
+
      public function __construct(\Exception $priorException=null, $errorDetail=''){
         $this->errorDetail = $errorDetail;
-        $this->priorException = $priorException; 
-        parent::__construct($priorException=null, $errorDetail); 
+        $this->priorException = $priorException;
+        parent::__construct($priorException=null, $errorDetail);
      }
-    
+
 }
 
 ?>

--- a/lib/Authentication/Exceptions/UsernameNotFoundException.php
+++ b/lib/Authentication/Exceptions/UsernameNotFoundException.php
@@ -5,7 +5,7 @@ namespace org\gocdb\security\authentication;
 /**
  * Description of UsernameNotFoundException
  *
- * @author David Meredith 
+ * @author David Meredith
  */
 class UsernameNotFoundException extends \Exception {
     private $errorDetail = '';
@@ -21,8 +21,8 @@ class UsernameNotFoundException extends \Exception {
      */
      public function __construct(\Exception $priorException=null, $errorDetail=''){
         $this->errorDetail = $errorDetail;
-        $this->priorException = $priorException; 
-         parent::__construct($errorDetail); 
+        $this->priorException = $priorException;
+         parent::__construct($errorDetail);
      }
     /**
      * Get the detail error message (if any)
@@ -34,16 +34,16 @@ class UsernameNotFoundException extends \Exception {
 
     /**
      * Get the nested causal exception (if any). Note, this replicates the final
-     * getPrevious() method that was added in PHP 5.3 (adding our own method 
+     * getPrevious() method that was added in PHP 5.3 (adding our own method
      * enables exception nesting in PHP 5.0+).
-     * @see http://www.php.net/manual/en/language.exceptions.extending.php 
-     * @return Exception 
+     * @see http://www.php.net/manual/en/language.exceptions.extending.php
+     * @return Exception
      */
     public function getPriorException(){
         // dont call this method getPrevious as in php5.3+ because this
         // method is final and we want this to run in 5 and 5.3+
         return $this->priorException;
-    } 
+    }
 }
 
 ?>

--- a/lib/Authentication/FirewallComponent.php
+++ b/lib/Authentication/FirewallComponent.php
@@ -18,44 +18,44 @@ namespace org\gocdb\security\authentication;
  * @author David Meredith
  */
 class FirewallComponent implements IFirewallComponent {
-    private $authManager; 
-    private $securityContext; 
-    private $config; 
-            
+    private $authManager;
+    private $securityContext;
+    private $config;
+
     function __construct(
-            IAuthenticationManager $authManager, 
-            ISecurityContext $securityContext, 
+            IAuthenticationManager $authManager,
+            ISecurityContext $securityContext,
             IConfigFirewallComponent $config) {
-        
+
         $this->authManager = $authManager;
         $this->securityContext = $securityContext;
         $this->config = $config;
     }
 
     /**
-     * @see ISecurityContext::getAuthentication() 
+     * @see ISecurityContext::getAuthentication()
      */
     public function getAuthentication(){
-        return $this->securityContext->getAuthentication(); 
+        return $this->securityContext->getAuthentication();
     }
 
     /**
-     * @see ISecurityContext::setAuthentication($auth) 
+     * @see ISecurityContext::setAuthentication($auth)
      */
     public function setAuthentication($auth = null){
         return $this->securityContext->setAuthentication($auth);
     }
 
     /**
-     * @see IAuthenticationManager::authenticate($auth)   
+     * @see IAuthenticationManager::authenticate($auth)
      */
     public function authenticate(IAuthentication $auth){
-        return $this->authManager->authenticate($auth);  
+        return $this->authManager->authenticate($auth);
     }
 
     /**
-     * @see IFirewallComponent  
-     * @throws \LogicException if no providers configured 
+     * @see IFirewallComponent
+     * @throws \LogicException if no providers configured
      */
     public function supports(IAuthentication $auth) {
         $providers = $this->config->getAuthProviders();

--- a/lib/Authentication/FirewallComponentManager.php
+++ b/lib/Authentication/FirewallComponentManager.php
@@ -18,64 +18,64 @@ namespace org\gocdb\security\authentication;
 //use Monolog\Handler\StreamHandler;
 
 
-// include all the Authentication packages classes 
+// include all the Authentication packages classes
 include_once __DIR__ . '/_autoload.php';
 
-// Load Monolog classes, this autoload may have been required 
-// previously in other packages, hence we require_once rather than include_once 
+// Load Monolog classes, this autoload may have been required
+// previously in other packages, hence we require_once rather than include_once
 //require_once  __DIR__."/../../vendor/autoload.php";
 
 /**
  * Singleton to create and serve one or more <code>IFirewallComponent</code>
- * implementations. FirewallComponent instances are created once and are  
- * accessible via the getFirewallArray() method.  
+ * implementations. FirewallComponent instances are created once and are
+ * accessible via the getFirewallArray() method.
  *
- * @author David Meredith 
+ * @author David Meredith
  */
 class FirewallComponentManager {
 
     private $firewallComponents;
     static $_instance;
     /** @var \Psr\Log\LoggerInterface logger */
-    //private $logger; 
+    //private $logger;
 
     private function __construct() {
-        // create logger 
+        // create logger
 //        $this->logger = new Logger('authPackageLogger');
 //        $this->logger->pushHandler(new StreamHandler(__DIR__.'/../../gocdb.log', Logger::DEBUG));
 //        //$log1->pushHandler(new FirePHPHandler());
 //        $this->logger->addDebug('authPackageLogger is now ready');
-        
+
         $this->firewallComponents = array();
-        $this->createFwC1(); 
-        //$this->createFwC2();  // create/add as many FirewallComponentS as needed  
+        $this->createFwC1();
+        //$this->createFwC2();  // create/add as many FirewallComponentS as needed
     }
 
     private function createFwC1(){
-        // create dependent objects 
+        // create dependent objects
         $myConfig1 = new MyConfig1();
         $mySecurityContext = new MySecurityContext();
         $myAuthManager = new MyAuthenticationManager();
-        
-        // set dependencies 
-        //$mySecurityContext->setLogger($this->logger); 
+
+        // set dependencies
+        //$mySecurityContext->setLogger($this->logger);
         $mySecurityContext->setAuthManager($myAuthManager);
         $mySecurityContext->setConfigFirewallComponent($myConfig1);
-        // set dependencies 
-        //$myAuthManager->setLogger($this->logger); 
+        // set dependencies
+        //$myAuthManager->setLogger($this->logger);
         $myAuthManager->setSecurityContext($mySecurityContext);
         $myAuthManager->setConfigFirewallComponent($myConfig1);
-        
-        // create FirewallComponent and add to our singleton array  
+
+        // create FirewallComponent and add to our singleton array
         $fwComponent1 = new FirewallComponent($myAuthManager, $mySecurityContext, $myConfig1);
-        //$fwComponent1->setLogger($this->logger); 
+        //$fwComponent1->setLogger($this->logger);
         $this->firewallComponents['fwC1'] = $fwComponent1;
     }
 
 
     private function __clone() {
-       // defining an empty clone closes small loophole in PHP that could make 
-       // a copy of the object and defeat singletone responsibility 
+       // defining an empty clone closes small loophole in PHP that could make
+       // a copy of the object and defeat singletone responsibility
     }
 
     public static function getInstance() {
@@ -86,8 +86,8 @@ class FirewallComponentManager {
     }
 
     /**
-     * Get an associative array of <code>IFirewallComponent</code> instances 
-     * @return array 
+     * Get an associative array of <code>IFirewallComponent</code> instances
+     * @return array
      */
     public function getFirewallArray() {
         return $this->firewallComponents;

--- a/lib/Authentication/IAuthentication.php
+++ b/lib/Authentication/IAuthentication.php
@@ -2,92 +2,92 @@
 namespace org\gocdb\security\authentication;
 
 /**
- * A token for a) authenticating the initial request or b) to represent an 
- * authenticated principal after the request has been processed by 
- * <code>AuthenticationManager.authenticate(Authentication)</code>. 
+ * A token for a) authenticating the initial request or b) to represent an
+ * authenticated principal after the request has been processed by
+ * <code>AuthenticationManager.authenticate(Authentication)</code>.
  * <p>
- * An explicit authentication request can be executed using the following: 
- * <code>SecurityContextService.setAuthentication(anIAuthentication);</code>. 
+ * An explicit authentication request can be executed using the following:
+ * <code>SecurityContextService.setAuthentication(anIAuthentication);</code>.
  * Once the request has been authenticated, the token may be optionally
  * stored in the http session's SecurityContext.
- * 
- * Inspired by Spring Security. 
- * @link http://static.springsource.org/spring-security Spring Security 
- * 
- * @author David Meredith 
+ *
+ * Inspired by Spring Security.
+ * @link http://static.springsource.org/spring-security Spring Security
+ *
+ * @author David Meredith
  */
 interface IAuthentication {
-   
-    /**
-     * Determins if this token can be stored in the http session. 
-     * If true, the token can be stored in http session and re-used across page 
-     * requests. If false, then the token will not be stored in session.  
-     * @return boolean True or False 
-     */
-     public static function isStateless(); 
 
     /**
-     * Does this token support a 'pre-authentication' scenario. 
-     * Pre-auth is when the user can be authenticated by some external system 
-     * allowing the tokens to be automatically created during the token 
-     * resolution process for automatic submission to 
-     * <code>AuthenticationManager.authenticate(Authentication)</code>.  
+     * Determins if this token can be stored in the http session.
+     * If true, the token can be stored in http session and re-used across page
+     * requests. If false, then the token will not be stored in session.
+     * @return boolean True or False
+     */
+     public static function isStateless();
+
+    /**
+     * Does this token support a 'pre-authentication' scenario.
+     * Pre-auth is when the user can be authenticated by some external system
+     * allowing the tokens to be automatically created during the token
+     * resolution process for automatic submission to
+     * <code>AuthenticationManager.authenticate(Authentication)</code>.
      * <p>
      * X509 is an example of a pre-authentication token - the server establishes
-     * that the user has provided a valid and trustworthy certificate before 
-     * reaching the underlying app (which means the token can be automatically 
-     * created during token resolution and authenticated). 
+     * that the user has provided a valid and trustworthy certificate before
+     * reaching the underlying app (which means the token can be automatically
+     * created during token resolution and authenticated).
      * <p>
-     * An exmple of a non pre-auth token is un/pw - the token will not be automatically 
-     * created during the token resolution process and must be created in client 
-     * code and and submitted to <code>AuthenticationManager.authenticate(IAuthentication)</code>. 
-     * 
+     * An exmple of a non pre-auth token is un/pw - the token will not be automatically
+     * created during the token resolution process and must be created in client
+     * code and and submitted to <code>AuthenticationManager.authenticate(IAuthentication)</code>.
+     *
      * @return boolean True or False
-     */ 
-     public static function isPreAuthenticating(); 
-    
+     */
+     public static function isPreAuthenticating();
+
     /**
-     * The identity of the principal being authenticated. 
-     * Note, this will vary according to differet authentication mechansisms. 
-     * In the case of an authentication request (<code>IAuthenticationManager.authentication($authToken)</code>) 
-     * with username and password, this would be the username. For X509 
-     * it would be the certificate DN. Callers are expected to populate the 
+     * The identity of the principal being authenticated.
+     * Note, this will vary according to differet authentication mechansisms.
+     * In the case of an authentication request (<code>IAuthenticationManager.authentication($authToken)</code>)
+     * with username and password, this would be the username. For X509
+     * it would be the certificate DN. Callers are expected to populate the
      * principal for an authentication request (<code>IAuthenticationManager.authentication($authToken)</code>).
      * <p>
-     * The <code>IAuthenticationManager</code> implementation will often return 
-     * an <code>IAuthentication</code> containing richer information as the principal 
-     * for use by the application. Authentication providers may create a <code>IUserDetails</code> 
-     * object as the principal after authentication. 
-     * 
+     * The <code>IAuthenticationManager</code> implementation will often return
+     * an <code>IAuthentication</code> containing richer information as the principal
+     * for use by the application. Authentication providers may create a <code>IUserDetails</code>
+     * object as the principal after authentication.
+     *
      * @return object
      */
-    public function getPrinciple(); 
-    
+    public function getPrinciple();
+
     /**
-     * Get current principal's credentials (usually a password). Never null. When a password is not 
-     * used for the chosen auth scheme (e.g. X509), return an empty string. 
-     * @return object never null 
+     * Get current principal's credentials (usually a password). Never null. When a password is not
+     * used for the chosen auth scheme (e.g. X509), return an empty string.
+     * @return object never null
      */
-    public function getCredentials(); 
-    
+    public function getCredentials();
+
     /**
-     * Sets the current principal's credentails (usually a password) to an empty string. 
+     * Sets the current principal's credentails (usually a password) to an empty string.
      */
-    public function eraseCredentials(); 
-    
+    public function eraseCredentials();
+
     /**
-     * A custom object used to store additional user details.  
-     * Allows non-security related user information (such as email addresses, 
-     * telephone numbers, IP address, certificate serial number etc) to be stored in a convenient location. 
-     * @return Object or null if not used 
+     * A custom object used to store additional user details.
+     * Allows non-security related user information (such as email addresses,
+     * telephone numbers, IP address, certificate serial number etc) to be stored in a convenient location.
+     * @return Object or null if not used
      */
-    public function getDetails(); 
-    
-    /** 
+    public function getDetails();
+
+    /**
      * @see getDetails()
      * @param Object $userDetails
      */
-    public function setDetails($userDetails); 
+    public function setDetails($userDetails);
 
     /**
      * Set by <code>AuthenticationManagerService</code> to indicate the authorities that the principal has been
@@ -97,30 +97,30 @@ interface IAuthentication {
      * @return array the authorities as strings granted to the principal, or an empty array if the token has not been authenticated.
      * Never null.
      */
-    public function getAuthorities(); 
-    
+    public function getAuthorities();
+
     /**
      * Called by <code>AuthenticationManagerService</code> to indicate the authorities that the principal has been
-     * granted after authentication. 
+     * granted after authentication.
      * @param array $authorities as a string array
      */
-    public function setAuthorities($authorities); 
+    public function setAuthorities($authorities);
 
    /**
-    * Validates the current state of the IAuth instance and is called internally 
-    * by the framework when returning credentials that have been cached in the 
-    * security context's http session. 
-    * Implementations MUST throw an AuthenticationException if the token's internal state becomes 
-    * invalid due to whatever change (required since instances are mutable). 
+    * Validates the current state of the IAuth instance and is called internally
+    * by the framework when returning credentials that have been cached in the
+    * security context's http session.
+    * Implementations MUST throw an AuthenticationException if the token's internal state becomes
+    * invalid due to whatever change (required since instances are mutable).
     * <p>
-    * For example, in the case of a cached x509 token, the client may freely change 
-    * their certificate in their browser by clearing the browser ssl 
-    * cache and refreshing the page. In this case, the DN may change from the  
-    * initial DN used when constructing the token. 
-    * 
-    * @throws AuthenticationException if authenitcation fails 
+    * For example, in the case of a cached x509 token, the client may freely change
+    * their certificate in their browser by clearing the browser ssl
+    * cache and refreshing the page. In this case, the DN may change from the
+    * initial DN used when constructing the token.
+    *
+    * @throws AuthenticationException if authenitcation fails
     */
-    public function validate(); 
+    public function validate();
 }
 
 ?>

--- a/lib/Authentication/IAuthenticationManager.php
+++ b/lib/Authentication/IAuthenticationManager.php
@@ -1,39 +1,39 @@
 <?php
 namespace org\gocdb\security\authentication;
 
-//require_once __DIR__.'/Exceptions/AuthenticationException.php'; 
-require_once __DIR__.'/IAuthentication.php'; 
+//require_once __DIR__.'/Exceptions/AuthenticationException.php';
+require_once __DIR__.'/IAuthentication.php';
 
 
 /**
  * Processes an Authentication request.
- *  
+ *
  * @author David Meredith
  */
 interface IAuthenticationManager {
 
     /**
-     * Attempts to authenticate the given <code>IAuthentication<code> object, returning the same 
-     * fully populated/updated <code>IAuthentication</code> object (including granted authorities) 
-     * if successful. The returned token is usually updated with a IUserDetails 
-     * object returned from UserDetailsService. The manager will iterate all the 
-     * configured IAuthenticationProviderS in an attempt to authenticate the given 
+     * Attempts to authenticate the given <code>IAuthentication<code> object, returning the same
+     * fully populated/updated <code>IAuthentication</code> object (including granted authorities)
+     * if successful. The returned token is usually updated with a IUserDetails
+     * object returned from UserDetailsService. The manager will iterate all the
+     * configured IAuthenticationProviderS in an attempt to authenticate the given
      * IAuthentication token.
-     * <p> 
-     * If the user can't be authenticated, an AuthenticationException is thrown.   
-     * A BadCredentialsException (which extends AuthenticationException) must be 
+     * <p>
+     * If the user can't be authenticated, an AuthenticationException is thrown.
+     * A BadCredentialsException (which extends AuthenticationException) must be
      * thrown if incorrect credentials are presented as an AuthenticationManager must always test credentials.
      * <p>
-     * On successful authentication <code>ISecurityContext.setAuthentication($auth);</code> 
-     * is called to (re)persist the auth token in the SecurityContext. 
-     * 
+     * On successful authentication <code>ISecurityContext.setAuthentication($auth);</code>
+     * is called to (re)persist the auth token in the SecurityContext.
+     *
      * @param IAuthentication $auth Token
-     * @return IAuthentication Fully populated Auth token on successful authentication. 
-     * @throws AuthenticationException if authentication fails. 
+     * @return IAuthentication Fully populated Auth token on successful authentication.
+     * @throws AuthenticationException if authentication fails.
      * @throws BadCredentialsException if incorrect credentails passed.
      */
-    public function authenticate(IAuthentication $auth) ; 
-   
+    public function authenticate(IAuthentication $auth) ;
+
 
 }
 

--- a/lib/Authentication/IAuthenticationProvider.php
+++ b/lib/Authentication/IAuthenticationProvider.php
@@ -1,45 +1,45 @@
 <?php
 namespace org\gocdb\security\authentication;
 
-//require_once __DIR__.'/Exceptions/AuthenticationException.php'; 
-require_once __DIR__.'/IAuthentication.php'; 
+//require_once __DIR__.'/Exceptions/AuthenticationException.php';
+require_once __DIR__.'/IAuthentication.php';
 
 
 /**
- * Indicates that a class can process a specific IAuthentication implementation. 
- *  
+ * Indicates that a class can process a specific IAuthentication implementation.
+ *
  * @author David Meredith
  */
 interface IAuthenticationProvider {
 
     /**
-     * Performs authentication with the same contract as 
+     * Performs authentication with the same contract as
      * <code>IAuthenticationManager.authenticate($anIAuthentication)</code>
-     * except that the implementation may return null if the AuthenticationProvider is unable to support 
-     * authentication of the passed Authentication object. In such a case, 
-     * the next AuthenticationProvider that supports the presented IAuthentication implementation will be tried. 
-     * 
+     * except that the implementation may return null if the AuthenticationProvider is unable to support
+     * authentication of the passed Authentication object. In such a case,
+     * the next AuthenticationProvider that supports the presented IAuthentication implementation will be tried.
+     *
      * @param IAuthentication $auth Token
-     * @return IAuthentication Fully authenticated object including credentials or null if provider can't support given token. 
-     * @throws AuthenticationException if authentication fails. 
+     * @return IAuthentication Fully authenticated object including credentials or null if provider can't support given token.
+     * @throws AuthenticationException if authentication fails.
      */
-    public function authenticate(IAuthentication $auth) ; 
-   
+    public function authenticate(IAuthentication $auth) ;
 
-    /** 
+
+    /**
      * Returns true if this AuthenticationProvider supports the given Authentication object.
-     * Returning true does not guarantee an AuthenticationProvider will be able to 
-     * authenticate the presented IAuthentication instance. It simply 
-     * indicates it can support closer evaluation of it. An AuthenticationProvider 
-     * can still return null from the authenticate(IAuthentication) method to indicate 
+     * Returning true does not guarantee an AuthenticationProvider will be able to
+     * authenticate the presented IAuthentication instance. It simply
+     * indicates it can support closer evaluation of it. An AuthenticationProvider
+     * can still return null from the authenticate(IAuthentication) method to indicate
      * another AuthenticationProvider should be tried.
-     * <p> 
-     * Used by the configured IAuthenticationManager at runtime for selecting an IAuthenticationProvider 
+     * <p>
+     * Used by the configured IAuthenticationManager at runtime for selecting an IAuthenticationProvider
      * that is capable of authenticating the given IAuthentication instance.
-     * 
-     * @return boolean true if the implementation can more closely evaluate the given IAuthentication object. 
+     *
+     * @return boolean true if the implementation can more closely evaluate the given IAuthentication object.
      */
-    public function supports(IAuthentication $auth) ; 
+    public function supports(IAuthentication $auth) ;
 }
 
 ?>

--- a/lib/Authentication/IConfigFirewallComponent.php
+++ b/lib/Authentication/IConfigFirewallComponent.php
@@ -22,43 +22,43 @@ namespace org\gocdb\security\authentication;
 interface IConfigFirewallComponent {
 
     /**
-     * Return a list of <code>IAuthenticationProvider</code> implementations. 
-     * @return array 
+     * Return a list of <code>IAuthenticationProvider</code> implementations.
+     * @return array
      */
     public function getAuthProviders();
 
     /**
-     * Return the <code>IUserDetailsService</code> implementation.  
-     * @return IUserDetailsService implementation 
+     * Return the <code>IUserDetailsService</code> implementation.
+     * @return IUserDetailsService implementation
      */
     public function getUserDetailsService();
 
     /**
-     * Return an array of fully qualified class name strings that lists the 
-     * supported <code>IAuthentication</code> tokens.  
+     * Return an array of fully qualified class name strings that lists the
+     * supported <code>IAuthentication</code> tokens.
      * <p>
-     * The class names are used to dynamically build preAuth class instances during 
-     * the token resolution process. Only preAuthenticating tokens are automatically 
-     * created during token resolution. Ordering is significant - tokens are 
-     * created in the order they appear in the array. 
-     * 
-     * @return array of class name strings. 
-     */ 
+     * The class names are used to dynamically build preAuth class instances during
+     * the token resolution process. Only preAuthenticating tokens are automatically
+     * created during token resolution. Ordering is significant - tokens are
+     * created in the order they appear in the array.
+     *
+     * @return array of class name strings.
+     */
     public function getAuthTokenClassList();
 
     /**
-     * Allow HTTP session creation for the security context. 
+     * Allow HTTP session creation for the security context.
      * <p>
      * If true, <code>IAuthentication</code> tokens may be stored
-     * in the session (provided the token declares that it can be 
-     * persisted with <code>$token.isStateless() == false)</code>. 
+     * in the session (provided the token declares that it can be
+     * persisted with <code>$token.isStateless() == false)</code>.
      * <p>
-     * If true, stateful tokens can be stored in HTTP session for 
-     * subsequent retrieval across page requests (e.g. a username/pw token). 
+     * If true, stateful tokens can be stored in HTTP session for
+     * subsequent retrieval across page requests (e.g. a username/pw token).
      * <p>
-     * Typically, REST style applications are stateless using only stateless auth tokens, 
-     * while portals are normally stateful requiring session tracking. 
-     * 
+     * Typically, REST style applications are stateless using only stateless auth tokens,
+     * while portals are normally stateful requiring session tracking.
+     *
      * @return boolean
      */
     public function getCreateSession();

--- a/lib/Authentication/IFirewallComponent.php
+++ b/lib/Authentication/IFirewallComponent.php
@@ -15,24 +15,24 @@
 namespace org\gocdb\security\authentication;
 
 /**
- * Defines a top-level class intended to be used by client code to authenticate 
- * HTTP requests by invoking the 'Token Resolution Process' 
- * or to authenticate/change the currently authenticated principal.  
+ * Defines a top-level class intended to be used by client code to authenticate
+ * HTTP requests by invoking the 'Token Resolution Process'
+ * or to authenticate/change the currently authenticated principal.
  * <p>
- * Multiple instances may be needed each with their own configuration 
- * to cater for different deployment scenarios.   
- *    
- * @see IAuthenticationManager 
- * @see ISecurityContext  
+ * Multiple instances may be needed each with their own configuration
+ * to cater for different deployment scenarios.
+ *
+ * @see IAuthenticationManager
+ * @see ISecurityContext
  * @author David Meredith
  */
 interface IFirewallComponent extends IAuthenticationManager, ISecurityContext {
-  
+
     /**
-     * Does this compoenent support the given authentication token. 
+     * Does this compoenent support the given authentication token.
      * @param \org\gocdb\security\authentication\IAuthentication $auth
-     * @return boolean true or false 
+     * @return boolean true or false
      */
-    public function supports(IAuthentication $auth); 
-    
+    public function supports(IAuthentication $auth);
+
 }

--- a/lib/Authentication/ISecurityContext.php
+++ b/lib/Authentication/ISecurityContext.php
@@ -15,8 +15,8 @@
 namespace org\gocdb\security\authentication;
 
 /**
- * Get/set an IAuthentication token for current thread of execution. 
- * @author David Meredith 
+ * Get/set an IAuthentication token for current thread of execution.
+ * @author David Meredith
  */
 interface ISecurityContext {
 
@@ -27,7 +27,7 @@ interface ISecurityContext {
      * @param IAuthentication $auth The new Authentication token,
      *   or null if http sessino token should be cleared.
      */
-    public function setAuthentication($auth = null); 
+    public function setAuthentication($auth = null);
 
     /**
      * Invoke the token resolution process to obtain the auth token for the
@@ -46,5 +46,5 @@ interface ISecurityContext {
      *
      * @return IAuthentication or null if not authenticated
      */
-    public function getAuthentication(); 
+    public function getAuthentication();
 }

--- a/lib/Authentication/IUserDetails.php
+++ b/lib/Authentication/IUserDetails.php
@@ -1,19 +1,19 @@
 <?php
 namespace org\gocdb\security\authentication;
 /**
- * Provides core user information. 
+ * Provides core user information.
  * <p>
- * Stores user information which is later encapsulated 
+ * Stores user information which is later encapsulated
  * into {@link IAuthentication.php} objects. This allows non-security related user
  * information (such as email addresses, telephone numbers etc) to be stored
  * in a convenient location.
  * <p>
  * Concrete implementations must take particular care to ensure the non-null
  * contract detailed for each method is enforced.
- * 
- * Largely based on Spring Security. 
- * @link http://static.springsource.org/spring-security Spring Security 
- * @author David Meredith  
+ *
+ * Largely based on Spring Security.
+ * @link http://static.springsource.org/spring-security Spring Security
+ * @author David Meredith
  */
 interface IUserDetails {
 
@@ -24,8 +24,8 @@ interface IUserDetails {
     public function getUsername();
 
     /**
-     * Returns the password used to authenticate the user. Cannot return <code>null</code>. 
-     * If a password is not required by the given auth mechanism, return an empty string. 
+     * Returns the password used to authenticate the user. Cannot return <code>null</code>.
+     * If a password is not required by the given auth mechanism, return an empty string.
      * @return String The password (never <code>null</code>)
      */
     public function getPassword();
@@ -37,7 +37,7 @@ interface IUserDetails {
     public function isEnabled();
 
     /**
-     * Set the credentials (usually a password) to an empty string. 
+     * Set the credentials (usually a password) to an empty string.
      */
     public function eraseCredentials();
 

--- a/lib/Authentication/IUserDetailsService.php
+++ b/lib/Authentication/IUserDetailsService.php
@@ -2,23 +2,23 @@
 namespace org\gocdb\security\authentication;
 
 /**
- * Core interface which loads user-specific data.  
- * The interface requires only one read-only method, which simplifies support for new data-access strategies. 
- * 
- * @author David Meredith 
+ * Core interface which loads user-specific data.
+ * The interface requires only one read-only method, which simplifies support for new data-access strategies.
+ *
+ * @author David Meredith
  */
 interface IUserDetailsService {
 
     /**
-     * Locates the user based on the given username string. 
-     * The username string must uniquely identify the user (its format can differ  
-     * depending on the authentication mechanism e.g. could be a DN string for x509). 
+     * Locates the user based on the given username string.
+     * The username string must uniquely identify the user (its format can differ
+     * depending on the authentication mechanism e.g. could be a DN string for x509).
      *
      * @param string $username the user string identifying the user whose data is required.
      * @return IUserDetails implementation (never <code>null</code>)
      * @throws UsernameNotFoundException if the user could not be found or the user has no GrantedAuthority
      */
-    public function loadUserByUsername($username); 
+    public function loadUserByUsername($username);
 }
 
 ?>

--- a/lib/Authentication/MyAuthenticationManager.php
+++ b/lib/Authentication/MyAuthenticationManager.php
@@ -20,8 +20,8 @@ namespace org\gocdb\security\authentication;
  * @author David Meredith
  */
 class MyAuthenticationManager implements IAuthenticationManager{
-    private $securityContext; 
-    private $config; 
+    private $securityContext;
+    private $config;
 
 
     public function setConfigFirewallComponent(IConfigFirewallComponent $configFwComp) {
@@ -37,54 +37,54 @@ class MyAuthenticationManager implements IAuthenticationManager{
      */
     public function authenticate(IAuthentication $auth) {
         if($auth == null) {
-            throw new BadCredentialsException(null, 'Coding error null IAuthentication given'); 
+            throw new BadCredentialsException(null, 'Coding error null IAuthentication given');
         }
-        // First do an explicit logout to clear the clients security context.  
+        // First do an explicit logout to clear the clients security context.
         $this->securityContext->setAuthentication(null);
 
-        // Iterate through our configured AuthProviders (in a defined order) 
-        // and call each to see if it supports the given IAuthentication 
-        // token. If true, attempt authentication. 
+        // Iterate through our configured AuthProviders (in a defined order)
+        // and call each to see if it supports the given IAuthentication
+        // token. If true, attempt authentication.
         // Break/return on the first (or all depending on voter strategy?) authProvider
-        // that can authenticate the user until all are tried.  
+        // that can authenticate the user until all are tried.
         $providers = $this->config->getAuthProviders();
         if(empty($providers)){
             throw new \LogicException("Configuration Error - "
-                    . "No AuthenticationProviders are configured"); 
-        } 
-        
-        $updatedAuth = null; 
-        $authProviderFound = false; 
+                    . "No AuthenticationProviders are configured");
+        }
+
+        $updatedAuth = null;
+        $authProviderFound = false;
         foreach ($providers as $provider){
             if($provider->supports($auth)){
                 $authProviderFound = TRUE;
                 try {
-                    $updatedAuth = $provider->authenticate($auth); 
+                    $updatedAuth = $provider->authenticate($auth);
                     if($updatedAuth != null){
-                        break; // break on our first returned auth object  
+                        break; // break on our first returned auth object
                     }
                 } catch(AuthenticationException $ex){
-                    // Auth failed using provider 'n', so catch and try next 
-                    // provider until configured providers are exhaused. 
-                    // TODO - need to log failed auth attempts.  
+                    // Auth failed using provider 'n', so catch and try next
+                    // provider until configured providers are exhaused.
+                    // TODO - need to log failed auth attempts.
                 }
             }
         }
         if(!$authProviderFound){
-            throw new BadCredentialsException(null, 
+            throw new BadCredentialsException(null,
                     "Configuration error - AuthToken [". get_class($auth) ."] "
-                    . "is not supported by any configured AuthProvider"); 
+                    . "is not supported by any configured AuthProvider");
         }
-        
-        // Request the token is saved in session (prevented if token or global config is stateless) 
+
+        // Request the token is saved in session (prevented if token or global config is stateless)
         if ($updatedAuth != null) {
             $this->securityContext->setAuthentication($updatedAuth);
             return $updatedAuth;
         } else {
-            throw new AuthenticationException(null, 
+            throw new AuthenticationException(null,
                     'Configured AuthProviderS failed to return an '
                     . 'IAuthentication token');
         }
-        
+
     }
 }

--- a/lib/Authentication/MyConfig1.php
+++ b/lib/Authentication/MyConfig1.php
@@ -15,38 +15,38 @@
 namespace org\gocdb\security\authentication;
 
 /**
- * A stateless configuration that supports the specified providers, tokens and 
- * user details service.  
- * 
+ * A stateless configuration that supports the specified providers, tokens and
+ * user details service.
+ *
  * @see IConfigFirewallComponent
  * @author David Meredith
  */
 class MyConfig1 implements IConfigFirewallComponent {
-    private $providerList; 
-    private $gocdbUserDetailsService; 
-    private $tokenClassList; 
-    
-    function __construct() {
-       $this->providerList = array(); 
-       $this->providerList[] = new GOCDBAuthProvider();  
-       //$this->providerList[] = new SampleAuthProvider(); 
-    
-       $this->gocdbUserDetailsService = new GOCDBUserDetailsService(); 
+    private $providerList;
+    private $gocdbUserDetailsService;
+    private $tokenClassList;
 
-       $this->tokenClassList = array(); 
-       $this->tokenClassList[] = 'org\gocdb\security\authentication\X509AuthenticationToken'; 
-       //$this->tokenClassList[] = 'org\gocdb\security\authentication\ShibAuthToken'; 
-       //$this->tokenClassList[] = 'org\gocdb\security\authentication\SimpleSamlPhpAuthToken'; 
-       //$this->tokenClassList[] = 'org\gocdb\security\authentication\UsernamePasswordAuthenticationToken'; 
+    function __construct() {
+       $this->providerList = array();
+       $this->providerList[] = new GOCDBAuthProvider();
+       //$this->providerList[] = new SampleAuthProvider();
+
+       $this->gocdbUserDetailsService = new GOCDBUserDetailsService();
+
+       $this->tokenClassList = array();
+       $this->tokenClassList[] = 'org\gocdb\security\authentication\X509AuthenticationToken';
+       //$this->tokenClassList[] = 'org\gocdb\security\authentication\ShibAuthToken';
+       //$this->tokenClassList[] = 'org\gocdb\security\authentication\SimpleSamlPhpAuthToken';
+       //$this->tokenClassList[] = 'org\gocdb\security\authentication\UsernamePasswordAuthenticationToken';
     }
 
     /**
      * Get an array containing <codeGOCDBAuthProvider</code> as the first element.
      * @see IConfigFirewallComponent::getAuthProviders()
-     * @return 
+     * @return
      */
     public function getAuthProviders(){
-        return $this->providerList; 
+        return $this->providerList;
     }
 
     /**
@@ -54,27 +54,27 @@ class MyConfig1 implements IConfigFirewallComponent {
      * @return \org\gocdb\security\authentication\GOCDBUserDetailsService
      */
     public function getUserDetailsService(){
-        return $this->gocdbUserDetailsService;  
+        return $this->gocdbUserDetailsService;
     }
 
     /**
-     * Get the supported auth token class names as strings. 
+     * Get the supported auth token class names as strings.
      * <pre>
-     * [0] = 'org\gocdb\security\authentication\X509AuthenticationToken' 
+     * [0] = 'org\gocdb\security\authentication\X509AuthenticationToken'
      * [1] = 'org\gocdb\security\authentication\SimpleSamlPhpAuthToken'
      * </pre>
      * @see IConfigFirewallComponent::getAuthTokenClassList()
      * @return array
      */
     public function getAuthTokenClassList(){
-        return $this->tokenClassList; 
+        return $this->tokenClassList;
     }
-   
+
     /**
      * @see IConfigFirewallComponent::getCreateSession()
      * @return false
      */
     public function getCreateSession(){
-        return false; 
+        return false;
     }
 }

--- a/lib/Authentication/MySecurityContext.php
+++ b/lib/Authentication/MySecurityContext.php
@@ -15,44 +15,44 @@
 namespace org\gocdb\security\authentication;
 
 /**
- * Get/set an IAuthentication token for current thread of execution. 
+ * Get/set an IAuthentication token for current thread of execution.
  * The token MAY be stored and managed in the HTTP session (provided
  * it is not stateless and the IConfigFirewallComponent allows session-creation).
- * 
+ *
  * @see ISecurityContext
- * @author David Meredith 
+ * @author David Meredith
  */
 class MySecurityContext implements ISecurityContext {
     //put your code here
     public static $authSessionKey = 'gocdb_IAuthentication_Impl';
     private static $salt = 'secretSaltValue';
     private static $delim = '[splitonthisdelimitervalueplease]';
-   
-    private $configFwComp; 
-    private $authManFwComp; 
-    
+
+    private $configFwComp;
+    private $authManFwComp;
+
 
     public function setConfigFirewallComponent(IConfigFirewallComponent $configFwComp){
-       $this->configFwComp = $configFwComp;  
+       $this->configFwComp = $configFwComp;
     }
 
     public function setAuthManager(IAuthenticationManager $authManFwComp){
-        $this->authManFwComp = $authManFwComp; 
+        $this->authManFwComp = $authManFwComp;
     }
-   
+
     /**
      * @see ISecurityContext::getAuthentication()
      */
     public function getAuthentication() {
-        // 1) If this configuration allows session creation, try to extract token 
-        // from session first 
-        if( $this->configFwComp->getCreateSession() ) {  
+        // 1) If this configuration allows session creation, try to extract token
+        // from session first
+        if( $this->configFwComp->getCreateSession() ) {
             $authToken = $this->getHttpSessionAuth();
             if ($authToken != null) {
-                // if $scheme param is requested, first check that auth supports 
+                // if $scheme param is requested, first check that auth supports
                 // requested scheme. If not, continue on with below
                 // if($authToken->supports('scheme'){
-                    // since we are returning a cached credential, we must 
+                    // since we are returning a cached credential, we must
                     // call validate first
                     $authToken->validate();
                     return $authToken;
@@ -60,34 +60,34 @@ class MySecurityContext implements ISecurityContext {
             }
         }
 
-        // 2) Try to authenticate with available pre-Auth tokens (if any are configured) 
-        // Iterate configured PRE_AUTH tokens in order (skip those that are not preAuthenticating)  
-        // If specific scheme is requested, skip those that don't support scheme 
-        // Attempt to create new pre-Auth token and authenitcate  
+        // 2) Try to authenticate with available pre-Auth tokens (if any are configured)
+        // Iterate configured PRE_AUTH tokens in order (skip those that are not preAuthenticating)
+        // If specific scheme is requested, skip those that don't support scheme
+        // Attempt to create new pre-Auth token and authenitcate
         $authTokenClassList = $this->configFwComp->getAuthTokenClassList();
         foreach ($authTokenClassList as $tokenClass){
-            // preAuthenitcated token only 
+            // preAuthenitcated token only
             if(call_user_func($tokenClass.'::isPreAuthenticating')){
                 // call_user_func($tokenClass.'::supports')
-                $authImpl = new $tokenClass; 
-                //echo 'created auth token [' . get_class($authImpl).']'; 
+                $authImpl = new $tokenClass;
+                //echo 'created auth token [' . get_class($authImpl).']';
                 try {
-                    // Iterate all configured AuthProviders  
-                    // and attempts to authenticate the token and if authenticated ok, calls 
+                    // Iterate all configured AuthProviders
+                    // and attempts to authenticate the token and if authenticated ok, calls
                     // SecurityContextService::setAuthentication($auth)
-                    $returnToken = $this->authManFwComp->authenticate($authImpl); 
+                    $returnToken = $this->authManFwComp->authenticate($authImpl);
                     if($returnToken != null){
-                        return $returnToken; 
+                        return $returnToken;
                     }
                 }catch (AuthenticationException $ex){
-                    // We don't want AuthenticationException being part of this 
-                    // methods public API, but continue to next token for auth attempt.  
-                    // TODO - log failed token auth attempt 
+                    // We don't want AuthenticationException being part of this
+                    // methods public API, but continue to next token for auth attempt.
+                    // TODO - log failed token auth attempt
                 }
             }
         }
-        
-        return null;  
+
+        return null;
     }
 
 
@@ -95,39 +95,39 @@ class MySecurityContext implements ISecurityContext {
      * @see ISecurityContext::setAuthentication()
      */
     public function setAuthentication($auth = null) {
-        // If can't create session, return - don't touch/create the session !  
-        if( $this->configFwComp->getCreateSession() === FALSE ) { 
-            return; 
+        // If can't create session, return - don't touch/create the session !
+        if( $this->configFwComp->getCreateSession() === FALSE ) {
+            return;
         }
 
-        // Only set the auth token in session if the token is not stateless ! 
+        // Only set the auth token in session if the token is not stateless !
         if ($auth != null && !$auth->isStateless()) {
-            
+
             if (!($auth instanceof IAuthentication)) {
                 throw new \RuntimeException('Argument 1 passed to '
                         . 'SecurityContextService::setAuthentication() must '
                         . 'implement interface IAuthentication');
             }
-            // Always unset the password as this auth object may be stored in 
-            // e.g. HTTP session and the password MUST be opaque. 
+            // Always unset the password as this auth object may be stored in
+            // e.g. HTTP session and the password MUST be opaque.
             $auth->eraseCredentials();
-            // The object stored in getDetails() may/may-not be an IUserDetails impl, 
-            // so check if it is and erase if true:  
+            // The object stored in getDetails() may/may-not be an IUserDetails impl,
+            // so check if it is and erase if true:
             if($auth->getDetails() instanceof IUserDetails){
-                $auth->getDetails()->eraseCredentials();  
+                $auth->getDetails()->eraseCredentials();
             }
-            // On successful authentication, some custom auth provider implementations 
-            // may set the auth->principle object to be a IUserDetails object 
-            // therefore we must test for this and clear if true: 
+            // On successful authentication, some custom auth provider implementations
+            // may set the auth->principle object to be a IUserDetails object
+            // therefore we must test for this and clear if true:
             if($auth->getPrinciple() instanceof IUserDetails){
-                $auth->getPrinciple()->eraseCredentials(); 
+                $auth->getPrinciple()->eraseCredentials();
             }
-            // Serialise $auth into a string so that it can be stored in 
-            // session (can't use references in session variables). In addition, 
-            // save a salted md5 hash of the auth so that we can ensure that the 
+            // Serialise $auth into a string so that it can be stored in
+            // session (can't use references in session variables). In addition,
+            // save a salted md5 hash of the auth so that we can ensure that the
             // session has not been tampered with when later callling getAuthentication()
             $serializedAuth = serialize($auth);
-            
+
             if(!self::is_session_started()){
                 // You must call session_start() before you'll have access to any variables in $_SESSION.
                 session_start();
@@ -137,42 +137,42 @@ class MySecurityContext implements ISecurityContext {
                     self::$delim .
                     md5($serializedAuth . self::$salt);
         }
-        
+
         if($auth == null){
             if (!self::is_session_started()){
-                session_start(); 
+                session_start();
             }
-            // Clear the session variable. We can't just call session_destroy, 
-            // we need to explicitly clear the session variable. 
+            // Clear the session variable. We can't just call session_destroy,
+            // we need to explicitly clear the session variable.
             if(isset($_SESSION[self::$authSessionKey])){
                 unset($_SESSION[self::$authSessionKey]);
             }
-            // Lets not kill the session completely - it may be used for other 
-            // session related stuff and we are only interested in the session 
-            // 'SecurityContextService::$authSessionKey' var (i.e. our custom security context).  
+            // Lets not kill the session completely - it may be used for other
+            // session related stuff and we are only interested in the session
+            // 'SecurityContextService::$authSessionKey' var (i.e. our custom security context).
             //session_destroy();
         }
     }
-    
+
 
     /**
-     * Fetch IAuthentication impl from HTTP session or null if not present. 
+     * Fetch IAuthentication impl from HTTP session or null if not present.
      * This implementation updates the session id if the session is older than 30 secs to
      * guard against session fixation attacks. The service never destroys
      * the session as the it may be in use in other code paths. Rather, this service
      * creates/destroys the <code>$_SESSION[SecurityContextService::authSessionKey]</code>
      * variable.
      *
-     * @return IAuthentication or null 
+     * @return IAuthentication or null
      */
     private function getHttpSessionAuth() {
-        // If can't create session, return null - don't touch/create a session !  
-        if( $this->configFwComp->getCreateSession() === FALSE ) { 
-            return null; 
+        // If can't create session, return null - don't touch/create a session !
+        if( $this->configFwComp->getCreateSession() === FALSE ) {
+            return null;
         }
 
-        // I want to check for a php session without starting one - but it seems 
-        // i can only resume a session or start a new one (either way, a session is started!) 
+        // I want to check for a php session without starting one - but it seems
+        // i can only resume a session or start a new one (either way, a session is started!)
         //http://stackoverflow.com/questions/13114185/how-can-you-check-if-a-php-session-exists
         //http://stackoverflow.com/questions/1780736/checking-for-php-session-without-starting-one?rq=1
         if (!self::is_session_started()) {
@@ -181,19 +181,19 @@ class MySecurityContext implements ISecurityContext {
         //if(!isset($_REQUEST['PHPSESSID'] )){
         //if(!isset($_COOKIE[session_name()])){
             // You must call session_start() before you'll have access to variables in $_SESSION.
-            // This always results in a session being started (or existing 
-            // session is resumed). This is not ideal - i want to check for a 
-            // php session without starting one - but this don't seem possible. 
+            // This always results in a session being started (or existing
+            // session is resumed). This is not ideal - i want to check for a
+            // php session without starting one - but this don't seem possible.
             session_start();
-            //echo 'here, why? - I know session cookie exists! but apparently session has not been started?'; 
-            //return null; 
+            //echo 'here, why? - I know session cookie exists! but apparently session has not been started?';
+            //return null;
         }
 
-        // Deal with Session Fixation attacks: 
-        // Maintain a value that will track the last time the session ID was 
-        // updated. Here we ensure a new session ID is is generated frequently 
-        // (every 30secs) so that the opportunity for an attacker to obtain a 
-        // valid session ID is dramatically reduced. 
+        // Deal with Session Fixation attacks:
+        // Maintain a value that will track the last time the session ID was
+        // updated. Here we ensure a new session ID is is generated frequently
+        // (every 30secs) so that the opportunity for an attacker to obtain a
+        // valid session ID is dramatically reduced.
         if (!isset($_SESSION['generated']) || $_SESSION['generated'] < (time() - 30)) {
             // Replace the current session id with a new one, and keep the current session information
             session_regenerate_id();
@@ -214,9 +214,9 @@ class MySecurityContext implements ISecurityContext {
             if (md5($serializedAuth . self::$salt) == $serializedAuthHash) {
                 return unserialize($serializedAuth);
             } else {
-                // Lets not kill the session completely - it may be used for other 
-                // session related stuff and we are only interested in the session 
-                // 'SecurityContextService::$authSessionKey' var (i.e. our custom security context).  
+                // Lets not kill the session completely - it may be used for other
+                // session related stuff and we are only interested in the session
+                // 'SecurityContextService::$authSessionKey' var (i.e. our custom security context).
                 //session_destroy();
                 die('Your session appears to have been tampered with');
             }

--- a/lib/Authentication/UserDetails/GOCDBUserDetails.php
+++ b/lib/Authentication/UserDetails/GOCDBUserDetails.php
@@ -1,40 +1,40 @@
 <?php
 namespace org\gocdb\security\authentication;
 
-require_once __DIR__ . '/../IUserDetails.php'; 
+require_once __DIR__ . '/../IUserDetails.php';
 
 /**
- * A custom Implementation of {@link IUserDetails.php} 
+ * A custom Implementation of {@link IUserDetails.php}
  *
- * @author David Meredith  
+ * @author David Meredith
  */
 class GOCDBUserDetails implements IUserDetails {
 
-    private $username; 
+    private $username;
     private $isEnabled;
-    private $password = ""; 
-    private $roles; 
-    private $val; 
+    private $password = "";
+    private $roles;
+    private $val;
 
 
     public function __construct($username, $isEnabled, $roles, $val, $password="" ) {
         $this->username = $username;
-        $this->isEnabled = $isEnabled; 
-        $this->password = $password; 
-        $this->roles = $roles; 
-        $this->val = $val; 
+        $this->isEnabled = $isEnabled;
+        $this->password = $password;
+        $this->roles = $roles;
+        $this->val = $val;
     }
-    
+
     public function getUsername() {
-        return $this->username;     
+        return $this->username;
     }
 
     public function isEnabled() {
-        return $this->isEnabled;         
+        return $this->isEnabled;
     }
 
-    public function getPassword() { 
-        return $this->password; 
+    public function getPassword() {
+        return $this->password;
     }
 
     public function eraseCredentials() {
@@ -42,11 +42,11 @@ class GOCDBUserDetails implements IUserDetails {
     }
 
     public function getAuthorities(){
-        return $this->roles; 
+        return $this->roles;
     }
 
     public function getGOCDBCustomVal(){
-        return $this->val; 
+        return $this->val;
     }
 }
 

--- a/lib/Authentication/UserDetailsServices/GOCDBUserDetailsService.php
+++ b/lib/Authentication/UserDetailsServices/GOCDBUserDetailsService.php
@@ -24,8 +24,8 @@ class GOCDBUserDetailsService implements IUserDetailsService {
      * @throws UsernameNotFoundException if the user could not be found or the user has no GrantedAuthority
      */
     public function loadUserByUsername($username) {
-        throw new \LogicException('not implemted yet'); 
-        
+        throw new \LogicException('not implemted yet');
+
         if ($username == null) {
             throw new UsernameNotFoundException(null, 'null username');
             //throw new \RuntimeException('null username');
@@ -61,7 +61,7 @@ class GOCDBUserDetailsService implements IUserDetailsService {
         $userDetails = new GOCDBUserDetails($username, true, $roles, $user, '');
         return $userDetails;
         //$userDetails = new GOCDBUserDetails($username, true, $roles, null, '');
-        //return $userDetails; 
+        //return $userDetails;
     }
 }
 

--- a/lib/Authentication/_autoload.php
+++ b/lib/Authentication/_autoload.php
@@ -16,19 +16,19 @@
 namespace org\gocdb\security\authentication;
 
 /**
- * Safe autoloader that a) registers any existing '__autoload' functions with 
- * the 'spl_autoload_register' (eg __autoloadS defined in other component),  
- * and b) registers an additional autoloader for this security component. 
- * 
- * Typically autoload code is included in a config file or some other file that 
+ * Safe autoloader that a) registers any existing '__autoload' functions with
+ * the 'spl_autoload_register' (eg __autoloadS defined in other component),
+ * and b) registers an additional autoloader for this security component.
+ *
+ * Typically autoload code is included in a config file or some other file that
  * is included with each pageload and contains common code required for the site to run.
- * 
- * @author David Meredith 
+ *
+ * @author David Meredith
  */
 
 if(false === spl_autoload_functions()){
     if(function_exists('__autoload')){
-        spl_autoload_register('__autoload', false); 
+        spl_autoload_register('__autoload', false);
     }
 }
 
@@ -36,41 +36,41 @@ if(false === spl_autoload_functions()){
 function securityLoader($className){
     // $className is namespace qualified, e.g. org\gocdb\security\authentication\GOCDBAuthProvider
     $parts = explode('\\', $className); //split out namespaces
-    $classNameNoNS = end($parts);//get classname (DONT lowercase className, the file won't be located on *nix)  
-    
+    $classNameNoNS = end($parts);//get classname (DONT lowercase className, the file won't be located on *nix)
+
     //Folder handling which returns classfile
     $file = __DIR__.'/'.$classNameNoNS.'.php';
     if(file_exists($file)){
-       require_once $file;  
-       return; 
+       require_once $file;
+       return;
     }
     $file = __DIR__.'/AuthProviders/'.$classNameNoNS.'.php';
     if(file_exists($file)){
-       require_once $file;  
-       return; 
-    } 
+       require_once $file;
+       return;
+    }
     $file = __DIR__.'/AuthTokens/'.$classNameNoNS.'.php';
     if(file_exists($file)){
-       require_once $file;  
-       return; 
-    } 
+       require_once $file;
+       return;
+    }
     $file = __DIR__.'/Exceptions/'.$classNameNoNS.'.php';
     if(file_exists($file)){
-       require_once $file;  
-       return; 
+       require_once $file;
+       return;
     }
     $file = __DIR__.'/UserDetails/'.$classNameNoNS.'.php';
     if(file_exists($file)){
-       require_once $file;  
-       return; 
+       require_once $file;
+       return;
     }
     $file = __DIR__.'/UserDetailsServices/'.$classNameNoNS.'.php';
     if(file_exists($file)){
-       require_once $file;  
-       return; 
+       require_once $file;
+       return;
     }
 }
- 
 
-spl_autoload_register(__NAMESPACE__ .'\securityLoader', false); 
+
+spl_autoload_register(__NAMESPACE__ .'\securityLoader', false);
 

--- a/lib/DAOs/AbstractDAO.php
+++ b/lib/DAOs/AbstractDAO.php
@@ -12,17 +12,17 @@ class AbstractDAO {
     }
 
     /**
-     * Set the EntityManager instance used by all DAO. 
+     * Set the EntityManager instance used by all DAO.
      * @param \Doctrine\ORM\EntityManager $em
      */
     public function setEntityManager(\Doctrine\ORM\EntityManager $em){
-        $this->em = $em;  
+        $this->em = $em;
     }
-    
+
     /**
-     * @return \Doctrine\ORM\EntityManager 
+     * @return \Doctrine\ORM\EntityManager
      */
     public function getEntityManager(){
-        return $this->em; 
+        return $this->em;
     }
 }

--- a/lib/DAOs/NGIDAO.php
+++ b/lib/DAOs/NGIDAO.php
@@ -1,16 +1,16 @@
 <?php
 include_once __DIR__ . '/AbstractDAO.php';
 /**
- * All public methods are non transacional. They should always be called from 
+ * All public methods are non transacional. They should always be called from
  * within a transaction. Authorisation and validation is not carried out here
  * and should take place in the service layer.
  *
  * @author George Ryall
- * @author David Meredith 
+ * @author David Meredith
  * @author John Casson
  */
 class NGIDAO extends AbstractDAO{
-    
+
     /**
      * Non-transactional. Removes a NGI  from GOCDB. No authorisation
      * or validation occours here.
@@ -18,17 +18,17 @@ class NGIDAO extends AbstractDAO{
      */
     public function removeNGI(\NGI $n){
         //remove any subgrids related to this ngi
-        
-        
+
+
         //remove ngi
         $this->em->remove($n);
-        
+
     }
      /**
-     * Creates an entry in the NGI archieve table, to enable auditing of 
-     * deletion. This code is designed to be run from within the try/catch 
+     * Creates an entry in the NGI archieve table, to enable auditing of
+     * deletion. This code is designed to be run from within the try/catch
      * block within the single transaction of the delete NGI function.
-     * Authorisation must have already been performed and the values come from 
+     * Authorisation must have already been performed and the values come from
      * an existing object and so are assumed valid. May not work if unregistered
      * users are ever allowed to delete things.
      * @param \NGI $ngi
@@ -40,14 +40,14 @@ class NGIDAO extends AbstractDAO{
         $archievedNgi->setName($ngi->getName());
         $archievedNgi->setOriginalCreationDate($ngi->getCreationDate());
         $archievedNgi->setScopes($ngi->getScopeNamesAsString());
-        
+
         $projectNamesAsArray = array();
         foreach ($ngi->getProjects() AS $p){
-            $projectNamesAsArray[] = $p->getName(); 
+            $projectNamesAsArray[] = $p->getName();
         }
         $projectNamesAsString = implode(", ", $projectNamesAsArray);
         $archievedNgi->setParentProjects($projectNamesAsString);
-        
+
         $this->em->persist($archievedNgi);
     }
 }

--- a/lib/DAOs/ServiceDAO.php
+++ b/lib/DAOs/ServiceDAO.php
@@ -1,37 +1,37 @@
 <?php
 include_once __DIR__ . '/AbstractDAO.php';
 /**
- * All public methods are non-transactional - they queue changes to the DB with 
- * EntityManager remove(), merge() but do not call commit() or rollback(). 
- * They should always be called from within a transaction. 
+ * All public methods are non-transactional - they queue changes to the DB with
+ * EntityManager remove(), merge() but do not call commit() or rollback().
+ * They should always be called from within a transaction.
  * Authorisation and validation is not carried out here
  * and should take place in another layer.
  *
  * @author George Ryall
- * @author David Meredith 
+ * @author David Meredith
  * @author John Casson
  */
 class ServiceDAO extends AbstractDAO{
-    
+
     /**
      * Queues a service for removal from GOCDB. In doing so, also removes
-     * any downtimes that will be orphaned. 
+     * any downtimes that will be orphaned.
      * <p>
-     * This method deletes downtimes that are ONLY associated with this 
-     * service and no others - if another servcie or service's EndpointLocation links to a 
+     * This method deletes downtimes that are ONLY associated with this
+     * service and no others - if another servcie or service's EndpointLocation links to a
      * downtime, the downtime is not removed - there is no cascade delete from EL-to-DT).
-     * <p> 
+     * <p>
      * No authorisation or validation occurs here.
-     * Non-transactional - invokes remove() and merge() of the EntityManager 
-     * but does not call flush(), commit() or rollback(). 
-     * 
+     * Non-transactional - invokes remove() and merge() of the EntityManager
+     * but does not call flush(), commit() or rollback().
+     *
      * @param \Service $s service to be removed
      * @param \User $user user doing the removal (for audit table)
      */
     public function removeService(\Service $s){
-        //Sort downtimes into those for deletion and those that only need their 
-        //link with $service and $service->endpoint breaking 
-        
+        //Sort downtimes into those for deletion and those that only need their
+        //link with $service and $service->endpoint breaking
+
         //Collate service's Reachable downtimes
         $downTimes= array();
 
@@ -44,53 +44,53 @@ class ServiceDAO extends AbstractDAO{
                 }
             }
         }
-        // Add downtimes Reachable through service 
+        // Add downtimes Reachable through service
         foreach($s->getDowntimes() as $dt){
             if(!in_array($dt, $downTimes)){
                 $downTimes[]=$dt;
-            } 
+            }
         }
-       
-        // Store downtimes that will be orphaned 
+
+        // Store downtimes that will be orphaned
         $downTimesForRemoval = array();
-       
-        // Iterate each reachable downtime and check if each references another 
-        // service (or another service's endpoint). If not in both cases, 
-        // remove the DT relationships (between DT<-->EL and DT<-->SE). 
+
+        // Iterate each reachable downtime and check if each references another
+        // service (or another service's endpoint). If not in both cases,
+        // remove the DT relationships (between DT<-->EL and DT<-->SE).
         foreach($downTimes as $reachableDT){
             $removeDT = true;
 
-            // Is dt linked to another service's endpoint ? 
+            // Is dt linked to another service's endpoint ?
             foreach($reachableDT->getEndpointLocations() as $el){
                 if($el->getService() != $s){
-                    // dt is linked to a different service's endpoint so 
-                    // we can't delete this downtime, and we must also  
+                    // dt is linked to a different service's endpoint so
+                    // we can't delete this downtime, and we must also
                     // maintain the link between $reachableDT and $el
                     $removeDT = false;
                 } else {
-                    // dt is linked to the targetService's endpoint, so we 
-                    // must delete the relationship 
-                    $reachableDT->removeEndpointLocation($el); 
+                    // dt is linked to the targetService's endpoint, so we
+                    // must delete the relationship
+                    $reachableDT->removeEndpointLocation($el);
                 }
             }
-            // Is dt linked to another service ? 
+            // Is dt linked to another service ?
             foreach($reachableDT->getServices() as $ser){
                 if($ser != $s){
-                   // yes, dt is linked to a different service so 
-                   // we can't delete this downtime, and we must also  
-                   // maintain the link between $reachableDT and $ser. 
-                   $removeDT = false; 
+                   // yes, dt is linked to a different service so
+                   // we can't delete this downtime, and we must also
+                   // maintain the link between $reachableDT and $ser.
+                   $removeDT = false;
                 } else {
-                    // dt is linked to the targetService, so we 
-                    // must delete the relationship 
+                    // dt is linked to the targetService, so we
+                    // must delete the relationship
                     $reachableDT->removeService($ser); // unlinks on both sides
-                    //$ser->getDowntimes()->removeElement($reachableDT); 
-                    //$reachableDT->getServices()->removeElement($ser);        
+                    //$ser->getDowntimes()->removeElement($reachableDT);
+                    //$reachableDT->getServices()->removeElement($ser);
                 }
             }
 
-            // this dt is not linked to any other service or service's endpoint 
-            // so we can store it for subsequent deletion. 
+            // this dt is not linked to any other service or service's endpoint
+            // so we can store it for subsequent deletion.
             if($removeDT){
                 $downTimesForRemoval[]=$reachableDT;
             }
@@ -100,41 +100,41 @@ class ServiceDAO extends AbstractDAO{
         foreach($downTimesForRemoval as $dt){
             $this->em->remove($dt);
         }
-       
+
         // Remove Endpoints
-        // Impt: When deleting a service, we can't rely solely on the DB level FK 
-        // 'onDelete=CASCADE' defined on the EndpointLocation's 'service' association 
-        // (the @JoinColumn annotation) to correctly cascade-delete the EndpointLocation.  
-        // This is because Downtimes can also be linked to the EL, meaning a FK integrity 
+        // Impt: When deleting a service, we can't rely solely on the DB level FK
+        // 'onDelete=CASCADE' defined on the EndpointLocation's 'service' association
+        // (the @JoinColumn annotation) to correctly cascade-delete the EndpointLocation.
+        // This is because Downtimes can also be linked to the EL, meaning a FK integrity
         // constraint violation exception would be thrown because the onDelete=cascade
-        // does not remove this association in 'DOWNTIMES_ENDPOINTLOCATIONS.ENDPOINTLOCATION_ID' FK column.  
-        // To solve this, we also need to do an ORM level remove of the EL 
-        // (either by adding cascade="remove" or manually invoking em->remove($el) on each EL) 
-        // to ensure the ORM Unit-of-work flags the EL to be removed which subsequently causes 
-        // Doctrine to automatically delete the relevant row(s) in 'DOWNTIMES_ENDPOINTLOCATIONS' 
-        // join table!  
+        // does not remove this association in 'DOWNTIMES_ENDPOINTLOCATIONS.ENDPOINTLOCATION_ID' FK column.
+        // To solve this, we also need to do an ORM level remove of the EL
+        // (either by adding cascade="remove" or manually invoking em->remove($el) on each EL)
+        // to ensure the ORM Unit-of-work flags the EL to be removed which subsequently causes
+        // Doctrine to automatically delete the relevant row(s) in 'DOWNTIMES_ENDPOINTLOCATIONS'
+        // join table!
         // See: http://docs.doctrine-project.org/en/2.0.x/reference/working-with-objects.html#removing-entities
-        // See: http://stackoverflow.com/questions/6328535/on-delete-cascade-with-doctrine2 
+        // See: http://stackoverflow.com/questions/6328535/on-delete-cascade-with-doctrine2
         foreach($eLs as $el){
             $this->em->remove($el);
         }
-        
+
         //remove service
         $this->em->remove($s);
     }
 
     /**
-     * Queues an EndpointLocation for removal by unlinking its associations 
+     * Queues an EndpointLocation for removal by unlinking its associations
      * with Service and Downtime.
-     * <p> 
+     * <p>
      * No authorisation or validation occurs here.
-     * Non-transactional - invokes remove() of the EntityManager 
-     * but does not call flush(), commit() or rollback(). 
-     * 
+     * Non-transactional - invokes remove() of the EntityManager
+     * but does not call flush(), commit() or rollback().
+     *
      * @param \EndpointLocation $endpoint
      */
     public function removeEndpoint(\EndpointLocation $endpoint) {
-        $service = $endpoint->getService(); 
+        $service = $endpoint->getService();
         // unset relation on both sides (SE<-->EL)
         $service->getEndpointLocations()->removeElement($endpoint);
         $endpoint->setServiceDoJoin(NULL);
@@ -149,8 +149,8 @@ class ServiceDAO extends AbstractDAO{
     }
 
     /**
-     * Creates an entry in the service archive table, to enable auditing 
-     * of deletion. 
+     * Creates an entry in the service archive table, to enable auditing
+     * of deletion.
      * @param \Service $service
      * @param \User $user
      */
@@ -165,7 +165,7 @@ class ServiceDAO extends AbstractDAO{
         $archievedService->setMonitored($service->getMonitored());
         $archievedService->setBeta($service->getBeta());
         $archievedService->setProduction($service->getProduction());
-        
+
         $this->em->persist($archievedService);
     }
 }

--- a/lib/DAOs/ServiceGroupDAO.php
+++ b/lib/DAOs/ServiceGroupDAO.php
@@ -1,16 +1,16 @@
 <?php
 include_once __DIR__ . '/AbstractDAO.php';
 /**
- * All public methods are non transacional. They should always be called from 
+ * All public methods are non transacional. They should always be called from
  * within a transaction. Authorisation and validation is not carried out here
  * and should take place in the service layer.
  *
  * @author George Ryall
- * @author David Meredith 
+ * @author David Meredith
  * @author John Casson
  */
 class ServiceGroupDAO extends AbstractDAO{
-    
+
     /**
      * Non-transactional. Removes a service group from GOCDB. No authorisation
      * or validation occours here.
@@ -21,10 +21,10 @@ class ServiceGroupDAO extends AbstractDAO{
         $this->em->remove($sg);
     }
 
-    
+
     /**
-     * Creates an entry in the servicegroup archive table, to enable auditing 
-     * of deletion. 
+     * Creates an entry in the servicegroup archive table, to enable auditing
+     * of deletion.
      * @param \ServiceGroup $sg
      * @param \User $user
      */
@@ -34,14 +34,14 @@ class ServiceGroupDAO extends AbstractDAO{
         $archievedSG->setName($sg->getName());
         $archievedSG->setOriginalCreationDate($sg->getCreationDate());
         $archievedSG->setScopes($sg->getScopeNamesAsString());
-        
+
         $serviceNamesAsArray = array();
         foreach ($sg->getServices() AS $s){
-            $serviceNamesAsArray[] = $s->getHostName() . "(" . $s->getServiceType()->getName() . ")"; 
+            $serviceNamesAsArray[] = $s->getHostName() . "(" . $s->getServiceType()->getName() . ")";
         }
         $serviceNamesAsString = implode(", ", $serviceNamesAsArray);
         $archievedSG->setServices($serviceNamesAsString);
-        
+
         $this->em->persist($archievedSG);
     }
 }

--- a/lib/DAOs/SiteDAO.php
+++ b/lib/DAOs/SiteDAO.php
@@ -1,34 +1,34 @@
 <?php
 include_once __DIR__ . '/AbstractDAO.php';
 /**
- * All public methods are non transacional. They should always be called from 
+ * All public methods are non transacional. They should always be called from
  * within a transaction. Authorisation and validation is not carried out here
  * and should take place in the service layer.
  *
  * @author George Ryall
- * @author David Meredith 
+ * @author David Meredith
  * @author John Casson
  */
 class SiteDAO extends AbstractDAO{
-    
+
     /**
-     * Non-transactional. Queues a site for removal from GOCDB with remove() but 
+     * Non-transactional. Queues a site for removal from GOCDB with remove() but
      * does not call commit() or rollback(). No authorisation or validation occours here.
      * @param \Site $s Site to be deleted
      */
     public function removeSite(\Site $s){
-        
+
 //        //remove the sites subgrid, if it has one and it is the only member.
 //        if(!is_null($s->getSubGrid())){
 //            //echo "Hello World";
 //            //die();
-//            
+//
 ////            $subGrid = $s->getSubGrid();/
 ///           $s->setSubGrid(null);
 ////            $subGrid->getSites()->removeElement($s);
-////            
+////
 ////            $this->em->merge($subGrid);
-//////            
+//////
 //////            if(sizeof($subGrid->getSites())==0){
 ////                $this->em->remove($subGrid);
 ////            //}
@@ -36,16 +36,16 @@ class SiteDAO extends AbstractDAO{
 
         //remove site
         $this->em->remove($s);
-        
+
     }
 
     /**
-     * Creates an entry in the site archive table, to enable auditing of 
-     * deletion. Authorisation must have already been performed and the values come from 
+     * Creates an entry in the site archive table, to enable auditing of
+     * deletion. Authorisation must have already been performed and the values come from
      * an existing object and so are assumed to be valid. May not work if unregistered
      * users are ever allowed to delete things.
      * @param \Site $site
-     * @param \User $user	 
+     * @param \User $user
      */
     public function addSiteToArchive(\Site $site, \User $user){
         $archievedSite = new \ArchivedSite();
@@ -58,7 +58,7 @@ class SiteDAO extends AbstractDAO{
         $archievedSite->setScopes($site->getScopeNamesAsString());
         $archievedSite->setV4PrimaryKey($site->getPrimaryKey());
         $archievedSite->setInfrastructure($site->getInfrastructure()->getName());
-                
+
         $this->em->persist($archievedSite);
     }
 }

--- a/lib/Doctrine/bootstrap.php
+++ b/lib/Doctrine/bootstrap.php
@@ -1,10 +1,10 @@
 <?php
 // bootstrap.php
- 
+
 //ini_set('memory_limit', '-1');
 //set_time_limit(300);
 // Above line may be needed but only when Seeding DB with script files. Othewise
-// definately DO NOT set the memory limit to unlimited. 
+// definately DO NOT set the memory limit to unlimited.
 $entitiesPath = dirname(__FILE__)."/entities";
 
 require_once $entitiesPath."/OwnedEntity.php";
@@ -36,8 +36,8 @@ require_once $entitiesPath."/ArchivedNGI.php";
 require_once $entitiesPath."/ArchivedService.php";
 require_once $entitiesPath."/ArchivedServiceGroup.php";
 require_once $entitiesPath."/ArchivedSite.php";
-require_once $entitiesPath."/EndpointProperty.php"; 
-require_once $entitiesPath."/RoleActionRecord.php"; 
+require_once $entitiesPath."/EndpointProperty.php";
+require_once $entitiesPath."/RoleActionRecord.php";
 
 //if (!class_exists("Doctrine\Common\Version", false)) {
 //    require_once __DIR__."/bootstrap_doctrine.php";

--- a/lib/Doctrine/bootstrap_doctrine_TEMPLATE.php
+++ b/lib/Doctrine/bootstrap_doctrine_TEMPLATE.php
@@ -54,7 +54,7 @@ $config = Setup::createAnnotationMetadataConfiguration(array(__DIR__."/entities"
     // );
     /////////////////////////////////////////////////////////////////////////////////////////////
 
-     
+
     ///////////////////////ORACLE CONNECTION DETAILS////////////////////////////////////////////
     //	$conn = array(
     //		'driver' => 'oci8',
@@ -67,10 +67,10 @@ $config = Setup::createAnnotationMetadataConfiguration(array(__DIR__."/entities"
     //	);
     //  // Need to explicitly set the Oracle session date format [1]
     //  $evm = new EventManager();
-    //  $evm->addEventSubscriber(new OracleSessionInit(array('NLS_TIME_FORMAT' => 'HH24:MI:SS')));	
+    //  $evm->addEventSubscriber(new OracleSessionInit(array('NLS_TIME_FORMAT' => 'HH24:MI:SS')));
     /////////////////////////////////////////////////////////////////////////////////////////////
 
-    
+
     ///////////////////////MYSQL CONNECTION DETAILS////////////////////////////////////////////
     //$conn = array(
     //	'driver' => 'pdo_mysql',
@@ -80,7 +80,7 @@ $config = Setup::createAnnotationMetadataConfiguration(array(__DIR__."/entities"
     //	'dbname' => 'doctrine'
     //);
     /////////////////////////////////////////////////////////////////////////////////////////////
-    
+
 
 
 

--- a/lib/Doctrine/cli-config.php
+++ b/lib/Doctrine/cli-config.php
@@ -14,12 +14,12 @@ require_once "bootstrap.php";
 
 // DM: Came across the following issue:
 // See: http://stackoverflow.com/questions/25131662/doctrine-orm-cli-tool-not-working
-// 
-// This occurred When we had the following $helperSet var assignment as commented out below 
+//
+// This occurred When we had the following $helperSet var assignment as commented out below
 // (note we only set the 'em' var, not the 'db' var and we didn't return the $helperSet var
-// which is now required). 
+// which is now required).
 // The issue occurred due to a change somewhere between Doctrine 2.3.* and 2.4.*
-// 
+//
 //$helperSet = new \Symfony\Component\Console\Helper\HelperSet(array(
 //    'em' => new \Doctrine\ORM\Tools\Console\Helper\EntityManagerHelper($entityManager)
 //));
@@ -28,6 +28,6 @@ $helperSet = new \Symfony\Component\Console\Helper\HelperSet(array(
     'db' => new \Doctrine\DBAL\Tools\Console\Helper\ConnectionHelper($entityManager->getConnection()),
     'em' => new \Doctrine\ORM\Tools\Console\Helper\EntityManagerHelper($entityManager)
 ));
-return $helperSet; 
+return $helperSet;
 */
 

--- a/lib/Doctrine/deploy/AddDowntimes.php
+++ b/lib/Doctrine/deploy/AddDowntimes.php
@@ -5,7 +5,7 @@ require_once __DIR__."/AddUtils.php";
 require_once __DIR__.'/../entities/AlreadyLinkedException.php';
 
 
-// For each of the hostnames below, GOCDB has two SRM services 
+// For each of the hostnames below, GOCDB has two SRM services
 // registered for each.
 // Similarly, the Doctrine prototype contains two of each of these SEs.
 // However when linking a downtime to one of these service els,
@@ -18,9 +18,9 @@ require_once __DIR__.'/../entities/AlreadyLinkedException.php';
 //
 // The duplicates are all SRM services apart from cert-ce-01 (CE) and
 // hyx.grid.icm.edu.pl (Unicore6.StorageManagement)  - something may be wrong with the
-// SRM service type the PROM GOCDB causing duplicate service eps 
+// SRM service type the PROM GOCDB causing duplicate service eps
 // to be registered. Either that or there's a business reason
-// for registering two. 
+// for registering two.
 $duplicateSes = array ("se.reef.man.poznan.pl",  "lcg05.sinp.msu.ru",
         "grid-se.ii.edu.mk",
         "storage01.lcg.cscs.ch", "grid002.ics.forth.gr",
@@ -33,20 +33,20 @@ $duplicateSes = array ("se.reef.man.poznan.pl",  "lcg05.sinp.msu.ru",
 // AddDowntimes.php: Loads a list of downtimes  from an
 // XML file and inserts them into the doctrine prototype.
 // XML format is the output from get_service_endpoints PI query.
-// 
+//
 
 
 $allDowntimes = array();
 $downtimeFileName = __DIR__ . "/" . $GLOBALS['dataDir'] . "/Downtimes.xml";
 $downtimes = simplexml_load_file($downtimeFileName);
-$largestV4DowntimePK = 0; 
+$largestV4DowntimePK = 0;
 
 foreach ($downtimes as $downtimeXml) {
     // Each "downtimeXML" element is one SE's downtime.
     // If a single downtime affects many SEs, each
     // SE will be named in a different $downtimeXml that will duplicate
     // all the downtime specific fields.
-    
+
     foreach($downtimeXml->attributes() as $key => $value) {
         if((string) $key == "ID") {
             $promId = (int) $value;
@@ -56,10 +56,10 @@ foreach ($downtimes as $downtimeXml) {
     $downtime = null;
     // See if we've already entered a downtime with this prom ID
     if(isset($allDowntimes[$promId])) {
-        // load $downtime from db by $promId rather than loading from global array  
-        // This assumes xml ID attribute (without 'G0' appended) is the same as 
-        // xml PRIMARY_KEY attribute. 
-        //  
+        // load $downtime from db by $promId rather than loading from global array
+        // This assumes xml ID attribute (without 'G0' appended) is the same as
+        // xml PRIMARY_KEY attribute.
+        //
         // $downtime = $entityManager->createQuery("select d FROM Downtime d WHERE d.primaryKey = ?1")
         //   ->setParameter(1, (string) $promId.'G0')
         //   ->getResult();
@@ -72,7 +72,7 @@ foreach ($downtimes as $downtimeXml) {
         // Finds one or more SEs by hostname and service type
         $services = findSEs((string) $downtimeXml->HOSTNAME
             , (string) $downtimeXml->SERVICE_TYPE);
-        
+
         // There are some edge cases where findSEs returns
         // more than one SE (see the comment at the top of this file)
         // However if the downtime isn't yet created we always
@@ -82,12 +82,12 @@ foreach ($downtimes as $downtimeXml) {
                     . "hostname " . $downtimeXml->HOSTNAME . " ");
         }
 
-        // Bidirectional link the el and dt 
-        $els = $services[0]->getEndpointLocations(); 
-        $downtime->addEndpointLocation($els[0]); 
+        // Bidirectional link the el and dt
+        $els = $services[0]->getEndpointLocations();
+        $downtime->addEndpointLocation($els[0]);
         //$downtime->addService($services[0]);
 
-        // save the id rather than the whole downtime to reduce memory 
+        // save the id rather than the whole downtime to reduce memory
         $GLOBALS['allDowntimes'][$promId] = $downtime;
     } else {
         // Find the SE and link it to the downtime
@@ -99,46 +99,46 @@ foreach ($downtimes as $downtimeXml) {
                     . "hostname " . $downtimeXml->HOSTNAME . " ");
         }
         try {
-            // TODO? - We should probably iterate each el and try to link each 
-            // to this DT. Will still need to throw alreadylinked exception when 
+            // TODO? - We should probably iterate each el and try to link each
+            // to this DT. Will still need to throw alreadylinked exception when
             // trying to link a SE that is already linked to the downtime
-            // in order to detect the SE duplicates. But iterating may only be necessary 
-            // if it emerges that there are instances of more than 2 duplicate SEs 
-            // (the duplicate SE count is tested for the expected 2 duplicates 
-            // below in catch block). 
-            $els = $services[0]->getEndpointLocations(); 
+            // in order to detect the SE duplicates. But iterating may only be necessary
+            // if it emerges that there are instances of more than 2 duplicate SEs
+            // (the duplicate SE count is tested for the expected 2 duplicates
+            // below in catch block).
+            $els = $services[0]->getEndpointLocations();
             if(count($els) > 1){
-                throw new LogicException('Coding error - there should only be one EL per Service'); 
+                throw new LogicException('Coding error - there should only be one EL per Service');
             }
-            
-            // Check this endpoint isn't already linked to downtime. 
+
+            // Check this endpoint isn't already linked to downtime.
             // The els have already been persisted/flushed against
-            // the DB and so already have IDs. 
+            // the DB and so already have IDs.
             foreach($downtime->getEndpointLocations() as $existingEL) {
-                if($existingEL == $els[0]) { // their Ids will be the same 
+                if($existingEL == $els[0]) { // their Ids will be the same
                     throw new AlreadyLinkedException("Downtime {$downtime->getId()} is already "
                     . "linked to el {$existingEL->getId()}");
                 }
             }
 
-            // Bidirectional link the el and dt 
-            $downtime->addEndpointLocation($els[0]); 
+            // Bidirectional link the el and dt
+            $downtime->addEndpointLocation($els[0]);
             //$downtime->addService($services[0]);
-            
+
         } catch (Exception $e) {
             if($e instanceof AlreadyLinkedException) {
-                // Downtime is already linked to this SE 
-                
+                // Downtime is already linked to this SE
+
                 // Check whether this exception is caused by a known issue
                 // with duplicate SEs (see comment at the top of the file).
                 // Issue is known if two SEs are found and the hostname is
-                // a known duplicate 
+                // a known duplicate
                 $twoSes = false;
                 if(count($services) == 2) {
                     $twoSes = true;
                 } else {
-                    // we will have to deal with this case and link the 
-                    throw new Exception("More than duplicate 2 SEs found: ".$services[0]->getHostName()); 
+                    // we will have to deal with this case and link the
+                    throw new Exception("More than duplicate 2 SEs found: ".$services[0]->getHostName());
                 }
 
                 $knownDup = false;
@@ -154,9 +154,9 @@ foreach ($downtimes as $downtimeXml) {
                 // The other SE will always be the second result in $services ([1])
                 if($twoSes && $knownDup) {
                     //$downtime->addService($services[1]);
-                    $els = $services[1]->getEndpointLocations(); 
+                    $els = $services[1]->getEndpointLocations();
 
-        
+
         // Check this SE isn't already registered
         //foreach($downtime->getEndpointLocations() as $existingEL) {
         //	if($existingEL == $els[0]) {
@@ -164,8 +164,8 @@ foreach ($downtimes as $downtimeXml) {
         //		. "linked to el {$existingEL->getId()}");
         //	}
         //}
-                   
-                    // Bidirectional link the el and dt 
+
+                    // Bidirectional link the el and dt
                     $downtime->addEndpointLocation($els[0]);
                 }
             }
@@ -202,10 +202,10 @@ function newDowntime($downtimeXml) {
     }
 
     // Get the largest v4 downtime PK which is an integer appended by the string 'G0'
-    // slice off the 'G0' and get the integer value. 
-    $v4pk = (int)substr($primaryKey, 0, strlen($primaryKey)-2); 
+    // slice off the 'G0' and get the integer value.
+    $v4pk = (int)substr($primaryKey, 0, strlen($primaryKey)-2);
     if($v4pk > $GLOBALS['largestV4DowntimePK']){
-        $GLOBALS['largestV4DowntimePK'] = $v4pk; 
+        $GLOBALS['largestV4DowntimePK'] = $v4pk;
     }
 
     $downtime->setClassification($classification);
@@ -217,7 +217,7 @@ function newDowntime($downtimeXml) {
     $downtime->setEndDate($endDate);
     $insertDate = new DateTime("@" . (string) $downtimeXml->INSERT_DATE);
     $downtime->setInsertDate($insertDate);
-    $downtime->setPrimaryKey($primaryKey);  
+    $downtime->setPrimaryKey($primaryKey);
 
     return $downtime;
 }

--- a/lib/Doctrine/deploy/AddEgiRoles.php
+++ b/lib/Doctrine/deploy/AddEgiRoles.php
@@ -3,12 +3,12 @@
 require_once __DIR__."/../bootstrap.php";
 require_once __DIR__."/AddUtils.php";
 
-/** 
+/**
  * AddEgiRoles.php: Loads a list of roles from the get_user PI
  * query output (XML), finds the EGI roles and inserts them into
  * the doctrine prototype.
  * XML format is the output from get_roc_list PI query, e.g:
- 
+
 
  <EGEE_USER USER_ID=" " PRIMARY_KEY="63777G0">
         <FORENAME>Patricia</FORENAME>
@@ -48,17 +48,17 @@ foreach($usersRoles as $user) {
         if((string) $role->USER_ROLE == "") {
             continue;
         }
-        
+
         // Skip all non-site roles
         if((string) $role->ENTITY_TYPE !== "group") {
             continue;
         }
-        
+
         // Skip all non-EGI level roles
         if((string) $role->ON_ENTITY != "EGI") {
             continue;
         }
-        
+
         // get roletype entity
         $dql = "SELECT rt FROM RoleType rt WHERE rt.name = :roleType";
         $roleTypes = $entityManager->createQuery($dql)
@@ -67,14 +67,14 @@ foreach($usersRoles as $user) {
         // /* Error checking: ensure each role type refers to exactly
          // * one role type*/
         if(count($roleTypes) !== 1) {
-            throw new Exception(count($roleTypes) . " role types found with name: " . 
+            throw new Exception(count($roleTypes) . " role types found with name: " .
                 $role->USER_ROLE);
         }
         foreach($roleTypes as $result) {
             $roleType = $result;
         }
-        
-        
+
+
         // get user entity
         $dql = "SELECT u FROM User u WHERE u.certificateDn = ?1";
         $users = $entityManager->createQuery($dql)
@@ -86,14 +86,14 @@ foreach($usersRoles as $user) {
             foreach($users as $u) {
                 echo "Certificate DN is " . $u->getCertificateDn() . "-------";
             }
-            throw new Exception(count($users) . " users found with DN: " . 
+            throw new Exception(count($users) . " users found with DN: " .
                 $user->CERTDN);
         }
         foreach($users as $doctrineUser) {
             $doctrineUser = $doctrineUser;
         }
-        
-        $doctrineRole = new Role($roleType, $doctrineUser, $egi, 'STATUS_GRANTED'); 
+
+        $doctrineRole = new Role($roleType, $doctrineUser, $egi, 'STATUS_GRANTED');
         $entityManager->persist($doctrineRole);
     }
 }

--- a/lib/Doctrine/deploy/AddGroupRoles.php
+++ b/lib/Doctrine/deploy/AddGroupRoles.php
@@ -3,11 +3,11 @@
 require_once __DIR__."/../bootstrap.php";
 require_once __DIR__."/AddUtils.php";
 
-/** 
+/**
  * AddNGIs.php: Loads a list of NGIs from an XML file and inserts them into
  * the doctrine prototype.
  * XML format is the output from get_roc_list PI query, e.g:
- 
+
 
  <EGEE_USER USER_ID=" " PRIMARY_KEY="63777G0">
         <FORENAME>Patricia</FORENAME>
@@ -44,12 +44,12 @@ foreach($usersRoles as $user) {
         if((string) $role->USER_ROLE == "") {
             continue;
         }
-        
+
         // Skip all non-site roles
         if((string) $role->ENTITY_TYPE !== "group") {
             continue;
         }
-        
+
         // get roletype entity
         $dql = "SELECT rt FROM RoleType rt WHERE rt.name = :roleType";
         $roleTypes = $entityManager->createQuery($dql)
@@ -58,14 +58,14 @@ foreach($usersRoles as $user) {
         // /* Error checking: ensure each role type refers to exactly
          // * one role type*/
         if(count($roleTypes) !== 1) {
-            throw new Exception(count($roleTypes) . " role types found with name: " . 
+            throw new Exception(count($roleTypes) . " role types found with name: " .
                 $role->USER_ROLE);
         }
         foreach($roleTypes as $result) {
             $roleType = $result;
         }
-        
-        
+
+
         // get user entity
         $dql = "SELECT u FROM User u WHERE u.certificateDn = ?1";
         $users = $entityManager->createQuery($dql)
@@ -77,13 +77,13 @@ foreach($usersRoles as $user) {
             foreach($users as $u) {
                 echo "Certificate DN is " . $u->getCertificateDn() . "-------";
             }
-            throw new Exception(count($users) . " users found with DN: " . 
+            throw new Exception(count($users) . " users found with DN: " .
                 $user->CERTDN);
         }
         foreach($users as $doctrineUser) {
             $doctrineUser = $doctrineUser;
         }
-       
+
         // Check for invalid NGIs and skip
         // typically these are decomissioned ROCs
         if($role->ON_ENTITY == 'GridIreland' || $role->ON_ENTITY == 'NGS'
@@ -91,7 +91,7 @@ foreach($usersRoles as $user) {
             || $role->ON_ENTITY == 'Tier1A') {
             continue;
         }
-        
+
         // get ngi entity
         // skip EGI level roles (these are inserted by AddEgiRoles.php)
         if((string) $role->ON_ENTITY == "EGI") {
@@ -105,13 +105,13 @@ foreach($usersRoles as $user) {
         // /* Error checking: ensure each "ngi" refers to exactly
          // * one ngi */
         if(count($ngis) !== 1) {
-            throw new Exception(count($ngis) . " ngis found name: " . 
+            throw new Exception(count($ngis) . " ngis found name: " .
                 $ngiName);
         }
         foreach($ngis as $ngi) {
             $ngi = $ngi;
         }
-        
+
         //check that the role is not a duplicate (v4 data contaisn duplicates)
         $ExistingUserRoles = $doctrineUser->getRoles();
         $thisIsADuplicateRole=false;
@@ -120,9 +120,9 @@ foreach($usersRoles as $user) {
                 $thisIsADuplicateRole = true;
             }
         }
-        
+
         if(!$thisIsADuplicateRole){
-            $doctrineRole = new Role($roleType, $doctrineUser, $ngi, 'STATUS_GRANTED'); 
+            $doctrineRole = new Role($roleType, $doctrineUser, $ngi, 'STATUS_GRANTED');
             $entityManager->persist($doctrineRole);
         }
     }

--- a/lib/Doctrine/deploy/AddNGIs.php
+++ b/lib/Doctrine/deploy/AddNGIs.php
@@ -3,7 +3,7 @@
 require_once __DIR__."/../bootstrap.php";
 require_once __DIR__."/AddUtils.php";
 
-/** 
+/**
  * AddNGIs.php: Loads a list of NGIs from an XML file and inserts them into
  * the doctrine prototype.
  * XML format is the output from get_roc_list PI query.
@@ -25,44 +25,44 @@ foreach($ngis as $xmlNgi) {
     $helpdeskEmail = "";
     $securityEmail = "";
     $creationDate = new \DateTime("now");
-    
+
     foreach($xmlNgi as $key => $value) {
         if((string) $key == "NAME") {
             $name = (string) $value;
         }
-        
+
         if((string) $key == "EMAIL") {
             $email = (string) $value;
         }
-        
+
         if((string) $key == "DESCRIPTION") {
             $description = (string) $value;
         }
-        
+
         if((string) $key == "ROD_EMAIL") {
             $rodEmail = (string) $value;
         }
-        
+
         if((string) $key == "HELPDESK_EMAIL") {
             $helpdeskEmail = (string) $value;
         }
-        
+
         if((string) $key == "SECURITY_EMAIL") {
             $securityEmail = (string) $value;
         }
-        
+
         if((string) $key == "CDATEON") {
-            // $cdateonString has the following format: '12-JAN-10 14.12.56.000000' 
+            // $cdateonString has the following format: '12-JAN-10 14.12.56.000000'
             $cdateonString = (string) $value;
-            
+
             //convert to date time
             $creationDate = DateTime::createFromFormat('d-M-y G.i.s.u', $cdateonString, new DateTimeZone('UTC'));
-        
+
             if ($creationDate == false) {
             throw new LogicException("Datetime in unexpected format. datetime: '" . $cdateonString . "'");
             }
-        }        
-        
+        }
+
     }
     $doctrineNgi->setCreationDate($creationDate);
     $doctrineNgi->setDescription($description);
@@ -71,18 +71,18 @@ foreach($ngis as $xmlNgi) {
     $doctrineNgi->setRodEmail($rodEmail);
     $doctrineNgi->setHelpdeskEmail($helpdeskEmail);
     $doctrineNgi->setSecurityEmail($securityEmail);
-    
-    // TODO 
-    //if($cdateon == null) throw new Exception("CDATEON is null"); 
+
+    // TODO
+    //if($cdateon == null) throw new Exception("CDATEON is null");
     //$doctrineNgi->setCreationDate($cdateon);
-    
+
     $egiProject->addNgi($doctrineNgi);
-    
+
     $doctrineNgi->addScope($egiScope);
-    
+
     $entityManager->persist($doctrineNgi);
-    
-    
+
+
 }
 
 // don't need to merge egiProject

--- a/lib/Doctrine/deploy/AddRoleTypes.php
+++ b/lib/Doctrine/deploy/AddRoleTypes.php
@@ -1,30 +1,30 @@
 <?php
 require_once __DIR__."/../bootstrap.php";
 require_once __DIR__."/AddUtils.php";
-require_once __DIR__."/../../Gocdb_Services/RoleConstants.php"; 
+require_once __DIR__."/../../Gocdb_Services/RoleConstants.php";
 /* AddRoleTypes.php: Manually inserts role types into
  * the doctrine prototype.
  */
- 
+
 /*$roleTypeArray = array (
-    array("Site Administrator", "C"), 
+    array("Site Administrator", "C"),
     array("Site Security Officer", "C'"),
     array("Site Operations Deputy Manager", "C'"),
     array("Site Operations Manager", "C'"),
-    
+
     array("Regional First Line Support", "D"),
     array("Regional Staff (ROD)", "D"),
     array("NGI Security Officer", "D'"),
     array("NGI Operations Deputy Manager", "D'"),
     array("NGI Operations Manager", "D'"),
-    
+
     array("COD Staff", "E"),
     array("COD Administrator", "E"),
     array("EGI CSIRT Officer", "E"),
     array("Chief Operations Officer", "E"),
-        
+
     array("Service Group Administrator", "ServiceGroupC'"),
-    
+
     // "Other" roles that have slipped by us
     array("CIC Staff", ""),
     array("Regional Staff", "")
@@ -37,11 +37,11 @@ foreach($roleTypeArray as $roleType) {
     $entityManager->persist($rt);
 }*/
 
-$roleTypeArray = RoleTypeName::getAsArray();  
+$roleTypeArray = RoleTypeName::getAsArray();
 
 foreach ($roleTypeArray as $key => $value) {
-    $rt = new RoleType($value); 
-    //echo $value; 
+    $rt = new RoleType($value);
+    //echo $value;
     if($value != RoleTypeName::GOCDB_ADMIN){
         $entityManager->persist($rt);
     }

--- a/lib/Doctrine/deploy/AddServiceEndpoints.php
+++ b/lib/Doctrine/deploy/AddServiceEndpoints.php
@@ -103,7 +103,7 @@ foreach ($ses as $xmlSe) {
     //set creation date
     $creationDate = new \DateTime("now", new DateTimeZone('UTC'));
 
-    
+
     $doctrineSe->setCreationDate($creationDate);
     $doctrineSe->setDn((string) $xmlSe->HOSTDN);
     $doctrineSe->setIpAddress((string) $xmlSe->HOST_IP);
@@ -112,7 +112,7 @@ foreach ($ses as $xmlSe) {
     $doctrineSe->setHostName((string) $xmlSe->HOSTNAME);
     $doctrineSe->setDescription((string) $xmlSe->DESCRIPTION);
 
-    // A service has ELs  
+    // A service has ELs
     $doctrineEndpointLocation = new EndpointLocation();
     $doctrineEndpointLocation->setUrl((string) $xmlSe->URL);
     $doctrineEndpointLocation->setName('sampleEndpoint');

--- a/lib/Doctrine/deploy/AddServiceTypes.php
+++ b/lib/Doctrine/deploy/AddServiceTypes.php
@@ -18,7 +18,7 @@ foreach($sts as $st) {
         if($key == "SERVICE_TYPE_NAME") {
             $name = (string) $value;
         }
-        
+
         if($key == "SERVICE_TYPE_DESC") {
             $desc = (string) $value;
         }

--- a/lib/Doctrine/deploy/AddSiteRoles.php
+++ b/lib/Doctrine/deploy/AddSiteRoles.php
@@ -3,7 +3,7 @@
 require_once __DIR__."/../bootstrap.php";
 require_once __DIR__."/AddUtils.php";
 
-/** 
+/**
  * AddNGIs.php: Loads a list of Site roles from an XML file and inserts them into
  * the doctrine prototype.
  * XML format is the output from get_user_doctrine PI query.
@@ -17,12 +17,12 @@ foreach($usersRoles as $user) {
         if((string) $role->USER_ROLE == "") {
             continue;
         }
-        
+
         // Skip all non-site roles
         if((string) $role->ENTITY_TYPE !== "site") {
             continue;
         }
-        
+
         // Find the role type
         // get the roletype entity
         $dql = "SELECT rt FROM RoleType rt WHERE rt.name = ?1";
@@ -32,7 +32,7 @@ foreach($usersRoles as $user) {
         // /* Error checking: ensure each role type refers to exactly
          // * one role type*/
         if(count($roleTypes) !== 1) {
-            throw new Exception(count($roleTypes) . " role types found with name: " . 
+            throw new Exception(count($roleTypes) . " role types found with name: " .
                 $role->USER_ROLE);
         }
         foreach($roleTypes as $result) {
@@ -41,7 +41,7 @@ foreach($usersRoles as $user) {
         if(!($roleType instanceof RoleType)) {
             throw new Exception("Not a doctrine role type");
         }
-        
+
         // Find the user
         // get the user entity
         $dql = "SELECT u FROM User u WHERE u.certificateDn = :certDn";
@@ -54,24 +54,24 @@ foreach($usersRoles as $user) {
             foreach($users as $u) {
                 echo "Certificate DN is " . $u->getCertificateDn() . "-------";
             }
-            throw new Exception(count($users) . " users found with DN: " . 
+            throw new Exception(count($users) . " users found with DN: " .
                 $user->CERTDN);
         }
-        
+
         foreach($users as $doctrineUser) {
             $doctrineUser = $doctrineUser;
         }
-        
+
         if(!($doctrineUser instanceof User)) {
             throw new Exception("Not a doctrine user");
         }
-        
+
         // Check for invalid sites and skip adding this role
         // typically these sites don't have an NGI, country or production status
         if(isBad((string) $role->ON_ENTITY)) {
             continue;
         }
-        
+
         // get the site entity
         $dql = "SELECT s FROM Site s WHERE s.shortName = ?1";
         $sites = $entityManager->createQuery($dql)
@@ -80,7 +80,7 @@ foreach($usersRoles as $user) {
         // /* Error checking: ensure each "site" refers to exactly
          // * one site */
         if(count($sites) !== 1) {
-            throw new Exception(count($sites) . " sites found with short name: " . 
+            throw new Exception(count($sites) . " sites found with short name: " .
                 $role->ON_ENTITY);
         }
         foreach($sites as $doctrineSite) {
@@ -89,7 +89,7 @@ foreach($usersRoles as $user) {
         if(!($doctrineSite instanceof Site)) {
             throw new Exception("Not a doctrine site");
         }
-        
+
         //check that the role is not a duplicate (v4 data contaisn duplicates)
         $ExistingUserRoles = $doctrineUser->getRoles();
         $thisIsADuplicateRole=false;
@@ -98,9 +98,9 @@ foreach($usersRoles as $user) {
                 $thisIsADuplicateRole = true;
             }
         }
-        
+
         if(!$thisIsADuplicateRole){
-            $doctrineRole = new Role($roleType, $doctrineUser, $doctrineSite, 'STATUS_GRANTED');  
+            $doctrineRole = new Role($roleType, $doctrineUser, $doctrineSite, 'STATUS_GRANTED');
             $entityManager->persist($doctrineRole);
         }
     }

--- a/lib/Doctrine/deploy/AddSites.php
+++ b/lib/Doctrine/deploy/AddSites.php
@@ -9,22 +9,22 @@ require_once __DIR__ . "/AddUtils.php";
 $sitesFileName = __DIR__ . "/" . $GLOBALS['dataDir'] . "/Sites.xml";
 $sites = simplexml_load_file($sitesFileName);
 
-$xmlCertStatusChanges = simplexml_load_file( __DIR__ . "/" . $GLOBALS['dataDir'] . "/CertStatusChanges.xml"); 
-$xmlCertStatusLinkDates = simplexml_load_file(__DIR__ . "/" . $GLOBALS['dataDir'] . "/CertStatusDate.xml"); 
+$xmlCertStatusChanges = simplexml_load_file( __DIR__ . "/" . $GLOBALS['dataDir'] . "/CertStatusChanges.xml");
+$xmlCertStatusLinkDates = simplexml_load_file(__DIR__ . "/" . $GLOBALS['dataDir'] . "/CertStatusDate.xml");
 
-$largestV4SitePk = 0; 
+$largestV4SitePk = 0;
 foreach($sites as $xmlSite) {
 
     // Check whether this site has a larger v4 primary key
-    // than any other recorded so far 
-    $v4pkGO = trim((string) $xmlSite->PRIMARY_KEY); 
-    // isolate just the number part (slice the 'GO' off the end) 
-    $v4pk = (int)substr($v4pkGO, 0, strlen($v4pkGO)-2); 
+    // than any other recorded so far
+    $v4pkGO = trim((string) $xmlSite->PRIMARY_KEY);
+    // isolate just the number part (slice the 'GO' off the end)
+    $v4pk = (int)substr($v4pkGO, 0, strlen($v4pkGO)-2);
     if($v4pk > $largestV4SitePk){
-        $largestV4SitePk = $v4pk; 
+        $largestV4SitePk = $v4pk;
     }
-    
-    
+
+
     $doctrineSite = new Site();
     $doctrineSite->setPrimaryKey((string) $xmlSite->PRIMARY_KEY);
     $doctrineSite->setOfficialName((string) $xmlSite->OFFICIAL_NAME);
@@ -36,7 +36,7 @@ foreach($sites as $xmlSite) {
     $doctrineSite->setGiisUrl((string) $xmlSite->GIIS_URL);
     if(strlen((string)$xmlSite->LATITUDE) > 0){
         $doctrineSite->setLatitude((float)$xmlSite->LATITUDE);
-    } 
+    }
     if(strlen((string)$xmlSite->LONGITUDE) > 0){
         $doctrineSite->setLongitude((float)$xmlSite->LONGITUDE);
     }
@@ -164,62 +164,62 @@ foreach($sites as $xmlSite) {
     }
 
 
-        
+
     //set creation date
     $creationDate = new \DateTime("now", new DateTimeZone('UTC'));
-    
+
     $doctrineSite->setCreationDate($creationDate);
-    
-    
-    // The date of the CURRENT certStatus in v4 is recorded as 
-    // a link/linkType object using the dateOn property. For simplicity, we 
-    // store this date as an attribute on the Site. 
+
+
+    // The date of the CURRENT certStatus in v4 is recorded as
+    // a link/linkType object using the dateOn property. For simplicity, we
+    // store this date as an attribute on the Site.
     foreach($xmlCertStatusLinkDates as $xmlCertStatusLinkDate){
-       $targetSiteName = (string) $xmlCertStatusLinkDate->name;  
-       // only interested in the current site 
+       $targetSiteName = (string) $xmlCertStatusLinkDate->name;
+       // only interested in the current site
        if($targetSiteName == $doctrineSite->getShortName()){
-          // '01-JUL-13 11.09.10.000000 AM' which has the php datetime 
+          // '01-JUL-13 11.09.10.000000 AM' which has the php datetime
           // format of 'd-M-y H.i.s A' provided we trim off the '.000000' (millisecs)
-          // Note, '.000000' is present in all the <cert_date> elements. 
-          $xmlLinkDateString = (string) $xmlCertStatusLinkDate->cert_date; 
+          // Note, '.000000' is present in all the <cert_date> elements.
+          $xmlLinkDateString = (string) $xmlCertStatusLinkDate->cert_date;
           $xmlLinkDateString = preg_replace('/\.000000/', "", $xmlLinkDateString);
           $linkDate =  \DateTime::createFromFormat('d-M-y H.i.s A', $xmlLinkDateString, new \DateTimeZone('UTC'));
           if(!$linkDate) {
-              throw new Exception("Can't parse date/time  " . $xmlLinkDateString . " for site " . 
+              throw new Exception("Can't parse date/time  " . $xmlLinkDateString . " for site " .
                       $doctrineSite->getShortName() . ". Correct format: 27-JUL-11 02.02.03 PM" );
           }
-          
+
           $doctrineSite->setCertificationStatusChangeDate($linkDate);
-           
+
        }
     }
-    
 
-    // Add the Site's certification status history/log. 
-    // If the Site certStatus has never been updated from its initial state, 
-    // then no changes will have occurred and the log will be empty for that Site. 
-    // 
-    // Importantly, because the v4 certStatus change log was added AFTER some 
-    // sites were already added to GOCDB4, the LAST AddedDate does NOT  
-    // necessarily correspond with the date of the CURRENT certification status. 
-    // Rather, the date of the CURRENT certStatus in v4 is recorded as 
-    // a link/linkType object using the dateOn property. 
+
+    // Add the Site's certification status history/log.
+    // If the Site certStatus has never been updated from its initial state,
+    // then no changes will have occurred and the log will be empty for that Site.
+    //
+    // Importantly, because the v4 certStatus change log was added AFTER some
+    // sites were already added to GOCDB4, the LAST AddedDate does NOT
+    // necessarily correspond with the date of the CURRENT certification status.
+    // Rather, the date of the CURRENT certStatus in v4 is recorded as
+    // a link/linkType object using the dateOn property.
     foreach($xmlCertStatusChanges as $xmlCertStatusChange){
-       $targetSiteName = (string) $xmlCertStatusChange->SITE; 
-       // only interested in the current site 
+       $targetSiteName = (string) $xmlCertStatusChange->SITE;
+       // only interested in the current site
        if($targetSiteName == $doctrineSite->getShortName()){
-           $doctrineCertStatusChangeLog = new \CertificationStatusLog(); 
-           $doctrineCertStatusChangeLog->setAddedBy((string) $xmlCertStatusChange->CHANGED_BY);  
-           $doctrineCertStatusChangeLog->setOldStatus((string) $xmlCertStatusChange->OLD_STATUS); 
-           $doctrineCertStatusChangeLog->setNewStatus((string) $xmlCertStatusChange->NEW_STATUS); 
-           $doctrineCertStatusChangeLog->setReason((string) $xmlCertStatusChange->COMMENT); 
+           $doctrineCertStatusChangeLog = new \CertificationStatusLog();
+           $doctrineCertStatusChangeLog->setAddedBy((string) $xmlCertStatusChange->CHANGED_BY);
+           $doctrineCertStatusChangeLog->setOldStatus((string) $xmlCertStatusChange->OLD_STATUS);
+           $doctrineCertStatusChangeLog->setNewStatus((string) $xmlCertStatusChange->NEW_STATUS);
+           $doctrineCertStatusChangeLog->setReason((string) $xmlCertStatusChange->COMMENT);
            $insertDate = new DateTime("@" . (string) $xmlCertStatusChange->UNIX_TIME);
-           $doctrineCertStatusChangeLog->setAddedDate($insertDate); 
+           $doctrineCertStatusChangeLog->setAddedDate($insertDate);
            $entityManager->persist($doctrineCertStatusChangeLog);
            $doctrineSite->addCertificationStatusLog($doctrineCertStatusChangeLog);
        }
     }
-    
+
     $entityManager->persist($doctrineSite);
 
 }

--- a/lib/Doctrine/deploy/AddTimezones.php
+++ b/lib/Doctrine/deploy/AddTimezones.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @deprecated since version v5.4 
+ * @deprecated since version v5.4
  */
 require_once __DIR__."/../bootstrap.php";
 require_once __DIR__."/AddUtils.php";

--- a/lib/Doctrine/deploy/AddUsers.php
+++ b/lib/Doctrine/deploy/AddUsers.php
@@ -2,7 +2,7 @@
 
 require_once __DIR__."/../bootstrap.php";
 require_once __DIR__."/AddUtils.php";
-        
+
 $usersRolesFileName = __DIR__ . "/" . $GLOBALS['dataDir'] . "/UsersAndRoles.xml";
 $usersRoles = simplexml_load_file($usersRolesFileName);
 // Used to check for duplicates
@@ -46,7 +46,7 @@ foreach($usersRoles as $user) {
     $doctrineUser->setCertificateDn($dn);
     $doctrineUser->setAdmin(false);
 //  echo "DN is " . (string) $doctrineUser->getCertificateDn() . ".\r\n";
-    
+
     // Roughly half of users don't have a home site set
     if($user->HOMESITE != "" &&  !isBad($user->HOMESITE)) {
         // get the home site entity
@@ -66,12 +66,12 @@ foreach($usersRoles as $user) {
         }
         $doctrineUser->setHomeSiteDoJoin($homeSite);
     }
-    
+
     //Make Dave an admin
     if ($doctrineUser->getCertificateDn()=="/C=UK/O=eScience/OU=CLRC/L=DL/CN=david meredith"){
         $doctrineUser->setAdmin(true);
     }
-    
+
     $entityManager->persist($doctrineUser);
 
 }

--- a/lib/Doctrine/deploy/AddUtils.php
+++ b/lib/Doctrine/deploy/AddUtils.php
@@ -20,8 +20,8 @@ function findSEs($hostName, $serviceType) {
 function isBad($site) {
     /* Roles over these sites are in the production data but can't be inserted
      * into v5 because they don't have an NGI or a domain. v5 doesn't import sites without an NGI
-     * or domain   
-     * 
+     * or domain
+     *
      * Sites ignored becuase of no parent NGI:
      * Australia-UNIMELB-LCG2, GUP-JKU,UNIBAS, FZK-PPS, MA-01-CNRST,  All sites under
      * ROC_IGALC which was closed Apr-2013, all NGI_IE sites closed Jul-2013.
@@ -35,9 +35,9 @@ function isBad($site) {
             , 'MA-01-CNRST', 'EELA-UC', 'CEFET-RJ', 'CMM-UChile', 'CPTEC-INPE'
             , 'CUBAENERGIA', 'EPN', 'FING', 'GRID-CEDIA', 'GRyDs-USB'
             , 'INCOR-HCFMUSP', 'UFCG-LSD', 'UIS-BUCARAMANGA',   'UTP-PANAMA', 'ITWM-PPS' , 'HU-BERLIN', 'SCAI-PPS'
-            , 'FZK-SC', 'FZK-Test', 'FZK-Test', 'GRIDOPS-GRIDVIEW', 'GSI-LCG2-PPS' 
-            // next lot is from NGI_IE which was deleted. 
-            , 'csTCDie', 'mpUCDie', 'giNUIMie', 'cpDIASie', 'csQUBuk', 'csUCCie' 
+            , 'FZK-SC', 'FZK-Test', 'FZK-Test', 'GRIDOPS-GRIDVIEW', 'GSI-LCG2-PPS'
+            // next lot is from NGI_IE which was deleted.
+            , 'csTCDie', 'mpUCDie', 'giNUIMie', 'cpDIASie', 'csQUBuk', 'csUCCie'
             , 'scgNUIGie', 'giITTAie', 'obsARMuk', 'giHECie', 'giRCSIie'
             , 'giDCUie');
 

--- a/lib/Doctrine/deploy/DeployRequiredDataRunner.php
+++ b/lib/Doctrine/deploy/DeployRequiredDataRunner.php
@@ -21,25 +21,25 @@ if(isset($argv[1])) {
     die("Please specify your data directory (requiredData) \n");
 }
 
-print_r("Deploying Required Lookup Data\n"); 
+print_r("Deploying Required Lookup Data\n");
 
-require __DIR__."/AddInfrastructures.php"; 
-echo "Added Infrastructures OK\n"; 
+require __DIR__."/AddInfrastructures.php";
+echo "Added Infrastructures OK\n";
 
-require __DIR__."/AddCountries.php"; 
-echo "Added Countries OK\n"; 
+require __DIR__."/AddCountries.php";
+echo "Added Countries OK\n";
 
-//require __DIR__."/AddTimezones.php"; 
-//echo "Added Timezones OK\n"; 
+//require __DIR__."/AddTimezones.php";
+//echo "Added Timezones OK\n";
 
-require __DIR__."/AddTiers.php"; 
-echo "Added Tiers OK\n"; 
+require __DIR__."/AddTiers.php";
+echo "Added Tiers OK\n";
 
-require __DIR__."/AddRoleTypes.php"; 
-echo "Added Roles OK\n"; 
+require __DIR__."/AddRoleTypes.php";
+echo "Added Roles OK\n";
 
-require __DIR__."/AddCertificationStatuses.php"; 
-echo "Added Certification Statuses OK\n"; 
+require __DIR__."/AddCertificationStatuses.php";
+echo "Added Certification Statuses OK\n";
 
-require __DIR__."/AddServiceTypes.php"; 
-echo "Added Service Types OK\n"; 
+require __DIR__."/AddServiceTypes.php";
+echo "Added Service Types OK\n";

--- a/lib/Doctrine/deploy/DeploySampleDataRunner.php
+++ b/lib/Doctrine/deploy/DeploySampleDataRunner.php
@@ -22,31 +22,31 @@ if(isset($argv[1])) {
     die("Please specify your data directory (sampleData) \n");
 }
 
-print_r("Deploying Sample Data\n"); 
+print_r("Deploying Sample Data\n");
 
-require __DIR__."/AddProjects.php"; 
-echo "Added Projects OK\n"; 
+require __DIR__."/AddProjects.php";
+echo "Added Projects OK\n";
 
-require __DIR__."/AddScopes.php"; 
-echo "Added Scopes OK\n"; 
+require __DIR__."/AddScopes.php";
+echo "Added Scopes OK\n";
 
-require __DIR__."/AddNGIs.php"; 
-echo "Added NGIs OK\n"; 
+require __DIR__."/AddNGIs.php";
+echo "Added NGIs OK\n";
 
-require __DIR__."/AddSites.php"; 
-echo "Added Sites and JOINED to NGIs OK\n"; 
+require __DIR__."/AddSites.php";
+echo "Added Sites and JOINED to NGIs OK\n";
 
-require __DIR__."/AddServiceEndpoints.php"; 
-echo "Added Services, EndpointLocations and JOINED associations OK\n"; 
+require __DIR__."/AddServiceEndpoints.php";
+echo "Added Services, EndpointLocations and JOINED associations OK\n";
 
-require __DIR__."/AddUsers.php"; 
-echo "Added Users OK\n"; 
+require __DIR__."/AddUsers.php";
+echo "Added Users OK\n";
 
-require __DIR__."/AddSiteRoles.php"; 
-echo "Added Site level Roles OK\n"; 
+require __DIR__."/AddSiteRoles.php";
+echo "Added Site level Roles OK\n";
 
-require __DIR__."/AddGroupRoles.php"; 
-echo "Added NGI level Roles OK\n"; 
+require __DIR__."/AddGroupRoles.php";
+echo "Added NGI level Roles OK\n";
 
-require __DIR__."/AddEgiRoles.php"; 
-echo "Added EGI level Roles OK\n"; 
+require __DIR__."/AddEgiRoles.php";
+echo "Added EGI level Roles OK\n";

--- a/lib/Doctrine/entities/AlreadyLinkedException.php
+++ b/lib/Doctrine/entities/AlreadyLinkedException.php
@@ -14,10 +14,10 @@
 
 
 /**
- * Thrown when a downtime is already linked to a service. 
- * @author John Casson  
- * @author David Meredith <david.meredith@stfc.ac.uk> 
+ * Thrown when a downtime is already linked to a service.
+ * @author John Casson
+ * @author David Meredith <david.meredith@stfc.ac.uk>
  */
 class AlreadyLinkedException extends Exception {
-    
+
 }

--- a/lib/Doctrine/entities/ArchivedNGI.php
+++ b/lib/Doctrine/entities/ArchivedNGI.php
@@ -14,71 +14,71 @@
 
 /**
  * Keeps a record of deleted NGIs and some information about the deletion.
- * This is a standalone table that has no relationships which is needed 
- * to allow these records to persist even when the target {@see NGI} is deleted. 
+ * This is a standalone table that has no relationships which is needed
+ * to allow these records to persist even when the target {@see NGI} is deleted.
  *
  * @author George Ryall
- * @author David Meredith <david.meredith@stfc.ac.uk> 
+ * @author David Meredith <david.meredith@stfc.ac.uk>
  * @Entity @Table(name="ArchivedNGIs")
  */
 class ArchivedNGI {
-   
+
     /** @Id @Column(type="integer") @GeneratedValue **/
     protected $id;
 
     /*
-     * Note, we define the entity attributes as simple types rather than linking 
-     * to related entities because we need to record a history/log, including 
+     * Note, we define the entity attributes as simple types rather than linking
+     * to related entities because we need to record a history/log, including
      * recordig information on entitites that may be deleted.  For exammple parent
-     * project is stored as a string of the name. These record the name of 
+     * project is stored as a string of the name. These record the name of
      * that entityu on the day the service group was delted. Similary, we record
      * the user's DN rather than linking to the User object as that User may be
-     * deleted in future.  
+     * deleted in future.
      */
-    
+
     /**
-     * ID/DN of deleting user 
-     * @Column(type="string", nullable=false) 
+     * ID/DN of deleting user
+     * @Column(type="string", nullable=false)
      */
-    protected $deletedBy; 
- 
+    protected $deletedBy;
+
     /* DATETIME NOTE:
      * Doctrine checks whether a date's been updated by doing a byreference comparison.
      * If you just update an existing DateTime object, Doctrine won't persist it!
      * Create a new DateTime object and reference that for it to persist during an update.
      * http://docs.doctrine-project.org/en/2.0.x/cookbook/working-with-datetime.html
      */
-    
-    /** 
-     * @Column(type="datetime", nullable=false) 
-     */
-    protected $deletedDate; 
 
     /**
-     * Name of NGI 
-     * @Column(type="string", nullable=false) 
+     * @Column(type="datetime", nullable=false)
      */
-    protected $name; 
-    
+    protected $deletedDate;
+
+    /**
+     * Name of NGI
+     * @Column(type="string", nullable=false)
+     */
+    protected $name;
+
     /**
      * Scopes applied to the NGI at the time it was deleted
-     * @Column(type="string", nullable=true) 
+     * @Column(type="string", nullable=true)
      */
     protected $scopes = null;
-    
+
     /**
      * Name of parent projects
-     * @Column(type="string", nullable=true) 
+     * @Column(type="string", nullable=true)
      */
     protected $parentProjects = null;
-    
-    /** 
-     * @Column(type="datetime", nullable=false) 
+
+    /**
+     * @Column(type="datetime", nullable=false)
      */
-    protected $originalCreationDate; 
+    protected $originalCreationDate;
 
     public function __construct() {
-        $this->deletedDate =  new \DateTime(null, new \DateTimeZone('UTC')); 
+        $this->deletedDate =  new \DateTime(null, new \DateTimeZone('UTC'));
     }
 
     /**
@@ -89,15 +89,15 @@ class ArchivedNGI {
     }
 
     /**
-     * ID/DN of deleting user.  
-     * @return String 
+     * ID/DN of deleting user.
+     * @return String
      */
     public function getDeletedBy() {
         return $this->deletedBy;
     }
 
     /**
-     * The UTC DateTime when the target NGI was deleted. 
+     * The UTC DateTime when the target NGI was deleted.
      * @return \DateTime
      */
     public function getDeletedDate() {
@@ -105,7 +105,7 @@ class ArchivedNGI {
     }
 
     /**
-     * Name of deleted NGI. 
+     * Name of deleted NGI.
      * @return String
      */
     public function getName() {
@@ -113,7 +113,7 @@ class ArchivedNGI {
     }
 
     /**
-     * Comma separated list of scope names applied to the NGI at the time it was deleted. 
+     * Comma separated list of scope names applied to the NGI at the time it was deleted.
      * @return String or null
      */
     public function getScopes() {
@@ -121,23 +121,23 @@ class ArchivedNGI {
     }
 
     /**
-     * Name of parent projects at the time it was deleted. 
-     * @return string or null  
+     * Name of parent projects at the time it was deleted.
+     * @return string or null
      */
     public function getParentProjects() {
         return $this->parentProjects;
     }
 
     /**
-     * The DateTime when the NGI was originally created. 
-     * @return \DateTime 
+     * The DateTime when the NGI was originally created.
+     * @return \DateTime
      */
     public function getOriginalCreationDate() {
         return $this->originalCreationDate;
     }
 
     /**
-     * The ID/DN of the deleting user. Required. 
+     * The ID/DN of the deleting user. Required.
      * @param string $deletedBy
      */
     public function setDeletedBy($deletedBy) {
@@ -145,7 +145,7 @@ class ArchivedNGI {
     }
 
     /**
-     * The name of the deleted NGI. Required. 
+     * The name of the deleted NGI. Required.
      * @param string $name
      */
     public function setName($name) {
@@ -153,8 +153,8 @@ class ArchivedNGI {
     }
 
     /**
-     * Comma separated list of scope names that were applied to the NGI at the 
-     * time it was deleted or null. 
+     * Comma separated list of scope names that were applied to the NGI at the
+     * time it was deleted or null.
      * @param string $scopesOnDeletion
      */
     public function setScopes($scopesOnDeletion) {
@@ -162,7 +162,7 @@ class ArchivedNGI {
     }
 
     /**
-     * Comma separated list of project names that the NGI belonged to. 
+     * Comma separated list of project names that the NGI belonged to.
      * @param type $parentProject
      */
     public function setParentProjects($parentProject) {
@@ -170,7 +170,7 @@ class ArchivedNGI {
     }
 
     /**
-     * Set the DateTime when this NGI was originally created. Required.  
+     * Set the DateTime when this NGI was originally created. Required.
      * @param \DateTime $originalCreationDate
      */
     public function setOriginalCreationDate($originalCreationDate) {

--- a/lib/Doctrine/entities/ArchivedService.php
+++ b/lib/Doctrine/entities/ArchivedService.php
@@ -14,7 +14,7 @@
 
 /**
  * Keeps a record of deleted services and some information about the deletion.
- * This is a standalone table that has no relationships, therefore these records 
+ * This is a standalone table that has no relationships, therefore these records
  * will persist even when an {@see Service} is deleted.
  *
  * @author George Ryall
@@ -22,83 +22,83 @@
  * @Entity @Table(name="ArchivedServices")
  */
 class ArchivedService {
-   
+
     /** @Id @Column(type="integer") @GeneratedValue **/
     protected $id;
 
     /*
-     * Note, we define the entity attributes as simple types rather than linking 
-     * to related entities because we need to record a history/log, including 
-     * recordig information on entitites that may be deleted. For example the 
-     * parents site is stored as a string containing the sitres name These record the 
+     * Note, we define the entity attributes as simple types rather than linking
+     * to related entities because we need to record a history/log, including
+     * recordig information on entitites that may be deleted. For example the
+     * parents site is stored as a string containing the sitres name These record the
      * name of that entity on the day the service was delted. Similary, we
-     * record the user's DN rather than linking to the User object as that User 
-     * may be deleted in future.  
+     * record the user's DN rather than linking to the User object as that User
+     * may be deleted in future.
      */
-    
+
     /**
-     * DN of deleting user 
-     * @Column(type="string", nullable=false) 
+     * DN of deleting user
+     * @Column(type="string", nullable=false)
      */
-    protected $deletedBy; 
- 
+    protected $deletedBy;
+
     /* DATETIME NOTE:
      * Doctrine checks whether a date's been updated by doing a byreference comparison.
      * If you just update an existing DateTime object, Doctrine won't persist it!
      * Create a new DateTime object and reference that for it to persist during an update.
      * http://docs.doctrine-project.org/en/2.0.x/cookbook/working-with-datetime.html
      */
-    
-    /** 
-     * @Column(type="datetime", nullable=false) 
+
+    /**
+     * @Column(type="datetime", nullable=false)
      */
-    protected $deletedDate; 
+    protected $deletedDate;
 
     /**
      * Name of Service  (not unique - only servicetype/hostname will be
-     * @Column(type="string", nullable=false) 
+     * @Column(type="string", nullable=false)
      */
-    protected $hostName; 
-    
+    protected $hostName;
+
     /**
      * service type of service
-     * @Column(type="string", nullable=false) 
+     * @Column(type="string", nullable=false)
      */
-    protected $serviceType; 
-    
+    protected $serviceType;
+
     /**
      * Scopes applied to the service group at the time it was deleted
      * @Column(type="string", nullable=true) */
     protected $scopes = null;
-    
+
     /**
      * Name of parent site when it was deleted.
      * @Column(type="string", nullable=true) */
     protected $parentSite = null;
-    
+
     /**
      * Was service monitored at the time it was deleted
      * @Column(type="boolean", nullable=true) */
     protected $monitored = null;
-    
+
     /**
      * Was the service beta when it was deleted
      * @Column(type="boolean", nullable=true) */
     protected $beta = null;
-    
+
     /**
      * Was the service production status when it was deleted
      * @Column(type="boolean", nullable=true) */
     protected $production = null;
-    
-    
+
+
     /** @Column(type="datetime", nullable=false) **/
-    protected $originalCreationDate; 
+    protected $originalCreationDate;
 
     public function __construct() {
-        $this->deletedDate =  new \DateTime(null, new \DateTimeZone('UTC')); 
+        $this->deletedDate =  new \DateTime(null, new \DateTimeZone('UTC'));
     }
-   
+
     /**
      * @return int The PK of this entity or null if not persisted
      */
@@ -107,15 +107,15 @@ class ArchivedService {
     }
 
     /**
-     * ID/DN of deleting user.  
-     * @return String 
+     * ID/DN of deleting user.
+     * @return String
      */
     public function getDeletedBy() {
         return $this->deletedBy;
     }
 
     /**
-     * The UTC DateTime when the target Service was deleted. 
+     * The UTC DateTime when the target Service was deleted.
      * @return \DateTime
      */
     public function getDeletedDate() {
@@ -123,7 +123,7 @@ class ArchivedService {
     }
 
     /**
-     * Service host name. 
+     * Service host name.
      * @return string
      */
     public function getHostName() {
@@ -131,7 +131,7 @@ class ArchivedService {
     }
 
     /**
-     * Comma separated list of scope names applied to the service at the time it was deleted. 
+     * Comma separated list of scope names applied to the service at the time it was deleted.
      * @return String or null
      */
     public function getScopes() {
@@ -139,39 +139,39 @@ class ArchivedService {
     }
 
     /**
-     * The name of the site that owned this service. 
-     * @return string or null 
+     * The name of the site that owned this service.
+     * @return string or null
      */
     public function getParentSite() {
         return $this->parentSite;
     }
 
     /**
-     * The DateTime when the Service was originally created.  
-     * @return \DateTime 
+     * The DateTime when the Service was originally created.
+     * @return \DateTime
      */
     public function getOriginalCreationDate() {
         return $this->originalCreationDate;
     }
-   
+
     /**
-     * Was this service monitored. 
-     * @return boolean or null 
+     * Was this service monitored.
+     * @return boolean or null
      */
     public function getMonitored() {
         return $this->monitored;
     }
 
     /**
-     * Was this a beta service. 
-     * @return boolean or null 
+     * Was this a beta service.
+     * @return boolean or null
      */
     public function getBeta() {
         return $this->beta;
     }
 
     /**
-     * Was this a production service. 
+     * Was this a production service.
      * @return boolean or null
      */
     public function getProduction() {
@@ -179,15 +179,15 @@ class ArchivedService {
     }
 
     /**
-     * Get the name of the service type. 
-     * @return string 
+     * Get the name of the service type.
+     * @return string
      */
     public function getServiceType() {
         return $this->serviceType;
     }
 
     /**
-     * ID/DN of deleting user. Required. 
+     * ID/DN of deleting user. Required.
      * @param string $deletedBy
      */
     public function setDeletedBy($deletedBy) {
@@ -195,7 +195,7 @@ class ArchivedService {
     }
 
     /**
-     * Host name of service. Required. 
+     * Host name of service. Required.
      * @param string $hostName
      */
     public function setHostName($hostName) {
@@ -204,7 +204,7 @@ class ArchivedService {
 
     /**
      * Comma separated list of scope names which applied to the servcie before
-     * it was deleted. 
+     * it was deleted.
      * @param string $scopes
      */
     public function setScopes($scopes) {
@@ -212,7 +212,7 @@ class ArchivedService {
     }
 
     /**
-     * Name of owning parent site. 
+     * Name of owning parent site.
      * @param string $parentSite
      */
     public function setParentSite($parentSite) {
@@ -220,7 +220,7 @@ class ArchivedService {
     }
 
     /**
-     * Date time when the service was created. Required. 
+     * Date time when the service was created. Required.
      * @param \DateTime $originalCreationDate
      */
     public function setOriginalCreationDate($originalCreationDate) {
@@ -228,7 +228,7 @@ class ArchivedService {
     }
 
     /**
-     * Was this service monitored. 
+     * Was this service monitored.
      * @param boolean $monitored
      */
     public function setMonitored($monitored) {
@@ -236,7 +236,7 @@ class ArchivedService {
     }
 
     /**
-     * Was this service beta. 
+     * Was this service beta.
      * @param boolean $beta
      */
     public function setBeta($beta) {
@@ -244,15 +244,15 @@ class ArchivedService {
     }
 
     /**
-     * Was this service production. 
+     * Was this service production.
      * @param boolean $production
      */
     public function setProduction($production) {
         $this->production = $production;
     }
-   
+
     /**
-     * Service type of service. Required. 
+     * Service type of service. Required.
      * @param string $serviceType
      */
     public function setServiceType($serviceType) {

--- a/lib/Doctrine/entities/ArchivedServiceGroup.php
+++ b/lib/Doctrine/entities/ArchivedServiceGroup.php
@@ -13,66 +13,66 @@
  */
 
 /**
- * Keeps a record of deleted {@see ServiceGroup}s and some information about the 
- * deletion.  This is a standalone table that has no relationships, therefore 
+ * Keeps a record of deleted {@see ServiceGroup}s and some information about the
+ * deletion.  This is a standalone table that has no relationships, therefore
  * these records will persist even when the ServiceGroup is deleted.
  *
  * @author George Ryall
- * @author David Meredith <david.meredith@stfc.ac.uk> 
+ * @author David Meredith <david.meredith@stfc.ac.uk>
  * @Entity @Table(name="ArchivedServiceGroups")
  */
 class ArchivedServiceGroup {
-   
+
     /** @Id @Column(type="integer") @GeneratedValue **/
     protected $id;
 
     /*
-     * Note, we define the entity attributes as simple types rather than linking 
-     * to related entities because we need to record a history/log, including 
-     * recordig information on entitites that may be deleted.  
-     * For exammple child services are simple strings. These record the name of 
+     * Note, we define the entity attributes as simple types rather than linking
+     * to related entities because we need to record a history/log, including
+     * recordig information on entitites that may be deleted.
+     * For exammple child services are simple strings. These record the name of
      * that entityu on the day the service group was delted. Similary, we record
      * the user's DN rather than linking to the User object as that User may be
-     *  deleted in future.  
+     *  deleted in future.
      */
-    
+
     /**
-     * DN of deleting user 
+     * DN of deleting user
      * @Column(type="string", nullable=false) */
-    protected $deletedBy; 
- 
+    protected $deletedBy;
+
     /* DATETIME NOTE:
      * Doctrine checks whether a date's been updated by doing a byreference comparison.
      * If you just update an existing DateTime object, Doctrine won't persist it!
      * Create a new DateTime object and reference that for it to persist during an update.
      * http://docs.doctrine-project.org/en/2.0.x/cookbook/working-with-datetime.html
      */
-    
+
     /** @Column(type="datetime", nullable=false) **/
-    protected $deletedDate; 
+    protected $deletedDate;
 
     /**
-     * Name of Service group 
+     * Name of Service group
      * @Column(type="string", nullable=false) */
-    protected $name; 
-    
+    protected $name;
+
     /**
      * Scopes applied to the service group at the time it was deleted
      * @Column(type="string", nullable=true) */
     protected $scopes = null;
-    
+
     /**
      * services in service group when it was deleted. stored as CSV string of hostName/service type
      * @Column(type="string", length=500, nullable=true) */
     protected $services = null;
-    
+
     /** @Column(type="datetime", nullable=false) **/
-    protected $originalCreationDate; 
+    protected $originalCreationDate;
 
     public function __construct() {
-        $this->deletedDate =  new \DateTime(null, new \DateTimeZone('UTC')); 
+        $this->deletedDate =  new \DateTime(null, new \DateTimeZone('UTC'));
     }
-   
+
     /**
      * @return int The PK of this entity or null if not persisted
      */
@@ -81,15 +81,15 @@ class ArchivedServiceGroup {
     }
 
     /**
-     * ID/DN of deleting user.  
-     * @return String 
+     * ID/DN of deleting user.
+     * @return String
      */
     public function getDeletedBy() {
         return $this->deletedBy;
     }
 
     /**
-     * The UTC DateTime when the target ServiceGroup was deleted. 
+     * The UTC DateTime when the target ServiceGroup was deleted.
      * @return \DateTime
      */
     public function getDeletedDate() {
@@ -97,15 +97,15 @@ class ArchivedServiceGroup {
     }
 
     /**
-     * Name of the deleted service group. 
-     * @return string 
+     * Name of the deleted service group.
+     * @return string
      */
     public function getName() {
         return $this->name;
     }
 
     /**
-     * Comma separated list of scope names applied to the SG at the time it was deleted. 
+     * Comma separated list of scope names applied to the SG at the time it was deleted.
      * @return String or null
      */
     public function getScopes() {
@@ -113,24 +113,24 @@ class ArchivedServiceGroup {
     }
 
     /**
-     * Date time when the ServiceGroup was originally created.  
+     * Date time when the ServiceGroup was originally created.
      * @return \DateTime
      */
     public function getOriginalCreationDate() {
         return $this->originalCreationDate;
     }
-   
+
     /**
-     * Service names belonging to the ServiceGroup. 
-     * Stored as CSV string of 'hostName(serviceType)' values.  
-     * @return string or null 
+     * Service names belonging to the ServiceGroup.
+     * Stored as CSV string of 'hostName(serviceType)' values.
+     * @return string or null
      */
     public function getServices() {
         return $this->services;
     }
 
     /**
-     * The ID/DN of the user who deleted the ServiceGroup. Required. 
+     * The ID/DN of the user who deleted the ServiceGroup. Required.
      * @param string $deletedBy
      */
     public function setDeletedBy($deletedBy) {
@@ -138,7 +138,7 @@ class ArchivedServiceGroup {
     }
 
     /**
-     * The name of the ServiceGroup. Required. 
+     * The name of the ServiceGroup. Required.
      * @param string $name
      */
     public function setName($name) {
@@ -146,7 +146,7 @@ class ArchivedServiceGroup {
     }
 
     /**
-     * Scopes applied to the service group at the time it was deleted.  
+     * Scopes applied to the service group at the time it was deleted.
      * @param string $scopesOnDeletion
      */
     public function setScopes($scopesOnDeletion) {
@@ -154,16 +154,16 @@ class ArchivedServiceGroup {
     }
 
     /**
-     * The DateTime when the ServiceGroup was originally created. Required. 
+     * The DateTime when the ServiceGroup was originally created. Required.
      * @param \DateTime $originalCreationDate
      */
     public function setOriginalCreationDate($originalCreationDate) {
         $this->originalCreationDate = $originalCreationDate;
     }
-  
+
     /**
-     * Names of Services in the SG. 
-     * Stored as CSV string of 'hostName(serviceType)' values. 
+     * Names of Services in the SG.
+     * Stored as CSV string of 'hostName(serviceType)' values.
      * @param string $services
      */
     public function setServices($services) {

--- a/lib/Doctrine/entities/ArchivedSite.php
+++ b/lib/Doctrine/entities/ArchivedSite.php
@@ -13,128 +13,128 @@
  */
 
 /**
- * Keeps a record of deleted Sites and selected information about the deletion 
- * and deleted {@see Site}. This is a standalone table that has no relationships, 
+ * Keeps a record of deleted Sites and selected information about the deletion
+ * and deleted {@see Site}. This is a standalone table that has no relationships,
  * therefore these records will persist even when the Site is deleted.
  *
  * @author George Ryall
- * @author David Meredith <david.meredith@stfc.ac.uk>  
+ * @author David Meredith <david.meredith@stfc.ac.uk>
  * @Entity @Table(name="ArchivedSites")
  */
 class ArchivedSite {
-   
+
     /** @Id @Column(type="integer") @GeneratedValue **/
     protected $id;
 
     /*
-     * Note, we record various site attributes and information about the Site's 
-     * relations as simple types (e.g. recording the country value as a string). 
-     *  
-     * We can't link ArchivedSite to 'live' entities (e.g. linking AchivedSite to Country) 
-     * because we need to record a snapshot of historical information at the 
-     * point of deletion (while the live data is subject to change/deletion). 
-     * 
-     * For example, we don't want to link ArchivedSite to the 'Country' entity 
-     * because the Country entity may be deleted in the future. 
-     *  
-     * This is why we record the name name of the parent NGI rather than its id. 
-     * Similary, we record the user's DN rather than linking to the User object as 
-     * that User may be deleted in future.  
+     * Note, we record various site attributes and information about the Site's
+     * relations as simple types (e.g. recording the country value as a string).
+     *
+     * We can't link ArchivedSite to 'live' entities (e.g. linking AchivedSite to Country)
+     * because we need to record a snapshot of historical information at the
+     * point of deletion (while the live data is subject to change/deletion).
+     *
+     * For example, we don't want to link ArchivedSite to the 'Country' entity
+     * because the Country entity may be deleted in the future.
+     *
+     * This is why we record the name name of the parent NGI rather than its id.
+     * Similary, we record the user's DN rather than linking to the User object as
+     * that User may be deleted in future.
      */
-    
+
     /**
-     * DN of deleting user 
+     * DN of deleting user
      * @Column(type="string", nullable=false) */
-    protected $deletedBy; 
- 
+    protected $deletedBy;
+
     /* DATETIME NOTE:
      * Doctrine checks whether a date's been updated by doing a byreference comparison.
      * If you just update an existing DateTime object, Doctrine won't persist it!
      * Create a new DateTime object and reference that for it to persist during an update.
      * http://docs.doctrine-project.org/en/2.0.x/cookbook/working-with-datetime.html
      */
-    
-    /** 
-     * @Column(type="datetime", nullable=false) 
-     */
-    protected $deletedDate; 
 
     /**
-     * Name of Site 
-     * @Column(type="string", nullable=false) 
+     * @Column(type="datetime", nullable=false)
      */
-    protected $name; 
-    
+    protected $deletedDate;
+
+    /**
+     * Name of Site
+     * @Column(type="string", nullable=false)
+     */
+    protected $name;
+
     /**
      * Scopes applied to the NGI at the time it was deleted
-     * @Column(type="string", nullable=true) 
+     * @Column(type="string", nullable=true)
      */
     protected $scopes = null;
-    
+
     /**
      * Certification status value of the site at the time it was deleted
-     * @Column(type="string", nullable=true) 
+     * @Column(type="string", nullable=true)
      */
     protected $CertStatus = null;
-    
+
     /**
      * Version 4 'Primary Key'
-     * @Column(type="string", nullable=true) 
+     * @Column(type="string", nullable=true)
      */
     protected $V4PrimaryKey = null;
-    
+
     /**
      * Country on deletion
-     * @Column(type="string", nullable=true) 
+     * @Column(type="string", nullable=true)
      */
     protected $Country = null;
-    
+
     /**
      * Name of parent NGI
-     * @Column(type="string", nullable=true) 
+     * @Column(type="string", nullable=true)
      */
     protected $parentNgi = null;
-    
+
     /**
      * Infrastructure value (i.e. Production status value) at point of deletion
-     * @Column(type="string", nullable=true) 
+     * @Column(type="string", nullable=true)
      */
     protected $Infrastructure = null;
-    
-    /** 
-     * @Column(type="datetime", nullable=false) 
+
+    /**
+     * @Column(type="datetime", nullable=false)
      */
-    protected $originalCreationDate; 
+    protected $originalCreationDate;
 
     public function __construct() {
-        $this->deletedDate =  new \DateTime(null, new \DateTimeZone('UTC')); 
+        $this->deletedDate =  new \DateTime(null, new \DateTimeZone('UTC'));
     }
-   
+
     /**
-     * @return int The PK of this entity or null if not persisted. 
+     * @return int The PK of this entity or null if not persisted.
      */
     public function getId() {
         return $this->id;
     }
 
     /**
-     * ID/DN of deleting user.  
-     * @return String 
+     * ID/DN of deleting user.
+     * @return String
      */
     public function getDeletedBy() {
         return $this->deletedBy;
     }
 
     /**
-     * The Date Time the site was deleted. 
-     * @return \DateTime 
+     * The Date Time the site was deleted.
+     * @return \DateTime
      */
     public function getDeletedDate() {
         return $this->deletedDate;
     }
 
     /**
-     * The name of the site.  
+     * The name of the site.
      * @return string
      */
     public function getName() {
@@ -142,7 +142,7 @@ class ArchivedSite {
     }
 
     /**
-     * Comma separated list of scope names applied to the SG at the time it was deleted. 
+     * Comma separated list of scope names applied to the SG at the time it was deleted.
      * @return String or null
      */
     public function getScopes() {
@@ -150,23 +150,23 @@ class ArchivedSite {
     }
 
     /**
-     * The Certification status of the site when it was deleted, e.g. 'Uncertified' 
-     * @return string or null 
+     * The Certification status of the site when it was deleted, e.g. 'Uncertified'
+     * @return string or null
      */
     public function getCertStatus() {
         return $this->CertStatus;
     }
 
     /**
-     * The legacy v4 PK string of the deleted site.  
-     * @return string or null 
+     * The legacy v4 PK string of the deleted site.
+     * @return string or null
      */
     public function getV4PrimaryKey() {
         return $this->V4PrimaryKey;
     }
 
     /**
-     * The country code for the deleted site. 
+     * The country code for the deleted site.
      * @return string or null
      */
     public function getCountry() {
@@ -174,7 +174,7 @@ class ArchivedSite {
     }
 
     /**
-     * The name of the owning parent NGI. 
+     * The name of the owning parent NGI.
      * @return string or null
      */
     public function getParentNgi() {
@@ -182,23 +182,23 @@ class ArchivedSite {
     }
 
     /**
-     * The date time when site was originally created.  
+     * The date time when site was originally created.
      * @return \DateTime
      */
     public function getOriginalCreationDate() {
         return $this->originalCreationDate;
     }
-   
+
     /**
      * The infrastructure of the Site.
-     * @return string or null 
+     * @return string or null
      */
     public function getInfrastructure() {
         return $this->Infrastructure;
     }
 
     /**
-     * The DN/ID of the user who deleted the site. Required. 
+     * The DN/ID of the user who deleted the site. Required.
      * @param string $deletedBy
      */
     public function setDeletedBy($deletedBy) {
@@ -206,7 +206,7 @@ class ArchivedSite {
     }
 
     /**
-     * The name of the deleted site. Required. 
+     * The name of the deleted site. Required.
      * @param string $name
      */
     public function setName($name) {
@@ -214,7 +214,7 @@ class ArchivedSite {
     }
 
     /**
-     * Scopes applied to the site at the time it was deleted.  
+     * Scopes applied to the site at the time it was deleted.
      * @param string $scopesOnDeletion
      */
     public function setScopes($scopesOnDeletion) {
@@ -222,7 +222,7 @@ class ArchivedSite {
     }
 
     /**
-     * The certification status of the site when it was deleted, e.g. 'Uncertified'. 
+     * The certification status of the site when it was deleted, e.g. 'Uncertified'.
      * @param string $CertStatus
      */
     public function setCertStatus($CertStatus) {
@@ -230,7 +230,7 @@ class ArchivedSite {
     }
 
     /**
-     * The legacy v4 GOCDB PK string. 
+     * The legacy v4 GOCDB PK string.
      * @param string $V4PrimaryKey
      */
     public function setV4PrimaryKey($V4PrimaryKey) {
@@ -238,7 +238,7 @@ class ArchivedSite {
     }
 
     /**
-     * The country of the deleted site. 
+     * The country of the deleted site.
      * @param string $Country
      */
     public function setCountry($Country) {
@@ -246,7 +246,7 @@ class ArchivedSite {
     }
 
     /**
-     * The name of the parent NGI. 
+     * The name of the parent NGI.
      * @param string $parentNgi
      */
     public function setParentNgi($parentNgi) {
@@ -254,7 +254,7 @@ class ArchivedSite {
     }
 
     /**
-     * The DateTime when the site was originally created. Required. 
+     * The DateTime when the site was originally created. Required.
      * @param \DateTime $originalCreationDate
      */
     public function setOriginalCreationDate($originalCreationDate) {
@@ -262,7 +262,7 @@ class ArchivedSite {
     }
 
     /**
-     * The infrastructure name of the deleted site. 
+     * The infrastructure name of the deleted site.
      * @param string $Infrastructure
      */
     public function setInfrastructure($Infrastructure) {

--- a/lib/Doctrine/entities/CertificationStatus.php
+++ b/lib/Doctrine/entities/CertificationStatus.php
@@ -15,27 +15,27 @@ use Doctrine\Common\Collections\ArrayCollection;
 
 
 /**
- * Defines a unique value for the certification status of each {@see Site} such as 
- * 'Certified' or 'Suspended'. Each unique cert status record is joined to 
- * the Sites which have that value. When a site CertificationStatus is updated, 
- * the Site is re-joined to another CertificationStatus record.  
- * 
+ * Defines a unique value for the certification status of each {@see Site} such as
+ * 'Certified' or 'Suspended'. Each unique cert status record is joined to
+ * the Sites which have that value. When a site CertificationStatus is updated,
+ * the Site is re-joined to another CertificationStatus record.
+ *
  * @author John Casson
- * @author David Meredith <david.meredith@stfc.ac.uk> 
- * 
+ * @author David Meredith <david.meredith@stfc.ac.uk>
+ *
  * @Entity @Table(name="CertificationStatuses")
  */
 class CertificationStatus {
-    
+
     /** @Id @Column(type="integer") @GeneratedValue **/
     protected $id;
 
     /** @Column(type="string", unique=true) **/
     protected $name;
 
-    /** 
-     * Bidirectional - A single CertStatus (INVERSE ORM SIDE) can be linked to many Sites. 
-     * @OneToMany(targetEntity="Site", mappedBy="certificationStatus") 
+    /**
+     * Bidirectional - A single CertStatus (INVERSE ORM SIDE) can be linked to many Sites.
+     * @OneToMany(targetEntity="Site", mappedBy="certificationStatus")
      */
     protected $sites = null;
 
@@ -51,7 +51,7 @@ class CertificationStatus {
     }
 
     /**
-     * Get the unique certification status value, e.g. 'Certified' or 'Suspended'. 
+     * Get the unique certification status value, e.g. 'Certified' or 'Suspended'.
      * @return string
      */
     public function getName() {
@@ -59,7 +59,7 @@ class CertificationStatus {
     }
 
     /**
-     * Set the unique value of this cert status. Required. 
+     * Set the unique value of this cert status. Required.
      * @param string $name
      */
     public function setName($name) {
@@ -67,7 +67,7 @@ class CertificationStatus {
     }
 
     /**
-     * Fetch all the {@see Site} objects that are linked to this certification status.  
+     * Fetch all the {@see Site} objects that are linked to this certification status.
      * @return Doctrine\Common\Collections\ArrayCollection
      */
     public function getSites() {
@@ -75,9 +75,9 @@ class CertificationStatus {
     }
 
     /**
-     * Add the given Site to this certifcation status sites list. 
+     * Add the given Site to this certifcation status sites list.
      * Note, this method calls the opposite <code>$site->setCertificationStatus($this);</code>
-     * method to establish the join on both sides of the relationship. 
+     * method to establish the join on both sides of the relationship.
      * @param \Site $site
      */
     public function addSiteDoJoin($site) {
@@ -86,8 +86,8 @@ class CertificationStatus {
     }
 
     /**
-     * Return the name of this CertificationStatus record. 
-     * @see CertificationStatus#getName(); 
+     * Return the name of this CertificationStatus record.
+     * @see CertificationStatus#getName();
      * @return string
      */
     public function __toString() {

--- a/lib/Doctrine/entities/CertificationStatusLog.php
+++ b/lib/Doctrine/entities/CertificationStatusLog.php
@@ -14,115 +14,115 @@
 //use Doctrine\Common\Collections\ArrayCollection;
 
 /**
- * Records the site certification status change history. A Site can own many 
- * CertificationStatusLog entities. When the parent site is deleted, the 
- * Site's certStatusLogs are also cascade deleted.   
+ * Records the site certification status change history. A Site can own many
+ * CertificationStatusLog entities. When the parent site is deleted, the
+ * Site's certStatusLogs are also cascade deleted.
  *
- * @author David Meredith <david.meredith@stfc.ac.uk>  
+ * @author David Meredith <david.meredith@stfc.ac.uk>
  * @Entity @Table(name="CertificationStatusLogs")
  */
 class CertificationStatusLog {
-   
+
     /** @Id @Column(type="integer") @GeneratedValue **/
     protected $id;
 
     /**
-     * Bidirectional - Many CertificationStatusLogs (OWNING ORM SIDE) can be linked to one Site. 
-     *   
-     * @ManyToOne(targetEntity="Site", inversedBy="certificationStatusLog") 
+     * Bidirectional - Many CertificationStatusLogs (OWNING ORM SIDE) can be linked to one Site.
+     *
+     * @ManyToOne(targetEntity="Site", inversedBy="certificationStatusLog")
      * @JoinColumn(name="parentSite_id", referencedColumnName="id", onDelete="CASCADE")
      */
-    protected $parentSite = null; 
+    protected $parentSite = null;
 
     /*
-     * Note, we define the entity attributes as simple types rather than linking 
-     * to related entities because we need to record a history/log, including 
-     * recordig information on entitites that may be deleted.  
-     * For exammple, oldStatus and newStatus are simple strings. These values 
-     * record the relevant <code>CertificationStatus.name</code> value, i.e; 
-     * either the current or historical value.   
-     * Similary, we record the user's DN rather than linking to the User object 
-     * as that User may be deleted in future.  
+     * Note, we define the entity attributes as simple types rather than linking
+     * to related entities because we need to record a history/log, including
+     * recordig information on entitites that may be deleted.
+     * For exammple, oldStatus and newStatus are simple strings. These values
+     * record the relevant <code>CertificationStatus.name</code> value, i.e;
+     * either the current or historical value.
+     * Similary, we record the user's DN rather than linking to the User object
+     * as that User may be deleted in future.
      */
-    
+
     /** @Column(type="string", nullable=true) */
-    protected $oldStatus = null; 
-    
+    protected $oldStatus = null;
+
     /** @Column(type="string", nullable=true) */
-    protected $newStatus = null; 
-    
+    protected $newStatus = null;
+
     /**
-     * User DN  
-     * @Column(type="string", nullable=true) 
+     * User DN
+     * @Column(type="string", nullable=true)
      */
-    protected $addedBy = null; 
- 
+    protected $addedBy = null;
+
     /* DATETIME NOTE:
      * Doctrine checks whether a date's been updated by doing a byreference comparison.
      * If you just update an existing DateTime object, Doctrine won't persist it!
      * Create a new DateTime object and reference that for it to persist during an update.
      * http://docs.doctrine-project.org/en/2.0.x/cookbook/working-with-datetime.html
      */
-    
+
     /** @Column(type="datetime", nullable=true) */
-    protected $addedDate = null; 
+    protected $addedDate = null;
 
 
     /** @Column(type="string", length=500, nullable=true) */
-    protected $reason = null; 
+    protected $reason = null;
 
     public function __construct() {
     }
 
     /**
      * Get the owning Site that owns this cert status log.
-     * A Site can own many CertificationStatusLog entities. When the parent 
-     * site is deleted, the Site's certStatusLogs are also cascade deleted.    
+     * A Site can own many CertificationStatusLog entities. When the parent
+     * site is deleted, the Site's certStatusLogs are also cascade deleted.
      * @return \Site
      */
     public function getParentSite(){
-        return $this->parentSite; 
+        return $this->parentSite;
     }
 
     /**
-     * Get the old/last certification status value of the site, e.g. 'Uncertified'. 
-     * @return string or null 
+     * Get the old/last certification status value of the site, e.g. 'Uncertified'.
+     * @return string or null
      */
     public function getOldStatus(){
-        return $this->oldStatus; 
+        return $this->oldStatus;
     }
 
     /**
-     * Get the newly updated certification status value, e.g. 'Certified' 
-     * @return string or null 
+     * Get the newly updated certification status value, e.g. 'Certified'
+     * @return string or null
      */
     public function getNewStatus(){
-        return $this->newStatus; 
+        return $this->newStatus;
     }
 
     /**
-     * Get the ID/DN of the user who created this cert status log. 
-     * @return string or null 
+     * Get the ID/DN of the user who created this cert status log.
+     * @return string or null
      */
     public function getAddedBy(){
         return $this->addedBy;
     }
-   
+
     /**
-     * Get the Date Time that this cert status log was created/persited. 
-     * @return \DateTime or null 
+     * Get the Date Time that this cert status log was created/persited.
+     * @return \DateTime or null
      */
     public function getAddedDate(){
-        return $this->addedDate; 
+        return $this->addedDate;
     }
 
     /**
      * A human readable description why this cert status log was created, max
-     * 500 chars. 
-     * @return string or null 
+     * 500 chars.
+     * @return string or null
      */
     public function getReason(){
-        return $this->reason; 
+        return $this->reason;
     }
 
     /**
@@ -134,36 +134,36 @@ class CertificationStatusLog {
     /**
      * Do not call in client code, always use the opposite
      * <code>$site->addCertificationStatusLog($certStatusLog)</code>
-     * instead which internally calls this method to keep the bidirectional 
-     * relationship consistent.  
+     * instead which internally calls this method to keep the bidirectional
+     * relationship consistent.
      * <p>
-     * This is the OWNING side of the ORM relationship so this method WILL 
-     * establish the relationship in the database. 
-     * 
+     * This is the OWNING side of the ORM relationship so this method WILL
+     * establish the relationship in the database.
+     *
      * @param \Site $site
      */
     public function setParentSite(\Site $site){
-        $this->parentSite = $site; 
+        $this->parentSite = $site;
     }
 
     /**
-     * Set the old status of the site, e.g. 'Suspended'  
+     * Set the old status of the site, e.g. 'Suspended'
      * @param string $oldStatus
      */
     public function setOldStatus($oldStatus){
-        $this->oldStatus = $oldStatus; 
+        $this->oldStatus = $oldStatus;
     }
-    
+
     /**
      * Set the new status of the site, e.g. 'Certified'
      * @param string $newStatus
      */
     public function setNewStatus($newStatus){
-        $this->newStatus = $newStatus; 
+        $this->newStatus = $newStatus;
     }
 
     /**
-     * The ID/DN of the user who created this cert status log. 
+     * The ID/DN of the user who created this cert status log.
      * @param string $addedBy
      */
     public function setAddedBy($addedBy){
@@ -171,19 +171,19 @@ class CertificationStatusLog {
     }
 
     /**
-     * The date time when this record was added. 
+     * The date time when this record was added.
      * @param \DateTime $addedDate
      */
     public function setAddedDate($addedDate){
-        $this->addedDate = $addedDate; 
+        $this->addedDate = $addedDate;
     }
 
     /**
-     * Human readable reason why this record was created, max 500 chars. 
+     * Human readable reason why this record was created, max 500 chars.
      * @param string $reason
      */
     public function setReason($reason){
-        $this->reason = $reason; 
+        $this->reason = $reason;
     }
 }
 

--- a/lib/Doctrine/entities/Country.php
+++ b/lib/Doctrine/entities/Country.php
@@ -17,11 +17,11 @@ use Doctrine\Common\Collections\ArrayCollection;
 
 /**
  * Defines lookup values for countries and joins all {@see Site}s that have
- * the same country value.   
- * 
+ * the same country value.
+ *
  * @author John Casson
- * @author David Meredith <david.meredith@stfc.ac.uk> 
- * 
+ * @author David Meredith <david.meredith@stfc.ac.uk>
+ *
  * @Entity @Table(name="Countries")
  */
 class Country {
@@ -39,18 +39,18 @@ class Country {
     protected $sites = null;
 
     public function __construct() {
-       $this->sites = new ArrayCollection();        
+       $this->sites = new ArrayCollection();
     }
 
     /**
-     * @return int The PK of this entity or null if not persisted. 
+     * @return int The PK of this entity or null if not persisted.
      */
     public function getId() {
         return $this->id;
     }
 
     /**
-     * The unique name of the country. 
+     * The unique name of the country.
      * @return string
      */
     public function getName() {
@@ -58,7 +58,7 @@ class Country {
     }
 
     /**
-     * The unique code for this country. 
+     * The unique code for this country.
      * @return string
      */
     public function getCode() {
@@ -66,7 +66,7 @@ class Country {
     }
 
     /**
-     * A unique country name. 
+     * A unique country name.
      * @param string $name
      */
     public function setName($name) {
@@ -74,7 +74,7 @@ class Country {
     }
 
     /**
-     * Set the unique country code. 
+     * Set the unique country code.
      * @param string $code
      */
     public function setCode($code) {
@@ -82,7 +82,7 @@ class Country {
     }
 
     /**
-     * Get all the sites that have this country value. 
+     * Get all the sites that have this country value.
      * @return ArrayCollection of {@see Site}s
      */
     public function getSites() {
@@ -90,9 +90,9 @@ class Country {
     }
 
     /**
-     * Add the given Site to this entities list of Sites. 
-     * Note, this method calls <code>$site->setCountry($this);</code> to 
-     * establish the join on both sides of the relationship. 
+     * Add the given Site to this entities list of Sites.
+     * Note, this method calls <code>$site->setCountry($this);</code> to
+     * establish the join on both sides of the relationship.
      * @param Site $site
      */
     public function addSiteDoJoin($site) {

--- a/lib/Doctrine/entities/Downtime.php
+++ b/lib/Doctrine/entities/Downtime.php
@@ -14,19 +14,19 @@
 use Doctrine\Common\Collections\ArrayCollection;
 
 /**
- * A single Downtime instance is linked to a single {@see Service} and to 
- * zero-or-more of the Service's {@see EndpointLocation}s. This allows selected 
- * endpoints of a service to be put into downtime - consider different types of 
- * endpoint that all belong to the same service which may/may-not be affected by the DT. 
+ * A single Downtime instance is linked to a single {@see Service} and to
+ * zero-or-more of the Service's {@see EndpointLocation}s. This allows selected
+ * endpoints of a service to be put into downtime - consider different types of
+ * endpoint that all belong to the same service which may/may-not be affected by the DT.
  * <p>
- * Note, the DB constraints actually allow multiple services to be joined with a 
- * single downtime, creating a many-to-many relationship between Service and 
+ * Note, the DB constraints actually allow multiple services to be joined with a
+ * single downtime, creating a many-to-many relationship between Service and
  * Downtime. The overlying business logic however currently limits the Downtime to a single
- * Service; linking a single Downtime to multiple Services may be needed in the 
- * future and so the DB was designed this way to cater for this requirement.   
- * 
- * @author David Meredith <david.meredithh@stfc.ac.uk> 
- * @author John Casson 
+ * Service; linking a single Downtime to multiple Services may be needed in the
+ * future and so the DB was designed this way to cater for this requirement.
+ *
+ * @author David Meredith <david.meredithh@stfc.ac.uk>
+ * @author John Casson
  * @Entity @Table(name="Downtimes")
  */
 class Downtime {
@@ -69,15 +69,15 @@ class Downtime {
     protected $services = null;
 
     /**
-     * Bidirectional - Many Downtimes (OWNING SIDE) can link to many ELs. 
-     * 
-     * The data model allows a Downtime to be linked to many ELs of a Service. 
-     * IF required, this allows selected ELs of a Service to be put into 
-     * downtime as per GLUE2. Alternatively, higher level business logic can 
-     * be used to limit the number of ELs per service to 1. In doing this, 
+     * Bidirectional - Many Downtimes (OWNING SIDE) can link to many ELs.
+     *
+     * The data model allows a Downtime to be linked to many ELs of a Service.
+     * IF required, this allows selected ELs of a Service to be put into
+     * downtime as per GLUE2. Alternatively, higher level business logic can
+     * be used to limit the number of ELs per service to 1. In doing this,
      * the whole Service can then be put into downtime. This multiplicity choice
-     * is left to the implementation.   
-     * 
+     * is left to the implementation.
+     *
      * @ManyToMany(targetEntity="EndpointLocation", inversedBy="downtimes")
      * @JoinTable(name="Downtimes_EndpointLocations",
      *      joinColumns={@JoinColumn(name="downtime_id", referencedColumnName="id")},
@@ -90,8 +90,8 @@ class Downtime {
      * The legacy Downtime primary key carried over from GOCDB4.
      * Other operational tools use this as the unique identifier for a Downtime.
      * For new Downtimes created in v5 this value is programmatically generated.
-     * 
-     * @Column(type="string", unique=true, nullable=true) 
+     *
+     * @Column(type="string", unique=true, nullable=true)
      */
     protected $primaryKey;
 
@@ -110,7 +110,7 @@ class Downtime {
     }
 
     /**
-     * Human readable description of downtime, 4000 chars max. 
+     * Human readable description of downtime, 4000 chars max.
      * @return string
      */
     public function getDescription() {
@@ -118,17 +118,17 @@ class Downtime {
     }
 
     /**
-     * The Severity string, either WARNING or OUTAGE. 
-     * @return string 
+     * The Severity string, either WARNING or OUTAGE.
+     * @return string
      */
     public function getSeverity() {
         return $this->severity;
     }
 
     /**
-     * A label to classify the downtime, either SCHEDULED or UNSCHEDULED. 
-     * SCHEDULED if the insertDate is 24 hours before startDate.  
-     * UNSCHEDULED if the insertDate is <24 hours before startDate.  
+     * A label to classify the downtime, either SCHEDULED or UNSCHEDULED.
+     * SCHEDULED if the insertDate is 24 hours before startDate.
+     * UNSCHEDULED if the insertDate is <24 hours before startDate.
      * @return string
      */
     public function getClassification() {
@@ -137,16 +137,16 @@ class Downtime {
 
     /**
      * Downtime insert date in server's default timezone (which may not be UTC).
-     * <p> 
-     * You will almost certainly need to set the returned DateTime's timezone to 
-     * UTC. This is not done here to allow calling code to either set the tz individually 
-     * per DateTime instance, or globally via <code>date_default_timezone_set("UTC");</code> 
-     * which is more performant for processing large result sets (e.g. as in the PI).  
-     * 
+     * <p>
+     * You will almost certainly need to set the returned DateTime's timezone to
+     * UTC. This is not done here to allow calling code to either set the tz individually
+     * per DateTime instance, or globally via <code>date_default_timezone_set("UTC");</code>
+     * which is more performant for processing large result sets (e.g. as in the PI).
+     *
      * @return \DateTime or null
      */
     public function getInsertDate() {
-        // Adds overhead when processing large result-sets. 
+        // Adds overhead when processing large result-sets.
 //        if($this->insertDate != NULL){
 //               $this->insertDate->setTimezone(new \DateTimeZone('UTC'));
 //        }
@@ -155,16 +155,16 @@ class Downtime {
 
     /**
      * Get downtime start date in server's default timezone (which may not be UTC).
-     * <p> 
-     * You will almost certainly need to set the returned DateTime's timezone to 
-     * UTC. This is not done here to allow calling code to either set the tz individually 
-     * per DateTime instance, or globally via <code>date_default_timezone_set("UTC");</code> 
-     * which is more performant for processing large result sets (e.g. as in the PI).  
-     * 
+     * <p>
+     * You will almost certainly need to set the returned DateTime's timezone to
+     * UTC. This is not done here to allow calling code to either set the tz individually
+     * per DateTime instance, or globally via <code>date_default_timezone_set("UTC");</code>
+     * which is more performant for processing large result sets (e.g. as in the PI).
+     *
      * @return \DateTime or null
      */
     public function getStartDate() {
-        // Adds overhead when processing large result-sets. 
+        // Adds overhead when processing large result-sets.
 //        if($this->startDate != NULL){
 //                   $this->startDate->setTimezone(new \DateTimeZone('UTC'));
 //        }
@@ -173,16 +173,16 @@ class Downtime {
 
     /**
      * Get downtime end date in server's default timezone (which may not be UTC).
-     * <p> 
-     * You will almost certainly need to set the returned DateTime's timezone to 
-     * UTC. This is not done here to allow calling code to either set the tz individually 
-     * per DateTime instance, or globally via <code>date_default_timezone_set("UTC");</code> 
-     * which is more performant for processing large result sets (e.g. as in the PI).  
-     * 
+     * <p>
+     * You will almost certainly need to set the returned DateTime's timezone to
+     * UTC. This is not done here to allow calling code to either set the tz individually
+     * per DateTime instance, or globally via <code>date_default_timezone_set("UTC");</code>
+     * which is more performant for processing large result sets (e.g. as in the PI).
+     *
      * @return \DateTime or null
      */
     public function getEndDate() {
-        // Adds overhead when processing large result-sets. 
+        // Adds overhead when processing large result-sets.
 //        if($this->endDate != NULL){
 //                   $this->endDate->setTimezone(new \DateTimeZone('UTC'));
 //        }
@@ -190,11 +190,11 @@ class Downtime {
     }
 
     /**
-     * Get the date that this downtime should be announced. 
-     * For SCHEDULED downtimes, this is 24hrs before the startDate.  
-     * For UNSCHEDULED downtimes, this is the insertDate.  
+     * Get the date that this downtime should be announced.
+     * For SCHEDULED downtimes, this is 24hrs before the startDate.
+     * For UNSCHEDULED downtimes, this is the insertDate.
      * @return \DateTime or null
-     */ 
+     */
     public function getAnnounceDate() {
         if ($this->getClassification() == "UNSCHEDULED") {
             return $this->insertDate;
@@ -206,7 +206,7 @@ class Downtime {
     }
 
     /**
-     * Get the list of {@see Service}s that this Downtime instance is linked to. 
+     * Get the list of {@see Service}s that this Downtime instance is linked to.
      * @return Doctrine\Common\Collections\ArrayCollection Of {@see Service}s
      */
     public function getServices() {
@@ -214,8 +214,8 @@ class Downtime {
     }
 
     /**
-     * Get the list of {@see EndpointLocation}s that this Downtime is linked to. 
-     * @return Doctrine\Common\Collections\ArrayCollection Of {@see EndpointLocation}s 
+     * Get the list of {@see EndpointLocation}s that this Downtime is linked to.
+     * @return Doctrine\Common\Collections\ArrayCollection Of {@see EndpointLocation}s
      */
     public function getEndpointLocations() {
         return $this->endpointLocations;
@@ -224,15 +224,15 @@ class Downtime {
     /**
      * The legacy Downtime primary key carried over from GOCDB4.
      * Other operational tools use this as the unique identifier for a Downtime.
-     * For new Downtimes created in v5 this value is programmatically generated. 
-     * @return string 
+     * For new Downtimes created in v5 this value is programmatically generated.
+     * @return string
      */
     public function getPrimaryKey() {
         return $this->primaryKey;
     }
 
     /**
-     * Provide the reasons for this downtime, 4000chars max. 
+     * Provide the reasons for this downtime, 4000chars max.
      * @param string $description
      */
     public function setDescription($description) {
@@ -240,7 +240,7 @@ class Downtime {
     }
 
     /**
-     * Flag to indicate the severity of the downtime, either OUTAGE or WARNING. 
+     * Flag to indicate the severity of the downtime, either OUTAGE or WARNING.
      * @param string $severity
      */
     public function setSeverity($severity) {
@@ -253,9 +253,9 @@ class Downtime {
     }
 
     /**
-     * A label to classify the downtime, either SCHEDULED or UNSCHEDULED. 
-     * SCHEDULED if the insertDate is 24 hours before startDate.  
-     * UNSCHEDULED if the insertDate is <24 hours before startDate.   
+     * A label to classify the downtime, either SCHEDULED or UNSCHEDULED.
+     * SCHEDULED if the insertDate is 24 hours before startDate.
+     * UNSCHEDULED if the insertDate is <24 hours before startDate.
      * @param string $classification
      */
     public function setClassification($classification) {
@@ -263,7 +263,7 @@ class Downtime {
     }
 
     /**
-     * The UTC DateTime when this Downtime was created/inserted.  
+     * The UTC DateTime when this Downtime was created/inserted.
      * @param \DateTime $insertDate
      */
     public function setInsertDate($insertDate) {
@@ -271,7 +271,7 @@ class Downtime {
     }
 
     /**
-     * The UTC DateTime when this downtime starts. 
+     * The UTC DateTime when this downtime starts.
      * @param \DateTime $startDate
      */
     public function setStartDate($startDate) {
@@ -279,7 +279,7 @@ class Downtime {
     }
 
     /**
-     * The UTC DateTime when this downtime ends. 
+     * The UTC DateTime when this downtime ends.
      * @param \DateTime $endDate
      */
     public function setEndDate($endDate) {
@@ -287,11 +287,11 @@ class Downtime {
     }
 
     /**
-     * The legacy Downtime primary key carried over from GOCDB4. 
-     * Other operational tools use this as the unique identifier for a Downtime. 
+     * The legacy Downtime primary key carried over from GOCDB4.
+     * Other operational tools use this as the unique identifier for a Downtime.
      * For new Downtimes created in v5 this value is programmatically generated
      * using the {@see \PrimaryKey} ID property with 'G0' appended.
-     * 
+     *
      * @param string $primaryKey
      */
     public function setPrimaryKey($primaryKey) {
@@ -299,18 +299,18 @@ class Downtime {
     }
 
     /**
-     * Add a service to this downtime's collection. 
-     * This method will establish the relationship on both sides by internally 
-     * calling <code>$service->_addDowntime($this);</code>. 
-     * Downtime is the OWNING side so this method WILL establish the relationship 
+     * Add a service to this downtime's collection.
+     * This method will establish the relationship on both sides by internally
+     * calling <code>$service->_addDowntime($this);</code>.
+     * Downtime is the OWNING side so this method WILL establish the relationship
      * in the database.
-     * 
+     *
      * @param Service $service
-     * @throws \AlreadyLinkedException If this downtime is already linked to the service. 
+     * @throws \AlreadyLinkedException If this downtime is already linked to the service.
      */
     public function addService($service) {
         require_once __DIR__ . '/AlreadyLinkedException.php';
-        // Check this SE isn't already registered (not sure we strictly need this) 
+        // Check this SE isn't already registered (not sure we strictly need this)
         foreach ($this->services as $existingSe) {
             if ($existingSe == $service) {
                 throw new AlreadyLinkedException("Downtime {$this->getId()} is already "
@@ -318,56 +318,56 @@ class Downtime {
             }
         }
         $this->services[] = $service;
-        //$service->_add Downtime($this); 
+        //$service->_add Downtime($this);
         $dts = $service->getDowntimes();
         $dts[] = $this;
     }
 
     /**
-     * Remove given service from $this services list and remove 
-     * $this instance from the given service's downtime list.  
+     * Remove given service from $this services list and remove
+     * $this instance from the given service's downtime list.
      * Downtime is the OWNING side so this method WILL remove the relationship from
      * the database.
-     * 
+     *
      * @param Service $service service for removal
      */
     public function removeService(Service $service) {
-        //$service->remove Downtime($this); 
+        //$service->remove Downtime($this);
         $service->getDowntimes()->removeElement($this);
         $this->services->removeElement($service);
     }
 
     /**
-     * Add the given EL to this downtime's EL list and then  
-     * calls <code>$endpointLocation->_addDowntime($this)</code> to 
-     * keep both sides of the relationship consistent.  
+     * Add the given EL to this downtime's EL list and then
+     * calls <code>$endpointLocation->_addDowntime($this)</code> to
+     * keep both sides of the relationship consistent.
      * <p>
      * This is the OWNING side so this method WILL establish the relationship in the database.
-     * 
+     *
      * @param EndpointLocation $endpointLocation
      */
     public function addEndpointLocation(EndpointLocation $endpointLocation) {
         $this->endpointLocations[] = $endpointLocation;
-        //$endpointLocation->_add Downtime($this); 
+        //$endpointLocation->_add Downtime($this);
         $dts = $endpointLocation->getDowntimes();
         $dts[] = $this;
     }
 
     /**
-     * Remove the downtime from the specified ELs list of downtimes and 
-     * then remoeve it from this downtime's EL list.  
-     * calls to <code>$endpointLocation->_removeDowntime($this)</code> to 
-     * keep both sides of the relationship consistent (i.e. no need to 
-     * call <code>$endpointLocation->removeDowntime($this)</code> in client code).  
+     * Remove the downtime from the specified ELs list of downtimes and
+     * then remoeve it from this downtime's EL list.
+     * calls to <code>$endpointLocation->_removeDowntime($this)</code> to
+     * keep both sides of the relationship consistent (i.e. no need to
+     * call <code>$endpointLocation->removeDowntime($this)</code> in client code).
      * <p>
      * This is the OWNING side so this method WILL remove the relationship from
      * the database.
-     * 
+     *
      * @param EndpointLocation $endpointLocation endpoint location for removal
      */
     public function removeEndpointLocation(EndpointLocation $endpointLocation) {
         $endpointLocation->getDowntimes()->removeElement($this);
-        //$endpointLocation->_remove Downtime($this); 
+        //$endpointLocation->_remove Downtime($this);
         $this->endpointLocations->removeElement($endpointLocation);
     }
 

--- a/lib/Doctrine/entities/EndpointLocation.php
+++ b/lib/Doctrine/entities/EndpointLocation.php
@@ -16,16 +16,16 @@
 use Doctrine\Common\Collections\ArrayCollection;
 
 /**
- * A {@see Service} owns zero or more EndpointLocations. ELs are linked to {@see Downtime}s.   
+ * A {@see Service} owns zero or more EndpointLocations. ELs are linked to {@see Downtime}s.
  * <p>
- * More formally; an EL models a network location that can be contacted to access certain 
- * functionalities based on a well-defined interface. The defined attributes 
- * refer to aspects such as the network location, the exposed interface name, 
- * the details of the implementation and the linked downtimes. 
- * 
- * @author David Meredith <david.meredith@stfc.ac.uk> 
- * @author John Casson 
- * 
+ * More formally; an EL models a network location that can be contacted to access certain
+ * functionalities based on a well-defined interface. The defined attributes
+ * refer to aspects such as the network location, the exposed interface name,
+ * the details of the implementation and the linked downtimes.
+ *
+ * @author David Meredith <david.meredith@stfc.ac.uk>
+ * @author John Casson
+ *
  * @Entity @Table(name="EndpointLocations")
  */
 class EndpointLocation {
@@ -59,21 +59,21 @@ class EndpointLocation {
      */
 
     /**
-     * Bidirectional - Many endpointlocations (DB OWNING SIDE) can link to one Service. 
-     *  
+     * Bidirectional - Many endpointlocations (DB OWNING SIDE) can link to one Service.
+     *
      * @ManyToOne(targetEntity="Service", inversedBy="endpointLocations")
      * @JoinColumn(name="service_id", referencedColumnName="id", onDelete="CASCADE")
      */
     protected $service = null;
 
     /**
-     * Bidirectional - Many Endpoints (INVERSE SIDE) can link to many Downtimes. 
-     * Note, we do not configure any cascade=remove behaviour here as we need to 
+     * Bidirectional - Many Endpoints (INVERSE SIDE) can link to many Downtimes.
+     * Note, we do not configure any cascade=remove behaviour here as we need to
      * have fine-grained programmatic control over which downtimes are deleted when a service
-     * endpoint is deleted (i.e. we only want to delete those DTs that exclusively link to 
-     * this EL only which would subsequently be orphaned). We do this managed 
-     * deletion of DTs in the DAO/Service layer. 
-     *   
+     * endpoint is deleted (i.e. we only want to delete those DTs that exclusively link to
+     * this EL only which would subsequently be orphaned). We do this managed
+     * deletion of DTs in the DAO/Service layer.
+     *
      * @ManyToMany(targetEntity="Downtime", mappedBy="endpointLocations")
      */
     protected $downtimes = null;
@@ -93,15 +93,15 @@ class EndpointLocation {
     }
 
     /**
-     * The human readable name of this endpoint location, e.g. 'Production GOCDB REST endpoint'. 
-     * @return string or null 
+     * The human readable name of this endpoint location, e.g. 'Production GOCDB REST endpoint'.
+     * @return string or null
      */
     public function getName() {
         return $this->name;
     }
 
     /**
-     * Get a list of the {@see Downtime}s linked to this EL. 
+     * Get a list of the {@see Downtime}s linked to this EL.
      * @return ArrayCollection
      */
     public function getDowntimes() {
@@ -109,16 +109,16 @@ class EndpointLocation {
     }
 
     /**
-     * Network location of an endpoint, which enables a specific component of 
-     * the Service to be contacted. Corresponds directly with the OGF GLUE2 Endpoint. 
-     * @return string or null 
+     * Network location of an endpoint, which enables a specific component of
+     * the Service to be contacted. Corresponds directly with the OGF GLUE2 Endpoint.
+     * @return string or null
      */
     public function getUrl() {
         return $this->url;
     }
 
     /**
-     * The Service instance that owns this EL. 
+     * The Service instance that owns this EL.
      * @return \Service
      */
     public function getService() {
@@ -128,15 +128,15 @@ class EndpointLocation {
     /**
      * The identification name of the primary protocol supported by the endpoint interface.
      * This corresponds directly with the OGF GLUE2 interfaceName.
-     * @return string or null 
+     * @return string or null
      */
     public function getInterfaceName() {
         return $this->interfaceName;
     }
 
     /**
-     * Custom Key=Value pairs (extension properties) used to augment the 
-     * ELs attributes. 
+     * Custom Key=Value pairs (extension properties) used to augment the
+     * ELs attributes.
      * @return ArrayCollection
      */
     public function getEndpointProperties() {
@@ -144,7 +144,7 @@ class EndpointLocation {
     }
 
     /**
-     * A human readable description for the EL, max 2000 chars. 
+     * A human readable description for the EL, max 2000 chars.
      * @return string or null
      */
     public function getDescription() {
@@ -154,7 +154,7 @@ class EndpointLocation {
     //Setters
 
     /**
-     * The human readable name of this endpoint location, e.g. 'Production GOCDB REST endpoint'. 
+     * The human readable name of this endpoint location, e.g. 'Production GOCDB REST endpoint'.
      * @param string $name
      */
     public function setName($name) {
@@ -162,7 +162,7 @@ class EndpointLocation {
     }
 
     /**
-     * Set the network location of an endpoint, which enables a specific component of 
+     * Set the network location of an endpoint, which enables a specific component of
      * the Service to be contacted. Corresponds directly with the OGF GLUE2 Endpoint.
      * @param string $url
      */
@@ -182,11 +182,11 @@ class EndpointLocation {
     /**
      * Do not call in client code, always use the opposite
      * <code>$service->addEndpointLocationDoJoin($endpointLocation)</code>
-     * instead which internally calls this method to keep the bidirectional 
-     * relationship consistent.  
+     * instead which internally calls this method to keep the bidirectional
+     * relationship consistent.
      * <p>
-     * EndpointLocation is the OWNING side so this method WILL establish the relationship in the database. 
-     * 
+     * EndpointLocation is the OWNING side so this method WILL establish the relationship in the database.
+     *
      * @param Service $service
      */
     public function setServiceDoJoin($service) {
@@ -194,23 +194,23 @@ class EndpointLocation {
     }
 
     /**
-     * Add a endpointProperty entity to this Endpoint's collection of properties. 
-     * This method also sets the EndpointProperty's parentEndpoint.  
+     * Add a endpointProperty entity to this Endpoint's collection of properties.
+     * This method also sets the EndpointProperty's parentEndpoint.
      * @param \EndpointProperty $endpointProperty
      */
     public function addEndpointPropertyDoJoin($endpointProperty) {
         $this->endpointProperties[] = $endpointProperty;
         $endpointProperty->_setParentEndpoint($this);
-        //$endpointProperty->getParentEndpoint() = $this; 
+        //$endpointProperty->getParentEndpoint() = $this;
     }
 
     /*
-     * Do not call in client code, always use the opposite 
-     * <code>$downtime->addEndpointLocation($thisEl)</code> instead which internally 
-     * calls this method to keep the bidirectional relationship consistent.   
+     * Do not call in client code, always use the opposite
+     * <code>$downtime->addEndpointLocation($thisEl)</code> instead which internally
+     * calls this method to keep the bidirectional relationship consistent.
      * <p>
-     * This is the INVERSE side so this method will NOT establish the relationship in the database. 
-     *  
+     * This is the INVERSE side so this method will NOT establish the relationship in the database.
+     *
      * @param Downtime $downtime
      */
 //    public function _addDowntime(Downtime $downtime) {
@@ -218,12 +218,12 @@ class EndpointLocation {
 //    }
 
     /*
-     * Do not call in client code, always use the opposite 
-     * <code>$downtime->removeEndpointLocation($thisEl)</code> instead which internally 
-     * calls this method to keep the bidirectional relationship consistent.   
+     * Do not call in client code, always use the opposite
+     * <code>$downtime->removeEndpointLocation($thisEl)</code> instead which internally
+     * calls this method to keep the bidirectional relationship consistent.
      * <p>
-     * This is the INVERSE side so this method will NOT remove the relationship in the database. 
-     *  
+     * This is the INVERSE side so this method will NOT remove the relationship in the database.
+     *
      * @param Downtime $downtime downtime to be removed
      */
 //    public function _removeDowntime(Downtime $downtime) {
@@ -231,7 +231,7 @@ class EndpointLocation {
 //    }
 
     /**
-     * Set the human readable description for this EL, max 2000 chars. 
+     * Set the human readable description for this EL, max 2000 chars.
      * @param string $description
      */
     public function setDescription($description) {

--- a/lib/Doctrine/entities/EndpointProperty.php
+++ b/lib/Doctrine/entities/EndpointProperty.php
@@ -16,19 +16,19 @@
 
 /**
  * A custom Key=Value pair (extension property) used to augment an {@see EndpointLocation}
- * object with additional attributes. These properties can also be used for 
+ * object with additional attributes. These properties can also be used for
  * the purposes of resource matching.
  * <p>
- * A unique constraint is defined on the DB preventing duplicate key=value pairs. 
- * Note, duplicate key names with different values ARE allowed for the purpose 
- * of defning multi-valued properties. 
+ * A unique constraint is defined on the DB preventing duplicate key=value pairs.
+ * Note, duplicate key names with different values ARE allowed for the purpose
+ * of defning multi-valued properties.
  * <p>
- * When the owning parent EndpointLocation is deleted, its EndpointProperties 
- * are also cascade-deleted.    
- *  
- * @author David Meredith <david.meredith@stfc.ac.uk> 
- * 
- * @Entity @Table(name="Endpoint_Properties", uniqueConstraints={@UniqueConstraint(name="endpointproperty_keypairs", columns={"parentEndpoint_id", "keyName", "keyValue"})}) 
+ * When the owning parent EndpointLocation is deleted, its EndpointProperties
+ * are also cascade-deleted.
+ *
+ * @author David Meredith <david.meredith@stfc.ac.uk>
+ *
+ * @Entity @Table(name="Endpoint_Properties", uniqueConstraints={@UniqueConstraint(name="endpointproperty_keypairs", columns={"parentEndpoint_id", "keyName", "keyValue"})})
  */
 class EndpointProperty {
 
@@ -36,10 +36,10 @@ class EndpointProperty {
     protected $id;
 
     /**
-     * Bidirectional - Many EndpointProperties (SIDE THAT OWNS FK) 
-     * can be linked to one EndpointLocation (OWNING ORM SIDE). 
-     *   
-     * @ManyToOne(targetEntity="EndpointLocation", inversedBy="endpointProperties") 
+     * Bidirectional - Many EndpointProperties (SIDE THAT OWNS FK)
+     * can be linked to one EndpointLocation (OWNING ORM SIDE).
+     *
+     * @ManyToOne(targetEntity="EndpointLocation", inversedBy="endpointProperties")
      * @JoinColumn(name="parentEndpoint_id", referencedColumnName="id", onDelete="CASCADE")
      */
     protected $parentEndpoint = null;
@@ -51,12 +51,12 @@ class EndpointProperty {
     protected $keyValue = null;
 
     public function __construct() {
-        
+
     }
 
     /**
-     * Get the owning EndpointLocation. When the parent EL is deleted, then 
-     * all the EndpointProperties are cascade deleted also. 
+     * Get the owning EndpointLocation. When the parent EL is deleted, then
+     * all the EndpointProperties are cascade deleted also.
      * @return \EndpointLocation
      */
     public function getParentEndpoint() {
@@ -64,8 +64,8 @@ class EndpointProperty {
     }
 
     /**
-     * Get the key name, usually a simple alphaNumeric name, but this is not 
-     * enforced by the entity. 
+     * Get the key name, usually a simple alphaNumeric name, but this is not
+     * enforced by the entity.
      * @return string
      */
     public function getKeyName() {
@@ -73,7 +73,7 @@ class EndpointProperty {
     }
 
     /**
-     * Get the key value, can contain any char. 
+     * Get the key value, can contain any char.
      * @return String
      */
     public function getKeyValue() {
@@ -90,12 +90,12 @@ class EndpointProperty {
     /**
      * Do not call in client code, always use the opposite
      * <code>$site->addEndpointPropertyDoJoin($endpointProperty)</code>
-     * instead which internally calls this method to keep the bidirectional 
-     * relationship consistent.  
+     * instead which internally calls this method to keep the bidirectional
+     * relationship consistent.
      * <p>
-     * This is the OWNING side of the ORM relationship so this method WILL 
-     * establish the relationship in the database. 
-     * 
+     * This is the OWNING side of the ORM relationship so this method WILL
+     * establish the relationship in the database.
+     *
      * @param \EndpointLocation $endpoint
      */
     public function _setParentEndpoint(\EndpointLocation $endpoint) {
@@ -103,9 +103,9 @@ class EndpointProperty {
     }
 
     /**
-     * The custom keyname of this key=value pair. 
-     * This value should be a simple alphanumeric name without special chars, but 
-     * this is not enforced here by the entity.   
+     * The custom keyname of this key=value pair.
+     * This value should be a simple alphanumeric name without special chars, but
+     * this is not enforced here by the entity.
      * @param string $keyName
      */
     public function setKeyName($keyName) {
@@ -113,8 +113,8 @@ class EndpointProperty {
     }
 
     /**
-     * The custom value of this key=value pair. 
-     * This value can contain any chars. 
+     * The custom value of this key=value pair.
+     * This value can contain any chars.
      * @param string $keyValue
      */
     public function setKeyValue($keyValue) {

--- a/lib/Doctrine/entities/IScopedEntity.php
+++ b/lib/Doctrine/entities/IScopedEntity.php
@@ -13,39 +13,39 @@
  */
 
 /**
- * A scoped entity is one that can be tagged with a {@see Scope} tag 
- * for the purposes of filtering based on the object's related scopes. 
+ * A scoped entity is one that can be tagged with a {@see Scope} tag
+ * for the purposes of filtering based on the object's related scopes.
  * <p>
- * Implementations include {@see Site}, {@see Service}, {@see ServiceGroup} and 
- * {@see NGI}. These resources can then be selected according to the 
- * scopes they are joined with. 
- * 
- * @author David Meredith <david.meredithh@stfc.ac.uk> 
- * @author John Casson 
+ * Implementations include {@see Site}, {@see Service}, {@see ServiceGroup} and
+ * {@see NGI}. These resources can then be selected according to the
+ * scopes they are joined with.
+ *
+ * @author David Meredith <david.meredithh@stfc.ac.uk>
+ * @author John Casson
  */
 interface IScopedEntity {
-    
+
     /**
-     * @return Doctrine\Common\Collections\ArrayCollection List of {@see Scope} entities.  
+     * @return Doctrine\Common\Collections\ArrayCollection List of {@see Scope} entities.
      */
     public function getScopes();
 
     /**
-     * A string of comma-separated scope names which tag this object.   
-     * @return string  
+     * A string of comma-separated scope names which tag this object.
+     * @return string
      */
     public function getScopeNamesAsString();
 
     /**
-     * Create a relationship between this entity and the given scope object.    
+     * Create a relationship between this entity and the given scope object.
      * @param Scope $scope
      */
     public function addScope(Scope $scope);
 
     /**
-     * Remove the relationship between the given scope and this entity.  
+     * Remove the relationship between the given scope and this entity.
      * @param Scope $removeScope
      */
     public function removeScope(Scope $removeScope);
-            
+
 }

--- a/lib/Doctrine/entities/Infrastructure.php
+++ b/lib/Doctrine/entities/Infrastructure.php
@@ -14,12 +14,12 @@
 use Doctrine\Common\Collections\ArrayCollection;
 
 /**
- * Defines a named e-Infrastructure such as 'TEST' or 'Production' and 
- * joins all the {@see Site}s that are linked to this infrastructure. 
- *  
+ * Defines a named e-Infrastructure such as 'TEST' or 'Production' and
+ * joins all the {@see Site}s that are linked to this infrastructure.
+ *
  * @author John Casson
- * @author David Meredith <david.meredith@stfc.ac.uk> 
- * 
+ * @author David Meredith <david.meredith@stfc.ac.uk>
+ *
  * @Entity @Table(name="Infrastructures")
  */
 class Infrastructure {
@@ -45,15 +45,15 @@ class Infrastructure {
     }
 
     /**
-     * Defines a unique name for the infrastructure, e.g. 'Test' or 'PPS' 
-     * @return string 
+     * Defines a unique name for the infrastructure, e.g. 'Test' or 'PPS'
+     * @return string
      */
     public function getName() {
         return $this->name;
     }
 
     /**
-     * Set the unique name for the infrastructure. Required. 
+     * Set the unique name for the infrastructure. Required.
      * @param string $name
      */
     public function setName($name) {
@@ -61,7 +61,7 @@ class Infrastructure {
     }
 
     /**
-     * Get all the {@see Site}s that define (are joined to) this infrastructure. 
+     * Get all the {@see Site}s that define (are joined to) this infrastructure.
      * @return ArrayCollection
      */
     public function getSites() {
@@ -69,9 +69,9 @@ class Infrastructure {
     }
 
     /**
-     * Add the given Site to this objects list of sites. 
-     * Note, this method calls <code>$site->setInfrastructure($this);</code> to 
-     * set the join on both sides of the relationship. 
+     * Add the given Site to this objects list of sites.
+     * Note, this method calls <code>$site->setInfrastructure($this);</code> to
+     * set the join on both sides of the relationship.
      * @param \Site $site
      */
     public function addSiteDoJoin($site) {

--- a/lib/Doctrine/entities/NGI.php
+++ b/lib/Doctrine/entities/NGI.php
@@ -17,16 +17,16 @@ require_once 'Site.php';
 require_once 'IScopedEntity.php';
 
 /**
- * An NGI represents the administrative domain for grouping child Sites. 
- * It is directly comparable to the GLUE2 AdminDomain class from OGF. 
+ * An NGI represents the administrative domain for grouping child Sites.
+ * It is directly comparable to the GLUE2 AdminDomain class from OGF.
  * <p>
- * An NGI groups zero or more child {@see Site}s, and is linked to one or more 
- * parent {@see Project}s. Users can request Roles over the NGI which grants 
- * various permissions over the NGI and its child Sites.  
- * 
- * @author David Meredith <david.meredithh@stfc.ac.uk> 
- * @author John Casson 
- * 
+ * An NGI groups zero or more child {@see Site}s, and is linked to one or more
+ * parent {@see Project}s. Users can request Roles over the NGI which grants
+ * various permissions over the NGI and its child Sites.
+ *
+ * @author David Meredith <david.meredithh@stfc.ac.uk>
+ * @author John Casson
+ *
  * @Entity @Table(name="NGIs")
  */
 class NGI extends OwnedEntity implements IScopedEntity {
@@ -45,7 +45,7 @@ class NGI extends OwnedEntity implements IScopedEntity {
 
     /** @Column(type="string", nullable=true) */
     protected $securityEmail;
-    
+
     /** @Column(type="string", nullable=true) */
     protected $description;
 
@@ -54,17 +54,17 @@ class NGI extends OwnedEntity implements IScopedEntity {
 
     /** @OneToMany(targetEntity="Site", mappedBy="ngi") */
     protected $sites = null;
-    
+
     /**
-     * Bidirectional - Many NGIs (INVERSE SIDE) can link to many Projects  
-     * 
+     * Bidirectional - Many NGIs (INVERSE SIDE) can link to many Projects
+     *
      * @ManyToMany(targetEntity="Project", mappedBy="ngis")
      */
     protected $projects = null;
-    
-    /**    
+
+    /**
      * Unidirectional - Scope tags associated with the NGI
-     * 
+     *
      * @ManyToMany(targetEntity="Scope")
      * @JoinTable(name="Ngis_Scopes",
      *      joinColumns={@JoinColumn(name="ngi_Id", referencedColumnName="id")},
@@ -72,24 +72,24 @@ class NGI extends OwnedEntity implements IScopedEntity {
      *      )
      */
     protected $scopes = null;
-    
+
     /* DATETIME NOTE:
      * Doctrine checks whether a date's been updated by doing a byreference comparison.
      * If you just update an existing DateTime object, Doctrine won't persist it!
      * Create a new DateTime object and reference that for it to persist during an update.
      * http://docs.doctrine-project.org/en/2.0.x/cookbook/working-with-datetime.html
      */
-    
+
     /** @Column(type="datetime", nullable=false) **/
     protected $creationDate;
 
 
     public function __construct() {
         parent::__construct();
-        
+
         // Set cretion date
         $this->creationDate =  new \DateTime("now");
-        
+
         $this->sites = new ArrayCollection();
         $this->projects = new ArrayCollection();
         $this->scopes = new ArrayCollection();
@@ -108,16 +108,16 @@ class NGI extends OwnedEntity implements IScopedEntity {
     }
 
     /**
-     * A nullable string that concatenates contact email addresses for the NGI. 
-     * @return String email  
+     * A nullable string that concatenates contact email addresses for the NGI.
+     * @return String email
      */
     public function getEmail() {
         return $this->email;
     }
 
     /**
-     * Nullable string that concatenates ROD email addresses (Regional Operator on Duty). 
-     * @return string  
+     * Nullable string that concatenates ROD email addresses (Regional Operator on Duty).
+     * @return string
      */
     public function getRodEmail() {
         return $this->rodEmail;
@@ -130,15 +130,15 @@ class NGI extends OwnedEntity implements IScopedEntity {
     public function getSecurityEmail() {
         return $this->securityEmail;
     }
-    
+
     public function getDescription() {
         return $this->description;
     }
 
     public function getGgus_Su(){
-        return $this->ggus_Su; 
+        return $this->ggus_Su;
     }
-    
+
     public function getSites() {
         return $this->sites;
     }
@@ -148,7 +148,7 @@ class NGI extends OwnedEntity implements IScopedEntity {
     }
 
     /**
-     * @return ArrayCollection Contains parent Projects or empty collection. 
+     * @return ArrayCollection Contains parent Projects or empty collection.
      */
     public function getParentOwnedEntities() {
         return $this->projects;
@@ -157,39 +157,39 @@ class NGI extends OwnedEntity implements IScopedEntity {
     public function getScopes() {
         return $this->scopes;
     }
-    
+
     public function getCreationDate() {
         return $this->creationDate;
     }
-        
+
     /**
-     * A string containg a list of concatenated scope names with which the 
+     * A string containg a list of concatenated scope names with which the
      * object been tagged.
-     * @return string  string containing ", " seperated list of the names 
-     */ 
+     * @return string  string containing ", " seperated list of the names
+     */
     public function getScopeNamesAsString() {
         //Get the scopes for the NGI
         $scopes = $this->getScopes();
-        
+
         //Create an empty array to contain scope names
         $scopeNames= array();
-        
+
         //populate the array
         foreach ($scopes as $scope){
             $scopeNames[]=$scope->getName();
         }
-        
+
         sort($scopeNames);
 
         //Turn into a string
         $scopeNamesAsString = implode(", " , $scopeNames);
-        
+
         return $scopeNamesAsString;
     }
-    
+
     /**
-     * Add the given site to the NGI list.  
-     * 
+     * Add the given site to the NGI list.
+     *
      * @see Site::setNgiDoJoin()
      * @param Site $site
      */
@@ -197,10 +197,10 @@ class NGI extends OwnedEntity implements IScopedEntity {
         $this->sites[] = $site;
         $site->setNgiDoJoin($this);
     }
-    
+
     /**
      * Note this is called by addNgi($ngi) in the project class. $prj->addNgi($ngi)
-     * should always be used rather than $ngi->addProject($prj) 
+     * should always be used rather than $ngi->addProject($prj)
      * @param \Project $project
      */
     public function addProject(\Project $project) {
@@ -222,19 +222,19 @@ class NGI extends OwnedEntity implements IScopedEntity {
     public function setSecurityEmail($securityEmail) {
         $this->securityEmail = $securityEmail;
     }
-    
+
     public function setName($name) {
         $this->name = $name;
     }
-    
+
     public function setDescription($description) {
         $this->description = $description;
     }
 
     public function setGgus_Su($ggus_su){
-        $this->ggus_Su = $ggus_su; 
+        $this->ggus_Su = $ggus_su;
     }
-    
+
     public function addScope(Scope $scope) {
         $this->scopes[] = $scope;
     }
@@ -242,7 +242,7 @@ class NGI extends OwnedEntity implements IScopedEntity {
     public function setCreationDate($creationDate) {
         $this->creationDate = $creationDate;
     }
-    
+
     /**
      * Removes the association between this site and a scope
      *
@@ -255,10 +255,10 @@ class NGI extends OwnedEntity implements IScopedEntity {
     /**
      * Returns value of {@link \OwnedEntity::TYPE_NGI}
      * @see \OwnedEntity::getType()
-     * @return string 
+     * @return string
      */
     public function getType() {
-        return parent::TYPE_NGI; 
+        return parent::TYPE_NGI;
     }
 
 }

--- a/lib/Doctrine/entities/OwnedEntity.php
+++ b/lib/Doctrine/entities/OwnedEntity.php
@@ -16,20 +16,20 @@ use Doctrine\Common\Collections\ArrayCollection;
 
 
 /**
- * Defines an 'owned' entity, i.e. one where a user can request a {@see Role} 
+ * Defines an 'owned' entity, i.e. one where a user can request a {@see Role}
  * over an implementing entity.
  * <p>
  * Implementations include {@see Project}, {@see Site}, {@see ServiceGroup} and {@see NGI}.
- * Owning a Role over an OwnedEntity grants certain permissions over that object, 
- * allowing the user to edit/delete attributes for example. 
- *  
- * @author David Meredith <david.meredithh@stfc.ac.uk> 
- * @author John Casson 
- * 
+ * Owning a Role over an OwnedEntity grants certain permissions over that object,
+ * allowing the user to edit/delete attributes for example.
+ *
+ * @author David Meredith <david.meredithh@stfc.ac.uk>
+ * @author John Casson
+ *
  * @Entity  @Table(name="OwnedEntities")
  * @InheritanceType("JOINED")
  * @DiscriminatorColumn(name="discr", type="string")
- * @DiscriminatorMap({"site" = "Site", "ngi" = "NGI", "project" = "Project", 
+ * @DiscriminatorMap({"site" = "Site", "ngi" = "NGI", "project" = "Project",
  *                      "serviceGroup" = "ServiceGroup"})
  */
 abstract class OwnedEntity {
@@ -37,13 +37,13 @@ abstract class OwnedEntity {
     /** @Id @Column(type="integer") @GeneratedValue **/
     protected $id;
 
-    const TYPE_NGI = 'ngi'; 
-    const TYPE_SITE = 'site'; 
-    const TYPE_SERVICEGROUP = 'servicegroup'; 
-    const TYPE_PROJECT = 'project'; 
-        
-    /** 
-     * @OneToMany(targetEntity="Role", mappedBy="ownedEntity") 
+    const TYPE_NGI = 'ngi';
+    const TYPE_SITE = 'site';
+    const TYPE_SERVICEGROUP = 'servicegroup';
+    const TYPE_PROJECT = 'project';
+
+    /**
+     * @OneToMany(targetEntity="Role", mappedBy="ownedEntity")
      * @OrderBy({"id" = "ASC"})
      */
     protected $roles = null;
@@ -53,8 +53,8 @@ abstract class OwnedEntity {
     }
 
     /**
-     * Get the array of {@see Role}s held by users over the implementing entity.   
-     * @return Doctrine\Common\Collections\ArrayCollection 
+     * Get the array of {@see Role}s held by users over the implementing entity.
+     * @return Doctrine\Common\Collections\ArrayCollection
      */
     public function getRoles() {
         return $this->roles;
@@ -66,24 +66,24 @@ abstract class OwnedEntity {
     public function getId() {
         return $this->id;
     }
-        
+
     /**
-     * Join the given Role to this OwnedEntity. 
+     * Join the given Role to this OwnedEntity.
      * <p>
-     * This method also calls <code>$role->setOwnedEntity($this)</code> which  
-     * establishes the relationship 'on both sides' and so does not need to be 
-     * called (again) by client code. 
+     * This method also calls <code>$role->setOwnedEntity($this)</code> which
+     * establishes the relationship 'on both sides' and so does not need to be
+     * called (again) by client code.
      * @param \Role $role
      */
     public function addRoleDoJoin(\Role $role) {
         $this->roles[] = $role;
         $role->setOwnedEntity($this);
     }
-        
+
 
     /**
-     * Get the entity type as a string.  
-     * The value is same as the discriminator column of the database (case may be different). 
+     * Get the entity type as a string.
+     * The value is same as the discriminator column of the database (case may be different).
      * <p>
      * Returns one of the following depending on the extending class type:
      * <ul>
@@ -92,28 +92,28 @@ abstract class OwnedEntity {
      * <li>OwnedEntity::TYPE_SERVICEGROUP</li>
      * <li>OwnedEntity::TYPE_SITE</li>
      * </ul>
-     * @return string The entity type as a string. 
+     * @return string The entity type as a string.
      */
     abstract public function getType();
 
     /**
-     * Get the entity name. 
-     * @return string The entity name as a string. 
+     * Get the entity name.
+     * @return string The entity name as a string.
      */
-    abstract public function getName(); 
+    abstract public function getName();
 
 
     /**
-     * Get the direct parent OwnedEntities that own this instance. 
-     * @return \Doctrine\Common\Collections\ArrayCollection An array of {@see \OwnedEntity} 
-     * instances or an empty array  
+     * Get the direct parent OwnedEntities that own this instance.
+     * @return \Doctrine\Common\Collections\ArrayCollection An array of {@see \OwnedEntity}
+     * instances or an empty array
      */
-    abstract public function getParentOwnedEntities(); 
+    abstract public function getParentOwnedEntities();
 
     /**
-     * Get the direct child OwnedEntities owned by this instance. 
-     * @return \Doctrine\Common\Collections\ArrayCollection An array of {@see \OwnedEntity} 
-     * instances or an empty array  
+     * Get the direct child OwnedEntities owned by this instance.
+     * @return \Doctrine\Common\Collections\ArrayCollection An array of {@see \OwnedEntity}
+     * instances or an empty array
      */
-    //abstract public function getChildOwnedEntities(); 
+    //abstract public function getChildOwnedEntities();
 }

--- a/lib/Doctrine/entities/PrimaryKey.php
+++ b/lib/Doctrine/entities/PrimaryKey.php
@@ -16,11 +16,11 @@
 
 /**
  * Used to create the PRIMARY_KEY field exposed through the PI.
- * This maintains backwards compatiblity with the v4 PRIMARY_KEY FIELDS. 
- * This sequence can be used when required to get the next primary key by 
- * creating and persisting an instance of PrimarKey and calling the getId() 
- * method. This value can then be used to programatically set the legacy 
- * PRIMARY_KEY fields when persisting new entities. 
+ * This maintains backwards compatiblity with the v4 PRIMARY_KEY FIELDS.
+ * This sequence can be used when required to get the next primary key by
+ * creating and persisting an instance of PrimarKey and calling the getId()
+ * method. This value can then be used to programatically set the legacy
+ * PRIMARY_KEY fields when persisting new entities.
  *
  * @author John Casson
  *
@@ -39,7 +39,7 @@ class PrimaryKey {
     }
 
     /**
-     * Get the Id value. 
+     * Get the Id value.
      * @return string
      */
     public function __toString() {

--- a/lib/Doctrine/entities/Project.php
+++ b/lib/Doctrine/entities/Project.php
@@ -14,15 +14,15 @@
 use Doctrine\Common\Collections\ArrayCollection;
 
 /**
- * A Project is the top level object in the core object/domain model and groups 
- * zero or more child {@see NGI}s. A project is comparable to a top 
- * level GLUE2 AdminDomain class. 
+ * A Project is the top level object in the core object/domain model and groups
+ * zero or more child {@see NGI}s. A project is comparable to a top
+ * level GLUE2 AdminDomain class.
  * <p>
- * Users can request Roles over the Project which grants 
- * various permissions over the Project and its child NGIs.  
- * 
- * @author David Meredith <david.meredith@stfc.ac.uk> 
- * 
+ * Users can request Roles over the Project which grants
+ * various permissions over the Project and its child NGIs.
+ *
+ * @author David Meredith <david.meredith@stfc.ac.uk>
+ *
  * @Entity @Table(name="Projects")
  */
 class Project extends OwnedEntity {
@@ -32,10 +32,10 @@ class Project extends OwnedEntity {
 
     /** @Column(type="string", length=2000, nullable=true) */
     protected $description;
-    
+
     /**
-     * Bidirectional - Many Projects (OWNING SIDE) can link to many NGIs 
-     * 
+     * Bidirectional - Many Projects (OWNING SIDE) can link to many NGIs
+     *
      * @ManyToMany(targetEntity="NGI", inversedBy="projects")
      * @JoinTable(name="Projects_NGIs",
      *      joinColumns={@JoinColumn(name="project_Id", referencedColumnName="id")},
@@ -43,14 +43,14 @@ class Project extends OwnedEntity {
      *      )
      */
     protected $ngis;
-    
+
     /* DATETIME NOTE:
      * Doctrine checks whether a date's been updated by doing a byreference comparison.
      * If you just update an existing DateTime object, Doctrine won't persist it!
      * Create a new DateTime object and reference that for it to persist during an update.
      * http://docs.doctrine-project.org/en/2.0.x/cookbook/working-with-datetime.html
      */
-    
+
     /** @Column(type="datetime", nullable=false) */
     protected $creationDate;
 
@@ -59,18 +59,18 @@ class Project extends OwnedEntity {
      * @param string $name The project's name
      */
     public function __construct($name) {
-        parent::__construct(); 
-        
+        parent::__construct();
+
         // Set cretion date
-        $this->creationDate =  new \DateTime(null, new \DateTimeZone('UTC')); 
-        
+        $this->creationDate =  new \DateTime(null, new \DateTimeZone('UTC'));
+
         $this->setName($name);
         $this->ngis = new ArrayCollection();
     }
 
-    
+
     /**
-     * Get the unique name of the Project. 
+     * Get the unique name of the Project.
      * @return string
      */
     public function getName() {
@@ -78,15 +78,15 @@ class Project extends OwnedEntity {
     }
 
     /**
-     * A nullable string for the human readable description of this project. 
+     * A nullable string for the human readable description of this project.
      * @return string
      */
     public function getDescription() {
         return $this->description;
     }
-    
+
     /**
-     * Get all the child {@see NGI} objects that are owned by this project. 
+     * Get all the child {@see NGI} objects that are owned by this project.
      * @return ArrayCollection
      */
     public function getNgis() {
@@ -94,7 +94,7 @@ class Project extends OwnedEntity {
     }
 
     /**
-     * Set the unique name of the project. Must be unique in the DB. 
+     * Set the unique name of the project. Must be unique in the DB.
      * @param string $name
      */
     public function setName($name) {
@@ -102,17 +102,17 @@ class Project extends OwnedEntity {
     }
 
     /**
-     * Set the human readable description for this project, max 2000 chars. 
+     * Set the human readable description for this project, max 2000 chars.
      * @param string $description
      */
     public function setDescription($description) {
         $this->description = $description;
     }
-   
+
     /**
-     * Add the given NGI to this project's list of child NGIs. Note, this 
-     * method calls the <code>$ngi->addProject($this);</code> to set the join 
-     * on both sides of the relationship.  
+     * Add the given NGI to this project's list of child NGIs. Note, this
+     * method calls the <code>$ngi->addProject($this);</code> to set the join
+     * on both sides of the relationship.
      * @param \NGI $ngi
      */
     public function addNgi(\NGI $ngi){
@@ -123,17 +123,17 @@ class Project extends OwnedEntity {
     /**
      * Returns value of {@link \OwnedEntity::TYPE_PROJECT}
      * @see \OwnedEntity::getType()
-     * @return string 
+     * @return string
      */
     public function getType() {
-        return parent::TYPE_PROJECT; 
+        return parent::TYPE_PROJECT;
     }
 
     /**
-     * @return ArrayCollection Empty collection, Project has no owning parents.  
+     * @return ArrayCollection Empty collection, Project has no owning parents.
      */
     public function getParentOwnedEntities() {
         return new ArrayCollection();
     }
-    
+
 }

--- a/lib/Doctrine/entities/RetrieveAccountRequest.php
+++ b/lib/Doctrine/entities/RetrieveAccountRequest.php
@@ -13,13 +13,13 @@
  */
 
 /**
- * Records a new retrieve account request record. 
+ * Records a new retrieve account request record.
  * <p>
- * Users may need to retrieve their old account when their ID/DN has changed. 
- * This record stores the relevant data needed to retrieve their old account, 
- * including a confirmation code that is sent to the user's existing email 
- * address - they need to provide the code to complete the account retrieval transaction.  
- * 
+ * Users may need to retrieve their old account when their ID/DN has changed.
+ * This record stores the relevant data needed to retrieve their old account,
+ * including a confirmation code that is sent to the user's existing email
+ * address - they need to provide the code to complete the account retrieval transaction.
+ *
  * @author John Casson
  * @author David Meredith <david.meredith@stfc.ac.uk>
  * @Entity @Table(name="RetrieveAccountRequests")
@@ -29,9 +29,9 @@ class RetrieveAccountRequest {
     /** @Id @Column(type="integer") @GeneratedValue */
     protected $id;
 
-    /** 
+    /**
      * @OneToOne(targetEntity="User")
-     * @JoinColumn(name="user_id", referencedColumnName="id", onDelete="CASCADE") 
+     * @JoinColumn(name="user_id", referencedColumnName="id", onDelete="CASCADE")
      */
     protected $user;
 
@@ -55,7 +55,7 @@ class RetrieveAccountRequest {
     }
 
     /**
-     * Get the User who made this request. 
+     * Get the User who made this request.
      * @return \User
      */
     public function getUser() {
@@ -63,9 +63,9 @@ class RetrieveAccountRequest {
     }
 
     /**
-     * Return the confirmation code that is used to authenticate the user. 
-     * This code is sent to the user's existing email address - they need to 
-     * provide the code to complete the account retrieval transaction. 
+     * Return the confirmation code that is used to authenticate the user.
+     * This code is sent to the user's existing email address - they need to
+     * provide the code to complete the account retrieval transaction.
      * @return string
      */
     public function getConfirmCode() {
@@ -73,7 +73,7 @@ class RetrieveAccountRequest {
     }
 
     /**
-     * Get the updated user DN/ID that newly identifies the user account. 
+     * Get the updated user DN/ID that newly identifies the user account.
      * @return string
      */
     public function getNewDn() {
@@ -81,7 +81,7 @@ class RetrieveAccountRequest {
     }
 
     /**
-     * Set the user. 
+     * Set the user.
      * @param \User $user
      */
     public function setUser($user) {
@@ -89,9 +89,9 @@ class RetrieveAccountRequest {
     }
 
     /**
-     * Set the confirmation code that is used to authenticate the user. 
-     * This code is sent to the user's existing email address - they need to 
-     * provide the code to complete the account retrieval transaction. 
+     * Set the confirmation code that is used to authenticate the user.
+     * This code is sent to the user's existing email address - they need to
+     * provide the code to complete the account retrieval transaction.
      * @param string $code
      */
     public function setConfirmCode($code) {
@@ -99,7 +99,7 @@ class RetrieveAccountRequest {
     }
 
     /**
-     * Set the new DN/ID string of the user account. 
+     * Set the new DN/ID string of the user account.
      * @param string $dn
      */
     public function setNewDn($dn) {

--- a/lib/Doctrine/entities/Role.php
+++ b/lib/Doctrine/entities/Role.php
@@ -14,12 +14,12 @@
 //use Doctrine\Common\Collections\ArrayCollection;
 
 /**
- * A Role establishes that the {@see User} has the specified {@see \RoleType} over the 
- * {@see \OwnedEntity} with the specified status.  
+ * A Role establishes that the {@see User} has the specified {@see \RoleType} over the
+ * {@see \OwnedEntity} with the specified status.
  * <p>
  * A Role doubles as a Role-Request if its status is e.g. 'STATUS_PENDING'
- * and becomes an official Role if it is updated to 'STATUS_GRANTED'. Ownership of a 
- * Role usually grants certain permissions over the OwnedEntity object.  
+ * and becomes an official Role if it is updated to 'STATUS_GRANTED'. Ownership of a
+ * Role usually grants certain permissions over the OwnedEntity object.
  * <p>
  * A single Role has ManyToOne relationships with RoleType, User and OwnedEntity
  * (Role is on the many side).
@@ -27,11 +27,11 @@
  * A joined Role must be deleted before a joined User, OwnedEntity or RoleType
  * can be deleted.
  * A user can't own duplcate roles, this is enforced with a 'NoDuplicateRoles' DB
- * constraint which prevents persisting of user+role type+ownedentity combinations 
- * that already exist.   
- * 
- * @author David Meredith <david.meredithh@stfc.ac.uk> 
- * @author John Casson 
+ * constraint which prevents persisting of user+role type+ownedentity combinations
+ * that already exist.
+ *
+ * @author David Meredith <david.meredithh@stfc.ac.uk>
+ * @author John Casson
  * @Entity @Table(name="Roles", uniqueConstraints={@UniqueConstraint(name="NoDuplicateRoles", columns={"user_id", "roleType_id", "ownedEntity_id"})})
  *
  */
@@ -43,7 +43,7 @@ class Role {
     /** @ManyToOne(targetEntity="RoleType") **/
     protected $roleType;
 
-    /** 
+    /**
      * @ManyToOne(targetEntity="User", inversedBy="roles")
      * @JoinColumn(name="user_id", referencedColumnName="id", onDelete="CASCADE")
      */
@@ -51,17 +51,17 @@ class Role {
 
     /**
      * Allows polymorphic queries - a role can be related to an OwnedEntity whose
-     * type can be different, e.g. Site, NGI. The onDelete means that if the 
-     * OwnedEntity is deleted, then all linked Roles are also deleted. 
-     * 
+     * type can be different, e.g. Site, NGI. The onDelete means that if the
+     * OwnedEntity is deleted, then all linked Roles are also deleted.
+     *
      * @ManyToOne(targetEntity="OwnedEntity", inversedBy="roles")
      * @JoinColumn(name="ownedEntity_id", referencedColumnName="id", onDelete="CASCADE")
      */
     protected $ownedEntity = null;
 
-    /** 
+    /**
      * Current status of this role, e.g. STATUS_GRANTED, STATUS_PENDING
-     * @Column(type="string", nullable=false) 
+     * @Column(type="string", nullable=false)
      */
     protected $status;
 
@@ -69,18 +69,18 @@ class Role {
     //protected $lastUpdatedByUserId;
 
     /*
-     * A transient extension object used to decorate this instance with extra information. 
+     * A transient extension object used to decorate this instance with extra information.
      * Note, this object is <b>NOT</b> persisted to the DB. It is intended for transient
-     * operations such as holding extra view parameters for transer/rendering in the view layer.  
+     * operations such as holding extra view parameters for transer/rendering in the view layer.
      */
-    protected $decoratorObject; 
-    
+    protected $decoratorObject;
+
     /**
      * Create a new role which establishes that the specified User has the
      * RoleType over the OwnedEntity.
      *
      * @param \RoleType $roleType The role's type
-     * @param string $name The role name 
+     * @param string $name The role name
      * @param \User $user The role is for this user
      * @param \OwnedEntity $ownedEntity The role is over this entity
      * @param string $status The current Role status, e.g. 'STATUS_PENDING' for
@@ -89,21 +89,21 @@ class Role {
     public function __construct(\RoleType $roleType, \User $user, \OwnedEntity $ownedEntity, $status) {
         $this->roleType = $roleType;
         $this->setStatus($status);
-        //$this->setName($name); 
+        //$this->setName($name);
         $ownedEntity->addRoleDoJoin($this);
         $user->addRoleDoJoin($this);
         // @link http://www.doctrine-project.org/blog/doctrine-2-give-me-my-constructor-back.html Using constructors in Entities
     }
 
     /**
-     * @return int The PK of this entity or null if not persisted. 
+     * @return int The PK of this entity or null if not persisted.
      */
     public function getId() {
         return $this->id;
     }
 
     /**
-     * @return \RoleType The type of this role. 
+     * @return \RoleType The type of this role.
      */
     public function getRoleType() {
         return $this->roleType;
@@ -117,7 +117,7 @@ class Role {
     }
 
     /**
-     * @return \OwnedEntity The object that this Role is over. 
+     * @return \OwnedEntity The object that this Role is over.
      */
     public function getOwnedEntity() {
         return $this->ownedEntity;
@@ -175,24 +175,24 @@ class Role {
     }*/
 
     /**
-     * Set a transient extension object used to decorate this instance with extra information. 
+     * Set a transient extension object used to decorate this instance with extra information.
      * Note, this object is <b>NOT</b> persisted to the DB. It is intended for transient
-     * operations such as holding extra view parameters for transer/rendering in the view layer.  
-     *   
+     * operations such as holding extra view parameters for transer/rendering in the view layer.
+     *
      * @param mixed $decoratorObject
      */
     public function setDecoratorObject($decoratorObject){
-      $this->decoratorObject = $decoratorObject;     
+      $this->decoratorObject = $decoratorObject;
     }
 
     /**
-     * Get the transient extension object used to decorate this instance with extra information. 
+     * Get the transient extension object used to decorate this instance with extra information.
      * Note, this object is <b>NOT</b> persisted to the DB. It is intended for transient
-     * operations such as holding extra view parameters for transer/rendering in the view layer.   
-     * @return mixed or null  
+     * operations such as holding extra view parameters for transer/rendering in the view layer.
+     * @return mixed or null
      */
     public function getDecoratorObject(){
-       return $this->decoratorObject;  
-    } 
+       return $this->decoratorObject;
+    }
 
 }

--- a/lib/Doctrine/entities/RoleActionRecord.php
+++ b/lib/Doctrine/entities/RoleActionRecord.php
@@ -13,17 +13,17 @@
  */
 
 /**
- * A standalone entity that logs a role related actions such as Role approval, 
- * deletion and denial. 
+ * A standalone entity that logs a role related actions such as Role approval,
+ * deletion and denial.
  * <p>
  * The entity is standalone and has no relationships. This is to allow
- * RoleActionRecords to have a lifespan that is independent of the {@link \Role} 
- * and {@link \OwnedEntity} affected by the role action. 
- * Therefore, while roles and owned entities may be deleted, the action record is 
- * unaffected and serves as a permanent change log.  
- * Once created, object is immutable. 
+ * RoleActionRecords to have a lifespan that is independent of the {@link \Role}
+ * and {@link \OwnedEntity} affected by the role action.
+ * Therefore, while roles and owned entities may be deleted, the action record is
+ * unaffected and serves as a permanent change log.
+ * Once created, object is immutable.
  *
- * @author David Meredith <david.meredith@stfc.ac.uk>  
+ * @author David Meredith <david.meredith@stfc.ac.uk>
  * @Entity @Table(name="RoleActionRecords")
  */
 class RoleActionRecord {
@@ -36,131 +36,131 @@ class RoleActionRecord {
 
 
     //========================================================================
-    // Who created/updated this record  
+    // Who created/updated this record
     //========================================================================
     /**
-     * Id of the {@link \User} who created the record.  
-     * @Column(type="integer", nullable=false) 
-     * @var int 
+     * Id of the {@link \User} who created the record.
+     * @Column(type="integer", nullable=false)
+     * @var int
      */
     protected $updatedByUserId;
 
     /**
-     * A human readable string to help identify the {@link \User} who last 
-     * updated this record, e.g. a principle such as a DN, or the concat of 
-     * 'Firstname, Lastname'. Note, this value should not be used as a natural 
-     * foreign key and is for display purposes only.  
+     * A human readable string to help identify the {@link \User} who last
+     * updated this record, e.g. a principle such as a DN, or the concat of
+     * 'Firstname, Lastname'. Note, this value should not be used as a natural
+     * foreign key and is for display purposes only.
      * @Column(type="string", nullable=false)
-     * @var string 
+     * @var string
      */
     protected $updatedByUserPrinciple;
-    
+
     //========================================================================
-    // Which Role does this record affect  
+    // Which Role does this record affect
     //========================================================================
     /**
-     * Id of the updated {@link \Role}. 
-     * @Column(type="integer", nullable=false) 
+     * Id of the updated {@link \Role}.
+     * @Column(type="integer", nullable=false)
      * @var int
      */
     protected $roleId;
 
     /**
      * The Role status before update (e.g. STATUS_PENDING)
-     * @Column(type="string", nullable=false) 
-     * @var string 
+     * @Column(type="string", nullable=false)
+     * @var string
      */
     protected $rolePreStatus;
 
     /**
      * The Role status after update (e.g. STATUS_GRANTED, STATUS_DELETED)
-     * @Column(type="string", nullable=false) 
-     * @var string 
+     * @Column(type="string", nullable=false)
+     * @var string
      */
     protected $roleNewStatus;
-    
+
     //========================================================================
-    // What was the RoleType   
+    // What was the RoleType
     //========================================================================
     /**
-     * The RoleType Id. 
-     * @Column(type="integer", nullable=false) 
-     * @var int 
+     * The RoleType Id.
+     * @Column(type="integer", nullable=false)
+     * @var int
      */
     protected $roleTypeId;
 
     /**
      * The RoleType name (e.g. 'Site Administrator')
-     * @Column(type="string", nullable=false) 
-     * @var string 
+     * @Column(type="string", nullable=false)
+     * @var string
      */
     protected $roleTypeName;
-    
+
     //========================================================================
     // What was the Roles target OwnedEntity
     //========================================================================
     /**
-     * Id of the Role's affected {@link \OwnedEntity}.  
-     * @Column(type="integer", nullable=false) 
-     * @var int 
+     * Id of the Role's affected {@link \OwnedEntity}.
+     * @Column(type="integer", nullable=false)
+     * @var int
      */
     protected $roleTargetOwnedEntityId;
 
     /**
      * The type of {@link \OwnedEntity}, i.e. NGI, Site, Service, ServiceGroup
      * @Column(type="string", nullable=false)
-     * @var string 
+     * @var string
      */
     protected $roleTargetOwnedEntityType;
-    
+
     //========================================================================
-    // Who was the Role's target user 
+    // Who was the Role's target user
     //========================================================================
     /**
-     * Id of the {@link \User}.  
-     * @Column(type="integer", nullable=false) 
-     * @var int 
+     * Id of the {@link \User}.
+     * @Column(type="integer", nullable=false)
+     * @var int
      */
     protected $roleUserId;
 
     /**
-     * A human readable string to help identify the {@link \User} who created 
-     * this record, e.g. a principle such as a DN, or the concat of 
-     * 'Firstname, Lastname'. Note, this value should not be used as a natural 
-     * foreign key and is for display purposes only.  
+     * A human readable string to help identify the {@link \User} who created
+     * this record, e.g. a principle such as a DN, or the concat of
+     * 'Firstname, Lastname'. Note, this value should not be used as a natural
+     * foreign key and is for display purposes only.
      * @Column(type="string", nullable=false)
-     * @var string 
+     * @var string
      */
     protected $roleUserPrinciple;
 
     /**
-     * Create a new instance. 
+     * Create a new instance.
      * Calling code should use {@link RoleActionRecord::construct($callingUser, $role, $newStatus)}
-     * instead to construct an instance. 
-     *  
-     * @param int    $updatedByUserId Id of {@link \User} who creates/updates the record. 
-     * @param string $updatedByUserPrinciple Human readable string of {@link \User} 
-     *               who updates the record (e.g. concat of 'firstName secondName' or principle string). 
-     *               Note, this value should not be used as a natural foreign 
+     * instead to construct an instance.
+     *
+     * @param int    $updatedByUserId Id of {@link \User} who creates/updates the record.
+     * @param string $updatedByUserPrinciple Human readable string of {@link \User}
+     *               who updates the record (e.g. concat of 'firstName secondName' or principle string).
+     *               Note, this value should not be used as a natural foreign
      *               key and is for display purposes only.
-     * @param int    $roleId The target {@link \Role} 
+     * @param int    $roleId The target {@link \Role}
      * @param string $rolePreStatus The Role status before update (e.g. STATUS_PENDING)
      * @param string $roleNewStatus The Role status after update (e.g. STATUS_GRANTED)
      * @param int    $roleTypeId The Id of the {@link \RoleType}
-     * @param string $roleTypeName The {@link \RoleType} name value 
-     * @param int    $roleTargetOwnedEntityId The {@link \OwnedEntity} id that the Role is over  
-     * @param string $roleTargetOwnedEntityType The type of {@link \OwnedEntity} e.g. Site, Service, NGI, ServiceGroup 
-     * @param int    $roleUserId The Id of the {@link \User} who owns the Role.  
-     * @param string $roleUserPrinciple Human readable string of {@link \User} 
-     *               who owns the Role (e.g. concat of 'firstName secondName' or principle string).  
-     *               Note, this value should not be used as a natural foreign 
+     * @param string $roleTypeName The {@link \RoleType} name value
+     * @param int    $roleTargetOwnedEntityId The {@link \OwnedEntity} id that the Role is over
+     * @param string $roleTargetOwnedEntityType The type of {@link \OwnedEntity} e.g. Site, Service, NGI, ServiceGroup
+     * @param int    $roleUserId The Id of the {@link \User} who owns the Role.
+     * @param string $roleUserPrinciple Human readable string of {@link \User}
+     *               who owns the Role (e.g. concat of 'firstName secondName' or principle string).
+     *               Note, this value should not be used as a natural foreign
      *               key and is for display purposes only.
      */
-    function __construct($updatedByUserId, $updatedByUserPrinciple, $roleId, 
-            $rolePreStatus, $roleNewStatus, $roleTypeId, $roleTypeName, 
+    function __construct($updatedByUserId, $updatedByUserPrinciple, $roleId,
+            $rolePreStatus, $roleNewStatus, $roleTypeId, $roleTypeName,
             $roleTargetOwnedEntityId, $roleTargetOwnedEntityType, $roleUserId, $roleUserPrinciple) {
-        
-        $this->actionDate =  new \DateTime(null, new \DateTimeZone('UTC')); 
+
+        $this->actionDate =  new \DateTime(null, new \DateTimeZone('UTC'));
 
         $this->updatedByUserId = $updatedByUserId;
         $this->updatedByUserPrinciple = $updatedByUserPrinciple;
@@ -176,26 +176,26 @@ class RoleActionRecord {
     }
 
     /**
-     * Convenience method to construct a new instance. 
-     * 
+     * Convenience method to construct a new instance.
+     *
      * @param \User $callingUser {@link \User} who creates/updates this record.
-     * @param \Role $role The target {@link \Role} 
+     * @param \Role $role The target {@link \Role}
      * @param string $newStatus
      * @return \self
      */
     public static function construct(\User $callingUser, \Role $role, $newStatus) {
         $rar = new self(
-                $callingUser->getId(), 
-                /* $callingUser->getCertificateDn(), */ 
-                $callingUser->getFullName(), 
-                $role->getId(), 
-                $role->getStatus(), 
-                $newStatus, 
-                $role->getRoleType()->getId(), 
-                $role->getRoleType()->getName(), 
-                $role->getOwnedEntity()->getId(), 
-                $role->getOwnedEntity()->getType(), 
-                $role->getUser()->getId(), 
+                $callingUser->getId(),
+                /* $callingUser->getCertificateDn(), */
+                $callingUser->getFullName(),
+                $role->getId(),
+                $role->getStatus(),
+                $newStatus,
+                $role->getRoleType()->getId(),
+                $role->getRoleType()->getName(),
+                $role->getOwnedEntity()->getId(),
+                $role->getOwnedEntity()->getType(),
+                $role->getUser()->getId(),
                 $role->getUser()->getFullName());
         return $rar;
     }
@@ -208,7 +208,7 @@ class RoleActionRecord {
     }
 
     /**
-     * The DateTime that this RoleActionRecord was created. 
+     * The DateTime that this RoleActionRecord was created.
      * @return \DateTime
      */
     function getActionDate() {
@@ -216,7 +216,7 @@ class RoleActionRecord {
     }
 
     /**
-     * Get the ID/DN of the user who created/last updated this record. 
+     * Get the ID/DN of the user who created/last updated this record.
      * @return string
      */
     function getUpdatedByUserId() {
@@ -224,8 +224,8 @@ class RoleActionRecord {
     }
 
     /**
-     * A human readable string to help identify the \User who last updated this 
-     * record, e.g. a principle such as a DN or the concat of 'Firstname, Lastname'. 
+     * A human readable string to help identify the \User who last updated this
+     * record, e.g. a principle such as a DN or the concat of 'Firstname, Lastname'.
      * Note, this value should not be used as a natural foreign key and is for display purposes only.
      * @return string
      */
@@ -234,7 +234,7 @@ class RoleActionRecord {
     }
 
     /**
-     * The PK/Id of the Role this record refers to. 
+     * The PK/Id of the Role this record refers to.
      * @return int
      */
     function getRoleId() {
@@ -258,8 +258,8 @@ class RoleActionRecord {
     }
 
     /**
-     * The RoleType Id. 
-     * @return int 
+     * The RoleType Id.
+     * @return int
      */
     function getRoleTypeId() {
         return $this->roleTypeId;
@@ -282,16 +282,16 @@ class RoleActionRecord {
     }
 
     /**
-     * The type name of {@see \OwnedEntity} that is the target of the Role, e.g. 
-     * NGI, Site, Service, ServiceGroup 
-     * @return string 
+     * The type name of {@see \OwnedEntity} that is the target of the Role, e.g.
+     * NGI, Site, Service, ServiceGroup
+     * @return string
      */
     function getRoleTargetOwnedEntityType() {
         return $this->roleTargetOwnedEntityType;
     }
 
     /**
-     * Id/PK of the {@see \User} who owns/owned the Role. 
+     * Id/PK of the {@see \User} who owns/owned the Role.
      * @return int
      */
     function getRoleUserId() {
@@ -299,10 +299,10 @@ class RoleActionRecord {
     }
 
     /**
-     * A human readable string to help identify the {@link \User} who created 
-     * this record, e.g. a principle such as a DN, or the concat of 
-     * 'Firstname, Lastname'. Note, this value should not be used as a natural 
-     * foreign key and is for display purposes only.  
+     * A human readable string to help identify the {@link \User} who created
+     * this record, e.g. a principle such as a DN, or the concat of
+     * 'Firstname, Lastname'. Note, this value should not be used as a natural
+     * foreign key and is for display purposes only.
      * @return string
      */
     function getRoleUserPrinciple() {

--- a/lib/Doctrine/entities/RoleType.php
+++ b/lib/Doctrine/entities/RoleType.php
@@ -14,12 +14,12 @@
 //use Doctrine\Common\Collections\ArrayCollection;
 
 /**
- * A RoleType defines the type of {@see Role}. 
- * The <code>name</code> is required and must be unique in the database. 
- * 
- * @author John Casson 
- * @author David Meredith <david.meredith@stfc.ac.uk> 
- * 
+ * A RoleType defines the type of {@see Role}.
+ * The <code>name</code> is required and must be unique in the database.
+ *
+ * @author John Casson
+ * @author David Meredith <david.meredith@stfc.ac.uk>
+ *
  * @Entity @Table(name="RoleTypes")
  */
 class RoleType {
@@ -31,14 +31,14 @@ class RoleType {
     protected $name;
 
     /**
-     * Create a new instance. The given name must have a value and be unique in the database. 
-     * 
-     * @param string $name The roleType name. 
-     * @throws RuntimeException if the given args are not strings 
+     * Create a new instance. The given name must have a value and be unique in the database.
+     *
+     * @param string $name The roleType name.
+     * @throws RuntimeException if the given args are not strings
      */
     public function __construct($name/* , $classification */) {
         $this->setName($name);
-        //$this->setClassification($classification);  
+        //$this->setClassification($classification);
     }
 
     /**
@@ -58,9 +58,9 @@ class RoleType {
 
 
     /**
-     * Set/update the name of the RoleType. It must be unique in the DB. 
+     * Set/update the name of the RoleType. It must be unique in the DB.
      * @param string $name
-     * @throws RuntimeException if the given param is not a string 
+     * @throws RuntimeException if the given param is not a string
      */
     public function setName($name) {
         if (!is_string($name)) {

--- a/lib/Doctrine/entities/Scope.php
+++ b/lib/Doctrine/entities/Scope.php
@@ -14,16 +14,16 @@
 //use Doctrine\Common\Collections\ArrayCollection;
 
 /**
- * A Scope is a tag that is joined to entities that define the 
- * {@see \IScopedEntity} interface. 
+ * A Scope is a tag that is joined to entities that define the
+ * {@see \IScopedEntity} interface.
  * <p>
- * Scopes are used for resource matching and filtering, e.g. find all Sites 
- * that have a Scope value of 'X'. 
- * The relationship between Scope and an {@see \IScopedEntity} is a 
- * uni-directional aggregation (IScopedEntities do not own scopes, they are 
- * only linked to Scope instances). 
- *  
- * @author David Meredith <david.meredith@stfc.ac.uk> 
+ * Scopes are used for resource matching and filtering, e.g. find all Sites
+ * that have a Scope value of 'X'.
+ * The relationship between Scope and an {@see \IScopedEntity} is a
+ * uni-directional aggregation (IScopedEntities do not own scopes, they are
+ * only linked to Scope instances).
+ *
+ * @author David Meredith <david.meredith@stfc.ac.uk>
  * @Entity @Table(name="Scopes")
  */
 class Scope {
@@ -45,7 +45,7 @@ class Scope {
     }
 
     /**
-     * Get the unique name of the scope. 
+     * Get the unique name of the scope.
      * @return string
      */
     public function getName() {
@@ -53,7 +53,7 @@ class Scope {
     }
 
     /**
-     * Get a human readable description of this scope. 
+     * Get a human readable description of this scope.
      * @return string or null
      */
     public function getDescription() {
@@ -61,7 +61,7 @@ class Scope {
     }
 
     /**
-     * Set the unique name of this Scope instance. 
+     * Set the unique name of this Scope instance.
      * @param string $name
      */
     public function setName($name) {
@@ -69,7 +69,7 @@ class Scope {
     }
 
     /**
-     * Set the human readable description of this scope. 
+     * Set the human readable description of this scope.
      * @param string $description
      */
     public function setDescription($description) {
@@ -77,7 +77,7 @@ class Scope {
     }
 
     /**
-     * Returns the unique name of this Scope instance. 
+     * Returns the unique name of this Scope instance.
      * @return string
      */
     public function __toString() {

--- a/lib/Doctrine/entities/Service.php
+++ b/lib/Doctrine/entities/Service.php
@@ -16,19 +16,19 @@ use Doctrine\Common\Collections\ArrayCollection;
 require_once __DIR__ . '/IScopedEntity.php';
 
 /**
- * A Service defines an instance of an e-Infrastructure service that 
- * is linked to a service type, has endpoints and is owned by a parent Site. 
+ * A Service defines an instance of an e-Infrastructure service that
+ * is linked to a service type, has endpoints and is owned by a parent Site.
  * <p>
- * More formally: a logical view of actual software components that 
- * participate in the creation of an entity providing one or more 
- * functionalities useful in an e-infrastructure  environment (from GLUE2). 
- *  
- * @author David Meredith <david.meredithh@stfc.ac.uk> 
- * @author John Casson 
+ * More formally: a logical view of actual software components that
+ * participate in the creation of an entity providing one or more
+ * functionalities useful in an e-infrastructure  environment (from GLUE2).
+ *
+ * @author David Meredith <david.meredithh@stfc.ac.uk>
+ * @author John Casson
  * @Entity @Table(name="Services")
  */
 class Service implements IScopedEntity {
-    
+
     /** @Id @Column(type="integer") @GeneratedValue */
     protected $id;
 
@@ -52,10 +52,10 @@ class Service implements IScopedEntity {
 
     /** @Column(type="string", nullable=true) */
     protected $ipAddress;
-        
+
     /** @Column(type="string", nullable=true) */
     protected $ipV6Address;
-        
+
     /** @Column(type="string", nullable=true) */
     protected $operatingSystem;
 
@@ -88,7 +88,7 @@ class Service implements IScopedEntity {
      * @ManyToMany(targetEntity="Downtime", mappedBy="services" )
      */
     protected $downtimes;
-        
+
     /**
      * @OneToMany(targetEntity="EndpointLocation", mappedBy="service" )
      */
@@ -99,7 +99,7 @@ class Service implements IScopedEntity {
      * @OneToMany(targetEntity="ServiceProperty", mappedBy="parentService", cascade={"remove"})
      */
     protected $serviceProperties = null;
-        
+
     /**
      * Unidirectional - Scope tags associated with the service
      *
@@ -117,7 +117,7 @@ class Service implements IScopedEntity {
      * Create a new DateTime object and reference that for it to persist during an update.
      * http://docs.doctrine-project.org/en/2.0.x/cookbook/working-with-datetime.html
      */
-    
+
     /** @Column(type="datetime", nullable=false) **/
     protected $creationDate;
 
@@ -140,11 +140,11 @@ class Service implements IScopedEntity {
     }
 
     /**
-     * The main network URL of this service. Note, a Service can define 
+     * The main network URL of this service. Note, a Service can define
      * additional {@see EndpointLocation}s to define different contact endpoints
-     * as required. External monitoring will usually contact this URL to test 
-     * service state. 
-     *  
+     * as required. External monitoring will usually contact this URL to test
+     * service state.
+     *
      * @return string or null
      */
     public function getUrl(){
@@ -152,9 +152,9 @@ class Service implements IScopedEntity {
     }
 
     /**
-     * The main hostname used for this service. 
-     * This is largely required for external monitoring that requires a distinct 
-     * host name to ping. 
+     * The main hostname used for this service.
+     * This is largely required for external monitoring that requires a distinct
+     * host name to ping.
      * @return string
      */
     public function getHostName() {
@@ -162,7 +162,7 @@ class Service implements IScopedEntity {
     }
 
     /**
-     * A nullable human readable description of this service. 
+     * A nullable human readable description of this service.
      * @return string
      */
     public function getDescription() {
@@ -170,7 +170,7 @@ class Service implements IScopedEntity {
     }
 
     /**
-     * Is this service considered production or not. 
+     * Is this service considered production or not.
      * @return boolean
      */
     public function getProduction() {
@@ -178,7 +178,7 @@ class Service implements IScopedEntity {
     }
 
     /**
-     * Is this service considered beta or not. 
+     * Is this service considered beta or not.
      * @return boolean
      */
     public function getBeta() {
@@ -186,7 +186,7 @@ class Service implements IScopedEntity {
     }
 
     /**
-     * Is this service monitored or not. 
+     * Is this service monitored or not.
      * @return boolean
      */
     public function getMonitored() {
@@ -194,15 +194,15 @@ class Service implements IScopedEntity {
     }
 
     /**
-     * Defines the DN of the services x509 certificate. 
-     * @return string or null 
+     * Defines the DN of the services x509 certificate.
+     * @return string or null
      */
     public function getDn() {
         return $this->dn;
     }
 
     /**
-     * The IPv4 address of the service. 
+     * The IPv4 address of the service.
      * @return string or null
      */
     public function getIpAddress() {
@@ -210,7 +210,7 @@ class Service implements IScopedEntity {
     }
 
     /**
-     * The IPv6 address of the service. 
+     * The IPv6 address of the service.
      * @return string or null
      */
     public function getIpV6Address() {
@@ -218,8 +218,8 @@ class Service implements IScopedEntity {
     }
 
     /**
-     * A label for the service OS such as 'linux' or 'windows'. 
-     * Refer to the GLUE2 OSName_t Enum type.  
+     * A label for the service OS such as 'linux' or 'windows'.
+     * Refer to the GLUE2 OSName_t Enum type.
      * @return string or null
      */
     public function getOperatingSystem() {
@@ -261,44 +261,44 @@ class Service implements IScopedEntity {
     public function getServiceGroups() {
         return $this->serviceGroups;
     }
-    
+
     /**
-     * provides a string containg a list of the names of scopes with which the 
+     * provides a string containg a list of the names of scopes with which the
      * object been tagged.
-     * @return string  string containing ", " seperated list of the names 
+     * @return string  string containing ", " seperated list of the names
      */
     public function getScopeNamesAsString() {
         //Get the scopes for the service
         $scopes = $this->getScopes();
-        
+
         //Create an empty array to contain scope names
         $scopeNames= array();
-        
+
         //populate the array
         foreach ($scopes as $scope){
             $scopeNames[]=$scope->getName();
         }
-        
+
         sort($scopeNames);
 
         //Turn into a string
         $scopeNamesAsString = implode(", " , $scopeNames);
-        
+
         return $scopeNamesAsString;
     }
 
     public function getCreationDate() {
         return $this->creationDate;
     }
-    
+
     public function getDowntimes() {
         return $this->downtimes;
     }
-    
+
     public function setUrl($url){
         $this->url = $url;
     }
-        
+
     public function setHostName($hostName) {
         $this->hostName = $hostName;
     }
@@ -310,7 +310,7 @@ class Service implements IScopedEntity {
     public function setIpV6Address($ipAddress) {
         $this->ipV6Address = $ipAddress;
     }
-        
+
     public function setProduction($production) {
         $this->production = $production;
     }
@@ -354,10 +354,10 @@ class Service implements IScopedEntity {
     public function setCreationDate($creationDate) {
         $this->creationDate = $creationDate;
     }
-    
+
     /**
-     * Add a ServiceProperty entity to this Service's collection of properties. 
-     * This method also sets the ServiceProperty's parentService.  
+     * Add a ServiceProperty entity to this Service's collection of properties.
+     * This method also sets the ServiceProperty's parentService.
      * @param \ServiceProperty $serviceProperty
      */
     public function addServicePropertyDoJoin($serviceProperty) {
@@ -366,39 +366,39 @@ class Service implements IScopedEntity {
     }
 
     /**
-     * Do not call in client code. 
-     * Instead call <code>$downtime->addService($service);</code> to keep 
-     * both sides of the bi-directional relationship consitent.  
+     * Do not call in client code.
+     * Instead call <code>$downtime->addService($service);</code> to keep
+     * both sides of the bi-directional relationship consitent.
      * @param Downtime $downtime
      */
-//    public function _addDowntime(Downtime $downtime) {                
+//    public function _addDowntime(Downtime $downtime) {
 //        $this->downtimes[] = $downtime;
-//        // adding below would cause a race condition 
-//        //$downtime->addService($this); 
+//        // adding below would cause a race condition
+//        //$downtime->addService($this);
 //    }
-        
+
 //    public function removeDowntime(Downtime $downtime) {
 //        $this->downtimes->removeElement($downtime);
 //    }
-        
+
     /**
-     * Add the given EL to the list. This method internally calls 
-     * <code>$endpointLocation->setServiceDoJoin($this)</code> to keep both  
-     * sides of the bidirectional relationship consistent (i.e. don't separately 
-     * call <code>$endpointLocation->setServiceDoJoin($this)</code>). 
+     * Add the given EL to the list. This method internally calls
+     * <code>$endpointLocation->setServiceDoJoin($this)</code> to keep both
+     * sides of the bidirectional relationship consistent (i.e. don't separately
+     * call <code>$endpointLocation->setServiceDoJoin($this)</code>).
      * <p>
-     * Service is the INVERSE side of the relation so the internal call to 
-     * <code>$endpointLocation->setServiceDoJoin($this)</code> actually establishes the relationship in the DB. 
-     * 
+     * Service is the INVERSE side of the relation so the internal call to
+     * <code>$endpointLocation->setServiceDoJoin($this)</code> actually establishes the relationship in the DB.
+     *
      * @param EndpointLocation $endpointLocation
      */
     public function addEndpointLocationDoJoin(EndpointLocation $endpointLocation) {
         $this->endpointLocations[] = $endpointLocation;
-        $endpointLocation->setServiceDoJoin($this);    
+        $endpointLocation->setServiceDoJoin($this);
     }
 
     /**
-     * Create a relationship between the given Scope and this Service. 
+     * Create a relationship between the given Scope and this Service.
      * @param Scope $scope
      */
     public function addScope(Scope $scope) {
@@ -406,10 +406,10 @@ class Service implements IScopedEntity {
     }
 
     /**
-     * Adds the given ServiceGroup to this service's list of SGs. 
+     * Adds the given ServiceGroup to this service's list of SGs.
      * Do not call in client code, always use the opposite
-     * <code>$sg->addService($service)</code> instead which internally calls this 
-     * method to keep the bidirectional relationship consistent.  
+     * <code>$sg->addService($service)</code> instead which internally calls this
+     * method to keep the bidirectional relationship consistent.
      * @param ServiceGroup $sg
      */
     public function addServiceGroup(ServiceGroup $sg) {
@@ -427,11 +427,11 @@ class Service implements IScopedEntity {
 
 
     /**
-     * Returns a string of the form 'serviceTypeName hostname' 
+     * Returns a string of the form 'serviceTypeName hostname'
      * @return string
      */
     public function __toString() {
-        return $this->getServiceType()->getName() . " " . $this->getHostName();                
+        return $this->getServiceType()->getName() . " " . $this->getHostName();
     }
 
 }

--- a/lib/Doctrine/entities/ServiceGroup.php
+++ b/lib/Doctrine/entities/ServiceGroup.php
@@ -15,22 +15,22 @@
 use Doctrine\Common\Collections\ArrayCollection;
 
 /**
- * A ServiceGroup aggregates existing {@see Service}s that may be hosted across 
- * different sites into a loosely defined group. 
+ * A ServiceGroup aggregates existing {@see Service}s that may be hosted across
+ * different sites into a loosely defined group.
  * <p>
- * Having Roles over the ServiceGroup does NOT cascade any permissions over 
- * those services. SGs are typically used to group a set of related services 
- * for monitoring purposes. 
- * 
- * @author John Casson 
- * @author David Meredith <david.meredith@stfc.ac.uk> 
- * 
+ * Having Roles over the ServiceGroup does NOT cascade any permissions over
+ * those services. SGs are typically used to group a set of related services
+ * for monitoring purposes.
+ *
+ * @author John Casson
+ * @author David Meredith <david.meredith@stfc.ac.uk>
+ *
  * @Entity @Table(name="ServiceGroups")
  */
 class ServiceGroup extends OwnedEntity implements IScopedEntity {
-   
-    // DM: The SG name should have a unique constraint, added to the todo list. 
-    // Right now there is nasty manual check run when adding a new service group. 
+
+    // DM: The SG name should have a unique constraint, added to the todo list.
+    // Right now there is nasty manual check run when adding a new service group.
 
     /** @Column(type="string") */
     protected $name;
@@ -64,17 +64,17 @@ class ServiceGroup extends OwnedEntity implements IScopedEntity {
      *      )
      */
     protected $services = null;
-    
+
     /* DATETIME NOTE:
      * Doctrine checks whether a date's been updated by doing a byreference comparison.
      * If you just update an existing DateTime object, Doctrine won't persist it!
      * Create a new DateTime object and reference that for it to persist during an update.
      * http://docs.doctrine-project.org/en/2.0.x/cookbook/working-with-datetime.html
      */
-    
+
     /** @Column(type="datetime", nullable=false) */
     protected $creationDate;
-    
+
     /**
      * Bidirectional - A ServiceGroup (INVERSE ORM SIDE) can have many properties
      * @OneToMany(targetEntity="ServiceGroupProperty", mappedBy="parentServiceGroup", cascade={"remove"})
@@ -83,7 +83,7 @@ class ServiceGroup extends OwnedEntity implements IScopedEntity {
 
     public function __construct() {
         parent::__construct();
-        
+
         // Set cretion date
         $this->creationDate =  new \DateTime("now");
         $this->serviceGroupProperties = new ArrayCollection();
@@ -93,15 +93,15 @@ class ServiceGroup extends OwnedEntity implements IScopedEntity {
 
 
     /**
-     * @return ArrayCollection Empty collection, ServiceGroup has no owning parents.  
+     * @return ArrayCollection Empty collection, ServiceGroup has no owning parents.
      */
     public function getParentOwnedEntities() {
-        // return empty collection - no parents 
+        // return empty collection - no parents
         return new ArrayCollection();
     }
 
     /**
-     * The name of the service group. 
+     * The name of the service group.
      * @return string
      */
     public function getName() {
@@ -131,32 +131,32 @@ class ServiceGroup extends OwnedEntity implements IScopedEntity {
     public function getServiceGroupProperties(){
         return $this->serviceGroupProperties;
     }
-        
+
     /**
-     * A string containg a list of the names of scopes with which the 
+     * A string containg a list of the names of scopes with which the
      * object has been tagged.
-     * @return string  string containing ", " seperated list of the names 
-     */ 
+     * @return string  string containing ", " seperated list of the names
+     */
     public function getScopeNamesAsString() {
-        //Get the scopes for the service 
+        //Get the scopes for the service
         $scopes = $this->getScopes();
-        
+
         //Create an empty array to contain scope names
         $scopeNames= array();
-        
+
         //populate the array
         foreach ($scopes as $scope){
             $scopeNames[]=$scope->getName();
         }
-        
+
         sort($scopeNames);
 
         //Turn into a string
         $scopeNamesAsString = implode(", " , $scopeNames);
-        
+
         return $scopeNamesAsString;
     }
-    
+
     public function getCreationDate() {
         return $this->creationDate;
     }
@@ -180,26 +180,26 @@ class ServiceGroup extends OwnedEntity implements IScopedEntity {
     public function setCreationDate($creationDate) {
         $this->creationDate = $creationDate;
     }
-  
+
     public function addScope(Scope $scope) {
         $this->scopes[] = $scope;
     }
 
     public function addService(Service $se) {
-        $this->services[] = $se;                
+        $this->services[] = $se;
         $se->addServiceGroup($this);
     }
-        
+
     /**
-     * Add a ServiceGroupProperty entity to this Service's collection of properties. 
-     * This method also sets the ServiceGroupProperty's parentService.  
+     * Add a ServiceGroupProperty entity to this Service's collection of properties.
+     * This method also sets the ServiceGroupProperty's parentService.
      * @param \ServiceGroupProperty $serviceGroupProperty
      */
     public function addServiceGroupPropertyDoJoin($serviceGroupProperty) {
         $this->serviceGroupProperties[] = $serviceGroupProperty;
         $serviceGroupProperty->_setParentServiceGroup($this);
     }
-        
+
     public function removeService(Service $se) {
         $this->services->removeElement($se);
     }
@@ -220,9 +220,9 @@ class ServiceGroup extends OwnedEntity implements IScopedEntity {
     /**
      * Returns value of {@link \OwnedEntity::TYPE_SERVICEGROUP}
      * @see \OwnedEntity::getType()
-     * @return string 
+     * @return string
      */
     public function getType() {
-        return parent::TYPE_SERVICEGROUP; 
+        return parent::TYPE_SERVICEGROUP;
     }
 }

--- a/lib/Doctrine/entities/ServiceGroupProperty.php
+++ b/lib/Doctrine/entities/ServiceGroupProperty.php
@@ -15,67 +15,67 @@
 
 /**
  * A custom Key=Value pair (extension property) used to augment a {@see ServiceGroup}
- * object with additional attributes. These properties can also be used for 
+ * object with additional attributes. These properties can also be used for
  * the purposes of resource matching.
  * <p>
- * A unique constraint is defined on the DB preventing key=value duplicates. 
- * Note, duplicate key names with different values are allowed for the purpose 
- * of defning multi-valued properties. 
+ * A unique constraint is defined on the DB preventing key=value duplicates.
+ * Note, duplicate key names with different values are allowed for the purpose
+ * of defning multi-valued properties.
  * <p>
- * When the owning parent ServiceGroup is deleted, its ServiceGroupProperties 
- * are also cascade-deleted. 
- * 
- * @author James McCarthy 
- * @author David Meredith <david.meredith@stfc.ac.uk> 
- * @Entity @Table(name="ServiceGroup_Properties", uniqueConstraints={@UniqueConstraint(name="sgroup_keypairs", columns={"parentServiceGroup_id", "keyName", "keyValue"})}) 
+ * When the owning parent ServiceGroup is deleted, its ServiceGroupProperties
+ * are also cascade-deleted.
+ *
+ * @author James McCarthy
+ * @author David Meredith <david.meredith@stfc.ac.uk>
+ * @Entity @Table(name="ServiceGroup_Properties", uniqueConstraints={@UniqueConstraint(name="sgroup_keypairs", columns={"parentServiceGroup_id", "keyName", "keyValue"})})
  */
 class ServiceGroupProperty {
-   
+
     /** @Id @Column(type="integer") @GeneratedValue */
     protected $id;
 
     /**
-     * Bidirectional - Many ServiceGroupProperty (SIDE OWNING FK) can be linked 
-     * to one ServiceGroup (OWNING ORM SIDE). 
-     *   
-     * @ManyToOne(targetEntity="ServiceGroup", inversedBy="serviceGroupProperties") 
-     * @JoinColumn(name="parentServiceGroup_id", referencedColumnName="id", onDelete="CASCADE") 
+     * Bidirectional - Many ServiceGroupProperty (SIDE OWNING FK) can be linked
+     * to one ServiceGroup (OWNING ORM SIDE).
+     *
+     * @ManyToOne(targetEntity="ServiceGroup", inversedBy="serviceGroupProperties")
+     * @JoinColumn(name="parentServiceGroup_id", referencedColumnName="id", onDelete="CASCADE")
      */
-    protected $parentServiceGroup = null; 
-    
+    protected $parentServiceGroup = null;
+
     /** @Column(type="string", nullable=false) */
-    protected $keyName = null; 
-    
+    protected $keyName = null;
+
     /** @Column(type="string", nullable=true) */
-    protected $keyValue = null; 
-   
+    protected $keyValue = null;
+
     public function __construct() {
     }
 
     /**
-     * Get the owning {@see ServiceGroup} object. When the SG is deleted, 
-     * these properties are also cascade deleted. 
+     * Get the owning {@see ServiceGroup} object. When the SG is deleted,
+     * these properties are also cascade deleted.
      * @return \ServiceGroup
      */
     public function getParentServiceGroup(){
-        return $this->parentServiceGroup; 
+        return $this->parentServiceGroup;
     }
 
     /**
-     * Get the key name, usually a simple alphaNumeric name, but this is not 
-     * enforced by the entity. 
+     * Get the key name, usually a simple alphaNumeric name, but this is not
+     * enforced by the entity.
      * @return string
      */
     public function getKeyName(){
-        return $this->keyName; 
+        return $this->keyName;
     }
 
     /**
-     * Get the key value, can contain any char. 
+     * Get the key value, can contain any char.
      * @return String
      */
     public function getKeyValue(){
-        return $this->keyValue; 
+        return $this->keyValue;
     }
 
     /**
@@ -88,35 +88,35 @@ class ServiceGroupProperty {
     /**
      * Do not call in client code, always use the opposite
      * <code>$site->addServiceGroupPropertyDoJoin($serviceGroupProperty)</code>
-     * instead which internally calls this method to keep the bidirectional 
-     * relationship consistent.  
+     * instead which internally calls this method to keep the bidirectional
+     * relationship consistent.
      * <p>
-     * This is the OWNING side of the ORM relationship so this method WILL 
-     * establish the relationship in the database. 
-     * 
+     * This is the OWNING side of the ORM relationship so this method WILL
+     * establish the relationship in the database.
+     *
      * @param \ServiceGroup $serviceGroup
      */
     public function _setParentServiceGroup($serviceGroup){
-        $this->parentServiceGroup = $serviceGroup; 
+        $this->parentServiceGroup = $serviceGroup;
     }
 
     /**
-     * The custom keyname of this key=value pair. 
-     * This value should be a simple alphanumeric name without special chars, but 
-     * this is not enforced here by the entity.   
+     * The custom keyname of this key=value pair.
+     * This value should be a simple alphanumeric name without special chars, but
+     * this is not enforced here by the entity.
      * @param string $keyName
      */
     public function setKeyName($keyName){
-        $this->keyName = $keyName; 
+        $this->keyName = $keyName;
     }
 
     /**
-     * The custom value of this key=value pair. 
-     * This value can contain any chars. 
+     * The custom value of this key=value pair.
+     * This value can contain any chars.
      * @param string $keyValue
      */
     public function setKeyValue($keyValue){
-        $this->keyValue = $keyValue; 
+        $this->keyValue = $keyValue;
     }
 
 }

--- a/lib/Doctrine/entities/ServiceProperty.php
+++ b/lib/Doctrine/entities/ServiceProperty.php
@@ -15,67 +15,67 @@
 
 /**
  * Custom Key=Value pairs (extension properties) used to augment a {@see Service}
- * object with additional attributes. These properties can also be used for 
+ * object with additional attributes. These properties can also be used for
  * the purposes of resource matching.
  * <p>
- * A unique constraint is defined on the DB preventing key=value duplicates. 
- * Note, duplicate key names with different values are allowed for the purpose 
- * of defning multi-valued properties. 
+ * A unique constraint is defined on the DB preventing key=value duplicates.
+ * Note, duplicate key names with different values are allowed for the purpose
+ * of defning multi-valued properties.
  * <p>
- * When the owning parent Service is deleted, its ServiceProperties 
- * are also cascade-deleted. 
- * 
- * @author James McCarthy 
+ * When the owning parent Service is deleted, its ServiceProperties
+ * are also cascade-deleted.
+ *
+ * @author James McCarthy
  * @author David Meredith
- * @Entity @Table(name="Service_Properties", uniqueConstraints={@UniqueConstraint(name="serv_keypairs", columns={"parentService_id", "keyName", "keyValue"})}) 
+ * @Entity @Table(name="Service_Properties", uniqueConstraints={@UniqueConstraint(name="serv_keypairs", columns={"parentService_id", "keyName", "keyValue"})})
  */
 class ServiceProperty {
-   
+
     /** @Id @Column(type="integer") @GeneratedValue */
     protected $id;
 
     /**
-     * Bidirectional - Many ServiceProperties (SIDE THAT OWNS FK) can be 
-     * linked to one Service (OWNING ORM SIDE). 
-     *   
-     * @ManyToOne(targetEntity="Service", inversedBy="serviceProperties") 
+     * Bidirectional - Many ServiceProperties (SIDE THAT OWNS FK) can be
+     * linked to one Service (OWNING ORM SIDE).
+     *
+     * @ManyToOne(targetEntity="Service", inversedBy="serviceProperties")
      * @JoinColumn(name="parentService_id", referencedColumnName="id", onDelete="CASCADE")
      */
-    protected $parentService = null; 
-    
+    protected $parentService = null;
+
     /** @Column(type="string", nullable=false) */
-    protected $keyName = null; 
-    
+    protected $keyName = null;
+
     /** @Column(type="string", nullable=true) */
-    protected $keyValue = null; 
-   
+    protected $keyValue = null;
+
     public function __construct() {
     }
 
     /**
-     * Get the owning {@see Service} entity. When the service is deleted, 
-     * the ServiceProperties are also cascade-deleted. 
+     * Get the owning {@see Service} entity. When the service is deleted,
+     * the ServiceProperties are also cascade-deleted.
      * @return \Service
      */
     public function getParentService(){
-        return $this->parentService; 
+        return $this->parentService;
     }
 
     /**
-     * Get the key name, usually a simple alphaNumeric name, but this is not 
-     * enforced by the entity. 
+     * Get the key name, usually a simple alphaNumeric name, but this is not
+     * enforced by the entity.
      * @return string
      */
     public function getKeyName(){
-        return $this->keyName; 
+        return $this->keyName;
     }
 
     /**
-     * Get the key value, can contain any char. 
+     * Get the key value, can contain any char.
      * @return String
      */
     public function getKeyValue(){
-        return $this->keyValue; 
+        return $this->keyValue;
     }
 
     /**
@@ -84,41 +84,41 @@ class ServiceProperty {
     public function getId() {
         return $this->id;
     }
-    
+
     /**
      * Do not call in client code, always use the opposite
      * <code>$site->addServicePropertyDoJoin($serviceProperty)</code>
-     * instead which internally calls this method to keep the bidirectional 
-     * relationship consistent.  
+     * instead which internally calls this method to keep the bidirectional
+     * relationship consistent.
      * <p>
-     * This is the OWNING side of the ORM relationship so this method WILL 
-     * establish the relationship in the database. 
-     * 
+     * This is the OWNING side of the ORM relationship so this method WILL
+     * establish the relationship in the database.
+     *
      * @param \Service $service
      */
     public function _setParentService(\Service $service){
-        $this->parentService = $service; 
+        $this->parentService = $service;
     }
 
     /**
-     * The custom keyname of this key=value pair. 
-     * This value should be a simple alphanumeric name without special chars, but 
-     * this is not enforced here by the entity.   
+     * The custom keyname of this key=value pair.
+     * This value should be a simple alphanumeric name without special chars, but
+     * this is not enforced here by the entity.
      * @param string $keyName
      */
     public function setKeyName($keyName){
-        $this->keyName = $keyName; 
+        $this->keyName = $keyName;
     }
 
     /**
-     * The custom value of this key=value pair. 
-     * This value can contain any chars. 
+     * The custom value of this key=value pair.
+     * This value can contain any chars.
      * @param string $keyValue
      */
     public function setKeyValue($keyValue){
-        $this->keyValue = $keyValue; 
+        $this->keyValue = $keyValue;
     }
-    
+
 }
 
 ?>

--- a/lib/Doctrine/entities/ServiceType.php
+++ b/lib/Doctrine/entities/ServiceType.php
@@ -16,12 +16,12 @@
 use Doctrine\Common\Collections\ArrayCollection;
 
 /**
- * A lookup record for different service types. 
- * A single serviceType can be joined to many different {@see Service} instances. 
- * 
+ * A lookup record for different service types.
+ * A single serviceType can be joined to many different {@see Service} instances.
+ *
  * @author John Casson
- * @author David Meredith <david.meredith@stfc.ac.uk> 
- * 
+ * @author David Meredith <david.meredith@stfc.ac.uk>
+ *
  * @Entity @Table(name="ServiceTypes")
  */
 class ServiceType {
@@ -41,7 +41,7 @@ class ServiceType {
     public function __construct() {
         $this->services = new ArrayCollection();
     }
-    
+
     /**
      * @return int The PK of this entity or null if not persisted
      */
@@ -50,7 +50,7 @@ class ServiceType {
     }
 
     /**
-     * Get the unique name of this service type. 
+     * Get the unique name of this service type.
      * @return string
      */
     public function getName() {
@@ -58,7 +58,7 @@ class ServiceType {
     }
 
     /**
-     * Get the human readable description of this service type.  
+     * Get the human readable description of this service type.
      * @return string or null
      */
     public function getDescription() {
@@ -66,7 +66,7 @@ class ServiceType {
     }
 
     /**
-     * Set the unique name of this service type. Required. 
+     * Set the unique name of this service type. Required.
      * @param string $name
      */
     public function setName($name) {
@@ -74,7 +74,7 @@ class ServiceType {
     }
 
     /**
-     * Set the human readable description of this service type. 
+     * Set the human readable description of this service type.
      * @param string $description
      */
     public function setDescription($description) {
@@ -82,7 +82,7 @@ class ServiceType {
     }
 
     /**
-     * Get all the {@see Service}s that are linked to this service type. 
+     * Get all the {@see Service}s that are linked to this service type.
      * @return ArrayCollection
      */
     public function getServices() {
@@ -90,9 +90,9 @@ class ServiceType {
     }
 
     /**
-     * Join the given Service to this ServiceType. 
-     * Note, this method calls the <code>$service->setServiceType($this);</code> 
-     * to establish the join on both sides of the relationship. 
+     * Join the given Service to this ServiceType.
+     * Note, this method calls the <code>$service->setServiceType($this);</code>
+     * to establish the join on both sides of the relationship.
      * @param \Service $service
      */
     public function addService($service) {
@@ -101,7 +101,7 @@ class ServiceType {
     }
 
     /**
-     * Gets the name of this service type. 
+     * Gets the name of this service type.
      * @return string
      */
     public function __toString() {

--- a/lib/Doctrine/entities/Site.php
+++ b/lib/Doctrine/entities/Site.php
@@ -16,33 +16,33 @@ use Doctrine\Common\Collections\ArrayCollection;
 require_once 'NGI.php';
 
 /**
- * A Site is an adminstrative domain (often a physical site) for hosting zero or more {@see Service}s. 
- * A Site has a single parent {@see NGI). Users hold Roles over their Sites which 
- * cascade to their services. Sites can be scoped using {@see Scope} tags 
- * for resource filtering/matching. 
- * 
+ * A Site is an adminstrative domain (often a physical site) for hosting zero or more {@see Service}s.
+ * A Site has a single parent {@see NGI). Users hold Roles over their Sites which
+ * cascade to their services. Sites can be scoped using {@see Scope} tags
+ * for resource filtering/matching.
+ *
  * @author John Casson
- * @author David Meredith <david.meredith@stfc.ac.uk> 
- * 
- * @Entity @Table(name="Sites") 
+ * @author David Meredith <david.meredith@stfc.ac.uk>
+ *
+ * @Entity @Table(name="Sites")
  */
 class Site extends OwnedEntity implements IScopedEntity{
-   
+
     /* The site primary key carried over from GOCDB4.
-     * Other operational tools use this 
+     * Other operational tools use this
      * as the unique identifier for a site.
-     * For new sites created in v5 this value is 
+     * For new sites created in v5 this value is
      * programmatically generated.
      */
     /** @Column(type="string", unique=true, nullable=true) */
     protected $primaryKey;
 
-    /** 
-     * It is v.important that the Site name is unique for backward compatibility 
-     * with the GOCDB v4 data. We therefore use a DB unique constraint. Other 
-     * deployments/instances may not require this restriction. 
-     * 
-     * @Column(type="string", unique=true) 
+    /**
+     * It is v.important that the Site name is unique for backward compatibility
+     * with the GOCDB v4 data. We therefore use a DB unique constraint. Other
+     * deployments/instances may not require this restriction.
+     *
+     * @Column(type="string", unique=true)
      */
     protected $shortName;
 
@@ -78,10 +78,10 @@ class Site extends OwnedEntity implements IScopedEntity{
 
     /** @Column(type="string", nullable=true) */
     protected $ipRange;
-        
+
     /** @Column(type="string", nullable=true) */
     protected $ipV6Range;
-        
+
     /** @Column(type="string", nullable=true) */
     protected $domain;
 
@@ -108,7 +108,7 @@ class Site extends OwnedEntity implements IScopedEntity{
      * @OneToMany(targetEntity="Service", mappedBy="parentSite")
      */
     protected $services = null;
-                
+
     /**
      * Bidirectional - A Site (INVERSE ORM SIDE) can have many properties
      * @OneToMany(targetEntity="SiteProperty", mappedBy="parentSite", cascade={"remove"})
@@ -120,27 +120,27 @@ class Site extends OwnedEntity implements IScopedEntity{
 
     /** @ManyToOne(targetEntity="CertificationStatus", inversedBy="sites") */
     protected $certificationStatus;
-    
+
     /* DATETIME NOTE:
      * Doctrine checks whether a date's been updated by doing a by reference comparison.
      * If you just update an existing DateTime object, Doctrine won't persist it!
      * Create a new DateTime object and reference that for it to persist during an update.
      * http://docs.doctrine-project.org/en/2.0.x/cookbook/working-with-datetime.html
      */
-    
+
     /** @Column(type="datetime", nullable=true) */
-    protected $certificationStatusChangeDate = null; 
+    protected $certificationStatusChangeDate = null;
 
 
     /**
-     * Bidirectional - A Site (INVERSE ORM SIDE) has a history of certification statuses 
+     * Bidirectional - A Site (INVERSE ORM SIDE) has a history of certification statuses
      * @OneToMany(targetEntity="CertificationStatusLog", mappedBy="parentSite")
      */
-    protected $certificationStatusLog; 
+    protected $certificationStatusLog;
 
-    /**    
+    /**
      * Unidirectional - Scope tags associated with this site.
-     * 
+     *
      * @ManyToMany(targetEntity="Scope")
      * @JoinTable(name="Sites_Scopes",
      *      joinColumns={@JoinColumn(name="site_Id", referencedColumnName="id")},
@@ -152,22 +152,22 @@ class Site extends OwnedEntity implements IScopedEntity{
     /** @ManyToOne(targetEntity="Country", inversedBy="sites")  */
     protected $country;
 
-    /** 
-     * Dont' use the Timezone entity, use the timezoneId variable instead. 
+    /**
+     * Dont' use the Timezone entity, use the timezoneId variable instead.
      * @deprecated since version 5.4
-     * @ManyToOne(targetEntity="Timezone", inversedBy="sites") 
+     * @ManyToOne(targetEntity="Timezone", inversedBy="sites")
      */
     protected $timezone;
 
-    /** @Column(type="string", nullable=true) */ 
-    protected $timezoneId; 
+    /** @Column(type="string", nullable=true) */
+    protected $timezoneId;
 
     /** @ManyToOne(targetEntity="Tier", inversedBy="sites")  */
     protected $tier;
 
-    /** 
+    /**
      * @ManyToOne(targetEntity="SubGrid", inversedBy="sites")
-     * @JoinColumn(name = "subgrid_id", referencedColumnName="id", onDelete="SET NULL")  
+     * @JoinColumn(name = "subgrid_id", referencedColumnName="id", onDelete="SET NULL")
      */
     protected $subGrid;
 
@@ -183,7 +183,7 @@ class Site extends OwnedEntity implements IScopedEntity{
 
     public function __construct() {
         parent::__construct();
-        $this->creationDate =  new \DateTime("now");        
+        $this->creationDate =  new \DateTime("now");
         $this->services = new ArrayCollection();
         $this->siteProperties = new ArrayCollection();
         $this->scopes = new ArrayCollection();
@@ -191,7 +191,7 @@ class Site extends OwnedEntity implements IScopedEntity{
         $this->certificationStatusLog = new ArrayCollection();
     }
 
-   
+
     /**
      * The Site's legacy GOCDBv4 PK.
      * Other operational tools require this as the unique identifier for a site.
@@ -210,15 +210,15 @@ class Site extends OwnedEntity implements IScopedEntity{
     }
 
     /**
-     * @see Site::getShortName() 
+     * @see Site::getShortName()
      * @return string Unique short name of this site
      */
     public function getName(){
-       return $this->shortName; 
+       return $this->shortName;
     }
 
     /**
-     * @return string The long/official name of the site. 
+     * @return string The long/official name of the site.
      */
     public function getofficialName() {
         return $this->officialName;
@@ -232,42 +232,42 @@ class Site extends OwnedEntity implements IScopedEntity{
     }
 
     /**
-     * @return string Nullable home URL for this Site.  
+     * @return string Nullable home URL for this Site.
      */
     public function getHomeUrl() {
         return $this->homeUrl;
     }
 
     /**
-     * @return string Nullable email addresses for this Site. 
+     * @return string Nullable email addresses for this Site.
      */
     public function getEmail() {
         return $this->email;
     }
 
     /**
-     * @return string Nullable tel number for this Site.  
+     * @return string Nullable tel number for this Site.
      */
     public function getTelephone() {
         return $this->telephone;
     }
 
     /**
-     * @return string Nullable field to record the URL of the Grid Info Service 
+     * @return string Nullable field to record the URL of the Grid Info Service
      */
     public function getGiisUrl() {
         return $this->giisUrl;
     }
 
     /**
-     * @return float Nullable latitute value for this site. 
+     * @return float Nullable latitute value for this site.
      */
     public function getLatitude() {
         return $this->latitude;
     }
 
     /**
-     * @return float Nullable longitude value for this site. 
+     * @return float Nullable longitude value for this site.
      */
     public function getLongitude() {
         return $this->longitude;
@@ -276,11 +276,11 @@ class Site extends OwnedEntity implements IScopedEntity{
     public function getIpRange() {
         return $this->ipRange;
     }
-        
+
     public function getIpV6Range() {
         return $this->ipV6Range;
     }
-        
+
     public function getDomain() {
         return $this->domain;
     }
@@ -316,10 +316,10 @@ class Site extends OwnedEntity implements IScopedEntity{
     public function getServices() {
         return $this->services;
     }
-        
+
     /**
-     * The Site's list of {@see SiteProperty} extension objects. When the 
-     * Site is deleted, the SiteProperties are also cascade deleted. 
+     * The Site's list of {@see SiteProperty} extension objects. When the
+     * Site is deleted, the SiteProperties are also cascade deleted.
      * @return ArrayCollection
      */
     public function getSiteProperties(){
@@ -327,56 +327,56 @@ class Site extends OwnedEntity implements IScopedEntity{
     }
 
     /**
-     * @return \NGI The Site's owning NGI  
+     * @return \NGI The Site's owning NGI
      */
     public function getNgi() {
         return $this->ngi;
     }
 
     /**
-     * @return ArrayCollection Contains parent NGI or empty collection if no parent. 
+     * @return ArrayCollection Contains parent NGI or empty collection if no parent.
      */
     public function getParentOwnedEntities() {
         $ngiArray = new ArrayCollection();
         if($this->ngi != null){
-            $ngiArray->add($this->ngi); 
+            $ngiArray->add($this->ngi);
         }
-        return $ngiArray; 
+        return $ngiArray;
     }
 
     /**
-     * @return \Infrastructure 
+     * @return \Infrastructure
      */
     public function getInfrastructure() {
         return $this->infrastructure;
     }
 
     /**
-     * @return \CertificationStatus 
+     * @return \CertificationStatus
      */
     public function getCertificationStatus() {
         return $this->certificationStatus;
     }
-   
+
     /**
-     * Get the DateTime when the certification status was last changed. 
+     * Get the DateTime when the certification status was last changed.
      * @return \DateTime
      */
     public function getCertificationStatusChangeDate(){
-        return $this->certificationStatusChangeDate; 
+        return $this->certificationStatusChangeDate;
     }
 
     /**
-     * Get the Site's {@see CertificationStatusLog} objects. 
+     * Get the Site's {@see CertificationStatusLog} objects.
      * @return ArrayCollection
      */
     public function getCertificationStatusLog(){
-        return $this->certificationStatusLog; 
+        return $this->certificationStatusLog;
     }
 
     /**
-     * Get all the Site's joined {@see Scope} objects. 
-     * @return ArrayCollection 
+     * Get all the Site's joined {@see Scope} objects.
+     * @return ArrayCollection
      */
     public function getScopes() {
         return $this->scopes;
@@ -390,82 +390,82 @@ class Site extends OwnedEntity implements IScopedEntity{
     }
 
     /**
-     * Don't use, use the getTimezoneId() instead. 
-     * @deprecated since version 5.4 
+     * Don't use, use the getTimezoneId() instead.
+     * @deprecated since version 5.4
      */
     public function getTimezone() {
         return $this->timezone;
     }
 
     /**
-     * Get the timezone identifier label. 
+     * Get the timezone identifier label.
      * Labels should be of the IANA form, e.g.  Europe/London
-     * @link http://www.iana.org/time-zones IANA timezones 
-     * @return String 
+     * @link http://www.iana.org/time-zones IANA timezones
+     * @return String
      */
-    public function getTimezoneId() { 
-        return $this->timezoneId; 
+    public function getTimezoneId() {
+        return $this->timezoneId;
     }
 
     /**
-     * @return \Tier  
+     * @return \Tier
      */
     public function getTier() {
         return $this->tier;
     }
 
     /**
-     * @return \SubGrid 
+     * @return \SubGrid
      */
     public function getSubGrid() {
         return $this->subGrid;
     }
 
     /**
-     * Get all the Site's {@see \User}s. 
+     * Get all the Site's {@see \User}s.
      * @return ArrayCollection
      */
     public function getUsers() {
         return $this->users;
     }
-     
+
     /**
-     * A CSV string listing the names of scopes with which the 
+     * A CSV string listing the names of scopes with which the
      * object been tagged.
-     * @return string  string containing ", " seperated list of the names 
+     * @return string  string containing ", " seperated list of the names
      */
     public function getScopeNamesAsString() {
-        //Get the scopes for the service 
+        //Get the scopes for the service
         $scopes = $this->getScopes();
-        
+
         //Create an empty array to contain scope names
         $scopeNames= array();
-        
+
         //populate the array
         foreach ($scopes as $scope){
             $scopeNames[]=$scope->getName();
         }
-        
+
         sort($scopeNames);
 
         //Turn into a string
         $scopeNamesAsString = implode(", " , $scopeNames);
-        
+
         return $scopeNamesAsString;
     }
 
     /**
-     * @return \DateTime The datetime when the Site was created.  
+     * @return \DateTime The datetime when the Site was created.
      */
     public function getCreationDate() {
         return $this->creationDate;
     }
-    
+
     /* ======== End of Getters ============= */
     public function setPrimaryKey($primaryKey) {
         $this->primaryKey = $primaryKey;
     }
-    
+
     public function setShortName($shortName) {
         $this->shortName = $shortName;
     }
@@ -509,11 +509,11 @@ class Site extends OwnedEntity implements IScopedEntity{
     public function setIpRange($ipRange) {
         $this->ipRange = $ipRange;
     }
-        
+
     public function setIpV6Range($ipRange) {
         $this->ipV6Range = $ipRange;
     }
-        
+
     public function setDomain($domain) {
         $this->domain = $domain;
     }
@@ -548,8 +548,8 @@ class Site extends OwnedEntity implements IScopedEntity{
     }
 
     /**
-     * Add a SiteProperty entity to this Site's collection of properties. 
-     * This method also sets the SiteProperty's parentSite. 
+     * Add a SiteProperty entity to this Site's collection of properties.
+     * This method also sets the SiteProperty's parentSite.
      * @param \SiteProperty $siteProperty
      */
     public function addSitePropertyDoJoin($siteProperty) {
@@ -578,31 +578,31 @@ class Site extends OwnedEntity implements IScopedEntity{
     }
 
     public function setCertificationStatusChangeDate($certStatusChangeDate){
-        $this->certificationStatusChangeDate = $certStatusChangeDate; 
+        $this->certificationStatusChangeDate = $certStatusChangeDate;
     }
 
     public function setCreationDate($creationDate) {
         $this->creationDate = $creationDate;
     }
-    
+
     /**
-     * Add the given certStatusLog to the list. This method internally calls 
-     * <code>$certStatusLog->setSite($this)</code> to keep both  
-     * sides of the bidirectional relationship consistent (i.e. don't separately 
-     * call <code>$certStatusLog->setSite($this)</code>). 
+     * Add the given certStatusLog to the list. This method internally calls
+     * <code>$certStatusLog->setSite($this)</code> to keep both
+     * sides of the bidirectional relationship consistent (i.e. don't separately
+     * call <code>$certStatusLog->setSite($this)</code>).
      * <p>
-     * This is the INVERSE side of the ORM relation so the internal call to 
-     * setSite actually establishes the relationship in the DB. 
-     * 
-     * @param \CertificationStatusLog $certStatusLog 
+     * This is the INVERSE side of the ORM relation so the internal call to
+     * setSite actually establishes the relationship in the DB.
+     *
+     * @param \CertificationStatusLog $certStatusLog
      */
     public function addCertificationStatusLog(\CertificationStatusLog $certStatusLog){
-        $this->certificationStatusLog[] = $certStatusLog; 
-        $certStatusLog->setParentSite($this); 
+        $this->certificationStatusLog[] = $certStatusLog;
+        $certStatusLog->setParentSite($this);
     }
 
     /**
-     * Tag this Site with the given Scope. 
+     * Tag this Site with the given Scope.
      * @param Scope $scope
      */
     public function addScope(Scope $scope) {
@@ -619,9 +619,9 @@ class Site extends OwnedEntity implements IScopedEntity{
     }
 
     /**
-     * Add the given {@see User} to the Site's list of users. 
-     * This method also calls <code>user->setHomeSiteDoJoin($this);</code> to 
-     * ensure the relationship is established from both sides. 
+     * Add the given {@see User} to the Site's list of users.
+     * This method also calls <code>user->setHomeSiteDoJoin($this);</code> to
+     * ensure the relationship is established from both sides.
      * @param User $user
      */
     public function addUserDoJoin(User $user) {
@@ -630,7 +630,7 @@ class Site extends OwnedEntity implements IScopedEntity{
     }
 
     /**
-     * Set this Site's country. 
+     * Set this Site's country.
      * @param \Country $country
      */
     public function setCountry($country) {
@@ -638,21 +638,21 @@ class Site extends OwnedEntity implements IScopedEntity{
     }
 
     /**
-     * Don't use, use the setTimezoneId() instead. 
-     * @deprecated since version 5.4 
+     * Don't use, use the setTimezoneId() instead.
+     * @deprecated since version 5.4
      */
     public function setTimezone($timezone) {
         $this->timezone = $timezone;
     }
 
     /**
-     * Set the timezone identifier label. 
+     * Set the timezone identifier label.
      * Labels should be of the IANA form, e.g.  Europe/London
-     * @link http://www.iana.org/time-zones IANA timezones 
-     * @return null 
+     * @link http://www.iana.org/time-zones IANA timezones
+     * @return null
      */
     public function setTimezoneId($timezoneId){
-        $this->timezoneId = $timezoneId; 
+        $this->timezoneId = $timezoneId;
     }
 
     /**
@@ -670,7 +670,7 @@ class Site extends OwnedEntity implements IScopedEntity{
     }
 
     /**
-     * Returns this Site's unique shortName 
+     * Returns this Site's unique shortName
      * @return string
      */
     public function __toString () {
@@ -680,10 +680,10 @@ class Site extends OwnedEntity implements IScopedEntity{
     /**
      * Returns value of {@link \OwnedEntity::TYPE_SITE}
      * @see \OwnedEntity::getType()
-     * @return string 
+     * @return string
      */
     public function getType() {
-        return 'site'; 
+        return 'site';
     }
 
 }

--- a/lib/Doctrine/entities/SiteProperty.php
+++ b/lib/Doctrine/entities/SiteProperty.php
@@ -15,67 +15,67 @@
 
 /**
  * Custom Key=Value pairs (extension properties) used to augment a {@see Site}
- * object with additional attributes. These properties can also be used for 
+ * object with additional attributes. These properties can also be used for
  * the purposes of resource matching.
  * <p>
- * A unique constraint is defined on the DB preventing key=value duplicates. 
- * Note, duplicate key names with different values are allowed for the purpose 
- * of defning multi-valued properties. 
+ * A unique constraint is defined on the DB preventing key=value duplicates.
+ * Note, duplicate key names with different values are allowed for the purpose
+ * of defning multi-valued properties.
  * <p>
- * When the owning parent Site is deleted, its SiteProperties 
- * are also cascade-deleted.  
- * 
- * @author James McCarthy 
+ * When the owning parent Site is deleted, its SiteProperties
+ * are also cascade-deleted.
+ *
+ * @author James McCarthy
  * @author David Meredith
- * @Entity @Table(name="Site_Properties",uniqueConstraints={@UniqueConstraint(name="site_keypairs", columns={"parentSite_id", "keyName", "keyValue"})}) 
+ * @Entity @Table(name="Site_Properties",uniqueConstraints={@UniqueConstraint(name="site_keypairs", columns={"parentSite_id", "keyName", "keyValue"})})
  */
 class SiteProperty {
-   
+
     /** @Id @Column(type="integer") @GeneratedValue */
     protected $id;
 
     /**
-     * Bidirectional - Many SiteProperties (SIDE OWNING FK) can be linked to 
-     * one Site (OWNING ORM SIDE). 
-     *   
-     * @ManyToOne(targetEntity="Site", inversedBy="siteProperties") 
-     * @JoinColumn(name="parentSite_id", referencedColumnName="id", onDelete="CASCADE") 
+     * Bidirectional - Many SiteProperties (SIDE OWNING FK) can be linked to
+     * one Site (OWNING ORM SIDE).
+     *
+     * @ManyToOne(targetEntity="Site", inversedBy="siteProperties")
+     * @JoinColumn(name="parentSite_id", referencedColumnName="id", onDelete="CASCADE")
      */
-    protected $parentSite = null; 
-    
+    protected $parentSite = null;
+
     /** @Column(type="string", nullable=false) */
-    protected $keyName = null; 
-    
+    protected $keyName = null;
+
     /** @Column(type="string", nullable=true) */
-    protected $keyValue = null; 
-   
+    protected $keyValue = null;
+
     public function __construct() {
     }
 
     /**
-     * Get the owning parent {@see Site}. When the Site is deleted, 
-     * these properties are also cascade deleted.  
+     * Get the owning parent {@see Site}. When the Site is deleted,
+     * these properties are also cascade deleted.
      * @return \Site
      */
     public function getParentSite(){
-        return $this->parentSite; 
+        return $this->parentSite;
     }
 
     /**
-     * Get the key name, usually a simple alphaNumeric name, but this is not 
-     * enforced by the entity. 
+     * Get the key name, usually a simple alphaNumeric name, but this is not
+     * enforced by the entity.
      * @return string
      */
     public function getKeyName(){
-        return $this->keyName; 
+        return $this->keyName;
     }
 
     /**
-     * Get the key value, can contain any char. 
+     * Get the key value, can contain any char.
      * @return String
      */
     public function getKeyValue(){
-        return $this->keyValue; 
+        return $this->keyValue;
     }
 
     /**
@@ -84,39 +84,39 @@ class SiteProperty {
     public function getId() {
         return $this->id;
     }
-    
+
     /**
      * Do not call in client code, always use the opposite
      * <code>$site->addSiteProperties($siteProperties)</code>
-     * instead which internally calls this method to keep the bidirectional 
-     * relationship consistent.  
+     * instead which internally calls this method to keep the bidirectional
+     * relationship consistent.
      * <p>
-     * This is the OWNING side of the ORM relationship so this method WILL 
-     * establish the relationship in the database. 
-     * 
+     * This is the OWNING side of the ORM relationship so this method WILL
+     * establish the relationship in the database.
+     *
      * @param \Site $site
      */
     public function _setParentSite($site){
-        $this->parentSite = $site; 
+        $this->parentSite = $site;
     }
 
     /**
-     * The custom keyname of this key=value pair. 
-     * This value should be a simple alphanumeric name without special chars, but 
-     * this is not enforced here by the entity.   
+     * The custom keyname of this key=value pair.
+     * This value should be a simple alphanumeric name without special chars, but
+     * this is not enforced here by the entity.
      * @param string $keyName
      */
     public function setKeyName($keyName){
-        $this->keyName = $keyName; 
+        $this->keyName = $keyName;
     }
 
     /**
-     * The custom value of this key=value pair. 
-     * This value can contain any chars. 
+     * The custom value of this key=value pair.
+     * This value can contain any chars.
      * @param string $keyValue
      */
     public function setKeyValue($keyValue){
-        $this->keyValue = $keyValue; 
+        $this->keyValue = $keyValue;
     }
 
 }

--- a/lib/Doctrine/entities/SubGrid.php
+++ b/lib/Doctrine/entities/SubGrid.php
@@ -30,9 +30,9 @@ class SubGrid {
     /** @OneToMany(targetEntity="Site", mappedBy="subGrid") */
     protected $sites = null;
 
-    /** 
-     * @ManyToOne(targetEntity="NGI") 
-     * @JoinColumn(name="NGI_Id", referencedColumnName="id", onDelete="CASCADE") 
+    /**
+     * @ManyToOne(targetEntity="NGI")
+     * @JoinColumn(name="NGI_Id", referencedColumnName="id", onDelete="CASCADE")
      */
     protected $ngi;
 

--- a/lib/Doctrine/entities/Timezone.php
+++ b/lib/Doctrine/entities/Timezone.php
@@ -3,9 +3,9 @@
 use Doctrine\Common\Collections\ArrayCollection;
 
 /**
- * Do not use, this will eventually be dropped from the schema. 
- * Entities such as Sites should specify their timezone directly as attributes 
- * on the owning entity rather than joining to this entity. 
+ * Do not use, this will eventually be dropped from the schema.
+ * Entities such as Sites should specify their timezone directly as attributes
+ * on the owning entity rather than joining to this entity.
  * @deprecated since version 5.4
  * @Entity @Table(name="Timezones")
  */

--- a/lib/Doctrine/entities/User.php
+++ b/lib/Doctrine/entities/User.php
@@ -14,11 +14,11 @@
 use Doctrine\Common\Collections\ArrayCollection;
 
 /**
- * Defines a registered GOCDB User who may request {@see Role}s over {@see OwnedEntity} objects. 
- * 
+ * Defines a registered GOCDB User who may request {@see Role}s over {@see OwnedEntity} objects.
+ *
  * @author John Casson
- * @author David Meredith <david.meredith@stfc.ac.uk> 
- * 
+ * @author David Meredith <david.meredith@stfc.ac.uk>
+ *
  * @Entity @Table(name="Users", options={"collate"="utf8_bin"})
  */
 class User {
@@ -70,17 +70,17 @@ class User {
 
     /** @Column(type="datetime", nullable=true)  */
     protected $lastLoginDate;
-    
+
     /*
-     * TODO: 
-     * This entity will need to own a property bag (akin to custom props) 
-     * to store zero-to-many additional attributes (e.g. SAML/AAA attributes). 
-     * For example, when a user authenticates via an IdP, a bunch of different attributes 
-     * can be sent in a SAML auth response which will need persisting in the 
-     * DB so that other users can see this data before they are approve any roles 
-     * for this user.    
+     * TODO:
+     * This entity will need to own a property bag (akin to custom props)
+     * to store zero-to-many additional attributes (e.g. SAML/AAA attributes).
+     * For example, when a user authenticates via an IdP, a bunch of different attributes
+     * can be sent in a SAML auth response which will need persisting in the
+     * DB so that other users can see this data before they are approve any roles
+     * for this user.
      */
-    
+
 
     public function __construct() {
         // Set cretion date
@@ -104,44 +104,44 @@ class User {
     }
 
     /**
-     * @return string The user's second name.  
+     * @return string The user's second name.
      */
     public function getSurname() {
         return $this->surname;
     }
 
     /**
-     * @return string User's optional title or null. 
+     * @return string User's optional title or null.
      */
     public function getTitle() {
         return $this->title;
     }
 
     /**
-     * @return string User's contact email address or null. 
+     * @return string User's contact email address or null.
      */
     public function getEmail() {
         return $this->email;
     }
 
     /**
-     * @return string User's contact tel or null.  
+     * @return string User's contact tel or null.
      */
     public function getTelephone() {
         return $this->telephone;
     }
 
     /**
-     * Nullable string for the user's working hours. 
+     * Nullable string for the user's working hours.
      * @deprecated since version 5.4
      * @return string
-     */ 
+     */
     public function getWorkingHoursStart() {
         return $this->workingHoursStart;
     }
 
     /**
-     * Nullable string for the user's working hours. 
+     * Nullable string for the user's working hours.
      * @deprecated since version 5.4
      * @return string
      */
@@ -150,7 +150,7 @@ class User {
     }
 
     /**
-     * Get the user's unique ID string, typically an x509 DN string. 
+     * Get the user's unique ID string, typically an x509 DN string.
      * @todo This needs to be renamed to getAccountID
      * @return string
      */
@@ -159,9 +159,9 @@ class User {
     }
 
     /**
-     * An optional field to define an extra username. 
-     * This field was added to store the EGI SSO username, but other values 
-     * could also be applied. 
+     * An optional field to define an extra username.
+     * This field was added to store the EGI SSO username, but other values
+     * could also be applied.
      * @return string or null
      */
     public function getUsername1() {
@@ -169,8 +169,8 @@ class User {
     }
 
     /**
-     * Get the user's optional home.  
-     * @deprecated since version 5.4 
+     * Get the user's optional home.
+     * @deprecated since version 5.4
      * @return \Site or null
      */
     public function getHomeSite() {
@@ -178,23 +178,23 @@ class User {
     }
 
     /**
-     * The DateTime when the user account was created. 
+     * The DateTime when the user account was created.
      * @return \DateTime
      */
     public function getCreationDate() {
         return $this->creationDate;
     }
-    
+
     /**
-     * The DateTime of the user's last authentication/login. 
+     * The DateTime of the user's last authentication/login.
      * @return \DateTime
      */
     public function getLastLoginDate(){
-        return $this->lastLoginDate; 
+        return $this->lastLoginDate;
     }
 
     /**
-     * Is the user a GOCDB admin user. Defaults to false.  
+     * Is the user a GOCDB admin user. Defaults to false.
      * @return boolean
      */
     public function isAdmin() {
@@ -202,7 +202,7 @@ class User {
     }
 
     /**
-     * Set the user's first name. Required. 
+     * Set the user's first name. Required.
      * @param string $forename
      */
     public function setForename($forename) {
@@ -210,7 +210,7 @@ class User {
     }
 
     /**
-     * Set the user's first name. Required. 
+     * Set the user's first name. Required.
      * @param string $surname
      */
     public function setSurname($surname) {
@@ -218,7 +218,7 @@ class User {
     }
 
     /**
-     * Set the user's optional title. 
+     * Set the user's optional title.
      * @param string $title
      */
     public function setTitle($title) {
@@ -226,7 +226,7 @@ class User {
     }
 
     /**
-     * Set the user's optional contact email address. 
+     * Set the user's optional contact email address.
      * @param string $email
      */
     public function setEmail($email) {
@@ -250,7 +250,7 @@ class User {
     }
 
     /**
-     * @deprecated since version 5.4 
+     * @deprecated since version 5.4
      * @param string $workingHoursEnd
      */
     public function setWorkingHoursEnd($workingHoursEnd) {
@@ -258,7 +258,7 @@ class User {
     }
 
     /**
-     * Set the user's unique account ID, typcially and x509 DN string. Required.  
+     * Set the user's unique account ID, typcially and x509 DN string. Required.
      * @todo Needs renaming to setAccountID
      * @param string $certificateDn
      */
@@ -267,9 +267,9 @@ class User {
     }
 
     /**
-     * Set an optional/additional name  to define an extra username. 
-     * This field was added to store the EGI SSO username, but other values 
-     * could also be applied.  
+     * Set an optional/additional name  to define an extra username.
+     * This field was added to store the EGI SSO username, but other values
+     * could also be applied.
      * @param string $username1
      */
     public function setUsername1($username1) {
@@ -277,8 +277,8 @@ class User {
     }
 
     /**
-     * Set the user's home Site, Legacy and optional.  
-     * @deprecated since version 5.4 
+     * Set the user's home Site, Legacy and optional.
+     * @deprecated since version 5.4
      * @param Site $homeSite
      */
     public function setHomeSiteDoJoin(Site $homeSite) {
@@ -286,7 +286,7 @@ class User {
     }
 
     /**
-     * Set this user as a GOCDB admin user. Defaults is false. 
+     * Set this user as a GOCDB admin user. Defaults is false.
      * @param boolean $isAdmin
      */
     public function setAdmin($isAdmin) {
@@ -294,32 +294,32 @@ class User {
     }
 
     /**
-     * Set the Date time when this user was registered. Required. 
+     * Set the Date time when this user was registered. Required.
      * @param \DateTime $creationDate
      */
     public function setCreationDate($creationDate) {
         $this->creationDate = $creationDate;
     }
-    
+
     /**
      * Set the date time of the user's last authentication/login
      * @param \DateTime $lastLoginDate
      */
     public function setLastLoginDate($lastLoginDate){
-        $this->lastLoginDate = $lastLoginDate; 
+        $this->lastLoginDate = $lastLoginDate;
     }
 
     /**
-     * @return string Concat of 'forename surname' 
+     * @return string Concat of 'forename surname'
      */
     public function getFullName() {
         return $this->forename . " " . $this->surname;
     }
 
     /**
-     * Add the given Role to the user's list of roles. 
-     * Note, this method calls the <code>$role->setUser($this);</code> to 
-     * establish the join on both sides of the relationship. 
+     * Add the given Role to the user's list of roles.
+     * Note, this method calls the <code>$role->setUser($this);</code> to
+     * establish the join on both sides of the relationship.
      * @param \Role $role
      */
     public function addRoleDoJoin(\Role $role) {
@@ -328,8 +328,8 @@ class User {
     }
 
     /**
-     * Get all the users {@see Role}s. 
-     * @return ArrayCollection 
+     * Get all the users {@see Role}s.
+     * @return ArrayCollection
      */
     public function getRoles() {
         return $this->roles;

--- a/lib/Doctrine/versionUpdateScripts/MEPS_update_scriptRunner.php
+++ b/lib/Doctrine/versionUpdateScripts/MEPS_update_scriptRunner.php
@@ -1,55 +1,55 @@
 <?php
 
 /**
- * This script is for updating a 5.2 (pre-meps) DB to work with the multiple 
+ * This script is for updating a 5.2 (pre-meps) DB to work with the multiple
  * endpoints (mep) GOCDBv5.3 data model. Follow steps 1) and 2) below BEFORE
- * running this script. 
- * 
- * This is a one time script that is used on first deployment of the MEPS model 
+ * running this script.
+ *
+ * This is a one time script that is used on first deployment of the MEPS model
  * against existing data from the pre-MEPS versions of GocDB. It is not required
- * for a new install of GocDB with no data.  
- * 
- * After running this script, you need to run the MEP GOCDBv5.3 
- * (v5.2 will not work against the udpated DB, you have been warned!).   
- * 
+ * for a new install of GocDB with no data.
+ *
+ * After running this script, you need to run the MEP GOCDBv5.3
+ * (v5.2 will not work against the udpated DB, you have been warned!).
+ *
  * Usage:
  * ======
- *  
+ *
  * 1) Update DB tables
  * ====================
- * Before running this script, you MUST update the DB schema to correspond to the 
+ * Before running this script, you MUST update the DB schema to correspond to the
  * 5.3 mep Doctrine entity model. This can be done using the following Doctrine
  * commands on the command line:
- * 
- * // 1.1) Test you can run the schema-tool on the command line: 
+ *
+ * // 1.1) Test you can run the schema-tool on the command line:
  *  $doctrine orm:schema-tool:update --help
- * 
+ *
  * // 1.2) View what DB schema changes would occur without actually updating the DB:
  * $doctrine orm:schema-tool:update --dump-sql
  *     ...SQL DDL statemetns will be printed here...
  *
- * // 1.3) Update the DB schema using force (or copy the DDL as printed above and run manually): 
+ * // 1.3) Update the DB schema using force (or copy the DDL as printed above and run manually):
  * $doctrine orm:schema-tool:update --force
  *     Updating database schema...
  *     Database schema updated successfully! "n" queries were executed
  *
- *  
- * 2) Run this script 
+ *
+ * 2) Run this script
  * ====================
- * // 2.1) Cd into '<GOCDB_SRC_HOME>/lib/Doctrine/versionUpdateScripts'  
- * 
- * // 2.2) Run this script on the command line using: 
- * $php MEPS_update_scriptRunner.php --force  
- * 
- * 
- * The script does the following: 
+ * // 2.1) Cd into '<GOCDB_SRC_HOME>/lib/Doctrine/versionUpdateScripts'
+ *
+ * // 2.2) Run this script on the command line using:
+ * $php MEPS_update_scriptRunner.php --force
+ *
+ *
+ * The script does the following:
  * a. Copies up the URL field from each service's single EndpointLocation entity
- *    up to the service entity's url field. 
+ *    up to the service entity's url field.
  * b. For each Downtime create a new link to the affected service and remove the join
- *    between the downtime and the endpoint 
- *    Then unlink the EndpointLocation from the downtime so only the Service-Downtime link remains. 
- * c. Finally all endpoints are unlinked from their parent services and deleted 
- *    to allow the MEPS model to be used correctly in the future. 
+ *    between the downtime and the endpoint
+ *    Then unlink the EndpointLocation from the downtime so only the Service-Downtime link remains.
+ * c. Finally all endpoints are unlinked from their parent services and deleted
+ *    to allow the MEPS model to be used correctly in the future.
  */
 use Doctrine\ORM\EntityManager;
 
@@ -58,12 +58,12 @@ require_once dirname(__FILE__) . "/../bootstrap.php";
 if (!isset($argv[1]) || strcmp($argv[1], '--force')) { //strcmp returns 0 (i.e. false) if strings are equal
     die("Error. Usage:  php " . basename(__FILE__) . " --force \n");
 }
-//if(true)die("forced die \n"); 
+//if(true)die("forced die \n");
 
 echo "Updating database relations and entities for MEPS \n";
 $em = $entityManager;
 
-//get all services	
+//get all services
 $dql = "SELECT se FROM Service se";
 $services = $entityManager->createQuery($dql)->getResult();
 
@@ -108,7 +108,7 @@ foreach ($downtimes as $downtime) {
 //Write changes to db
 $em->flush();
 
-//get all services	
+//get all services
 $dql = "SELECT se FROM Service se";
 $services = $entityManager->createQuery($dql)->getResult();
 

--- a/lib/Doctrine/versionUpdateScripts/TransferLegacySiteTimezoneRunner.php
+++ b/lib/Doctrine/versionUpdateScripts/TransferLegacySiteTimezoneRunner.php
@@ -15,51 +15,51 @@
 
 require_once dirname(__FILE__) . "/../bootstrap.php";
 /**
- * Script used to copy over legacy/deprecated Timezone->name lookup value (v5.3) 
- * to the Site->timezoneId value (v5.4). 
- * The Timezone entity is a legacy lookup table and should not be used anymore, 
- * it will be removed from the domain model in the future. Instead, the timezoneId 
- * value is declared directly as a memeber of Site and will store a standard PHP timezone 
- * identifier from the internal PHP timezone db. 
- *  
- * Note: 
- * The script will only update the new Site->timezoneId value if it is null 
- * or an empty string (users may have already manually set their site timezoneId). 
- * 
- * Not all legacy timezone lookup values can be automatically mapped to a 
+ * Script used to copy over legacy/deprecated Timezone->name lookup value (v5.3)
+ * to the Site->timezoneId value (v5.4).
+ * The Timezone entity is a legacy lookup table and should not be used anymore,
+ * it will be removed from the domain model in the future. Instead, the timezoneId
+ * value is declared directly as a memeber of Site and will store a standard PHP timezone
+ * identifier from the internal PHP timezone db.
+ *
+ * Note:
+ * The script will only update the new Site->timezoneId value if it is null
+ * or an empty string (users may have already manually set their site timezoneId).
+ *
+ * Not all legacy timezone lookup values can be automatically mapped to a
  * new Site->timezoneId value, e.g. those starting with 'Etc/'. This is because
- * there is no new equivalent. In these cases, the Site will be skipped and the 
- * value will need to be manually updated ("can all NGIs please check and update their 
- * Site timezone value").   
- * 
- * Usage: 
+ * there is no new equivalent. In these cases, the Site will be skipped and the
+ * value will need to be manually updated ("can all NGIs please check and update their
+ * Site timezone value").
+ *
+ * Usage:
  * ======
- * 
+ *
  * 1) Update DB tables
  * ====================
- * Before running this script, you MUST update the DB schema to correspond to the 
+ * Before running this script, you MUST update the DB schema to correspond to the
  * latest Gocdb entity model. This can be done using the following Doctrine
  * commands on the command line:
- * 
- * // 1.1) Test you can run the schema-tool on the command line: 
+ *
+ * // 1.1) Test you can run the schema-tool on the command line:
  *  $doctrine orm:schema-tool:update --help
- * 
+ *
  * // 1.2) View what DB schema changes would occur without actually updating the DB:
  * $doctrine orm:schema-tool:update --dump-sql
  *     ...SQL DDL statemetns will be printed here...
  *
- * // 1.3) Update the DB schema using force (or copy the DDL as printed above and run manually): 
+ * // 1.3) Update the DB schema using force (or copy the DDL as printed above and run manually):
  * $doctrine orm:schema-tool:update --force
  *     Updating database schema...
  *     Database schema updated successfully! "n" queries were executed
  *
- * 2) Run this script 
+ * 2) Run this script
  * ====================
- * // 2.1) Cd into '<GOCDB_SRC_HOME>/lib/Doctrine/versionUpdateScripts'  
- * 
- * // 2.2) Run this script on the command line using: 
- * $php TransferLegacySiteTimezonesRunner.php --show      // shows what will be updated  
- * $php TransferLegacySiteTimezonesRunner.php --force     // does the update 
+ * // 2.1) Cd into '<GOCDB_SRC_HOME>/lib/Doctrine/versionUpdateScripts'
+ *
+ * // 2.2) Run this script on the command line using:
+ * $php TransferLegacySiteTimezonesRunner.php --show      // shows what will be updated
+ * $php TransferLegacySiteTimezonesRunner.php --force     // does the update
  */
 
 $commandLineArgValid = false;
@@ -85,14 +85,14 @@ $skippedDueToExistingValue = 0;
 foreach ($sites as $site) {
     $oldTzName = $site->getTimezone()->getName();
     if (!in_array($oldTzName, $timezones)) {
-        // legacy timezone value is not supported, so skip 
+        // legacy timezone value is not supported, so skip
         //print_r("Skipping site: " . $site->getName() . ' ' . $site->getId() . ' ' . $oldTz . "\n");
         ++$skippdCount;
     } else {
-        // copy the old timezone value into the new site->setTimzoneId() field 
-        // if there is no value already present. 
+        // copy the old timezone value into the new site->setTimzoneId() field
+        // if there is no value already present.
         if ($site->getTimezoneId() == null || trim($site->getTimezoneId()) == '') {
-            print_r("Changing SiteTimezoneId to: [".$oldTzName."]\n"); 
+            print_r("Changing SiteTimezoneId to: [".$oldTzName."]\n");
             if ($forceOrShow == '--force') {
                 $site->setTimezoneId($oldTzName);
                 $entityManager->persist($site);
@@ -102,7 +102,7 @@ foreach ($sites as $site) {
             ++$skippedDueToExistingValue;
         }
     }
-    //print_r('SiteTimezoneId: ['.$site->getTimezoneId()."] OldTz: [".$oldTz."]\n"); 
+    //print_r('SiteTimezoneId: ['.$site->getTimezoneId()."] OldTz: [".$oldTz."]\n");
 }
 if ($forceOrShow == '--force') {
     $entityManager->flush();

--- a/lib/Doctrine/versionUpdateScripts/updateProdMon.php
+++ b/lib/Doctrine/versionUpdateScripts/updateProdMon.php
@@ -1,8 +1,8 @@
 <?php
 
 /**
- * Script to update Mon=T for all Prod=T services. 
- * This script is not needed to perform a version update. 
+ * Script to update Mon=T for all Prod=T services.
+ * This script is not needed to perform a version update.
  */
 use Doctrine\ORM\EntityManager;
 
@@ -11,22 +11,22 @@ require_once dirname(__FILE__) . "/../bootstrap.php";
 if (!isset($argv[1]) || strcmp($argv[1], '--force')) { //strcmp returns 0 (i.e. false) if strings are equal
     die("Error. Usage:  php " . basename(__FILE__) . " --force \n");
 }
-//if(true)die("forced die \n"); 
+//if(true)die("forced die \n");
 
 echo "Updating database relations and entities - For each service set Mon=T where Prod=T \n";
 
 $em = $entityManager;
 
-//get all services	
+//get all services
 $dql = "SELECT se FROM Service se";
 $services = $entityManager->createQuery($dql)->getResult();
 
-//For each service set mon to true where prod is true 
+//For each service set mon to true where prod is true
 echo "\n";
 $s_count = 0;
 foreach ($services as $service) {
     if ($service->getProduction() && ($service->getMonitored() == FALSE)) {
-    // exclude closed sites 
+    // exclude closed sites
     if ($service->getParentSite()->getCertificationStatus()->getName() != 'Closed') {
         if ($service->getServiceType()->getName() != 'VOMS' && $service->getServiceType()->getName() != 'emi.ARGUS') {
         echo 'Service: ' . $service->getId() . ' ' . $service->getHostName() . "\n";

--- a/lib/Gocdb_Services/AbstractEntityService.php
+++ b/lib/Gocdb_Services/AbstractEntityService.php
@@ -14,7 +14,7 @@ namespace org\gocdb\services;
  */
 
 /**
- * Parent class to those service classes that deal with entities, containing 
+ * Parent class to those service classes that deal with entities, containing
  * those methods required by all classes.
  *
  * @author John Casson
@@ -31,30 +31,30 @@ abstract class AbstractEntityService {
     }
 
     /**
-     * Set the EntityManager instance used by all service methods. 
+     * Set the EntityManager instance used by all service methods.
      * @param \Doctrine\ORM\EntityManager $em
      */
     public function setEntityManager(\Doctrine\ORM\EntityManager $em){
-        $this->em = $em;  
+        $this->em = $em;
     }
-    
+
     /**
-     * @return \Doctrine\ORM\EntityManager 
+     * @return \Doctrine\ORM\EntityManager
      */
     public function getEntityManager(){
-        return $this->em; 
+        return $this->em;
     }
-    
+
      /**
-     * Checks witht the config service if the portal is in read only mode and if 
+     * Checks witht the config service if the portal is in read only mode and if
      * it is throws an exception unless the user is a GOCDB admin
-     * 
+     *
      * @param \User $user user
      * @throws \Exception
      */
     protected function checkPortalIsNotReadOnlyOrUserIsAdmin(\User $user = NULL){
         require_once __DIR__ . '/Config.php';
-        
+
         //this block is required to deal with unregistered users (where $user is null)
         $userIsAdmin = false;
         if(!is_null($user)){
@@ -62,18 +62,18 @@ abstract class AbstractEntityService {
                 $userIsAdmin = true;
             }
         }
-        
-        $configServ = new \org\gocdb\services\Config();     
+
+        $configServ = new \org\gocdb\services\Config();
         if ($configServ->IsPortalReadOnly() and !$userIsAdmin){
             throw new \Exception("The portal is currently in read only mode, so this action is not permitted");
         }
     }
-    
+
     /**
-     * Checks if a user is an administrator and throws an exception if they are 
+     * Checks if a user is an administrator and throws an exception if they are
      * not. Used in functions that make changes that only GOCDB admins should be
      * able to make
-     * 
+     *
      * @param \User $user User making the change
      * @throws \Exception
      */

--- a/lib/Gocdb_Services/CertificationStatus.php
+++ b/lib/Gocdb_Services/CertificationStatus.php
@@ -12,7 +12,7 @@ namespace org\gocdb\services;
  * limitations under the License.
  */
 require_once __DIR__ . '/AbstractEntityService.php';
-require_once __DIR__ . '/RoleActionAuthorisationService.php'; 
+require_once __DIR__ . '/RoleActionAuthorisationService.php';
 
 /**
  * GOCDB Stateless service facade (business routnes) for certification status entities.
@@ -31,7 +31,7 @@ class CertificationStatus extends AbstractEntityService{
     }
 
     public function setRoleActionAuthorisationService(RoleActionAuthorisationService $roleActionAuthService){
-        $this->roleActionAuthorisationService = $roleActionAuthService; 
+        $this->roleActionAuthorisationService = $roleActionAuthService;
     }
 
     /**
@@ -57,52 +57,52 @@ class CertificationStatus extends AbstractEntityService{
     }
 
     /**
-     * User attempts to update the given site's certification status. 
+     * User attempts to update the given site's certification status.
      * @param \Site $site
      * @param \CertificationStatus $newCertStatus
      * @param \User $user
-     * @param string $reason The reason for this change, max 300 char. 
+     * @param string $reason The reason for this change, max 300 char.
      * @throws \Exception If access is denied or the change is invalid
      */
     public function editCertificationStatus(\Site $site, \CertificationStatus $newCertStatus, \User $user, $reason) {
         //$this->editAuthorization($site, $user);
-        //require_once __DIR__ . '/Site.php'; 
-        //$siteService = new \org\gocdb\services\Site(); 
+        //require_once __DIR__ . '/Site.php';
+        //$siteService = new \org\gocdb\services\Site();
         //$siteService->setEntityManager($this->em);
         //if(count($siteService->authorize Action(\Action::SITE_EDIT_CERT_STATUS, $site, $user))==0 ){
-       if($this->roleActionAuthorisationService->authoriseAction(\Action::SITE_EDIT_CERT_STATUS, $site, $user)->getGrantAction()== FALSE){ 
-           throw new \Exception('You do not have permission to change site certification status'); 
+       if($this->roleActionAuthorisationService->authoriseAction(\Action::SITE_EDIT_CERT_STATUS, $site, $user)->getGrantAction()== FALSE){
+           throw new \Exception('You do not have permission to change site certification status');
        }
-        // TODO use validate service 
+        // TODO use validate service
         if(empty($reason) ){
-           throw new \LogicException('A reason is required');     
+           throw new \LogicException('A reason is required');
         }
         if(strlen($reason) > 300){
-            throw new \LogicException('Invalid reason - 300 char max'); 
-        } 
+            throw new \LogicException('Invalid reason - 300 char max');
+        }
         // Admins can do any cert status change, e.g. to undo mistakes.
         if(!$user->isAdmin()){
           $this->isChangeValid($site, $newCertStatus);
         }
-        $oldStatusString = $site->getCertificationStatus()->getName(); 
+        $oldStatusString = $site->getCertificationStatus()->getName();
         try {
             $this->em->beginTransaction();
-            $now = new \DateTime('now', new \DateTimeZone('UTC')); 
-            
-            // create a new CertStatusLog 
-            $certLog = new \CertificationStatusLog(); 
-            $certLog->setAddedBy($user->getCertificateDn()); 
-            $certLog->setNewStatus($newCertStatus->getName()); 
-            $certLog->setOldStatus($oldStatusString); 
-            $certLog->setAddedDate($now); 
-            $certLog->setReason($reason); 
-            $this->em->persist($certLog); 
-            
-            // update our site  
-            $site->addCertificationStatusLog($certLog); 
+            $now = new \DateTime('now', new \DateTimeZone('UTC'));
+
+            // create a new CertStatusLog
+            $certLog = new \CertificationStatusLog();
+            $certLog->setAddedBy($user->getCertificateDn());
+            $certLog->setNewStatus($newCertStatus->getName());
+            $certLog->setOldStatus($oldStatusString);
+            $certLog->setAddedDate($now);
+            $certLog->setReason($reason);
+            $this->em->persist($certLog);
+
+            // update our site
+            $site->addCertificationStatusLog($certLog);
             $site->setCertificationStatus($newCertStatus);
-            $site->setCertificationStatusChangeDate($now); 
-            
+            $site->setCertificationStatusChangeDate($now);
+
             $this->em->merge($site);
             $this->em->flush();
             $this->em->getConnection()->commit();

--- a/lib/Gocdb_Services/Config.php
+++ b/lib/Gocdb_Services/Config.php
@@ -14,20 +14,20 @@ namespace org\gocdb\services;
 
 
 /**
- * GOCDB service for GOCDB configuration settings in config files:  
+ * GOCDB service for GOCDB configuration settings in config files:
  * <code>config/local_info.xml</code> and <code>config/gocdb_schema.xml</code>.
  *
- * @author David Meredith <david.meredith@stfc.ac.uk> 
+ * @author David Meredith <david.meredith@stfc.ac.uk>
  * @author John Casson
  */
 class Config {
-    private $gocdb_schemaFile;   
-    private $local_infoFile; 
-    
+    private $gocdb_schemaFile;
+    private $local_infoFile;
+
 
     public function __construct() {
         $this->gocdb_schemaFile = __DIR__."/../../config/gocdb_schema.xml";
-        $this->local_infoFile =  __DIR__."/../../config/local_info.xml"; 
+        $this->local_infoFile =  __DIR__."/../../config/local_info.xml";
     }
 
     /**
@@ -39,19 +39,19 @@ class Config {
     }
 
     /**
-     * Set the full path to the 'gocdb_schema.xml' config file. 
+     * Set the full path to the 'gocdb_schema.xml' config file.
      * <p>
-     * Useful for testing when creating a sample seed configuration. If not 
-     * set, then defaults to <src>__DIR__."/../../config/gocdb_schema.xml</src> 
-     * 
+     * Useful for testing when creating a sample seed configuration. If not
+     * set, then defaults to <src>__DIR__."/../../config/gocdb_schema.xml</src>
+     *
      * @param string $filePath
      * @throws \LogicException If not a string
      */
     public function setSchemaFileLocation($filePath){
         if(!is_string($filePath)){
-            throw new \LogicException("Invalid filePath given for gocdb_schema.xml file"); 
+            throw new \LogicException("Invalid filePath given for gocdb_schema.xml file");
         }
-        $this->gocdb_schemaFile = $filePath; 
+        $this->gocdb_schemaFile = $filePath;
     }
 
     /**
@@ -63,19 +63,19 @@ class Config {
     }
 
     /**
-     * Set the full path to the 'local_info.xml' config file. 
+     * Set the full path to the 'local_info.xml' config file.
      * <p>
-     * Useful for testing when creating a sample seed configuration. If not 
-     * set, then defaults to <src>__DIR__."/../../config/local_info.xml</src> 
-     * 
+     * Useful for testing when creating a sample seed configuration. If not
+     * set, then defaults to <src>__DIR__."/../../config/local_info.xml</src>
+     *
      * @param string $filePath
      * @throws \LogicException If not a string
      */
     public function setLocalInfoFileLocation($filePath){
         if(!is_string($filePath)){
-            throw new \LogicException("Invalid filePath given for local_info.xml file"); 
+            throw new \LogicException("Invalid filePath given for local_info.xml file");
         }
-        $this->local_infoFile = $filePath;  
+        $this->local_infoFile = $filePath;
     }
 
     /**
@@ -94,7 +94,7 @@ class Config {
         return simplexml_load_file($this->getLocalInfoFileLocation());
     }
 
-    
+
     /**
      * returns true if the portal has ben set to read only mode in local_info.xml
      * @return boolean
@@ -104,10 +104,10 @@ class Config {
         if (strtolower($localInfo->local_info->read_only) == 'true'){
             return true;
         }
-        
+
         return false;
     }
-    
+
     /**
      * Determine if the requested feature is set in the local_info.xml file.
      * @param type $featureName The feature name which should correspond to an
@@ -134,7 +134,7 @@ class Config {
         $url = $localInfo->local_info->web_portal_url;
         return strval($url);
     }
-    
+
     public function getDefaultScopeName(){
         $scopeName = $this->GetLocalInfoXML()->local_info->default_scope->name;
 
@@ -144,7 +144,7 @@ class Config {
 
         return strval($scopeName);
     }
-    
+
     public function getDefaultScopeMatch(){
         $scopeMatch = $this->GetLocalInfoXML()->local_info->default_scope_match;
 
@@ -157,27 +157,27 @@ class Config {
 
     public function  getMinimumScopesRequired($entityType){
         $supportedEntities = array('ngi', 'site', 'service', 'service_group');
-        
+
         if(!in_array($entityType, $supportedEntities)){
             throw new \LogicException("Function does not support entity type");
         }
-        
+
         $numScopesRequired = $this->GetLocalInfoXML()->local_info->minimum_scopes->$entityType;
-                
+
         if (empty($numScopesRequired)){
             $numScopesRequired = 0;
         }
-        
+
         return intval($numScopesRequired);
     }
-    
+
     /**
      * Get an array of 'reserved' scope strings or an empty array if non are configured.
      *
      * <p>
      * Reserved scopes can only be assiged by gocdb admin (and in future by selected roles);
      * they can't be freely assigned to resources by their users/owners.
-     * 
+     *
      * @return array Reserved scopes as Strings
      */
     public function getReservedScopeList() {
@@ -192,10 +192,10 @@ class Config {
         }
         return $reservedScopes;
     }
-     
+
     public function getShowMapOnStartPage(){
         $showMapString = $this->GetLocalInfoXML()->local_info->google->show_map_on_start_page;
-                
+
         if(empty($showMapString)){
             $showMap = false;
         }
@@ -208,24 +208,24 @@ class Config {
 
         return $showMap;
     }
-    
+
     public function getGoogleAPIKey(){
         $apiKey = $this->GetLocalInfoXML()->local_info->google->google_API_key;
-                
+
         if(empty($apiKey)){
             $apiKey = '';
         }
 
         return $apiKey;
     }
-    
+
     public function getExtensionsLimit(){
-        return $this->GetLocalInfoXML()->local_info->extensions->max;        
+        return $this->GetLocalInfoXML()->local_info->extensions->max;
     }
-    
-        
+
+
     public function getSendEmails(){
-        $sendEmailString = $this->GetLocalInfoXML()->local_info->send_email;  
+        $sendEmailString = $this->GetLocalInfoXML()->local_info->send_email;
          if(empty($sendEmailString)){
             $sendEmail = false;
         }
@@ -237,7 +237,7 @@ class Config {
         }
         return $sendEmail;
     }
-    
+
 }
 
 

--- a/lib/Gocdb_Services/Downtime.php
+++ b/lib/Gocdb_Services/Downtime.php
@@ -113,8 +113,8 @@ class Downtime extends AbstractEntityService{
             throw new \Exception("A downtime must affect at least one service");
         }
 
-        // Check that each endpoint belongs to one of the services. 
-        // It is an error if an endpoint does not belong to one of the services. 
+        // Check that each endpoint belongs to one of the services.
+        // It is an error if an endpoint does not belong to one of the services.
         foreach($endpoints as $checkEndpoint){
             $endpointBelongsToService = false;
             foreach($services as $checkService){
@@ -127,7 +127,7 @@ class Downtime extends AbstractEntityService{
             }
         }
 
-        // get the affected sites 
+        // get the affected sites
         $sites = array();
         foreach($services as $se){
             $site = $se->getParentSite();
@@ -137,10 +137,10 @@ class Downtime extends AbstractEntityService{
         }
 
         if(count($sites) != 1){
-            // if there are multiple affected services from multiple sites, 
-            // the gui must either enforce single site selection 
-            // or prevent selecting 'define DT in site timezone' if selecting 
-            // multiple sites (i.e. utc only when selecting services from multiple sites). 
+            // if there are multiple affected services from multiple sites,
+            // the gui must either enforce single site selection
+            // or prevent selecting 'define DT in site timezone' if selecting
+            // multiple sites (i.e. utc only when selecting services from multiple sites).
             throw new \Exception("Downtime creation for multiple sites not supported yet");
         }
 
@@ -153,29 +153,29 @@ class Downtime extends AbstractEntityService{
         $endStr = $values['DOWNTIME']['END_TIMESTAMP'];
         //echo($startStr. ' '.$endStr); // 14/05/2015 16:16      14/05/2015 16:17   d/m/Y H:i
 
-        // did the user specify the downtime info in utc (default) or in site's local timezone? 
+        // did the user specify the downtime info in utc (default) or in site's local timezone?
         /*$requestUtcOrSiteTimezone = $values['DOWNTIME']['DEFINE_TZ_BY_UTC_OR_SITE'];
-        $tzStr = 'UTC'; // the timezone label specified by the user (e.g. 'UTC' or 'Europe/London') 
+        $tzStr = 'UTC'; // the timezone label specified by the user (e.g. 'UTC' or 'Europe/London')
         if($requestUtcOrSiteTimezone == 'site'){
-            // if there are multiple affected services from multiple sites, 
-            // we assume utc - the gui must therefore either enforce single site selection 
-            // or prevent selecting 'define DT in site timezone' if selecting 
-            // multiple sites (i.e. utc only when selecting services from multiple sites). 
-             
-            // get the site timezone label 
+            // if there are multiple affected services from multiple sites,
+            // we assume utc - the gui must therefore either enforce single site selection
+            // or prevent selecting 'define DT in site timezone' if selecting
+            // multiple sites (i.e. utc only when selecting services from multiple sites).
+
+            // get the site timezone label
             if(count($sites) > 1){
-                $tzStr = 'UTC'; // if many sites are affected (not implemented yet), assume UTC 
+                $tzStr = 'UTC'; // if many sites are affected (not implemented yet), assume UTC
             } else {
-                $siteTzOrNull = $sites[0]->getTimezoneId();  
+                $siteTzOrNull = $sites[0]->getTimezoneId();
                 if( !empty($siteTzOrNull)){
-                    $tzStr = $siteTzOrNull;  
+                    $tzStr = $siteTzOrNull;
                 } else {
-                    $tzStr = 'UTC'; 
+                    $tzStr = 'UTC';
                 }
             }
         }
 
-        // convert start and end into UTC 
+        // convert start and end into UTC
         $UTC = new \DateTimeZone("UTC");
         if($tzStr != 'UTC'){
             // specify dateTime in source TZ
@@ -183,11 +183,11 @@ class Downtime extends AbstractEntityService{
             $start = \DateTime::createFromFormat($this::FORMAT, $startStr, $sourceTZ);
             $end = \DateTime::createFromFormat($this::FORMAT, $endStr, $sourceTZ);
             // reset the TZ to UTC
-            $start->setTimezone($UTC); 
-            $end->setTimezone($UTC); 
+            $start->setTimezone($UTC);
+            $end->setTimezone($UTC);
         } else {
             $start = \DateTime::createFromFormat($this::FORMAT, $startStr, $UTC);
-            $end = \DateTime::createFromFormat($this::FORMAT, $endStr, $UTC); 
+            $end = \DateTime::createFromFormat($this::FORMAT, $endStr, $UTC);
         }*/
 
         $start = \DateTime::createFromFormat($this::FORMAT, $startStr, new \DateTimeZone("UTC"));
@@ -214,10 +214,10 @@ class Downtime extends AbstractEntityService{
             $dt->setStartDate($start);
             $dt->setEndDate($end);
             $dt->setInsertDate(new \DateTime(null, new \DateTimeZone('UTC')) );
-            // Create a new pk and persist/flush to sync in-mem object state 
+            // Create a new pk and persist/flush to sync in-mem object state
             // with DB - is needed so that the call to v4DowntimePK->getId() actually
             // returns a value (we can still rollback no probs if an issue occurs
-            // to remove the Downtime) 
+            // to remove the Downtime)
             $v4DowntimePk = new \PrimaryKey();
             $this->em->persist($v4DowntimePk);
             $this->em->flush();
@@ -253,9 +253,9 @@ class Downtime extends AbstractEntityService{
         if(is_null($user)) {
             throw new \Exception("Unregistered users can't edit a downtime.");
         }
-        //require_once __DIR__.'/ServiceService.php'; 
-        //$serviceService = new \org\gocdb\services\ServiceService(); 
-        //$serviceService->setEntityManager($this->em);  
+        //require_once __DIR__.'/ServiceService.php';
+        //$serviceService = new \org\gocdb\services\ServiceService();
+        //$serviceService->setEntityManager($this->em);
          if (!$user->isAdmin()) {
             foreach ($ses as $se) {
                 //if(count($serviceService->authorize Action(\Action::EDIT_OBJECT, $se, $user))==0){
@@ -330,7 +330,7 @@ class Downtime extends AbstractEntityService{
         //throw new \Exception('@DAVE - This is the point at which I left you. The function is receiving the correct values for the edit
         // contained in the newValues variable and the $dt variable is the existing downtime we want to edit. <br>
         //<br>The id of the downtime we are editting:'.$dt->getId().'<br>'.var_dump($newValues));
-        //-----------------------------------------------------------------------------//                  
+        //-----------------------------------------------------------------------------//
 
 
         //Check the portal is not in read only mode, throws exception if it is
@@ -341,10 +341,10 @@ class Downtime extends AbstractEntityService{
         $serviceService->setEntityManager($this->em);
 
         // Get the services that are **ALREADY LINKED** to this downtime
-        // 
-        // Check that the user has adequate permissions over these services. This 
-        // is necessary if the user wants to either edit or *remove* the existing 
-        // service(s) associated with this downtime. 
+        //
+        // Check that the user has adequate permissions over these services. This
+        // is necessary if the user wants to either edit or *remove* the existing
+        // service(s) associated with this downtime.
         $downtimesExistingSEs = array();
         foreach($dt->getEndpointLocations() as $els){
             $downtimesExistingSEs[] = $els->getService();
@@ -354,10 +354,10 @@ class Downtime extends AbstractEntityService{
 
 
         // Get the **NEWLY SELECTED** services and endpoints to be linked to this dt
-        // 
-        // Check that at least one Service was actually selected to be associated 
+        //
+        // Check that at least one Service was actually selected to be associated
         // with the downtime - these can be the same as the exising services and/or
-        // new services entirley.  
+        // new services entirley.
         if(!isset($newValues['Impacted_Services'])){
            throw new \Exception('Error, this downtime affects no service -
                at least one service must be selected');
@@ -374,13 +374,13 @@ class Downtime extends AbstractEntityService{
            throw new \Exception('Error, this downtime affects no service -
                at least one service must be selected');
         }
-        // Check that the user has permissions over the list of (potentially different) 
-        // services affected by this downtime. 
+        // Check that the user has permissions over the list of (potentially different)
+        // services affected by this downtime.
         $this->authorisation($newServices, $user);
 
-        // Check that each newEndpoint belongs to one of the newServices. 
+        // Check that each newEndpoint belongs to one of the newServices.
         // It is an error if a newEndpoint does not belong to one
-        // of the newServices. 
+        // of the newServices.
         foreach($newEndpoints as $checkNewEndpoint){
             $newEndpointBelongsToNewService = false;
             foreach($newServices as $newService){
@@ -393,12 +393,12 @@ class Downtime extends AbstractEntityService{
             }
         }
 
-        // Validate the submitted downtime properties against regex in gocdb_schema 
+        // Validate the submitted downtime properties against regex in gocdb_schema
         $this->validate($newValues['DOWNTIME']);
 
 
-        // Check only one site is affected (don't support multiple site selection yet) 
-        // get the affected sites 
+        // Check only one site is affected (don't support multiple site selection yet)
+        // get the affected sites
         $newSites = array();
         foreach($newServices as $se){
             $site = $se->getParentSite();
@@ -407,10 +407,10 @@ class Downtime extends AbstractEntityService{
             }
         }
         if(count($newSites) != 1){
-            // if there are multiple affected services from multiple sites, 
-            // the gui must either enforce single site selection 
-            // or prevent selecting 'define DT in site timezone' if selecting 
-            // multiple sites (i.e. utc only when selecting services from multiple sites). 
+            // if there are multiple affected services from multiple sites,
+            // the gui must either enforce single site selection
+            // or prevent selecting 'define DT in site timezone' if selecting
+            // multiple sites (i.e. utc only when selecting services from multiple sites).
             throw new \Exception("Downtime editing for multiple sites not supported yet");
         }
 
@@ -418,30 +418,30 @@ class Downtime extends AbstractEntityService{
         $newEndStr = $newValues['DOWNTIME']['END_TIMESTAMP'];
         //echo($newStartStr. ' '.$newEndStr); // 14/05/2015 16:16      14/05/2015 16:17   d/m/Y H:i
 
-        // did the user specify the downtime info in utc (default) or in site's local timezone? 
+        // did the user specify the downtime info in utc (default) or in site's local timezone?
         /*$requestUtcOrSiteTimezone = $newValues['DOWNTIME']['DEFINE_TZ_BY_UTC_OR_SITE'];
-        $tzStr = 'UTC'; // the timezone label specified by the user (e.g. 'UTC' or 'Europe/London') 
+        $tzStr = 'UTC'; // the timezone label specified by the user (e.g. 'UTC' or 'Europe/London')
         if($requestUtcOrSiteTimezone == 'site'){
-            // if there are multiple affected services from multiple sites, 
-            // we assume utc - the gui must therefore either enforce single site selection 
-            // or prevent selecting 'define DT in site timezone' if selecting 
-            // multiple sites (i.e. utc only when selecting services from multiple sites). 
-             
-            // get the site timezone label 
+            // if there are multiple affected services from multiple sites,
+            // we assume utc - the gui must therefore either enforce single site selection
+            // or prevent selecting 'define DT in site timezone' if selecting
+            // multiple sites (i.e. utc only when selecting services from multiple sites).
+
+            // get the site timezone label
             if(count($newSites) > 1){
-                $tzStr = 'UTC'; // if many sites are affected (not implemented yet), assume UTC 
+                $tzStr = 'UTC'; // if many sites are affected (not implemented yet), assume UTC
             } else {
-                $siteTzOrNull = $newSites[0]->getTimezoneId();  
+                $siteTzOrNull = $newSites[0]->getTimezoneId();
                 if( !empty($siteTzOrNull)){
-                    $tzStr = $siteTzOrNull;  
+                    $tzStr = $siteTzOrNull;
                 } else {
-                    $tzStr = 'UTC'; 
+                    $tzStr = 'UTC';
                 }
             }
         }
-       
 
-        // convert start and end into UTC 
+
+        // convert start and end into UTC
         $UTC = new \DateTimeZone("UTC");
         if($tzStr != 'UTC'){
             // specify dateTime in source TZ
@@ -449,11 +449,11 @@ class Downtime extends AbstractEntityService{
             $newStart = \DateTime::createFromFormat($this::FORMAT, $newStartStr, $sourceTZ);
             $newEnd = \DateTime::createFromFormat($this::FORMAT, $newEndStr, $sourceTZ);
             // reset the TZ to UTC
-            $newStart->setTimezone($UTC); 
-            $newEnd->setTimezone($UTC); 
+            $newStart->setTimezone($UTC);
+            $newEnd->setTimezone($UTC);
         } else {
             $newStart = \DateTime::createFromFormat($this::FORMAT, $newStartStr, $UTC);
-            $newEnd = \DateTime::createFromFormat($this::FORMAT, $newEndStr, $UTC); 
+            $newEnd = \DateTime::createFromFormat($this::FORMAT, $newEndStr, $UTC);
         }*/
 
         // Make sure all dates are treated as UTC!
@@ -463,8 +463,8 @@ class Downtime extends AbstractEntityService{
         $newEnd = \DateTime::createFromFormat($this::FORMAT, $newEndStr, new \DateTimeZone("UTC"));
 
 
-        // check the new start/end times of the downtime are valid according 
-        // to GOCDB business rules  
+        // check the new start/end times of the downtime are valid according
+        // to GOCDB business rules
         $this->editValidation($dt, $newStart, $newEnd);
         $this->validateDates($newStart, $newEnd);
 
@@ -486,7 +486,7 @@ class Downtime extends AbstractEntityService{
             $dt->setStartDate($newStart);
             $dt->setEndDate($newEnd);
 
-            // First unlink all the previous els from the downtime  
+            // First unlink all the previous els from the downtime
             foreach ($dt->getEndpointLocations() as $linkedEl) {
                 $dt->getEndpointLocations()->removeElement($linkedEl);
                 $linkedEl->getDowntimes()->removeElement($dt);
@@ -626,11 +626,11 @@ class Downtime extends AbstractEntityService{
         if ($dt->getStartDate()->setTimezone(new \DateTimeZone('UTC')) >= $sixtySecsFromNow) {
             throw new \Exception ("Logic error - Downtime start time is after the requested end time");
         }
-        // dt has already ended 
+        // dt has already ended
         if($dt->getEndDate()->setTimezone(new \DateTimeZone('UTC')) < $now){
             throw new \Exception ("Logic error - Downtime has already ended or will within the next 60 secs");
         }
-        // ok. dt endDate is in the future and dt is ongoing/has started. 
+        // ok. dt endDate is in the future and dt is ongoing/has started.
 
         $this->em->getConnection()->beginTransaction();
         try {
@@ -671,9 +671,9 @@ class Downtime extends AbstractEntityService{
             //For MEPS we need to delete from both service and enpoints
             foreach($dt->getServices() as $se){
                 // Downtime is the owning side so remove elements from downtime.
-                $dt->removeService($se);  // unlinks on both sides 
+                $dt->removeService($se);  // unlinks on both sides
                 //$dt->getServices()->removeElement($se); //unlinking
-                //$se->getDowntimes()->removeElement($dt); 
+                //$se->getDowntimes()->removeElement($dt);
 
             }
 
@@ -746,18 +746,18 @@ class Downtime extends AbstractEntityService{
      */
     public function getActiveAndImminentDowntimes($windowStart, $windowEnd) {
     $dql = "SELECT DISTINCT d, se, s, st
-                FROM Downtime d                
+                FROM Downtime d
                 JOIN d.services se
                 JOIN se.parentSite s
-                JOIN se.serviceType st        
+                JOIN se.serviceType st
                 WHERE (
                     :windowStart IS null
                     OR d.endDate > :windowStart
-                )        
+                )
                 AND (
                     :windowEnd IS null
                     OR d.startDate < :windowEnd
-                )                
+                )
                 OR (
                         :onGoingOnly = 'no'
                         OR
@@ -775,12 +775,12 @@ class Downtime extends AbstractEntityService{
 
     return $downtimes = $q->getResult();
     }
-    
+
     /**
      */
     public function getActiveDowntimes() {
         $dql = "SELECT DISTINCT d, se, s, st
-                FROM Downtime d                
+                FROM Downtime d
                 JOIN d.services se
                 JOIN se.parentSite s
                 JOIN se.serviceType st
@@ -792,22 +792,22 @@ class Downtime extends AbstractEntityService{
                         AND d.endDate > :now)
                 )
                 ORDER BY d.startDate DESC";
-        
+
         $q = $this->em->createQuery( $dql )->setParameter( 'onGoingOnly', 'yes' )->setParameter( 'now', new \DateTime () );
-        
+
         return $downtimes = $q->getResult ();
     }
-    
+
     /**
      * Get downtimes where the downtime endDate is after windowStart, and
      * downtime start date is before windowEnd.
-     * 
+     *
      * @param \Date $windowStart
      * @param \Date $windowEnd
      */
     public function getImminentDowntimes($windowStart, $windowEnd) {
         $dql = "SELECT DISTINCT d, se, s, st
-                FROM Downtime d                
+                FROM Downtime d
                 JOIN d.services se
                 JOIN se.parentSite s
                 JOIN se.serviceType st
@@ -820,9 +820,9 @@ class Downtime extends AbstractEntityService{
                     OR d.startDate < :windowEnd
                 )
                 ORDER BY d.startDate DESC";
-        
+
         $q = $this->em->createQuery( $dql )->setParameter( 'windowStart', $windowStart )->setParameter( 'windowEnd', $windowEnd );
-        
+
         return $downtimes = $q->getResult ();
     }
 

--- a/lib/Gocdb_Services/ExtensionsService.php
+++ b/lib/Gocdb_Services/ExtensionsService.php
@@ -19,43 +19,43 @@ require_once __DIR__ . '/AbstractEntityService.php';;
  * @author James McCarthy
  */
 class ExtensionsService extends AbstractEntityService{
-    
+
     /**
-     * This method will return all site extensions from the siteProperties 
+     * This method will return all site extensions from the siteProperties
      * table.
      */
     public function getSiteExtensionsKeynames() {
-                
+
         $qb = $this->em->createQueryBuilder();
         $qb ->select('DISTINCT sp')
             ->from('SiteProperty', 'sp');
-    
+
         return $qb->getQuery()->execute();
     }
-    
+
     /**
      * This method will return all service extensions from the serviceProperties
-     * table.     
+     * table.
      */
     public function getServiceExtensionsKeyNames() {
-    
+
         $qb = $this->em->createQueryBuilder();
         $qb ->select('DISTINCT sp')
             ->from('ServiceProperty', 'sp');
-    
+
         return $qb->getQuery()->execute();
     }
-    
+
     /**
      * This method will return all service group extensions from the serviceGroupProperties
      * table.
      */
     public function getServiceGroupExtensionsKeyNames() {
-    
+
         $qb = $this->em->createQueryBuilder();
         $qb ->select('DISTINCT sp')
         ->from('ServiceGroupProperty', 'sp');
-    
+
         return $qb->getQuery()->execute();
-    }    
+    }
 }

--- a/lib/Gocdb_Services/Factory.php
+++ b/lib/Gocdb_Services/Factory.php
@@ -12,15 +12,15 @@
  * limitations under the License.
  */
 
-require_once __DIR__ . '/RoleConstants.php'; 
+require_once __DIR__ . '/RoleConstants.php';
 /**
  * A factory for returning GOCDB business services.
  * Most services are managed as static singleton instances, but you can choose
  * to instantiate a service class instance directly if necessary.
- * 
- * Without a dependency injection framework, this class implements an object 
+ *
+ * Without a dependency injection framework, this class implements an object
  * creational pattern
- * {@link https://en.wikipedia.org/wiki/Creational_pattern Object creation} 
+ * {@link https://en.wikipedia.org/wiki/Creational_pattern Object creation}
  *
  * @author David Meredith
  */
@@ -29,8 +29,8 @@ class Factory {
     private static $siteService = null;
     private static $scopeService = null;
     private static $roleService = null;
-    private static $roleActionAuthorisationService = null; 
-    private static $roleActionMappingService = null; 
+    private static $roleActionAuthorisationService = null;
+    private static $roleActionMappingService = null;
     private static $userService = null;
     private static $searchService = null;
     private static $downtimeService = null;
@@ -49,8 +49,8 @@ class Factory {
     private static $exService = null;
     private static $notificationService = null;
 
-    public static $properties = array(); 
-    //private static $properties = null; 
+    public static $properties = array();
+    //private static $properties = null;
 
     /**
      * Force non-instantiablity with private constructor
@@ -59,19 +59,19 @@ class Factory {
     }
 
     /**
-     * Get a reference to the static/shared properties. 
-     * Note, if you want to update these properties, you will need to assign a 
-     * variable to that reference using 'assign by reference' e.g. in callling code: 
-     * @return array 
+     * Get a reference to the static/shared properties.
+     * Note, if you want to update these properties, you will need to assign a
+     * variable to that reference using 'assign by reference' e.g. in callling code:
+     * @return array
      */
 //    public static function &getPropertes(){
 //        if(self::$properties == null){
-//            self::$properties = array(); 
-//            // configure with default properties first 
-//            self::$properties['PORTALURL'] = self::getConfigService()->GetPortalURL(); 
-//            self::$properties['LOGOUTURL'] = self::getConfigService()->GetPortalURL(); 
+//            self::$properties = array();
+//            // configure with default properties first
+//            self::$properties['PORTALURL'] = self::getConfigService()->GetPortalURL();
+//            self::$properties['LOGOUTURL'] = self::getConfigService()->GetPortalURL();
 //        }
-//        return self::$properties; 
+//        return self::$properties;
 //    }
 
     /**
@@ -101,8 +101,8 @@ class Factory {
      */
     public static function getEntityManager(){
         if(self::$em == null){
-            // we should only require the one file; bootstrap.php (note, the  
-            // gap file below introduced intentionally to eliminate from grep/search) 
+            // we should only require the one file; bootstrap.php (note, the
+            // gap file below introduced intentionally to eliminate from grep/search)
             //require __DIR__ . "/../Doctrine/bootstrap    _doctrine.php";
             require __DIR__ . "/../Doctrine/bootstrap.php";
             self::$em = $entityManager;
@@ -118,9 +118,9 @@ class Factory {
         if (self::$siteService == null) {
             require_once __DIR__ . '/Site.php';
             self::$siteService = new org\gocdb\services\Site();
-            self::$siteService->setEntityManager(self::getEntityManager()); 
-            self::$siteService->setRoleActionAuthorisationService(self::getRoleActionAuthorisationService()); 
-            self::$siteService->setScopeService(self::getScopeService()); 
+            self::$siteService->setEntityManager(self::getEntityManager());
+            self::$siteService->setRoleActionAuthorisationService(self::getRoleActionAuthorisationService());
+            self::$siteService->setScopeService(self::getScopeService());
         }
         return self::$siteService;
     }
@@ -135,7 +135,7 @@ class Factory {
             //self::$serviceGroupService = new org\gocdb\services\ServiceGroup(self::getRoleActionAuthorisationService());
             self::$serviceGroupService = new org\gocdb\services\ServiceGroup();
             self::$serviceGroupService->setEntityManager(self::getEntityManager());
-            self::$serviceGroupService->setRoleActionAuthorisationService(self::getRoleActionAuthorisationService()); 
+            self::$serviceGroupService->setRoleActionAuthorisationService(self::getRoleActionAuthorisationService());
             self::$serviceGroupService->setScopeService(self::getScopeService());
         }
         return self::$serviceGroupService;
@@ -149,7 +149,7 @@ class Factory {
         if (self::$downtimeService == null) {
             require_once __DIR__ . '/Downtime.php';
             self::$downtimeService = new org\gocdb\services\Downtime();
-            self::$downtimeService->setEntityManager(self::getEntityManager()); 
+            self::$downtimeService->setEntityManager(self::getEntityManager());
             self::$downtimeService->setRoleActionAuthorisationService(self::getRoleActionAuthorisationService());
         }
         return self::$downtimeService;
@@ -163,9 +163,9 @@ class Factory {
         if (self::$seService == null) {
             require_once __DIR__ . '/ServiceService.php';
             self::$seService = new org\gocdb\services\ServiceService();
-            self::$seService->setEntityManager(self::getEntityManager()); 
+            self::$seService->setEntityManager(self::getEntityManager());
             self::$seService->setRoleActionAuthorisationService(self::getRoleActionAuthorisationService());
-            self::$seService->setScopeService(self::getScopeService()); 
+            self::$seService->setScopeService(self::getScopeService());
         }
         return self::$seService;
     }
@@ -178,39 +178,39 @@ class Factory {
     public static function getRoleService() {
         if (self::$roleService == null) {
             require_once __DIR__ . '/Role.php';
-            self::$roleService = new org\gocdb\services\Role(); 
-            self::$roleService->setEntityManager(self::getEntityManager()); 
-            self::$roleService->setDowntimeService(self::getDowntimeService()); 
-            self::$roleService->setRoleActionAuthorisationService(self::getRoleActionAuthorisationService()); 
+            self::$roleService = new org\gocdb\services\Role();
+            self::$roleService->setEntityManager(self::getEntityManager());
+            self::$roleService->setDowntimeService(self::getDowntimeService());
+            self::$roleService->setRoleActionAuthorisationService(self::getRoleActionAuthorisationService());
         }
         return self::$roleService;
     }
 
     /**
-     * Get singleton RoleActionAuthorisationService instance with injected dependencies. 
+     * Get singleton RoleActionAuthorisationService instance with injected dependencies.
      * @return org\gocdb\services\RoleActionAuthorisationService
      */
     public static function getRoleActionAuthorisationService(){
         if(self::$roleActionAuthorisationService == null){
-            require_once __DIR__ . '/RoleActionAuthorisationService.php'; 
-            $roleActionMappingService = self::getRoleActionMappingService(); 
-            //$roleService = self::getRoleService(); 
-            self::$roleActionAuthorisationService = new org\gocdb\services\RoleActionAuthorisationService($roleActionMappingService/*, $roleService*/); 
-            self::$roleActionAuthorisationService->setEntityManager(self::getEntityManager());  
+            require_once __DIR__ . '/RoleActionAuthorisationService.php';
+            $roleActionMappingService = self::getRoleActionMappingService();
+            //$roleService = self::getRoleService();
+            self::$roleActionAuthorisationService = new org\gocdb\services\RoleActionAuthorisationService($roleActionMappingService/*, $roleService*/);
+            self::$roleActionAuthorisationService->setEntityManager(self::getEntityManager());
         }
-        return self::$roleActionAuthorisationService; 
+        return self::$roleActionAuthorisationService;
     }
 
     /**
-     * Get singleton RoleActionMappingService instance with injected dependencies. 
+     * Get singleton RoleActionMappingService instance with injected dependencies.
      * @return org\gocdb\services\RoleActionMappingService
      */
     public static function getRoleActionMappingService(){
         if(self::$roleActionMappingService == null){
-            require_once __DIR__ . '/RoleActionMappingService.php'; 
-            self::$roleActionMappingService = new \org\gocdb\services\RoleActionMappingService(); 
+            require_once __DIR__ . '/RoleActionMappingService.php';
+            self::$roleActionMappingService = new \org\gocdb\services\RoleActionMappingService();
         }
-        return self::$roleActionMappingService; 
+        return self::$roleActionMappingService;
     }
 
 
@@ -222,7 +222,7 @@ class Factory {
         if (self::$userService == null) {
             require_once __DIR__ . '/User.php';
             self::$userService = new org\gocdb\services\User();
-            self::$userService->setEntityManager(self::getEntityManager()); 
+            self::$userService->setEntityManager(self::getEntityManager());
         }
         return self::$userService;
     }
@@ -236,8 +236,8 @@ class Factory {
             require_once __DIR__ . '/NGI.php';
             self::$ngiService = new org\gocdb\services\NGI();
             self::$ngiService->setEntityManager(self::getEntityManager());
-            self::$ngiService->setRoleActionAuthorisationService(self::getRoleActionAuthorisationService());  
-            self::$ngiService->setScopeService(self::getScopeService()); 
+            self::$ngiService->setRoleActionAuthorisationService(self::getRoleActionAuthorisationService());
+            self::$ngiService->setScopeService(self::getScopeService());
         }
         return self::$ngiService;
     }
@@ -250,7 +250,7 @@ class Factory {
         if (self::$searchService == null) {
             require_once __DIR__ . '/Search.php';
             self::$searchService = new org\gocdb\services\Search();
-            self::$searchService->setEntityManager(self::getEntityManager()); 
+            self::$searchService->setEntityManager(self::getEntityManager());
         }
         return self::$searchService;
     }
@@ -302,11 +302,11 @@ class Factory {
             require_once __DIR__ . '/CertificationStatus.php';
             self::$certStatusService = new org\gocdb\services\CertificationStatus();
             self::$certStatusService->setEntityManager(self::getEntityManager());
-            self::$certStatusService->setRoleActionAuthorisationService(self::getRoleActionAuthorisationService()); 
+            self::$certStatusService->setRoleActionAuthorisationService(self::getRoleActionAuthorisationService());
         }
         return self::$certStatusService;
     }
-    
+
      /**
      * Singleton Service Type service
      * @return org\gocdb\services\ServiceType
@@ -319,7 +319,7 @@ class Factory {
         }
         return self::$serviceTypeService;
     }
-    
+
      /**
      * Singleton project service
      * @return org\gocdb\services\Project
@@ -329,7 +329,7 @@ class Factory {
             require_once __DIR__ . '/Project.php';
             self::$projectService = new org\gocdb\services\Project;
             self::$projectService->setEntityManager(self::getEntityManager());
-            self::$projectService->setRoleActionAuthorisationService(self::getRoleActionAuthorisationService());  
+            self::$projectService->setRoleActionAuthorisationService(self::getRoleActionAuthorisationService());
         }
         return self::$projectService;
     }
@@ -342,7 +342,7 @@ class Factory {
         if (self::$retrieveAccountService == null) {
             require_once __DIR__ . '/RetrieveAccount.php';
             self::$retrieveAccountService = new org\gocdb\services\RetrieveAccount();
-            self::$retrieveAccountService->setEntityManager(self::getEntityManager()); 
+            self::$retrieveAccountService->setEntityManager(self::getEntityManager());
         }
         return self::$retrieveAccountService;
     }
@@ -355,11 +355,11 @@ class Factory {
         if (self::$OwnedEntityService == null) {
             require_once __DIR__ . '/OwnedEntity.php';
             self::$OwnedEntityService = new org\gocdb\services\OwnedEntity();
-            self::$OwnedEntityService->setEntityManager(self::getEntityManager()); 
+            self::$OwnedEntityService->setEntityManager(self::getEntityManager());
         }
         return self::$OwnedEntityService;
     }
-    
+
     /**
      * Singleton ExtensionsService
      * @return org\gocdb\services\ExtensionsService
@@ -372,7 +372,7 @@ class Factory {
         }
         return self::$exService;
     }
-    
+
     /**
      * Singleton NotificationService
      * @return org\gocdb\services\NotificationService

--- a/lib/Gocdb_Services/NotificationService.php
+++ b/lib/Gocdb_Services/NotificationService.php
@@ -13,7 +13,7 @@ require_once __DIR__ . '/Factory.php';
  * @author James McCarthy
  */
 class NotificationService extends AbstractEntityService {
-    
+
     /**
      * This class will take an entity of either site, service group, NGI or Project.
      * It will then get the roles from the entity
@@ -25,24 +25,24 @@ class NotificationService extends AbstractEntityService {
      * send an email to those users to approve. It does this by passing the parent entity back into this method recursively.
      *
      *
-     * @param Site/ServiceGroup/NGI/Project $entity            
+     * @param Site/ServiceGroup/NGI/Project $entity
      */
     public function roleRequest($entity) {
         $project = null;
         $emails = null;
         $projectIds = null;
-        
+
         // Get the roles from the entity
         foreach ( $entity->getRoles () as $role ) {
             $roles [] = $role;
         }
-        
+
         // Now for each role get the user
         foreach ( $roles as $role ) {
-            $enablingRoles = \Factory::getRoleActionAuthorisationService()->authoriseAction(\Action::GRANT_ROLE, $entity, $role->getUser())->getGrantingRoles(); 
+            $enablingRoles = \Factory::getRoleActionAuthorisationService()->authoriseAction(\Action::GRANT_ROLE, $entity, $role->getUser())->getGrantingRoles();
             if ($entity instanceof \Site) {
                 //$enablingRoles = \Factory::getSiteService ()->authorize Action ( \Action::GRANT_ROLE, $entity, $role->getUser () );
-                
+
                 // If the site has no site adminstrators to approve the role request then send an email to the parent NGI users to approve the request
                 if ($roles == null) {
                     $this->roleRequest ( $entity->getNgi () ); // Recursivly call this function to send email to the NGI users
@@ -54,7 +54,7 @@ class NotificationService extends AbstractEntityService {
             } else if ($entity instanceof \NGI) {
                 //$enablingRoles = \Factory::getNgiService ()->authorize Action ( \Action::GRANT_ROLE, $entity, $role->getUser () );
                 $projects = $entity->getProjects (); // set project with the NGI's parent project and later recurse with this
-                                                    
+
                 // Only send emails to Project users if there are no users with grant_roles over the NGI
                 if ($roles == null) {
                     // Get the ID's of each project so we can remove duplicates
@@ -64,7 +64,7 @@ class NotificationService extends AbstractEntityService {
                     $projectIds = array_unique ( $projectIds );
                 }
             }
-            
+
             // remove admin from enabling roles
             /*$position = array_search ( 'GOCDB_ADMIN', $enablingRoles );
             if ($position != null) {
@@ -75,7 +75,7 @@ class NotificationService extends AbstractEntityService {
                 $emails [] = $role->getUser ()->getEmail ();
             }
         }
-        
+
         /*
          * No users are able to grant the role or there are no users over this entity. In this case we will email the parent entity for approval
          */
@@ -87,7 +87,7 @@ class NotificationService extends AbstractEntityService {
                  * It is important to remove duplicate projects here otherwise we will spam the same addresses as we recursively call this method.
                  */
                 $projects = $entity->getProjects (); // set project with the NGI's parent project and later recurse with this
-                $projectIds = array();                                      
+                $projectIds = array();
                 // Get the ID's of each project so we can remove duplicates
                 foreach ( $projects as $project ) {
                     $projectIds [] = $project->getId ();
@@ -96,28 +96,28 @@ class NotificationService extends AbstractEntityService {
             }
         } else {
             // If the entity has valid users who can approve the role then send the email notification.
-            
+
             // Remove duplicate emails from array
             $emails = array_unique ( $emails );
-            
+
             // Get the PortalURL to create an accurate link to the role approval view
             $localInfoLocation = __DIR__ . "/../../config/local_info.xml";
             $localInfoXML = simplexml_load_file ( $localInfoLocation );
             $webPortalURL = $localInfoXML->local_info->web_portal_url;
-            
+
             // Email content
             $headers = "From: no-reply@goc.egi.eu";
             $subject = "GocDB: A Role request requires attention";
-            
-            $body = "Dear GOCDB User,\n\n" . "A user has requested a role that requires attention.\n\n" . 
-                    "You can approve or deny this request here:\n\n" . $webPortalURL . "/index.php?Page_Type=Role_Requests\n\n" . 
+
+            $body = "Dear GOCDB User,\n\n" . "A user has requested a role that requires attention.\n\n" .
+                    "You can approve or deny this request here:\n\n" . $webPortalURL . "/index.php?Page_Type=Role_Requests\n\n" .
                     "Note: This role may already have been approved or denied by another GocDB User";
-        
-            $sendMail = TRUE; 
+
+            $sendMail = TRUE;
             // Send email to all users who can approve this role request
             if ($emails != null) {
                 foreach ( $emails as $email ) {
-                    if($sendMail){ 
+                    if($sendMail){
                        mail($email, $subject, $body, $headers);
                     } else {
                        echo "Email: " . $email . "<br>";
@@ -127,7 +127,7 @@ class NotificationService extends AbstractEntityService {
                 }
             }
         }
-        
+
         /**
          * For each project ID get the entity and run this function again for each entity so
          * that for each NGI the email notification is sent to all users who hold roles over the parent
@@ -136,7 +136,7 @@ class NotificationService extends AbstractEntityService {
         if ($projectIds != null) {
             foreach ( $projectIds as $pid ) {
                 $project = \Factory::getOwnedEntityService ()->getOwnedEntityById ( $pid );
-                if(sendMail){ 
+                if(sendMail){
                     $this->roleRequest ( $project );
                 } else {
                     echo $project->getName () . "<br>";

--- a/lib/Gocdb_Services/OwnedEntity.php
+++ b/lib/Gocdb_Services/OwnedEntity.php
@@ -14,56 +14,56 @@ namespace org\gocdb\services;
 require_once __DIR__ . '/AbstractEntityService.php';
 
 /**
- * Service class that contain generic functions for working with doctrine 
- * database entities.   
+ * Service class that contain generic functions for working with doctrine
+ * database entities.
  *
- * @author David Meredith  
+ * @author David Meredith
  */
 class OwnedEntity  extends AbstractEntityService{
     /**
-     * Get the OwnedEntity that has the given id. 
-     * @param integer $id 
+     * Get the OwnedEntity that has the given id.
+     * @param integer $id
      * @return \OwnedEntity
      */
     public function getOwnedEntityById($id){
-        // will only load a lazy loading proxy until method on the proxy is called 
+        // will only load a lazy loading proxy until method on the proxy is called
         //$entity = $this->em->find('OwnedEntity', (int)$id);
-        //return $entity; 
-        $dql = "SELECT oe from OwnedEntity oe where oe.id = :id"; 
-        $oe = $this->em->createQuery($dql)->setParameter(":id", $id)->getSingleResult(); 
-        return $oe; 
+        //return $entity;
+        $dql = "SELECT oe from OwnedEntity oe where oe.id = :id";
+        $oe = $this->em->createQuery($dql)->setParameter(":id", $id)->getSingleResult();
+        return $oe;
     }
 
     /**
-     * Get the class name of the class that extends the given OwnedEntity, e.g. 
-     * NGI, Site, ServiceGroup, Project. 
+     * Get the class name of the class that extends the given OwnedEntity, e.g.
+     * NGI, Site, ServiceGroup, Project.
      * @param \OwnedEntity $entity
-     * @return string Class name 
-     * @throws LogicException if the OwnedEntity is not supported/configured 
+     * @return string Class name
+     * @throws LogicException if the OwnedEntity is not supported/configured
      */
     public function getOwnedEntityDerivedClassName(\OwnedEntity $entity){
-        // Would be better to use the get_class method to determine the instance 
+        // Would be better to use the get_class method to determine the instance
         // class name, however, there have been instances where this has returned
         // a class name of the following form: 'DoctrineProxies\__CG__\Site'
-        // which would cause issues. 
-        // 
+        // which would cause issues.
+        //
         //$entityClassName= get_class($entity);
-        
+
          if($entity instanceof \Site){
-           $entityClassName = 'Site';  
+           $entityClassName = 'Site';
         } else if($entity instanceof \NGI){
-            $entityClassName = 'NGI'; 
+            $entityClassName = 'NGI';
         } else if($entity instanceof \Project){
-            $entityClassName = 'Project'; 
+            $entityClassName = 'Project';
         } else if($entity instanceof \ServiceGroup){
-            $entityClassName = 'ServiceGroup'; 
+            $entityClassName = 'ServiceGroup';
         } else {
             throw new LogicException("Coding error - OwnedEntity type is not mapped");
         }
-        return $entityClassName; 
+        return $entityClassName;
     }
-    
-    
+
+
 
 }
 

--- a/lib/Gocdb_Services/PI/GetCertStatusDate.php
+++ b/lib/Gocdb_Services/PI/GetCertStatusDate.php
@@ -20,28 +20,28 @@ require_once __DIR__ . '/IPIQuery.php';
  * <pre>
  * 'roc', 'certification_status'
  * </pre>
- * 
+ *
  * @author James McCarthy
  * @author David Meredith
  */
 class GetCertStatusDate implements IPIQuery{
-    
+
     protected $query;
     protected $validParams;
     protected $em;
     private $helpers;
     private $allSites;
-    
+
     /** Constructor takes entity manager which is then used by the
      *  query builder
-     * 
+     *
      * @param EntityManager $em
      */
     public function __construct($em){
         $this->em = $em;
-        $this->helpers=new Helpers();		
+        $this->helpers=new Helpers();
     }
-    
+
     /** Validates parameters against array of pre-defined valid terms
      *  for this PI type
      * @param array $parameters
@@ -51,42 +51,42 @@ class GetCertStatusDate implements IPIQuery{
         // Define supported parameters and validate given params (die if an unsupported param is given)
         $supportedQueryParams = array (
                 'certification_status',
-                'roc' 
+                'roc'
         );
-        
+
         $this->helpers->validateParams ( $supportedQueryParams, $parameters );
         $this->validParams = $parameters;
     }
-    
+
     /** Creates the query by building on a queryBuilder object as
-     *  required by the supplied parameters 
+     *  required by the supplied parameters
      */
     public function createQuery() {
         $parameters = $this->validParams;
         $binds= array();
         $bc=-1;
-    
+
         $qb = $this->em->createQueryBuilder();
-        
-        //Initialize base query		
+
+        //Initialize base query
         $qb	->select('s')
-            ->from('Site', 's')		
+            ->from('Site', 's')
             ->join('s.certificationStatus', 'cs')
             ->join('s.ngi', 'n')
             ->leftJoin('s.scopes', 'sc')
             ->join('s.infrastructure', 'i')
             ->andWhere($qb->expr()->like('i.name', '?'.++$bc))
             ->orderBy('s.id', 'ASC');
-        
-            
+
+
             $binds[] = array($bc, 'Production');
-            
-            
-            
-    
+
+
+
+
         /*Pass parameters to the ParameterBuilder and allow it to add relevant where clauses
          * based on set parameters.
-        */	
+        */
         $parameterBuilder = new ParameterBuilder($parameters, $qb, $this->em, $bc);
         //Get the result of the scope builder
         $qb = $parameterBuilder->getQB();
@@ -95,40 +95,40 @@ class GetCertStatusDate implements IPIQuery{
         foreach((array)$parameterBuilder->getBinds() as $bind){
             $binds[] = $bind;
         }
-            
+
         //Bind all variables
         $qb = $this->helpers->bindValuesToQuery($binds, $qb);
-    
+
         $dql = $qb->getDql(); //for testing
-    
+
         //Get the dql query from the Query Builder object
         $query = $qb->getQuery();
-        
-        $this->query = $query;	
-         return $this->query; 
-    }	
-    
+
+        $this->query = $query;
+         return $this->query;
+    }
+
     /**
      * Executes the query that has been built and stores the returned data
      * so it can later be used to create XML, Glue2 XML or JSON.
      */
     public function executeQuery(){
         $this->allSites = $this->query->execute();
-        return $this->allSites;	     
+        return $this->allSites;
     }
-    
-    /** 
-     * Returns proprietary GocDB rendering of the downtime data 
+
+    /**
+     * Returns proprietary GocDB rendering of the downtime data
      *  in an XML String
-     *  
+     *
      * @return String
      */
     public function getXML(){
         $helpers = $this->helpers;
-        
+
         $allSites = $this->allSites;
-        
-        
+
+
         $xml = new \SimpleXMLElement ( "<results />" );
         foreach ( $allSites as $site ) {
 
@@ -136,7 +136,7 @@ class GetCertStatusDate implements IPIQuery{
                 $xmlSite->addChild ( 'name', $site->getShortName () );
                 $xmlSite->addChild ( 'cert_status', $site->getCertificationStatus ()->getName () );
                 //Some V4 data was imported without dates. This stops those sites being displayed
-                if ($site->getCertificationStatusChangeDate () != null) {            		
+                if ($site->getCertificationStatusChangeDate () != null) {
                 // e.g. <cert_date>29-JAN-13 05.13.08 PM</cert_date>
                 $xmlSite->addChild ( 'cert_date', $site->getCertificationStatusChangeDate ()->format ( 'd-M-y H.i.s A' ) );
             }
@@ -150,19 +150,19 @@ class GetCertStatusDate implements IPIQuery{
         $xmlString = $dom->saveXML ();
         return $xmlString;
     }
-    
-    /** Returns the site data in Glue2 XML string. 
+
+    /** Returns the site data in Glue2 XML string.
      * @return String
      */
-    public function getGlue2XML(){	
+    public function getGlue2XML(){
         throw new LogicException("Not implemented yet");
     }
-    
-    /** Not yet implemented, in future will return the sites 
+
+    /** Not yet implemented, in future will return the sites
      *  data in JSON format
      * @throws LogicException
      */
-    public function getJSON(){		
+    public function getJSON(){
         throw new LogicException("Not implemented yet");
     }
 }

--- a/lib/Gocdb_Services/PI/GetDowntime.php
+++ b/lib/Gocdb_Services/PI/GetDowntime.php
@@ -43,7 +43,7 @@ class GetDowntime implements IPIQuery, IPIQueryPageable
     protected $query;
     protected $validParams;
     protected $em;
-    private $baseUrl; 
+    private $baseUrl;
     private $helpers;
     private $nested;
     private $downtimes;
@@ -57,13 +57,13 @@ class GetDowntime implements IPIQuery, IPIQueryPageable
     private $defaultPaging = false;
 
 
-    /** 
+    /**
      * Constructor takes entity manager which is then used by the query builder
      *
      * @param EntityManager $em
-     * @param Boolean $nested When true the affected service endpoints are nested within each downtime element, 
-     *   when false the dowmtime element is repeated for each affected service endpoint (legacy) 
-     * @param string $baseUrl The base url string to prefix to urls generated in the query output.  
+     * @param Boolean $nested When true the affected service endpoints are nested within each downtime element,
+     *   when false the dowmtime element is repeated for each affected service endpoint (legacy)
+     * @param string $baseUrl The base url string to prefix to urls generated in the query output.
      */
     public function __construct($em, $nested = false, $baseUrl = 'https://goc.egi.eu/portal')
     {
@@ -71,7 +71,7 @@ class GetDowntime implements IPIQuery, IPIQueryPageable
         $this->em = $em;
         $this->helpers = new Helpers();
         $this->renderMultipleEndpoints = true;
-        $this->baseUrl = $baseUrl; 
+        $this->baseUrl = $baseUrl;
     }
 
     /**

--- a/lib/Gocdb_Services/PI/GetDowntimeFallback.php
+++ b/lib/Gocdb_Services/PI/GetDowntimeFallback.php
@@ -37,7 +37,7 @@ class GetDowntime implements IPIQuery {
     private $nested;
     private $downtimes;
     private $renderMultipleEndpoints;
-    private $baseUrl; 
+    private $baseUrl;
 
     /** Constructor takes entity manager which is then used by the
      *  query builder
@@ -45,14 +45,14 @@ class GetDowntime implements IPIQuery {
      * @param EntityManager $em
      * @param Boolean $nested when true this method will return the
      * nested rendering of the downtime data
-     * @param string $baseUrl The base url string to prefix to urls generated in the query output. 
+     * @param string $baseUrl The base url string to prefix to urls generated in the query output.
      */
     public function __construct($em, $nested = false, $baseUrl = 'https://goc.egi.eu/portal') {
         $this->nested = $nested;
         $this->em = $em;
         $this->helpers = new Helpers();
         $this->renderMultipleEndpoints = true;
-        $this->baseUrl = $baseUrl; 
+        $this->baseUrl = $baseUrl;
     }
 
     /**

--- a/lib/Gocdb_Services/PI/GetNGI.php
+++ b/lib/Gocdb_Services/PI/GetNGI.php
@@ -15,12 +15,12 @@ require_once __DIR__ . '/IPIQuery.php';
 /**
  * Return an XML document that encodes the NGIs selected from the DB.
  * Optionally provide an associative array of query parameters with values to restrict the results.
- * Only known parameters are honoured while unknown params produce an error doc. 
+ * Only known parameters are honoured while unknown params produce an error doc.
  * Parmeter array keys include:
  * <pre>
- * 'roc', 'scope', 'scope_match' (where scope refers to NGI scope)  
+ * 'roc', 'scope', 'scope_match' (where scope refers to NGI scope)
  * </pre>
- * 
+ *
  * @author James McCarthy
  * @author David Meredith
  */
@@ -34,7 +34,7 @@ class GetNGI implements IPIQuery {
 
     /** Constructor takes entity manager which is then used by the
      *  query builder
-     * 
+     *
      * @param EntityManager $em
      */
     public function __construct($em) {
@@ -60,7 +60,7 @@ class GetNGI implements IPIQuery {
     }
 
     /** Creates the query by building on a queryBuilder object as
-     *  required by the supplied parameters 
+     *  required by the supplied parameters
      */
     public function createQuery() {
     $parameters = $this->validParams;
@@ -69,7 +69,7 @@ class GetNGI implements IPIQuery {
 
     $qb = $this->em->createQueryBuilder();
 
-    //Initialize base query		
+    //Initialize base query
     $qb->select('n')
         ->from('NGI', 'n')
         ->leftJoin('n.scopes', 'sc')
@@ -90,8 +90,8 @@ class GetNGI implements IPIQuery {
     //////Start Scope
     //Run ScopeQueryBuilder regardless of if scope is set.
     $scopeQueryBuilder = new ScopeQueryBuilder(
-        (isset($parameters['scope'])) ? $parameters['scope'] : null, 
-        (isset($parameters['scope_match'])) ? $parameters['scope_match'] : null, 
+        (isset($parameters['scope'])) ? $parameters['scope'] : null,
+        (isset($parameters['scope_match'])) ? $parameters['scope_match'] : null,
         $qb, $this->em, $bc, 'NGI', 'n'
     );
 
@@ -123,7 +123,7 @@ class GetNGI implements IPIQuery {
     return $this->ngis;
     }
 
-    /** Returns proprietary GocDB rendering of the NGI data 
+    /** Returns proprietary GocDB rendering of the NGI data
      *  in an XML String
      * @return String
      */
@@ -146,7 +146,7 @@ class GetNGI implements IPIQuery {
         $xmlNgi->addChild("HELPDESK_EMAIL", $ngi->getHelpdeskEmail());
         $xmlNgi->addChild("SECURITY_EMAIL", $ngi->getSecurityEmail());
         $xmlNgi->addChild("SITE_COUNT", count($ngi->getSites()));
-        // scopes  
+        // scopes
         $xmlScopes = $xmlNgi->addChild('SCOPES');
         foreach ($ngi->getScopes() as $scope) {
         $xmlScopes->addChild('SCOPE', xssafe($scope->getName()));
@@ -164,7 +164,7 @@ class GetNGI implements IPIQuery {
     }
 
     /** Returns the NGI data in Glue2 XML string.
-     * 
+     *
      * @return String
      */
     public function getGlue2XML() {
@@ -214,7 +214,7 @@ class GetNGI implements IPIQuery {
     return $xmlString;
     }
 
-    /** Not yet implemented, in future will return the NGI 
+    /** Not yet implemented, in future will return the NGI
      *  data in JSON format
      * @throws LogicException
      */

--- a/lib/Gocdb_Services/PI/GetNGIList.php
+++ b/lib/Gocdb_Services/PI/GetNGIList.php
@@ -12,36 +12,36 @@ require_once __DIR__ . '/QueryBuilders/Helpers.php';
 require_once __DIR__ . '/IPIQuery.php';
 
 
-/** 
+/**
  * Return an XML document that encodes the NGIs selected from the DB.
  * Optionally provide an associative array of query parameters with values to restrict the results.
- * Only known parameters are honoured while unknown params produce an error doc. 
+ * Only known parameters are honoured while unknown params produce an error doc.
  * Parmeter array keys include:
  * <pre>
  * 'roc'
  * </pre>
- * 
+ *
  * @author James McCarthy
- * @author David Meredith 
+ * @author David Meredith
  */
 class GetNGIList implements IPIQuery{
-    
+
 protected $query;
     protected $validParams;
     protected $em;
     private $helpers;
     private $ngis;
-    
+
     /** Constructor takes entity manager which is then used by the
      *  query builder
-     * 
+     *
      * @param EntityManager $em
      */
     public function __construct($em){
         $this->em = $em;
-        $this->helpers=new Helpers();		
+        $this->helpers=new Helpers();
     }
-    
+
     /** Validates parameters against array of pre-defined valid terms
      *  for this PI type
      * @param array $parameters
@@ -50,31 +50,31 @@ protected $query;
 
         // Define supported parameters and validate given params (die if an unsupported param is given)
         $supportedQueryParams = array (
-                'roc' 
+                'roc'
         );
-        
+
         $this->helpers->validateParams ( $supportedQueryParams, $parameters );
         $this->validParams = $parameters;
     }
-    
+
     /** Creates the query by building on a queryBuilder object as
-     *  required by the supplied parameters 
+     *  required by the supplied parameters
      */
     public function createQuery() {
         $parameters = $this->validParams;
         $binds= array();
         $bc=-1;
-    
+
         $qb = $this->em->createQueryBuilder();
-        
-        //Initialize base query		
+
+        //Initialize base query
         $qb	->select('n')
         ->from('NGI', 'n')
         ->orderBy('n.id', 'ASC');
-    
+
         /*Pass parameters to the ParameterBuilder and allow it to add relevant where clauses
         * based on set parameters.
-        */	
+        */
         $parameterBuilder = new ParameterBuilder($parameters, $qb, $this->em, $bc);
         //Get the result of the scope builder
         $qb = $parameterBuilder->getQB();
@@ -83,17 +83,17 @@ protected $query;
         foreach((array)$parameterBuilder->getBinds() as $bind){
             $binds[] = $bind;
         }
-    
+
         //Bind all variables
         $qb = $this->helpers->bindValuesToQuery($binds, $qb);
-    
+
         //Get the dql query from the Query Builder object
         $query = $qb->getQuery();
 
-        $this->query = $query;	
-         return $this->query; 
-    }	
-    
+        $this->query = $query;
+         return $this->query;
+    }
+
     /**
      * Executes the query that has been built and stores the returned data
      * so it can later be used to create XML, Glue2 XML or JSON.
@@ -102,8 +102,8 @@ protected $query;
         $this->ngis = $this->query->execute();
         return $this->ngis;
     }
-    
-    /** Returns proprietary GocDB rendering of the NGI data 
+
+    /** Returns proprietary GocDB rendering of the NGI data
      *  in an XML String
      * @return String
      */
@@ -111,15 +111,15 @@ protected $query;
         $helpers = $this->helpers;
 
         $ngis = $this->query->execute();
-        
+
         $xml = new \SimpleXMLElement ( "<results />" );
-        
+
         foreach ( $ngis as $ngi ) {
             $xmlNgi = $xml->addChild ( 'ROC' );
             $xmlNgi->addAttribute ( 'PRIMARY_KEY', $ngi->getId () . "G0" );
             $xmlNgi->addAttribute ( 'ROC_NAME', $ngi->getName () );
         }
-        
+
         $dom_sxe = dom_import_simplexml ( $xml );
         $dom = new \DOMDocument ( '1.0' );
         $dom->encoding = 'UTF-8';
@@ -129,45 +129,45 @@ protected $query;
         $xmlString = $dom->saveXML ();
         return $xmlString;
     }
-    
+
     /** Returns the NGI data in Glue2 XML string.
-     * 
+     *
      * @return String
      */
     public function getGlue2XML(){
         $helpers = $this->helpers;
         $query = $this->query;
-        
+
         $ngis = $query->getResult();
 
         $xml = new \SimpleXMLElement("<Entities />");
-        
+
         foreach($ngis as $ngi) {
             $xmlNgi = $xml->addChild("AdminDomain");
             $xmlNgi->addAttribute("BaseType", "Domain");
-            $xmlNgi->addChild("ID", $ngi->getId());                                 
+            $xmlNgi->addChild("ID", $ngi->getId());
             $xmlNgi->addChild("Name", $ngi->getName());
-            
+
             $xmlNgiExtParent = $xmlNgi->addChild("Extensions");
-            
-            $helpers->addExtIfNotEmpty($xmlNgiExtParent, 'Email', $ngi->getEmail());           
-            $helpers->addExtIfNotEmpty($xmlNgiExtParent, 'Object_ID', $ngi->getId());           
-            $helpers->addExtIfNotEmpty($xmlNgiExtParent, 'GGUS_SU', $ngi->getGgus_Su());           
-            $helpers->addExtIfNotEmpty($xmlNgiExtParent, 'Rod_Email', $ngi->getRodEmail());  
-            $helpers->addExtIfNotEmpty($xmlNgiExtParent, 'Helpdesk_Email', $ngi->getHelpdeskEmail());  
-            $helpers->addExtIfNotEmpty($xmlNgiExtParent, 'Security_Email', $ngi->getSecurityEmail());  
-            $helpers->addExtIfNotEmpty($xmlNgiExtParent, 'Site_Count', count($ngi->getSites()));  
-         
+
+            $helpers->addExtIfNotEmpty($xmlNgiExtParent, 'Email', $ngi->getEmail());
+            $helpers->addExtIfNotEmpty($xmlNgiExtParent, 'Object_ID', $ngi->getId());
+            $helpers->addExtIfNotEmpty($xmlNgiExtParent, 'GGUS_SU', $ngi->getGgus_Su());
+            $helpers->addExtIfNotEmpty($xmlNgiExtParent, 'Rod_Email', $ngi->getRodEmail());
+            $helpers->addExtIfNotEmpty($xmlNgiExtParent, 'Helpdesk_Email', $ngi->getHelpdeskEmail());
+            $helpers->addExtIfNotEmpty($xmlNgiExtParent, 'Security_Email', $ngi->getSecurityEmail());
+            $helpers->addExtIfNotEmpty($xmlNgiExtParent, 'Site_Count', count($ngi->getSites()));
+
             $xmlNgi->addChild("Description", $ngi->getDescription());
             $xmlNgi->addChild("Distributed", "true");
-            
+
             $xmlNgiAsoc = $xmlNgi->addChild("Associations");
-            
+
             $sites = $ngi->getSites();
             foreach($sites as $site) {
                 $xmlNgiAsoc->addChild("ChildDomainID", $site->getPrimaryKey());
             }
-            
+
         }
 
         $dom_sxe = dom_import_simplexml($xml);
@@ -181,13 +181,13 @@ protected $query;
 
         return $xmlString;
     }
-    
-    /** Not yet implemented, in future will return the NGI 
+
+    /** Not yet implemented, in future will return the NGI
      *  data in JSON format
      * @throws LogicException
      */
     public function getJSON(){
-        $query = $this->query;		
+        $query = $this->query;
         throw new LogicException("Not implemented yet");
     }
 }

--- a/lib/Gocdb_Services/PI/GetService.php
+++ b/lib/Gocdb_Services/PI/GetService.php
@@ -19,46 +19,46 @@ use Doctrine\ORM\Tools\Pagination\Paginator;
 /**
  * Return an XML document that encodes the services.
  * Optionally provide an associative array of query parameters with values to restrict the results.
- * Only known parameters are honoured while unknown params produce an error doc. 
+ * Only known parameters are honoured while unknown params produce an error doc.
  * Parmeter array keys include:
  * <pre>
- * 'hostname', 'sitename', 'roc', 'country', 'service_type', 'monitored', 
- * 'scope', 'scope_match', 'properties', page (where scope refers to Service scope) 
+ * 'hostname', 'sitename', 'roc', 'country', 'service_type', 'monitored',
+ * 'scope', 'scope_match', 'properties', page (where scope refers to Service scope)
  * </pre>
- * 
+ *
  * @author James McCarthy
- * @author David Meredith 
- * @author Tom Byrne 
+ * @author David Meredith
+ * @author Tom Byrne
  */
 class GetService implements IPIQuery, IPIQueryPageable {
 
     protected $query;
     protected $validParams;
     protected $em;
-    protected $queryBuilder; 
+    protected $queryBuilder;
     private $helpers;
     private $serviceEndpoints;
     private $renderMultipleEndpoints;
-    private $baseUrl; 
-    
+    private $baseUrl;
+
     private $page;  // specifies the requested page number - must be null if not paging
     private $maxResults = 500; //1000;
     private $seCountTotal;
     private $queryBuilder2;
     private $query2;
-    private $defaultPaging = false; 
+    private $defaultPaging = false;
 
-    /** 
-     * Constructor takes entity manager which is then used by the query builder. 
+    /**
+     * Constructor takes entity manager which is then used by the query builder.
      *
      * @param EntityManager $em
-     * @param string $baseUrl The base url string to prefix to urls generated in the query output. 
+     * @param string $baseUrl The base url string to prefix to urls generated in the query output.
      */
     public function __construct($em, $baseUrl = 'https://goc.egi.eu/portal') {
         $this->em = $em;
         $this->helpers = new Helpers();
         $this->renderMultipleEndpoints = true;
-        $this->baseUrl = $baseUrl; 
+        $this->baseUrl = $baseUrl;
     }
 
     /** Validates parameters against array of pre-defined valid terms
@@ -144,7 +144,7 @@ class GetService implements IPIQuery, IPIQueryPageable {
 
         //Run ScopeQueryBuilder regardless of if scope is set.
         $scopeQueryBuilder = new ScopeQueryBuilder(
-                (isset($parameters['scope'])) ? $parameters['scope'] : null, 
+                (isset($parameters['scope'])) ? $parameters['scope'] : null,
                 (isset($parameters['scope_match'])) ? $parameters['scope_match'] : null,
                 $qb, $this->em, $bc, 'Service', 'se'
         );
@@ -200,23 +200,23 @@ class GetService implements IPIQuery, IPIQueryPageable {
             $this->query2 = $this->queryBuilder2->getQuery();
             //then we don't use setFirst/MaxResult on this query
             //so all SE's will be returned and counted, but without all the additional info
-            
-            // offset is zero offset (starts from zero) 
+
+            // offset is zero offset (starts from zero)
             $offset = (($this->page - 1) * $this->maxResults);
             // sets the position of the first result to retrieve (the "offset")
-            $query->setFirstResult($offset); 
+            $query->setFirstResult($offset);
             // Sets the maximum number of results to retrieve (the "limit")
             $query->setMaxResults($this->maxResults);
 
         }
-         
-        $this->queryBuilder = $qb; 
+
+        $this->queryBuilder = $qb;
         $this->query = $query;
         return $this->query;
     }
 
     public function getQueryBuilder(){
-        return $this->queryBuilder; 
+        return $this->queryBuilder;
     }
 
     /**
@@ -231,15 +231,15 @@ class GetService implements IPIQuery, IPIQueryPageable {
             $this->serviceEndpoints = new Paginator($this->query, $fetchJoinCollection = true);
             //put the total number of SE's into $this->seCountTotal
             $this->seCountTotal = $this->query2->getSingleScalarResult();
-            
+
         } else {
             $this->serviceEndpoints = $this->query->execute();
         }
-        
+
         return $this->serviceEndpoints;
     }
 
-    /** Returns proprietary GocDB rendering of the service endpoint data 
+    /** Returns proprietary GocDB rendering of the service endpoint data
      *  in an XML String
      * @return String
      */
@@ -263,7 +263,7 @@ class GetService implements IPIQuery, IPIQueryPageable {
         $serviceEndpoints = $this->serviceEndpoints;
 
         foreach ($serviceEndpoints as $se) {
-            // maybe rename SERVICE_ENDPOINT to SERVICE 
+            // maybe rename SERVICE_ENDPOINT to SERVICE
             $xmlSe = $xml->addChild('SERVICE_ENDPOINT');
             $xmlSe->addAttribute("PRIMARY_KEY", $se->getId() . "G0");
             $helpers->addIfNotEmpty($xmlSe, 'PRIMARY_KEY', $se->getId() . "G0");
@@ -312,7 +312,7 @@ class GetService implements IPIQuery, IPIQueryPageable {
                     $xmlEndpoint = $xmlEndpoints->addChild('ENDPOINT');
                     $xmlEndpoint->addChild('ID', $endpoint->getId());
                     $xmlEndpoint->addChild('NAME', xssafe($endpoint->getName()));
-                    // Endpoint Extensions 
+                    // Endpoint Extensions
                     $xmlExtensions = $xmlEndpoint->addChild('EXTENSIONS');
                     foreach ($endpoint->getEndpointProperties() as $prop) {
                         $xmlProperty = $xmlExtensions->addChild('EXTENSION');
@@ -325,13 +325,13 @@ class GetService implements IPIQuery, IPIQueryPageable {
                 }
             }
 
-            // scopes  
+            // scopes
             $xmlScopes = $xmlSe->addChild('SCOPES');
             foreach($se->getScopes() as $scope){
-               $xmlScopes->addChild('SCOPE', xssafe($scope->getName())); 
+               $xmlScopes->addChild('SCOPE', xssafe($scope->getName()));
             }
-            
-            // Service Extensions 
+
+            // Service Extensions
             $xmlExtensions = $xmlSe->addChild('EXTENSIONS');
             foreach ($se->getServiceProperties() as $prop) {
                 $xmlProperty = $xmlExtensions->addChild('EXTENSION');
@@ -352,14 +352,14 @@ class GetService implements IPIQuery, IPIQueryPageable {
     }
 
     /** Returns the service endpoint data in Glue2 XML string.
-     * 
+     *
      * @return String
      */
     public function getGlue2XML() {
         throw new LogicException("Not implemented yet");
     }
 
-    /** Not yet implemented, in future will return the service endpoint 
+    /** Not yet implemented, in future will return the service endpoint
      *  data in JSON format
      * @throws LogicException
      */
@@ -368,26 +368,26 @@ class GetService implements IPIQuery, IPIQueryPageable {
     }
 
     /**
-     * Choose to render the multiple endpoints of a service (or not) 
+     * Choose to render the multiple endpoints of a service (or not)
      * @param boolean $renderMultipleEndpoints
      */
     public function setRenderMultipleEndpoints($renderMultipleEndpoints) {
         $this->renderMultipleEndpoints = $renderMultipleEndpoints;
     }
 
-    
-    
+
+
     /**
-     * This query does not page by default.   
+     * This query does not page by default.
      * If set to true, the query will return the first page of results even if the
      * the <pre>page</page> URL param is not provided.
      *
      * @return bool
      */
     public function getDefaultPaging(){
-        return $this->defaultPaging; 
+        return $this->defaultPaging;
     }
-    
+
     /**
      * @param boolean $pageTrueOrFalse Set if this query pages by default
      */
@@ -395,27 +395,27 @@ class GetService implements IPIQuery, IPIQueryPageable {
         if(!is_bool($pageTrueOrFalse)){
             throw new \InvalidArgumentException('Invalid pageTrueOrFalse, requried bool');
         }
-        $this->defaultPaging = $pageTrueOrFalse;  
+        $this->defaultPaging = $pageTrueOrFalse;
     }
-     
+
     /**
-     * Set the default page size (100 by default if not set) 
+     * Set the default page size (100 by default if not set)
      * @return int The page size (number of results per page)
      */
     public function getPageSize(){
-        return $this->maxResults; 
+        return $this->maxResults;
     }
-    
+
     /**
      * Set the size of a single page.
      * @param int $pageSize
      */
     public function setPageSize($pageSize){
         if(!is_int($pageSize)){
-            throw new \InvalidArgumentException('Invalid pageSize, required int'); 
+            throw new \InvalidArgumentException('Invalid pageSize, required int');
         }
-        $this->maxResults = $pageSize; 
+        $this->maxResults = $pageSize;
     }
-    
-    
+
+
 }

--- a/lib/Gocdb_Services/PI/GetServiceGroup.php
+++ b/lib/Gocdb_Services/PI/GetServiceGroup.php
@@ -15,17 +15,17 @@ require_once __DIR__ . '/IPIQuery.php';
 /**
  * Return an XML document that encodes the service groups selected from the DB.
  * Optionally provide an associative array of query parameters with values used to restrict the results.
- * Only known parameters are honoured while unknown params produce error doc. 
+ * Only known parameters are honoured while unknown params produce error doc.
  * Parmeter array keys include:
  * <pre>
  *         'service_group_name',
  *         'scope',
- *         'scope_match', 
- *      'extensions' 
+ *         'scope_match',
+ *      'extensions'
  * </pre>
- * 
+ *
  * @author James McCarthy
- * @author David Meredith 
+ * @author David Meredith
  */
 class GetServiceGroup implements IPIQuery {
 
@@ -35,22 +35,22 @@ class GetServiceGroup implements IPIQuery {
     private $helpers;
     private $sgs;
     private $renderMultipleEndpoints;
-    private $baseUrl; 
+    private $baseUrl;
 
-    /** 
+    /**
      * Constructor takes entity manager which is then used by the query builder
      *
      * @param EntityManager $em
-     * @param string $baseUrl The base url string to prefix to urls generated in the query output. 
+     * @param string $baseUrl The base url string to prefix to urls generated in the query output.
      */
     public function __construct($em, $baseUrl = 'https://goc.egi.eu/portal') {
         $this->em = $em;
         $this->helpers = new Helpers();
         $this->renderMultipleEndpoints = true;
-        $this->baseUrl = $baseUrl; 
+        $this->baseUrl = $baseUrl;
     }
 
-    /** 
+    /**
      * Validates parameters against array of pre-defined valid terms for this PI type
      * @param array $parameters
      */
@@ -68,7 +68,7 @@ class GetServiceGroup implements IPIQuery {
         $this->validParams = $parameters;
     }
 
-    /** 
+    /**
      * Creates the query by building on a queryBuilder object as
      * required by the supplied parameters
      */
@@ -109,8 +109,8 @@ class GetServiceGroup implements IPIQuery {
 
         //Run ScopeQueryBuilder regardless of if scope is set.
         $scopeQueryBuilder = new ScopeQueryBuilder(
-                (isset($parameters['scope'])) ? $parameters['scope'] : null, 
-                (isset($parameters['scope_match'])) ? $parameters['scope_match'] : null, 
+                (isset($parameters['scope'])) ? $parameters['scope'] : null,
+                (isset($parameters['scope_match'])) ? $parameters['scope_match'] : null,
                 $qb, $this->em, $bc, 'ServiceGroup', 'sg'
         );
 
@@ -156,7 +156,7 @@ class GetServiceGroup implements IPIQuery {
         return $this->sgs;
     }
 
-    /** Returns proprietary GocDB rendering of the service group data 
+    /** Returns proprietary GocDB rendering of the service group data
      *  in an XML String
      * @return String
      */
@@ -200,7 +200,7 @@ class GetServiceGroup implements IPIQuery {
                         $xmlEndpoint = $xmlEndpoints->addChild('ENDPOINT');
                         $xmlEndpoint->addChild('ID', $endpoint->getId());
                         $xmlEndpoint->addChild('NAME', htmlspecialchars($endpoint->getName()));
-                        // Endpoint Extensions 
+                        // Endpoint Extensions
                         $xmlEndpointExtensions = $xmlEndpoint->addChild('EXTENSIONS');
                         foreach ($endpoint->getEndpointProperties() as $prop) {
                             $xmlProperty = $xmlEndpointExtensions->addChild('EXTENSION');
@@ -213,13 +213,13 @@ class GetServiceGroup implements IPIQuery {
                     }
                 }
 
-                // Service scopes  
+                // Service scopes
                 $xmlScopes = $xmlService->addChild('SCOPES');
                 foreach ($service->getScopes() as $scope) {
                     $xmlScopes->addChild('SCOPE', xssafe($scope->getName()));
                 }
 
-                // Service Extensions 
+                // Service Extensions
                 $xmlServiceExtensions = $xmlService->addChild('EXTENSIONS');
                 foreach ($service->getServiceProperties() as $prop) {
                     $xmlProperty = $xmlServiceExtensions->addChild('EXTENSION');
@@ -229,13 +229,13 @@ class GetServiceGroup implements IPIQuery {
                 }
             }
 
-            // SG scopes  
+            // SG scopes
             $xmlScopes = $xmlSg->addChild('SCOPES');
             foreach ($sg->getScopes() as $scope) {
                 $xmlScopes->addChild('SCOPE', xssafe($scope->getName()));
             }
 
-            // SG extensions 
+            // SG extensions
             $xmlSGExtensions = $xmlSg->addChild('EXTENSIONS');
             foreach ($sg->getServiceGroupProperties() as $sgProp) {
                 $xmlSgProperty = $xmlSGExtensions->addChild('EXTENSION');
@@ -256,7 +256,7 @@ class GetServiceGroup implements IPIQuery {
     }
 
     /** Returns the service group data in Glue2 XML string.
-     * 
+     *
      * @return String
      */
     public function getGlue2XML() {
@@ -264,7 +264,7 @@ class GetServiceGroup implements IPIQuery {
         throw new LogicException("Not implemented yet");
     }
 
-    /** Not yet implemented, in future will return the service group 
+    /** Not yet implemented, in future will return the service group
      *  data in JSON format
      * @throws LogicException
      */
@@ -274,7 +274,7 @@ class GetServiceGroup implements IPIQuery {
     }
 
     /**
-     * Choose to render the multiple endpoints of a service (or not) 
+     * Choose to render the multiple endpoints of a service (or not)
      * @param boolean $renderMultipleEndpoints
      */
     public function setRenderMultipleEndpoints($renderMultipleEndpoints) {

--- a/lib/Gocdb_Services/PI/GetServiceTypes.php
+++ b/lib/Gocdb_Services/PI/GetServiceTypes.php
@@ -12,14 +12,14 @@ require_once __DIR__ . '/QueryBuilders/Helpers.php';
 require_once __DIR__ . '/IPIQuery.php';
 
 
-/** 
+/**
  * Return an XML document that encodes the NGI contacts selected from the DB.
  * Optionally provide an associative array of query parameters with values used to restrict the results.
  * Only known parameters are honoured while unknown params are ignored.
  * <pre>
- * </pre> 
+ * </pre>
  * @author James McCarthy
- * @author David Meredith 
+ * @author David Meredith
  */
 class GetServiceTypes implements IPIQuery{
     protected $query;
@@ -27,7 +27,7 @@ class GetServiceTypes implements IPIQuery{
     protected $em;
     private $helpers;
     private $sts;
-    
+
     /** Constructor takes entity manager which is then used by the
      *  query builder
      *
@@ -37,20 +37,20 @@ class GetServiceTypes implements IPIQuery{
         $this->em = $em;
         $this->helpers=new Helpers();
     }
-    
+
     /** Validates parameters against array of pre-defined valid terms
      *  for this PI type
      * @param array $parameters
      */
     public function validateParameters($parameters){
-    
+
         // Define supported parameters and validate given params (die if an unsupported param is given)
         $supportedQueryParams = array ();
-    
+
         $this->helpers->validateParams ( $supportedQueryParams, $parameters );
         $this->validParams = $parameters;
     }
-    
+
     /** Creates the query by building on a queryBuilder object as
      *  required by the supplied parameters
      */
@@ -58,13 +58,13 @@ class GetServiceTypes implements IPIQuery{
         $parameters = $this->validParams;
         $binds= array();
         $bc=-1;
-    
+
         $qb = $this->em->createQueryBuilder();
-    
+
         //Initialize base query
         $qb	->select('st')
         ->from('ServiceType', 'st');
-    
+
         /*Pass parameters to the ParameterBuilder and allow it to add relevant where clauses
          * based on set parameters.
         */
@@ -76,17 +76,17 @@ class GetServiceTypes implements IPIQuery{
         foreach((array)$parameterBuilder->getBinds() as $bind){
             $binds[] = $bind;
         }
-            
+
         //Bind all variables
         $qb = $this->helpers->bindValuesToQuery($binds, $qb);
-    
+
         //Get the dql query from the Query Builder object
         $query = $qb->getQuery();
-    
+
         $this->query = $query;
         return $this->query;
     }
-    
+
     /**
      * Executes the query that has been built and stores the returned data
      * so it can later be used to create XML, Glue2 XML or JSON.
@@ -95,19 +95,19 @@ class GetServiceTypes implements IPIQuery{
         $this->sts = $this->query->execute();
         return $this->sts;
     }
-    
-    
-    /** Returns proprietary GocDB rendering of the SerivceType data 
+
+
+    /** Returns proprietary GocDB rendering of the SerivceType data
      *  in an XML String
      * @return String
      */
     public function getXML(){
         $helpers = $this->helpers;
-    
+
         $sts = $this->sts;
 
         $xml = new \SimpleXMLElement ( "<results />" );
-                    
+
         foreach($sts as $st) {
             $xmlServiceType = $xml->addChild('SERVICE_TYPE');
             $xmlServiceType->addAttribute('TYPE_ID', $st->getId() . "G0");
@@ -115,7 +115,7 @@ class GetServiceTypes implements IPIQuery{
             $xmlServiceType->addChild('SERVICE_TYPE_NAME', $st->getName());
             $xmlServiceType->addChild('SERVICE_TYPE_DESC', $st->getDescription());
         }
-        
+
         $dom_sxe = dom_import_simplexml ( $xml );
         $dom = new \DOMDocument ( '1.0' );
         $dom->encoding = 'UTF-8';
@@ -125,21 +125,21 @@ class GetServiceTypes implements IPIQuery{
         $xmlString = $dom->saveXML ();
         return $xmlString;
     }
-    
+
     /** Returns the SerivceType data in Glue2 XML string.
-     * 
+     *
      * @return String
      */
     public function getGlue2XML(){
-        throw new LogicException("Not implemented yet");	     
+        throw new LogicException("Not implemented yet");
     }
-    
-    /** Not yet implemented, in future will return the SerivceType 
+
+    /** Not yet implemented, in future will return the SerivceType
      *  data in JSON format
      * @throws LogicException
      */
     public function getJSON(){
-        $query = $this->query;		
+        $query = $this->query;
         throw new LogicException("Not implemented yet");
     }
 }

--- a/lib/Gocdb_Services/PI/GetSite.php
+++ b/lib/Gocdb_Services/PI/GetSite.php
@@ -13,18 +13,18 @@ require_once __DIR__ . '/QueryBuilders/Helpers.php';
 require_once __DIR__ . '/IPIQuery.php';
 
 /**
- * Return an XML document that encodes the Site entities. 
- * Optionally provide an associative array of query parameters with values 
- * used to restrict the results. Only known parameters are honoured while 
+ * Return an XML document that encodes the Site entities.
+ * Optionally provide an associative array of query parameters with values
+ * used to restrict the results. Only known parameters are honoured while
  * unknown produce and error doc. Parmeter array keys include:
  * <pre>
- * 'sitename', 'roc', 'country', 'certification_status', 
+ * 'sitename', 'roc', 'country', 'certification_status',
  * 'exclude_certification_status', 'production_status', 'scope', 'scope_match', 'extensions'
- * (where scope refers to Site scope) 
+ * (where scope refers to Site scope)
  * </pre>
- * 
+ *
  * @author James McCarthy
- * @author David Meredith 
+ * @author David Meredith
  */
 class GetSite implements IPIQuery {
 
@@ -33,20 +33,20 @@ class GetSite implements IPIQuery {
     protected $em;
     private $helpers;
     private $sites;
-    private $baseUrl; 
+    private $baseUrl;
 
-    /** 
-     * Constructor takes entity manager which is then used by the query builder 
+    /**
+     * Constructor takes entity manager which is then used by the query builder
      * @param EntityManager $em
-     * @param string $baseUrl The base url string to prefix to urls generated in the query output. 
+     * @param string $baseUrl The base url string to prefix to urls generated in the query output.
      */
     public function __construct($em, $baseUrl = 'https://goc.egi.eu/portal') {
         $this->em = $em;
         $this->helpers = new Helpers();
-        $this->baseUrl = $baseUrl; 
+        $this->baseUrl = $baseUrl;
     }
 
-    /** 
+    /**
      * Validates parameters against array of pre-defined valid terms for this PI type
      * @param array $parameters
      */
@@ -105,8 +105,8 @@ class GetSite implements IPIQuery {
 
         //Run ScopeQueryBuilder regardless of if scope is set.
         $scopeQueryBuilder = new ScopeQueryBuilder(
-                (isset($parameters['scope'])) ? $parameters['scope'] : null, 
-                (isset($parameters['scope_match'])) ? $parameters['scope_match'] : null, 
+                (isset($parameters['scope'])) ? $parameters['scope'] : null,
+                (isset($parameters['scope_match'])) ? $parameters['scope_match'] : null,
                 $qb, $this->em, $bc, 'Site', 's'
         );
 
@@ -162,7 +162,7 @@ class GetSite implements IPIQuery {
         return $this->sites;
     }
 
-    /** Returns proprietary GocDB rendering of the sites data 
+    /** Returns proprietary GocDB rendering of the sites data
      *  in an XML String
      * @return String
      */
@@ -212,12 +212,12 @@ class GetSite implements IPIQuery {
             $helpers->addIfNotEmpty($xmlSite, 'SITE_IP', $site->getIpRange());
             $helpers->addIfNotEmpty($xmlSite, 'SITE_IPV6', $site->getIpV6Range());
 
-            // scopes  
+            // scopes
             $xmlScopes = $xmlSite->addChild('SCOPES');
             foreach($site->getScopes() as $scope){
-               $xmlScope = $xmlScopes->addChild('SCOPE', xssafe($scope->getName())); 
+               $xmlScope = $xmlScopes->addChild('SCOPE', xssafe($scope->getName()));
             }
-            
+
             $xmlExtensions = $xmlSite->addChild('EXTENSIONS');
             foreach ($site->getSiteProperties() as $siteProp) {
                 //if ($siteProp != "") {
@@ -226,27 +226,27 @@ class GetSite implements IPIQuery {
                     $xmlSiteProperty->addChild('KEY', xssafe($siteProp->getKeyName()));
                     $xmlSiteProperty->addChild('VALUE', xssafe($siteProp->getKeyValue()));
 
-                    // If we want support any char in a property, then we will probably 
+                    // If we want support any char in a property, then we will probably
                     // need to support CDATA sections rather than escaping the
-                    // value using xsafe. Below shows how this can be done.  
-                    // this don't work for obvious reasons: 
+                    // value using xsafe. Below shows how this can be done.
+                    // this don't work for obvious reasons:
                     //$xmlSiteProperty->addChild ( 'VALUE', '<![CDATA[<dave>d</dave>]]>' );
                     //$xmlSiteProperty->addChild ( 'VALUE', '<dave>d</dave>' );
-                    // Both the samples below show how a CDATA section can be 
-                    // added to a SimpleXMLElement. The logic uses the DOM api 
-                    // because the SimpleXML api don't support adding CDATA. 
-                    // For performance reasons, it may be necessary to create the 
+                    // Both the samples below show how a CDATA section can be
+                    // added to a SimpleXMLElement. The logic uses the DOM api
+                    // because the SimpleXML api don't support adding CDATA.
+                    // For performance reasons, it may be necessary to create the
                     // whole doc using DOM rather than SimpleXML which would save
-                    // on expesnive conversion to/from the SimpleXML to/from DOM. 
+                    // on expesnive conversion to/from the SimpleXML to/from DOM.
 //                    $myextended = new SimpleXMLExtended('<mycdata/>');
 //                    $myextended->title = NULL; // VERY IMPORTANT! We need a node where to append
 //                    $myextended->title->addCData('<dave>d</dave>');
 //                    $myextended->title->addAttribute('lang', 'en');
-//                    $this->sxml_append($xmlSiteProperty, $myextended); 
+//                    $this->sxml_append($xmlSiteProperty, $myextended);
 //                    $myextended = new SimpleXMLExtended('<mycdata/>');
 //                    $myextended->addCData('<dave>https://dave.dl.ac.uk/query?a=b&c=d</dave>');
 //                    $myextended->addAttribute('lang', 'en');
-//                    $this->sxml_append($xmlSiteProperty, $myextended); 
+//                    $this->sxml_append($xmlSiteProperty, $myextended);
                 //}
             }
         }
@@ -262,7 +262,7 @@ class GetSite implements IPIQuery {
     }
 
     /**
-     * Append the $to element as a child to $from. 
+     * Append the $to element as a child to $from.
      * @param \SimpleXMLElement $to
      * @param \SimpleXMLElement $from
      */
@@ -273,7 +273,7 @@ class GetSite implements IPIQuery {
     }
 
     /** Returns the site data in Glue2 XML string.
-     * 
+     *
      * @return String
      */
     public function getGlue2XML() {
@@ -361,7 +361,7 @@ class GetSite implements IPIQuery {
         return $xmlString;
     }
 
-    /** Not yet implemented, in future will return the sites 
+    /** Not yet implemented, in future will return the sites
      *  data in JSON format
      * @throws LogicException
      */

--- a/lib/Gocdb_Services/PI/GetSiteContacts.php
+++ b/lib/Gocdb_Services/PI/GetSiteContacts.php
@@ -12,18 +12,18 @@ require_once __DIR__ . '/QueryBuilders/Helpers.php';
 require_once __DIR__ . '/IPIQuery.php';
 
 
-/** 
+/**
  * Return an XML document that encodes the site contacts.
- * Optionally provide an associative array of query parameters with values 
- * used to restrict the results. Only known parameters are honoured while 
+ * Optionally provide an associative array of query parameters with values
+ * used to restrict the results. Only known parameters are honoured while
  * unknown params produce an error doc.
  * <pre>
- * 'sitename', 'roc', 'country', 'roletype', 'scope', 'scope_match' 
- * (where scope refers to Site scope) 
+ * 'sitename', 'roc', 'country', 'roletype', 'scope', 'scope_match'
+ * (where scope refers to Site scope)
  * </pre>
- * 
+ *
  * @author James McCarthy
- * @author David Meredith 
+ * @author David Meredith
  */
 class GetSiteContacts implements IPIQuery{
     protected $query;
@@ -32,7 +32,7 @@ class GetSiteContacts implements IPIQuery{
     private $helpers;
     private $roleT;
     private $sites;
-    
+
     /** Constructor takes entity manager which is then used by the
      *  query builder
      *
@@ -42,13 +42,13 @@ class GetSiteContacts implements IPIQuery{
         $this->em = $em;
         $this->helpers=new Helpers();
     }
-    
+
     /** Validates parameters against array of pre-defined valid terms
      *  for this PI type
      * @param array $parameters
      */
     public function validateParameters($parameters){
-    
+
         // Define supported parameters and validate given params (die if an unsupported param is given)
         $supportedQueryParams = array (
                 'sitename',
@@ -58,11 +58,11 @@ class GetSiteContacts implements IPIQuery{
                 'scope',
                 'scope_match'
         );
-    
+
         $this->helpers->validateParams ( $supportedQueryParams, $parameters );
         $this->validParams = $parameters;
     }
-    
+
     /** Creates the query by building on a queryBuilder object as
      *  required by the supplied parameters
      */
@@ -70,19 +70,19 @@ class GetSiteContacts implements IPIQuery{
         $parameters = $this->validParams;
         $binds= array();
         $bc=-1;
-    
+
         $qb = $this->em->createQueryBuilder();
-    
+
         //Initialize base query
         $qb	->select('s', 'n', 'r', 'u', 'rt')
-        ->from('Site', 's')		
+        ->from('Site', 's')
         ->leftJoin('s.ngi', 'n')
-        ->leftJoin('s.country', 'c')		
-        ->leftJoin('s.roles', 'r')        
-        ->leftJoin('r.user', 'u')        
-        ->leftJoin('r.roleType', 'rt')        
+        ->leftJoin('s.country', 'c')
+        ->leftJoin('s.roles', 'r')
+        ->leftJoin('r.user', 'u')
+        ->leftJoin('r.roleType', 'rt')
         ->orderBy('s.shortName', 'ASC');
-    
+
         /**This is used to filter the reults at the point
          * of building the XML to only show the correct roletypes.
         * Future work could see this build into the query.
@@ -92,7 +92,7 @@ class GetSiteContacts implements IPIQuery{
         } else {
             $this->roleT = '%%';
         }
-    
+
         /*Pass parameters to the ParameterBuilder and allow it to add relevant where clauses
          * based on set parameters.
         */
@@ -104,8 +104,8 @@ class GetSiteContacts implements IPIQuery{
         foreach((array)$parameterBuilder->getBinds() as $bind){
             $binds[] = $bind;
         }
-    
-    
+
+
         //Run ScopeQueryBuilder regardless of if scope is set.
         $scopeQueryBuilder = new ScopeQueryBuilder(
                 (isset($parameters['scope'])) ? $parameters['scope'] : null,
@@ -116,26 +116,26 @@ class GetSiteContacts implements IPIQuery{
                 'Site',
                 's'
         );
-    
+
         //Get the result of the scope builder
         $qb = $scopeQueryBuilder->getQB();
         $bc = $scopeQueryBuilder->getBindCount();
-    
+
         //Get the binds and store them in the local bind array only if any binds are fetched from scopeQueryBuilder
         foreach((array)$scopeQueryBuilder->getBinds() as $bind){
             $binds[] = $bind;
         }
-    
+
         //Bind all variables
         $qb = $this->helpers->bindValuesToQuery($binds, $qb);
-    
+
         //Get the dql query from the Query Builder object
         $query = $qb->getQuery();
-    
+
         $this->query = $query;
         return $this->query;
     }
-    
+
     /**
      * Executes the query that has been built and stores the returned data
      * so it can later be used to create XML, Glue2 XML or JSON.
@@ -144,14 +144,14 @@ class GetSiteContacts implements IPIQuery{
         $this->sites = $this->query->execute();
         return $this->sites;
     }
-    
-    /** Returns proprietary GocDB rendering of the site contacts data 
+
+    /** Returns proprietary GocDB rendering of the site contacts data
      *  in an XML String
      * @return String
      */
     public function getXML(){
         $helpers = $this->helpers;
-    
+
         $sites = $this->sites;
         $xml = new \SimpleXMLElement("<results />");
         foreach ( $sites as $site ) {
@@ -159,12 +159,12 @@ class GetSiteContacts implements IPIQuery{
             $xmlSite->addAttribute ( 'ID', $site->getId () . "G0" );
             $xmlSite->addAttribute ( 'PRIMARY_KEY', $site->getPrimaryKey () );
             $xmlSite->addAttribute ( 'NAME', $site->getShortName () );
-            
+
             $xmlSite->addChild ( 'PRIMARY_KEY', $site->getPrimaryKey () );
             $xmlSite->addChild ( 'SHORT_NAME', $site->getShortName () );
             foreach ( $site->getRoles () as $role ) {
                 if ($role->getStatus () == "STATUS_GRANTED") { // Only show users who are granted the role, not pending
-                    
+
                     $rtype = $role->getRoleType ()->getName ();
                     if ($this->roleT == '%%' || $rtype == $this->roleT) {
                         $user = $role->getUser ();
@@ -192,21 +192,21 @@ class GetSiteContacts implements IPIQuery{
         $xmlString = $dom->saveXML();
         return $xmlString;
     }
-    
+
     /** Returns the site contact data in Glue2 XML string.
-     * 
+     *
      * @return String
      */
     public function getGlue2XML(){
-    
+
     }
-    
+
     /** Not yet implemented, in future will return the site contact
      *  data in JSON format
      * @throws LogicException
      */
     public function getJSON(){
-        $query = $this->query;		
+        $query = $this->query;
         throw new LogicException("Not implemented yet");
     }
 }

--- a/lib/Gocdb_Services/PI/GetSiteCountPerCountry.php
+++ b/lib/Gocdb_Services/PI/GetSiteCountPerCountry.php
@@ -15,30 +15,30 @@ require_once __DIR__ . '/../OwnedEntity.php';
 
 
 /**
- * Returns and XML document showing which sites within the EGI scope are production and certified grouped by country. 
- * 
+ * Returns and XML document showing which sites within the EGI scope are production and certified grouped by country.
+ *
  * @author James McCarthy
- * @author David Meredith 
+ * @author David Meredith
  */
 class GetSiteCountPerCountry implements IPIQuery{
-    
+
     protected $query;
     protected $validParams;
     protected $em;
     private $helpers;
     private $countries;
     private $sites;
-    
+
     /** Constructor takes entity manager which is then used by the
      *  query builder
-     * 
+     *
      * @param EntityManager $em
      */
     public function __construct($em){
         $this->em = $em;
-        $this->helpers=new Helpers();		
+        $this->helpers=new Helpers();
     }
-    
+
     /** Validates parameters against array of pre-defined valid terms
      *  for this PI type
      * @param array $parameters
@@ -49,62 +49,62 @@ class GetSiteCountPerCountry implements IPIQuery{
         $supportedQueryParams = array (
                 'production_status', 'certification_status', 'scope'
         );
-        
+
         $this->helpers->validateParams ( $supportedQueryParams, $parameters );
         $this->validParams = $parameters;
     }
-    
+
     /** Creates the query by building on a queryBuilder object as
-     *  required by the supplied parameters 
+     *  required by the supplied parameters
      */
     public function createQuery() {
         $parameters = $this->validParams;
         $binds= array();
         $bc=-1;
-        
-        $qb = $this->em->createQueryBuilder();		
-        
+
+        $qb = $this->em->createQueryBuilder();
+
         //Main query
         $qb	->select('COUNT(c.name) as cCount', 'c.name')
-            ->from('Site', 's')    		  
+            ->from('Site', 's')
             ->leftJoin('s.scopes', 'sc')
             ->join('s.ngi', 'n')
             ->join('s.country', 'c')
             ->join('s.certificationStatus', 'cs')
             ->join('s.infrastructure', 'i')
             ->groupBy('c.name')
-            ->orderBy('c.name');        
-        
-        
+            ->orderBy('c.name');
+
+
         //If a scope was specified attach the sub query to query by EGI scope
         if(isset($parameters['scope'])) {
-            
+
             /**
              * We are using a simplified scope query here that only supports a single scope
              * instead of using the scope-query builder. When using the scope query builder (SQB)
              * the sub query created by the SQB will count sites with more than one scope and this
-             * can cause an error in the results. To combat this you can put a distinct within the 
-             * select clause: "COUNT (DISTINCT c.name)" and this will fix that issue. However we 
+             * can cause an error in the results. To combat this you can put a distinct within the
+             * select clause: "COUNT (DISTINCT c.name)" and this will fix that issue. However we
              * still are not using the SQB as this supports comma seperated lists and scope matching
              * which is not supported by the NGI scope sub query. In conclusion this PI query supports
-             * only a single scope. 
+             * only a single scope.
              */
-            
+
             $sQ = $this->em->createQueryBuilder();
             $sQ ->select('n2')
                 ->from('NGI', 'n2')
                 ->leftJoin('n2.scopes', 'sqsc2')
-                ->where($sQ->expr()->eq('sqsc2.name', '?'.++$bc));            
+                ->where($sQ->expr()->eq('sqsc2.name', '?'.++$bc));
 
-            
+
             $qb ->andWhere($qb->expr()->eq('sc.name', '?'.$bc))
                 ->andWhere($qb->expr()->in('n', $sQ->getDQL()));
-            
-            
+
+
             $binds[] = array($bc, $parameters['scope']);
         }
-        
-        
+
+
         /*Pass parameters to the ParameterBuilder and allow it to add relevant where clauses
          * based on set parameters. */
         $parameterBuilder = new ParameterBuilder($parameters, $qb, $this->em, $bc);
@@ -115,72 +115,72 @@ class GetSiteCountPerCountry implements IPIQuery{
         foreach((array)$parameterBuilder->getBinds() as $bind){
             $binds[] = $bind;
         }
-        
+
         //Bind all variables
         $qb = $this->helpers->bindValuesToQuery($binds, $qb);
 
-        
+
         //echo $qb->getDql(); //for testing
-        
-        
-        
-        
-        $query[0] = $qb->getQuery();        
-        
+
+
+
+
+        $query[0] = $qb->getQuery();
+
         $qb = $this->em->createQueryBuilder();
-        
+
         $qb	->select('c.name')
             ->from('Country', 'c')
             ->orderBy('c.name');
-        
-        $query[1] = $qb->getQuery();	
-        $this->query = $query;		
-        return $this->query; 			
-    }	
-    
+
+        $query[1] = $qb->getQuery();
+        $this->query = $query;
+        return $this->query;
+    }
+
     /**
      * To display countries with 0 count we execute two queries here but only sites
-     * which holds the data of all countries with a count > 0. 
+     * which holds the data of all countries with a count > 0.
      * Executes the query that has been built and stores the returned data
      * so it can later be used to create XML, Glue2 XML or JSON.
      */
-    public function executeQuery(){	 
-        //Execute the two queries   
+    public function executeQuery(){
+        //Execute the two queries
         $this->sites = $this->query[0]->execute();
         $this->countries = $this->query[1]->execute();
         return $this->sites;
     }
-    
-    
-    /** Returns proprietary GocDB rendering of data 
+
+
+    /** Returns proprietary GocDB rendering of data
      *  in an XML String
      * @return String
      */
     public function getXML(){
         $helpers = $this->helpers;
-        
+
         //Get the two result sets
         $sites = $this->sites;
         $countries = $this->countries;
-        
+
         //Create an array with the names as the key
         foreach($countries as $country){
             $output[$country['name']] = 0;
         }
-        
+
         //For each site with a count store the count
         foreach ( $sites as $site ) {
             $output[$site['name']] = $site['cCount'];
         }
-        
+
         //Render the XML
         $xml = new \SimpleXMLElement ('<results />');
-        foreach ($output as $country => $count) {		    
+        foreach ($output as $country => $count) {
             $xmlSite = $xml->addChild ('SITE');
             $helpers->addIfNotEmpty ($xmlSite, 'COUNTRY', $country);
             $xmlSite->addChild('COUNT', $count);
         }
-        
+
         $dom_sxe = dom_import_simplexml ( $xml );
         $dom = new \DOMDocument ( '1.0' );
         $dom->encoding = 'UTF-8';
@@ -188,23 +188,23 @@ class GetSiteCountPerCountry implements IPIQuery{
         $dom_sxe = $dom->appendChild ( $dom_sxe );
         $dom->formatOutput = true;
         $xmlString = $dom->saveXML ();
-        
+
         return $xmlString;
     }
-    
+
     /** Returns the user data in Glue2 XML string.
-     * 
+     *
      * @return String
      */
-    public function getGlue2XML(){	
+    public function getGlue2XML(){
         throw new LogicException("Not implemented yet");
     }
-    
-    /** Not yet implemented, in future will return the user 
+
+    /** Not yet implemented, in future will return the user
      *  data in JSON format
      * @throws LogicException
      */
-    public function getJSON(){		
+    public function getJSON(){
         throw new LogicException("Not implemented yet");
     }
 }

--- a/lib/Gocdb_Services/PI/GetSubGridList.php
+++ b/lib/Gocdb_Services/PI/GetSubGridList.php
@@ -12,16 +12,16 @@ require_once __DIR__ . '/QueryBuilders/Helpers.php';
 require_once __DIR__ . '/IPIQuery.php';
 
 
-/** 
+/**
  * Return an XML document that encodes the sub grid info from the DB.
  * Optionally provide an associative array of query parameters with values used to restrict the results.
  * Only known parameters are honoured while unknown params are ignored.
  * <pre>
  * 'subgrid'
  * </pre>
- *  
+ *
  * @author James McCarthy
- * @author David Meredith 
+ * @author David Meredith
  */
 class GetSubGridList implements IPIQuery{
 
@@ -30,7 +30,7 @@ class GetSubGridList implements IPIQuery{
     protected $em;
     private $helpers;
     private $subGrids;
-    
+
     /** Constructor takes entity manager which is then used by the
      *  query builder
      *
@@ -40,22 +40,22 @@ class GetSubGridList implements IPIQuery{
         $this->em = $em;
         $this->helpers=new Helpers();
     }
-    
+
     /** Validates parameters against array of pre-defined valid terms
      *  for this PI type
      * @param array $parameters
      */
     public function validateParameters($parameters){
-    
+
         // Define supported parameters and validate given params (die if an unsupported param is given)
         $supportedQueryParams = array (
                 'subgrid'
         );
-    
+
         $this->helpers->validateParams ( $supportedQueryParams, $parameters );
         $this->validParams = $parameters;
     }
-    
+
     /** Creates the query by building on a queryBuilder object as
      *  required by the supplied parameters
      */
@@ -63,14 +63,14 @@ class GetSubGridList implements IPIQuery{
         $parameters = $this->validParams;
         $binds= array();
         $bc=-1;
-    
+
         $qb = $this->em->createQueryBuilder();
-    
+
         //Initialize base query
         $qb	->select('s')
         ->from('SubGrid', 's')
         ->orderBy('s.id', 'ASC');
-    
+
         /*Pass parameters to the ParameterBuilder and allow it to add relevant where clauses
          * based on set parameters.
         */
@@ -82,18 +82,18 @@ class GetSubGridList implements IPIQuery{
         foreach((array)$parameterBuilder->getBinds() as $bind){
             $binds[] = $bind;
         }
-    
-    
+
+
         //Bind all variables
         $qb = $this->helpers->bindValuesToQuery($binds, $qb);
-    
+
         //Get the dql query from the Query Builder object
         $query = $qb->getQuery();
-    
+
         $this->query = $query;
         return $this->query;
     }
-    
+
     /**
      * Executes the query that has been built and stores the returned data
      * so it can later be used to create XML, Glue2 XML or JSON.
@@ -102,26 +102,26 @@ class GetSubGridList implements IPIQuery{
         $this->subGrids = $this->query->execute();
         return $this->subGrids;
     }
-    
-    
-    /** Returns proprietary GocDB rendering of the Sub Grid data 
+
+
+    /** Returns proprietary GocDB rendering of the Sub Grid data
      *  in an XML String
      * @return String
      */
     public function getXML(){
         $helpers = $this->helpers;
-        
+
         $subGrids = $this->query->execute();
-        
-        $xml = new \SimpleXMLElement ( "<results />" );	
-        
+
+        $xml = new \SimpleXMLElement ( "<results />" );
+
         foreach ( $subGrids as $subGrid ) {
             $xmlSubGrid = $xml->addChild ( 'SUBGRID' );
             $xmlSubGrid->addAttribute ( 'PRIMARY_KEY', $subGrid->getId () . "G0" );
             $xmlSubGrid->addAttribute ( 'SUBGRID_NAME', $subGrid->getName () );
             $xmlSubGrid->addAttribute ( 'PARENT_ROC', $subGrid->getNgi ()->getName () );
         }
-        
+
         $dom_sxe = dom_import_simplexml ( $xml );
         $dom = new \DOMDocument ( '1.0' );
         $dom->encoding = 'UTF-8';
@@ -131,22 +131,22 @@ class GetSubGridList implements IPIQuery{
         $xmlString = $dom->saveXML ();
         return $xmlString;
     }
-    
+
     /** Returns the Sub Grid data in Glue2 XML string.
-     * 
+     *
      * @return String
      */
     public function getGlue2XML(){
         throw new LogicException("Not implemented yet");
-        
+
     }
-    
-    /** Not yet implemented, in future will return the Sub Grid 
+
+    /** Not yet implemented, in future will return the Sub Grid
      *  data in JSON format
      * @throws LogicException
      */
     public function getJSON(){
-        $query = $this->query;		
+        $query = $this->query;
         throw new LogicException("Not implemented yet");
     }
 }

--- a/lib/Gocdb_Services/PI/GetUser.php
+++ b/lib/Gocdb_Services/PI/GetUser.php
@@ -3,13 +3,13 @@
 namespace org\gocdb\services;
 
 /*
- * Copyright © 2011 STFC Licensed under the Apache License, 
- * Version 2.0 (the "License"); you may not use this file except in compliance 
- * with the License. You may obtain a copy of the License at 
- * http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable 
- * law or agreed to in writing, software distributed under the License is 
- * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, 
- * either express or implied. See the License for the specific language 
+ * Copyright © 2011 STFC Licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable
+ * law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
 require_once __DIR__ . '/QueryBuilders/ExtensionsQueryBuilder.php';
@@ -29,9 +29,9 @@ require_once __DIR__ . '/../OwnedEntity.php';
  * 'dn', 'dnlike', 'forename', 'surname', 'roletype'
  * </pre>
  * Implemented with Doctrine.
- * 
+ *
  * @author James McCarthy
- * @author David Meredith 
+ * @author David Meredith
  */
 class GetUser implements IPIQuery {
 
@@ -40,21 +40,21 @@ class GetUser implements IPIQuery {
     protected $em;
     private $helpers;
     private $users;
-    private $roleAuthorisationService; 
-    private $baseUrl; 
+    private $roleAuthorisationService;
+    private $baseUrl;
 
     /** Constructor takes entity manager which is then used by the
      *  query builder
      *
      * @param EntityManager $em
-     * @param $roleAuthorisationService org\gocdb\services\RoleActionAuthorisationService 
-     * @param string $baseUrl The base url string to prefix to urls generated in the query output. 
+     * @param $roleAuthorisationService org\gocdb\services\RoleActionAuthorisationService
+     * @param string $baseUrl The base url string to prefix to urls generated in the query output.
      */
     public function __construct($em, $roleAuthorisationService, $baseUrl = 'https://goc.egi.eu/portal') {
         $this->em = $em;
         $this->helpers = new Helpers();
-        $this->roleAuthorisationService = $roleAuthorisationService; 
-        $this->baseUrl = $baseUrl; 
+        $this->roleAuthorisationService = $roleAuthorisationService;
+        $this->baseUrl = $baseUrl;
     }
 
     /** Validates parameters against array of pre-defined valid terms
@@ -150,7 +150,7 @@ class GetUser implements IPIQuery {
         return $this->users;
     }
 
-    /** Returns proprietary GocDB rendering of the user data 
+    /** Returns proprietary GocDB rendering of the user data
      *  in an XML String
      * @return String
      */
@@ -165,7 +165,7 @@ class GetUser implements IPIQuery {
             $xmlUser->addChild('SURNAME', $user->getSurname());
             $xmlUser->addChild('TITLE', $user->getTitle());
             /*
-             * Description is always blank in the PROM get_user output so 
+             * Description is always blank in the PROM get_user output so
              * we'll keep it blank in the Doctrine output for compatibility
              */
             $xmlUser->addChild('DESCRIPTION', "");
@@ -186,7 +186,7 @@ class GetUser implements IPIQuery {
             }
 
             /*
-             * APPROVED and ACTIVE are always blank in the GOCDBv4 get_user 
+             * APPROVED and ACTIVE are always blank in the GOCDBv4 get_user
              * output so we'll keep it blank in the GOCDBv5 output for compatibility
              */
             $xmlUser->addChild('APPROVED', null);
@@ -235,17 +235,17 @@ class GetUser implements IPIQuery {
                     if ($entityPk != '') {
                         $xmlRole->addChild('PRIMARY_KEY', $entityPk);
                     }
-                   
+
                     // Show which projects recognise the role
                     $xmlProjects = $xmlRole->addChild('RECOGNISED_IN_PROJECTS');
                     $parentProjectsForRole = $this->roleAuthorisationService
-                            ->getReachableProjectsFromOwnedEntity($role->getOwnedEntity()); 
+                            ->getReachableProjectsFromOwnedEntity($role->getOwnedEntity());
                     foreach($parentProjectsForRole as $_proj){
-                       $xmlProj = $xmlProjects->addChild('PROJECT', $_proj->getName());           
-                       $xmlProj->addAttribute('ID', $_proj->getId()); 
+                       $xmlProj = $xmlProjects->addChild('PROJECT', $_proj->getName());
+                       $xmlProj->addAttribute('ID', $_proj->getId());
                     }
-        
-                    
+
+
                 }
             }
         }
@@ -257,19 +257,19 @@ class GetUser implements IPIQuery {
         $dom_sxe = $dom->appendChild ( $dom_sxe );
         $dom->formatOutput = true;
         $xmlString = $dom->saveXML ();
-        return $xmlString; 
-        //return $xml->asXML(); // loses formatting 
+        return $xmlString;
+        //return $xml->asXML(); // loses formatting
     }
 
     /** Returns the user data in Glue2 XML string.
-     * 
+     *
      * @return String
      */
     public function getGlue2XML() {
         throw new LogicException("Not implemented yet");
     }
 
-    /** Not yet implemented, in future will return the user 
+    /** Not yet implemented, in future will return the user
      *  data in JSON format
      * @throws LogicException
      */

--- a/lib/Gocdb_Services/PI/IPIQuery.php
+++ b/lib/Gocdb_Services/PI/IPIQuery.php
@@ -3,43 +3,43 @@
 namespace org\gocdb\services;
 
 /**
- * Defines the default functions for PI Query classes. 
- * Typical usage is (where $query is an IPIQuery implementation): 
+ * Defines the default functions for PI Query classes.
+ * Typical usage is (where $query is an IPIQuery implementation):
  * <code>
  *  $query->validateParameters($params);
  *  $query->createQuery();
- *  $results = $query->executeQuery(); 
- *  $xml = $query->getXML(); 
+ *  $results = $query->executeQuery();
+ *  $xml = $query->getXML();
  * </code>
- * 
+ *
  * @author James McCarthy
  * @author David Meredith
  */
 interface IPIQuery {
 
     /**
-     * Validates the parameters passed to the class. 
+     * Validates the parameters passed to the class.
      * @param array $parameters
-     *   An associatative array of string pairs (parameterKey => parameterValue) 
-     * @throws \InvalidArgumentException if the parameters are invalid. 
+     *   An associatative array of string pairs (parameterKey => parameterValue)
+     * @throws \InvalidArgumentException if the parameters are invalid.
      */
     public function validateParameters($parameters);
 
     /**
-     * Creates and returns the query using validated parameters. 
-     * Typically, the query is cached locally as a class parameter for subsequent re-use. 
+     * Creates and returns the query using validated parameters.
+     * Typically, the query is cached locally as a class parameter for subsequent re-use.
      */
     public function createQuery();
 
     /**
-     * Executes the query that has been built with {@link createQuery()} and 
-     * returns the query results. 
+     * Executes the query that has been built with {@link createQuery()} and
+     * returns the query results.
      * <p>
-     * Important: Typically the results are stored/cached in the class 
-     * for subsequent re-use without repeating a call to the database. 
-     * This is not enforced, and different implementations may differ (refer 
-     * to implementation docs). 
-     * 
+     * Important: Typically the results are stored/cached in the class
+     * for subsequent re-use without repeating a call to the database.
+     * This is not enforced, and different implementations may differ (refer
+     * to implementation docs).
+     *
      * @return DoctrineResultSet or ArrayResults
      */
     public function executeQuery();

--- a/lib/Gocdb_Services/PI/IPIQueryPageable.php
+++ b/lib/Gocdb_Services/PI/IPIQueryPageable.php
@@ -4,37 +4,37 @@ namespace org\gocdb\services;
 
 
 /**
- * Defines functions for queries that support paging. 
- * 
+ * Defines functions for queries that support paging.
+ *
  * @author David Meredith <david.meredith@stfc.ac.uk>
- * @author Tom Byrne 
+ * @author Tom Byrne
  *
  */
 interface IPIQueryPageable {
-   
+
     /**
-     * Does the query page by default? 
+     * Does the query page by default?
      * If true, the query will return the first page of results even if the
      * the <pre>page</page> URL param is not provided.
-     *   
-     * @return bool 
-     */   
-    public function getDefaultPaging(); 
-    
+     *
+     * @return bool
+     */
+    public function getDefaultPaging();
+
     /**
      * @param boolean $pageTrueOrFalse Set if this query pages by default
      */
     public function setDefaultPaging($pageTrueOrFalse);
-   
+
     /**
      * @return int The page size (number of results per page)
      */
-    public function getPageSize(); 
-    
+    public function getPageSize();
+
     /**
-     * Set the size of a single page. 
+     * Set the size of a single page.
      * @param int $pageSize
      */
-    public function setPageSize($pageSize); 
-    
+    public function setPageSize($pageSize);
+
 }

--- a/lib/Gocdb_Services/PI/QueryBuilders/ExtensionsParser.php
+++ b/lib/Gocdb_Services/PI/QueryBuilders/ExtensionsParser.php
@@ -6,27 +6,27 @@ require_once __DIR__ . '/IExtensionsParser.php';
  * Copyright © 2011 STFC Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 */
 /**
- * Class to parse and validate LDAP style queries 
+ * Class to parse and validate LDAP style queries
  * Valid queries are: keyname=keyvalue
  * 					 AND(keyname=keyvalue)(keyname=keyvalue)
  * 					 OR(keyname=keyvalue)(keyname=keyvalue)
  *                   NOT(keyname=keyvalue)
  *                   wildcards:(keyname=*)
- *          
+ *
  * A limit on the number of key value pairs is defined in local_info.xml and enforced in this class
- * @deprecated since version 5.5 Use {@see ExtensionsParser2} instead 
+ * @deprecated since version 5.5 Use {@see ExtensionsParser2} instead
  * @author James McCarthy
  */
 class ExtensionsParser implements IExtensionsParser{
 
     /**
      * {@inheritDoc}
-     * The rules for allowed chars in the 'key' and 'value' parts depend on the 
-     * implementation. This implementation defines the following rules:  
+     * The rules for allowed chars in the 'key' and 'value' parts depend on the
+     * implementation. This implementation defines the following rules:
      * <ul>
      *    <li>The key conforms to the regex: <code>/^([a-zA-Z0-9\s@_\-\[\]\+\.]{1,255})$/</code>
      *   (1 to 255 alpha numeric chars and selected chars)</li>
-     *   <li>The value conforms to the followign regex, i.e. any char except those negated 
+     *   <li>The value conforms to the followign regex, i.e. any char except those negated
      *    including <code>'";)(`</code> <code>/^[^'\";\(\)`]{0,255}$/</code></li>
      * </ul>
      */
@@ -45,35 +45,35 @@ class ExtensionsParser implements IExtensionsParser{
         // must specify at least 1 kv pair
         $regexKeyVal = "(".$keyVal.")+";
         $regexOperator = "(AND|OR|NOT)?";
-         
+
         // This regex can be used to extract the captures
         $regexCapture = $anchLeftToCapture."(".$regexOperator.$regexKeyVal.")".$anchRightToCapture;
         // This regex can be used to test that the whole string in full passes (using full left and right anchors)
-        $regexFull = $anchLeftFull."(".$regexOperator.$regexKeyVal.")".$anchRightFull;    
-        
+        $regexFull = $anchLeftFull."(".$regexOperator.$regexKeyVal.")".$anchRightFull;
+
         if(!preg_match($regexFull, $rawQuery)){
             throw new \InvalidArgumentException("This is not a valid extensions expression. Please see the wiki for information on valid expressions.
                     \nhttps://wiki.egi.eu/wiki/GOCDB/Release4/Development/ExtensibilityMechanism#PI_Examples\n\n");
         }
-        
+
         /**
          * Query is now validated but we now use regexCapture to extract the parts of the query
          */
-        
+
         /* We now use regex capture to extract and clean the queries */
         preg_match_all($regexCapture, $rawQuery, $matches);
         //Remove surplus array elements
         unset($matches[1]);
         unset($matches[3]);
         $matches = array_values($matches); //reindex
-            
+
         //If no operator was supplied set it AND as a default
         for($i=0; $i<count($matches[1]); $i++){
             if($matches[1][$i] == ''){
                 $matches[1][$i] = 'AND';
             }
         }
-            
+
         //Remove operator from start of the query strings
         for($i=0; $i<count($matches[0]); $i++){
             $c=0;
@@ -82,11 +82,11 @@ class ExtensionsParser implements IExtensionsParser{
             }
             $matches[0][$i]=substr($matches[0][$i], $c);
         }
-            
-        /** Given this query: 
+
+        /** Given this query:
          * AND(VO=Alice)(VO=Atlas)NOT(VO=LHCB)
          * Matches array should now have this structure:
-         
+
         Array
         (
             [0] => Array
@@ -94,17 +94,17 @@ class ExtensionsParser implements IExtensionsParser{
                     [0] => (VO=Alice)(VO=Atlas)
                     [1] => (VO=LHCB)
                 )
-        
+
             [1] => Array
                 (
                     [0] => AND
                     [1] => NOT
                 )
-        
+
         )
         */
-        
-                
+
+
         /** This loop will normalize the query so each pair of brackets is paired with an operator **/
         for($i=0; $i<count($matches[0]); $i++){
             $operator = $matches[1][$i]; //store the operator
@@ -113,9 +113,9 @@ class ExtensionsParser implements IExtensionsParser{
                 $normalized[] = array($operator, $q);	//store each operator and query in 2d array
             }
         }
-        
-                 
-        
+
+
+
         /** After normalization the query AND(VO=Alice)(VO=Atlas)NOT(VO=LHCB) will be in this format:
         Array
         (
@@ -124,27 +124,27 @@ class ExtensionsParser implements IExtensionsParser{
                     [0] => AND
                     [1] => VO=Alice
                 )
-        
+
             [1] => Array
                 (
                     [0] => AND
                     [1] => VO=Atlas
                 )
-        
+
             [2] => Array
                 (
                     [0] => NOT
                     [1] => VO=LHCB
                 )
-        
+
         )
          */
 
         if($this->checkLimit($normalized)){
             return $normalized;
-        }   
+        }
     }
-    
+
     /**
      * Check that the amount of queries the user has entered is not greater
      * than the limit set in local_info.xml
@@ -152,13 +152,13 @@ class ExtensionsParser implements IExtensionsParser{
      * @return boolean
      */
     private function checkLimit($parsedQueries){
-        $configService = \Factory::getConfigService();	     
+        $configService = \Factory::getConfigService();
         $limit = $configService->getExtensionsLimit();
             if(count($parsedQueries) < $limit){
                 return true;
             }else{
                 throw new \InvalidArgumentException("You have exceeded the max amount of quieries allowed. Max allowed is: ".$limit);
-            }	    
+            }
     }
 
 }

--- a/lib/Gocdb_Services/PI/QueryBuilders/ExtensionsParser2.php
+++ b/lib/Gocdb_Services/PI/QueryBuilders/ExtensionsParser2.php
@@ -15,57 +15,57 @@
 namespace org\gocdb\services;
 require_once __DIR__ . '/IExtensionsParser.php';
 require_once __DIR__ . '/ExtensionsQueryNormaliser.php';
-require_once __DIR__ . '/KeyValueValidator.php'; 
+require_once __DIR__ . '/KeyValueValidator.php';
 
 /**
  * @author David Meredith
  */
 class ExtensionsParser2 implements IExtensionsParser{
-   
+
     /**
      * {@inheritDoc}
      * <p>
-     * The rules for allowed chars in the 'key' and 'value' parts depend on the 
-     * implementation. This implementation defines the following rules:  
+     * The rules for allowed chars in the 'key' and 'value' parts depend on the
+     * implementation. This implementation defines the following rules:
      * <ul>
      *    <li>The key conforms to the regex: <code>/^([a-zA-Z0-9\s@_\-\[\]\+\.]{1,255})$/</code>
      *   (1 to 255 alpha numeric chars and selected chars)</li>
-     *   <li>The value conforms to the regex (any char 0 to 255 times including 
+     *   <li>The value conforms to the regex (any char 0 to 255 times including
      *     newline/whitespace): <code>/^([\s\S]{0,255})$/</code></li>
-     *   <li>Parenthesis occuring within each 'value' must be escaped with a backslash.</li> 
-     *   <li>Whitespace is allowed before and after the AND_OR_NOT_OPERATOR.</li> 
+     *   <li>Parenthesis occuring within each 'value' must be escaped with a backslash.</li>
+     *   <li>Whitespace is allowed before and after the AND_OR_NOT_OPERATOR.</li>
      * </ul>
      */
     public function parseQuery($extensionsQuery) {
-        $queryNormaliser = new \org\gocdb\services\ExtensionsQueryNormaliser(); 
-        $keyValueValidator = new \org\gocdb\services\KeyValueValidator(); 
+        $queryNormaliser = new \org\gocdb\services\ExtensionsQueryNormaliser();
+        $keyValueValidator = new \org\gocdb\services\KeyValueValidator();
 
-        $normalisedQuery = $queryNormaliser->convert($extensionsQuery); 
-        // validate the k=v pairs 
-        $errors = array(); 
-        $normalisedAndSlashStripped = array(); 
+        $normalisedQuery = $queryNormaliser->convert($extensionsQuery);
+        // validate the k=v pairs
+        $errors = array();
+        $normalisedAndSlashStripped = array();
         foreach ($normalisedQuery as $singleOperatorAndExpression) {
-            // don't strictly need to validate the operator, its already done in the 
-            // extensions query normalizer 
+            // don't strictly need to validate the operator, its already done in the
+            // extensions query normalizer
             $operator = $singleOperatorAndExpression[0];
             if($operator != 'AND' && $operator != 'NOT' && $operator != 'OR'){
                 throw new \InvalidArgumentException(
-                        'Illegal operator in expression, should be one of AND OR NOT'); 
+                        'Illegal operator in expression, should be one of AND OR NOT');
             }
             $errors = $keyValueValidator->validate($singleOperatorAndExpression[1], $errors);
-            
-            $normalisedAndSlashStrippedChildArray = array(); 
-            $normalisedAndSlashStrippedChildArray[0] = $singleOperatorAndExpression[0]; 
-            $normalisedAndSlashStrippedChildArray[1] = stripslashes($singleOperatorAndExpression[1]); 
-            $normalisedAndSlashStripped[] = $normalisedAndSlashStrippedChildArray; 
+
+            $normalisedAndSlashStrippedChildArray = array();
+            $normalisedAndSlashStrippedChildArray[0] = $singleOperatorAndExpression[0];
+            $normalisedAndSlashStrippedChildArray[1] = stripslashes($singleOperatorAndExpression[1]);
+            $normalisedAndSlashStripped[] = $normalisedAndSlashStrippedChildArray;
         }
         if(count($errors) > 0){
-            throw new \InvalidArgumentException($errors[0]);  
+            throw new \InvalidArgumentException($errors[0]);
         }
-        
-        //$this->checkLimit($normalisedQuery); 
+
+        //$this->checkLimit($normalisedQuery);
         //return $normalisedQuery;
-        return $normalisedAndSlashStripped; 
+        return $normalisedAndSlashStripped;
     }
 
     /**
@@ -75,13 +75,13 @@ class ExtensionsParser2 implements IExtensionsParser{
      * @return boolean
      */
 //	private function checkLimit($parsedQueries){
-//	    $configService = \Factory::getConfigService();	     
+//	    $configService = \Factory::getConfigService();
 //	    $limit = $configService->getExtensionsLimit();
 //    	    if(count($parsedQueries) < $limit){
 //    	        return true;
 //    	    }else{
 //    	        throw new \InvalidArgumentException("You have exceeded the max amount of quieries allowed. Max allowed is: ".$limit);
-//    	    }	    
+//    	    }
 //	}
 
 }

--- a/lib/Gocdb_Services/PI/QueryBuilders/ExtensionsQueryBuilder.php
+++ b/lib/Gocdb_Services/PI/QueryBuilders/ExtensionsQueryBuilder.php
@@ -2,41 +2,41 @@
 
 namespace org\gocdb\services;
 /*
- * Copyright © 2011 STFC Licensed under the Apache License, 
- * Version 2.0 (the "License"); you may not use this file except in compliance 
- * with the License. You may obtain a copy of the License at 
- * http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law 
- * or agreed to in writing, software distributed under the License is distributed 
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either 
- * express or implied. See the License for the specific language governing 
+ * Copyright © 2011 STFC Licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law
+ * or agreed to in writing, software distributed under the License is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
  * permissions and limitations under the License.
 */
 //require_once __DIR__ . '/ExtensionsParser.php';
 require_once __DIR__ . '/ExtensionsParser2.php';
 use Doctrine\ORM\EntityManager, Doctrine\ORM\QueryBuilder;
 
-/** 
- * Appends sub-queries to the WHERE clause of a DQL query builder 
- * by parsing the value of the 'extensions' URL query parameter. 
+/**
+ * Appends sub-queries to the WHERE clause of a DQL query builder
+ * by parsing the value of the 'extensions' URL query parameter.
  * <p>
- * For example, a {@link \Site} owns {@link \SiteProperty} proprties while a 
- * {@link \Service} owns {@link \ServiceProperty} properties - this allows 
- * clients to use the 'extensions' URL parameter to define a key=value 
- * type expression to filter the selected entities according to their properties. 
- * <p> 
- * The class takes a Doctrine {@link QueryBuilder} object which represents 
- * the current query that will be appended. This query may contain other 
- * bind parameters. This class also takes a raw 'extensions' query string that 
- * specifies the query expression {@see IExtensionsParser::parseQuery($extensionsQuery)}. 
- * <p>  
- * It parses the query using an {@link IExtensionsParser} and creates 
+ * For example, a {@link \Site} owns {@link \SiteProperty} proprties while a
+ * {@link \Service} owns {@link \ServiceProperty} properties - this allows
+ * clients to use the 'extensions' URL parameter to define a key=value
+ * type expression to filter the selected entities according to their properties.
+ * <p>
+ * The class takes a Doctrine {@link QueryBuilder} object which represents
+ * the current query that will be appended. This query may contain other
+ * bind parameters. This class also takes a raw 'extensions' query string that
+ * specifies the query expression {@see IExtensionsParser::parseQuery($extensionsQuery)}.
+ * <p>
+ * It parses the query using an {@link IExtensionsParser} and creates
  * subqueries to limit the results. These subqueries are then appended to the original.
  * <p>
  * This query and its bind variables can then be fetched and used with getQB() and getBinds().
- * Important: This does not return the query or bind variables, they must be fetched. 
+ * Important: This does not return the query or bind variables, they must be fetched.
  *
  * @author James McCarthy
- * @author David Meredith (modifications)  
+ * @author David Meredith (modifications)
  */
 class ExtensionsQueryBuilder{
 
@@ -56,11 +56,11 @@ class ExtensionsQueryBuilder{
     private $valuesToBind = array();
 
     /**
-     * An ever increasing integer used to create unique table aliases used 
-     * in the DQL query, eg: WHERE 'sp2.keyName' (uID is 2). 
-     * Without this, repeated clauses may end up using the same identifier and 
-     * break the query.   
-     * @var integer 
+     * An ever increasing integer used to create unique table aliases used
+     * in the DQL query, eg: WHERE 'sp2.keyName' (uID is 2).
+     * Without this, repeated clauses may end up using the same identifier and
+     * break the query.
+     * @var integer
      */
     private $tableAliasBindCounter = 0;
 
@@ -77,17 +77,17 @@ class ExtensionsQueryBuilder{
     }
 
     /**
-     * Get the updated query builder with the newly added WHERE clauses.    
-     * @return \Doctrine\ORM\QueryBuilder 
+     * Get the updated query builder with the newly added WHERE clauses.
+     * @return \Doctrine\ORM\QueryBuilder
      */
     public function getQB() {
     return $this->qb;
     }
 
     /**
-     * Get the current bind-parameter counter (an ever increasing integer). 
-     * Incrementing this value creates unique positional bind parameters in the QueryBuilder.   
-     * @return int 
+     * Get the current bind-parameter counter (an ever increasing integer).
+     * Incrementing this value creates unique positional bind parameters in the QueryBuilder.
+     * @return int
      */
     public function getParameterBindCounter() {
     return $this->parameterBindCounter;
@@ -98,14 +98,14 @@ class ExtensionsQueryBuilder{
     }
 
     /**
-     * 2D array of 'parameterBindCounter-to-bindValue' mappings for the 
-     * new WHERE clauses that are appended to the QueryBuilder.  
+     * 2D array of 'parameterBindCounter-to-bindValue' mappings for the
+     * new WHERE clauses that are appended to the QueryBuilder.
      * <p>
-     * Each outer element stores a child array that has two elements; 
-     * 1st element stores the parameterBindCounter (int) used for the positional bind param. 
+     * Each outer element stores a child array that has two elements;
+     * 1st element stores the parameterBindCounter (int) used for the positional bind param.
      * 2nd element stores the bindValue (string).
-     * 
-     * @return array counter-to-value mapping array or empty array    
+     *
+     * @return array counter-to-value mapping array or empty array
      */
     public function getValuesToBind() {
     return $this->valuesToBind;
@@ -116,10 +116,10 @@ class ExtensionsQueryBuilder{
     }
 
     /**
-     * Get current table-alias bind counter (an ever increasing integer). 
-     * Used to create unique table alias names in the appended QueryBuilder 
-     * (unique aliases are created by appending an int incremented from this value to the alias) 
-     * @return int 
+     * Get current table-alias bind counter (an ever increasing integer).
+     * Used to create unique table alias names in the appended QueryBuilder
+     * (unique aliases are created by appending an int incremented from this value to the alias)
+     * @return int
      */
     public function getTableAliasBindCounter() {
     return $this->tableAliasBindCounter;
@@ -136,7 +136,7 @@ class ExtensionsQueryBuilder{
      * PropertyType is the corrosponding table where the properties are stored eg; 'siteProperties'
      * Ltype is the single letter designator used in the main select statment  eg; 's'
      * which needs to be consistent through the statement
-     * 
+     *
      * @param String $entityType
      */
     private function setPropType($entityType) {
@@ -159,29 +159,29 @@ class ExtensionsQueryBuilder{
     }
     }
 
-    /** 
-     * Construct a new instance, initialize variables, then stores the 
-     * new query ready for fetching by calling code. 
+    /**
+     * Construct a new instance, initialize variables, then stores the
+     * new query ready for fetching by calling code.
      * <p>
-     * The $extensionsQuery parameter represents an 'extensions' query. 
-     * See {@see IExtensionsParser::parseQuery($extensionsQuery)} for details.  
-     *  
-     * @param string $extensionsQuery Value of the 'extensions' URL query parameter.   
-     * @param \Doctrine\ORM\QueryBuilder $qb QueryBuilder that will be appended 
-     *    with new where clause restrictions. 
+     * The $extensionsQuery parameter represents an 'extensions' query.
+     * See {@see IExtensionsParser::parseQuery($extensionsQuery)} for details.
+     *
+     * @param string $extensionsQuery Value of the 'extensions' URL query parameter.
+     * @param \Doctrine\ORM\QueryBuilder $qb QueryBuilder that will be appended
+     *    with new where clause restrictions.
      * @param \Doctrine\ORM\EntityManager $em
-     * @param int $parameterBindCounter Current bind-parameter count 
+     * @param int $parameterBindCounter Current bind-parameter count
      *        (this value is incremented to create new unique positional bind parameters)
-     * @param string $entityType The name of the entity that owns the extensions, 
-     *        one of 'Site' 'Service' or 'ServiceGroup' 
-     * @param int $tableAliasBindCounter Current table-alias bind count, used to create unique table alias names 
+     * @param string $entityType The name of the entity that owns the extensions,
+     *        one of 'Site' 'Service' or 'ServiceGroup'
+     * @param int $tableAliasBindCounter Current table-alias bind count, used to create unique table alias names
      *        (aliases will be created by appending an int incremented from this value to the alias)
-     * @throws \InvalidArgumentException if query can't be processed. 
+     * @throws \InvalidArgumentException if query can't be processed.
      */
-    public function __construct($extensionsQuery, \Doctrine\ORM\QueryBuilder $qb, 
-        \Doctrine\ORM\EntityManager $em, $parameterBindCounter, $entityType, 
+    public function __construct($extensionsQuery, \Doctrine\ORM\QueryBuilder $qb,
+        \Doctrine\ORM\EntityManager $em, $parameterBindCounter, $entityType,
         $tableAliasBindCounter = 0) {
-    //die($rawExt); 
+    //die($rawExt);
     $this->setTableAliasBindCounter($tableAliasBindCounter);
     $this->em = $em;
     $this->parseExtensions($extensionsQuery);
@@ -197,7 +197,7 @@ class ExtensionsQueryBuilder{
      * This method takes the raw extensions from the extensions parameter
      * and uses the ExtensionsParser() class to convert this into a normalized
      * array of queries and their opereators.
-     * 
+     *
      * @param unknown $rawExt
      */
     private function parseExtensions($rawExt) {
@@ -211,29 +211,29 @@ class ExtensionsQueryBuilder{
     }
 
     /**
-     * Build a subquery that will be added as a new restriction to the  
-     * main class-query in the WHERE clause.   
-     * The $query array has the form: 
+     * Build a subquery that will be added as a new restriction to the
+     * main class-query in the WHERE clause.
+     * The $query array has the form:
      * <tt>
-     * Array ( 
-     * [0] => OR 
+     * Array (
+     * [0] => OR
      * [1] => VO2=baz
      * )
      * <tt>
-     * 
-     * @param string $entityT The name of the entity that owns the extensions, 
+     *
+     * @param string $entityT The name of the entity that owns the extensions,
      *        e.g. 'Site' or 'Service'
      * @param type $propT The name of the extension properties in the main query
-     *       e.g. 'SiteProperties' or 'ServiceProperties'  
-     * @param array $query A two element array, 
+     *       e.g. 'SiteProperties' or 'ServiceProperties'
+     * @param array $query A two element array,
      *   [0]=>predicateString, eg 'AND', 'OR' or 'NOT', [1]=>expressionString, eg 'key=value'
      */
     private function createSubQuery($entityT, $propT, $query){
-    //Get core variables    	    
+    //Get core variables
     $valuesToBind = $this->getValuesToBind();
     $bc = $this->getParameterBindCounter();
     $uID = $this->getTableAliasBindCounter(); //Used to keep each subqueries table aliases unique
-    
+
     //Create query builder and start of the subquery
     /* @var $sQ \Doctrine\ORM\QueryBuilder */
     $sQ = $this->em->createQueryBuilder();
@@ -242,35 +242,35 @@ class ExtensionsQueryBuilder{
         ->join('s' . $uID . '.' . $propT, 'sp' . $uID);
 
     // Split each given keyname and keyvalue pair on the first '=' char
-    // If limit arg is set and positive, the returned array will contain a 
-    // maximum of limit elements with the last element containing the rest of string. 
+    // If limit arg is set and positive, the returned array will contain a
+    // maximum of limit elements with the last element containing the rest of string.
     // namevalue[0] = keyName
-    // namevalue[1] = keyValue 
+    // namevalue[1] = keyValue
     $namevalue = explode('=', $query[1], 2);
 
     if (trim($namevalue[1]) == null) { //if no value or no value after trim do a wildcard search
-        $namevalue[1] = '%%'; //Set value as database wildcard symbol	                        
+        $namevalue[1] = '%%'; //Set value as database wildcard symbol
     }
     /*
-     * Create the where clause of the subquery, e.g: 
-     * WHERE sp0.keyName = ?0 AND sp0.keyValue = ?1 
-     * ...and append, e.g: 
-     * SELECT s0.id FROM Site s0 INNER JOIN s0.siteProperties sp0 WHERE sp0.keyName = ?0 AND sp0.keyValue = ?1 
+     * Create the where clause of the subquery, e.g:
+     * WHERE sp0.keyName = ?0 AND sp0.keyValue = ?1
+     * ...and append, e.g:
+     * SELECT s0.id FROM Site s0 INNER JOIN s0.siteProperties sp0 WHERE sp0.keyName = ?0 AND sp0.keyValue = ?1
      */
-    // This could be simplified further - no need to andX the property 
+    // This could be simplified further - no need to andX the property
         // value if the query doesn't need to match the property value..
         $sQ->where($sQ->expr()->andX(
-        $sQ->expr()->eq('sp' . $uID . '.keyName', '?' . ++$bc), 
-        $namevalue[1] == "%%" ? 
-        $sQ->expr()->like('sp' . $uID . '.keyValue', '?' . ++$bc) : 
+        $sQ->expr()->eq('sp' . $uID . '.keyName', '?' . ++$bc),
+        $namevalue[1] == "%%" ?
+        $sQ->expr()->like('sp' . $uID . '.keyValue', '?' . ++$bc) :
             $sQ->expr()->eq('sp' . $uID . '.keyValue', '?' . ++$bc)
     ));
 
     // Bind keyName
-    $valuesToBind[] = array(($bc - 1), $namevalue[0]);   
+    $valuesToBind[] = array(($bc - 1), $namevalue[0]);
     // Bind keyValue
-    $valuesToBind[] = array(($bc), $namevalue[1]);   
-    
+    $valuesToBind[] = array(($bc), $namevalue[1]);
+
     //Update core variables
         $this->setTableAliasBindCounter(++$uID);
     $this->setParameterBindCounter($bc);
@@ -279,47 +279,47 @@ class ExtensionsQueryBuilder{
         $this->addSubQueryToMainQuery($sQ, $query[0]);
     }
 
-    
+
     /**
-     * Add the given subquery as a new clause in the main query's  
-     * WHERE clause using and an AND or OR operator. 
+     * Add the given subquery as a new clause in the main query's
+     * WHERE clause using and an AND or OR operator.
      * <p>
-     * Important: The method *APPENDS* the suquery as a new restriction in the 
-     * WHERE clause, forming a logical AND/OR conjunction with any 
+     * Important: The method *APPENDS* the suquery as a new restriction in the
+     * WHERE clause, forming a logical AND/OR conjunction with any
      * **PREVIOUSLY** specified restrictions in the WHERE clause.
-     * 
+     *
      * @param QueryBuilder $sQ
-     * @param String $operator AND, OR or NOT 
+     * @param String $operator AND, OR or NOT
      */
     private function addSubQueryToMainQuery($sQ, $operator){
     //Get the query that was passed at initialization
         /* @var $qb \Doctrine\ORM\QueryBuilder */
-    $qb = $this->getQB(); 
-       
-        // QueryBuilder:  
-        // orWhere() forms a logical DISCJUNCTION with all 
-        // previously specfied restrictions while andWhere() forms a logical 
-        // CONJUNCTION with any previously specified restrictions. 
-        // 
-        // Therefore, the order of AND/OR in URL query string 
-        // is significant (we iterate subqueries from left to right, each time 
-        // adding the new conjunction/disjunction to the previous restrictions. 
-        
-        // To support nesting parethesis around different subqueries 
-        // to create complex where clauses, e.g.  
-        // 'ConditionA OR (ConditionB AND ConditionC)'  versus 
+    $qb = $this->getQB();
+
+        // QueryBuilder:
+        // orWhere() forms a logical DISCJUNCTION with all
+        // previously specfied restrictions while andWhere() forms a logical
+        // CONJUNCTION with any previously specified restrictions.
+        //
+        // Therefore, the order of AND/OR in URL query string
+        // is significant (we iterate subqueries from left to right, each time
+        // adding the new conjunction/disjunction to the previous restrictions.
+
+        // To support nesting parethesis around different subqueries
+        // to create complex where clauses, e.g.
+        // 'ConditionA OR (ConditionB AND ConditionC)'  versus
         // '(ConditionA OR ConditionB) AND ConditionC'
-        // will require something like a 'whereParamWrap()' 
-        // method as described in the following post: 
+        // will require something like a 'whereParamWrap()'
+        // method as described in the following post:
         // http://criticalpursuits.com/solving-the-doctrine-parenthesis-problem/
-        // Of course, this will also require a change in the syntax of the 
-        // 'expressions' query string to support nesting parethesis.  
-                
+        // Of course, this will also require a change in the syntax of the
+        // 'expressions' query string to support nesting parethesis.
+
     switch ($operator) {
         case 'OR': //OR
         $qb->orWhere($qb->expr()->in($this->ltype, $sQ->getDQL()));
         break;
-        case 'AND': //AND        	           
+        case 'AND': //AND
         $qb->andWhere($qb->expr()->in($this->ltype, $sQ->getDQL()));
         break;
         case 'NOT': //NOT
@@ -329,15 +329,15 @@ class ExtensionsQueryBuilder{
 
     //finally replace original query with updated query ready for fetching by the calling class
     $this->setQB($qb);
-    }		
-}  
+    }
+}
 
 
 /**
  * Example Queries:
- * 
+ *
  *  ?method=get_site&extensions=AND(VO=Alice)&scope=
- *   
+ *
  *  SELECT s,
  *          sc,
  *          sp
@@ -355,10 +355,10 @@ class ExtensionsQueryBuilder{
  *        WHERE sp0.keyName = ?0
  *          AND sp0.keyValue = ?1)
  *   ORDER BY s.shortName ASC
- *  
- *  
+ *
+ *
  *  ?method=get_site&extensions=OR(VO=Alice)(VO=LHCB)&scope=
- *  
+ *
  *  SELECT s,
  *          sc,
  *          sp
@@ -383,9 +383,9 @@ class ExtensionsQueryBuilder{
  *              AND sp1.keyValue = ?3))
  *   ORDER BY s.shortName ASC
  *
- *   
+ *
  *  ?method=get_site&extensions=AND(VO=Alice)OR(VO=Atlas)NOT(VO=LHCB)&scope=
- *  
+ *
  *  SELECT s,
  *          sc,
  *          sp
@@ -415,5 +415,5 @@ class ExtensionsQueryBuilder{
  *             WHERE sp2.keyName = ?4
  *               AND sp2.keyValue = ?5))
  *   ORDER BY s.shortName ASC
- *   
- */   
+ *
+ */

--- a/lib/Gocdb_Services/PI/QueryBuilders/ExtensionsQueryNormaliser.php
+++ b/lib/Gocdb_Services/PI/QueryBuilders/ExtensionsQueryNormaliser.php
@@ -15,8 +15,8 @@
 namespace org\gocdb\services;
 
 /**
- * Converts the given query string into a tokenised array. 
- * Used for parsing the 'extensions' URL parameter in the API.  
+ * Converts the given query string into a tokenised array.
+ * Used for parsing the 'extensions' URL parameter in the API.
  *
  * @author David Meredith
  */
@@ -24,35 +24,35 @@ class ExtensionsQueryNormaliser {
 
 
     /**
-     * Convert the query string into a tokenised array with a known structure. 
+     * Convert the query string into a tokenised array with a known structure.
      * <p>
-     * The format of the query string is one or more <code>OPERATOR(xxxx)</code> 
-     * groups, where the OPERATOR is optional and the xxxx string is 
+     * The format of the query string is one or more <code>OPERATOR(xxxx)</code>
+     * groups, where the OPERATOR is optional and the xxxx string is
      * enclosed in parenthesis.
      * <p>
-     * The format of the query string must be as follows:  
+     * The format of the query string must be as follows:
      * <ul>
-     *   <li>The OPERATOR is optional, but if specified must be one of 
+     *   <li>The OPERATOR is optional, but if specified must be one of
      *      <code>AND</code>, <code>OR</code> or <code>NOT</code>.</li>
      *   <li>The xxxx value must be enclosed with a leading and trailing parenthesis.</li>
-     *   <li>Parenthesis occuring within the xxxx value must be escaped with a single backslash.</li> 
+     *   <li>Parenthesis occuring within the xxxx value must be escaped with a single backslash.</li>
      *   <li>Any other char including whitespace is allowed within the xxxx value
      *      including slash-escaped chars.</li>
      *   <li>Whitespace is allowed before/after the OPERATOR.</li>
      * </ul>
-     * The format of the returned array is a two dimensional array. Each nested 
-     * array has two elements, the first being an operator string, the second 
-     * being the raw xxxx value with the leading/trailing parenthesis removed. 
-     * If the query string does not define a leading operator, <code>AND</code> is assumed. 
-     * For subsequent groups, if no OPERATOR is defined, then the last 
-     * encountered operator is used to populate the nested array element.  
+     * The format of the returned array is a two dimensional array. Each nested
+     * array has two elements, the first being an operator string, the second
+     * being the raw xxxx value with the leading/trailing parenthesis removed.
+     * If the query string does not define a leading operator, <code>AND</code> is assumed.
+     * For subsequent groups, if no OPERATOR is defined, then the last
+     * encountered operator is used to populate the nested array element.
      * <p>
-     * Note, calling clients will probably want to run each returned xxxx value 
-     * through <code>stripslashes($string)</code> to remove the character escaping 
-     * (e.g. of slash-escaped nested parethesis).  
-     * <p> 
-     * Given the expression <code>(VO=Alice)(VO=Atlas)NOT(VO=LHCB)(VO=AAA)OR(VO=\(BBB\))</code> 
-     * the following array is returned:  
+     * Note, calling clients will probably want to run each returned xxxx value
+     * through <code>stripslashes($string)</code> to remove the character escaping
+     * (e.g. of slash-escaped nested parethesis).
+     * <p>
+     * Given the expression <code>(VO=Alice)(VO=Atlas)NOT(VO=LHCB)(VO=AAA)OR(VO=\(BBB\))</code>
+     * the following array is returned:
      * <code>
      *    Array
      *    (
@@ -82,113 +82,113 @@ class ExtensionsQueryNormaliser {
      *                [1] => VO=\(BBB\)
      *            )
      *    )
-     * </code> 
-     * 
-     * @see IExtensionsParamParser::parseQuery($query) 
-     * @param string $extensionsExpression query string as described above 
-     * @return array Formatted array as described above 
-     * @throws \InvalidArgumentException if a problem occurs or the expression 
+     * </code>
+     *
+     * @see IExtensionsParamParser::parseQuery($query)
+     * @param string $extensionsExpression query string as described above
+     * @return array Formatted array as described above
+     * @throws \InvalidArgumentException if a problem occurs or the expression
      *   is invalid and can't be parsed
      */
     public function convert($extensionsExpression) {
-        $this->validateExpression($extensionsExpression); 
-        return $this->extractPatternGroups($extensionsExpression); 
+        $this->validateExpression($extensionsExpression);
+        return $this->extractPatternGroups($extensionsExpression);
     }
 
     /**
-     * Validate the given query expression, throw if invalid. 
+     * Validate the given query expression, throw if invalid.
      * @param string $string
      * @throws \InvalidArgumentException
      */
     private function validateExpression($string){
         if($string == null || trim($string) == ''){
-            // throw early 
-            throw new \InvalidArgumentException('Query expression is null or empty');     
+            // throw early
+            throw new \InvalidArgumentException('Query expression is null or empty');
         }
-        
+
         $optionalPredicateAndWhitespaceGroup = '(?:(?:AND|OR|NOT)[\s]*)?' ; // occurs 0 or 1
-        $parethesisGroup = '\((?:\\\\.|[^()\\\\])+\)';  // occurs 1 
-            
-        $patternGreedyMatchAllLine = 
+        $parethesisGroup = '\((?:\\\\.|[^()\\\\])+\)';  // occurs 1
+
+        $patternGreedyMatchAllLine =
                 '/^'.    // anchor left
                   '(?:'.   // start main group but don't capture group
                       '[\s]*'.  // optional whitespace
                       $optionalPredicateAndWhitespaceGroup. // occus 0 or 1
-                      $parethesisGroup.  // occurs 1 
+                      $parethesisGroup.  // occurs 1
                       '[\s]*'.  // optional whitespace
-                  ')+'.    // close main group, at least one required 
-                '$/s';   // anchor right, keep newlines     
-                    
-        // returns 1 if match, 0 if not match, FALSE if error 
-        $matchAllString = preg_match($patternGreedyMatchAllLine, $string); 
+                  ')+'.    // close main group, at least one required
+                '$/s';   // anchor right, keep newlines
+
+        // returns 1 if match, 0 if not match, FALSE if error
+        $matchAllString = preg_match($patternGreedyMatchAllLine, $string);
         if($matchAllString === FALSE){
-            throw new \InvalidArgumentException("An error occurred parsing query"); 
+            throw new \InvalidArgumentException("An error occurred parsing query");
         }
         if($matchAllString != 1){
-           throw new \InvalidArgumentException("Invalid query expression");  
-        } 
+           throw new \InvalidArgumentException("Invalid query expression");
+        }
     }
 
     /**
-     * Parse the string and return the formatted array.  
+     * Parse the string and return the formatted array.
      * @param string $string
-     * @return array 
+     * @return array
      * @throws \InvalidArgumentException
      */
     private function extractPatternGroups($string){
-        // Regarding $optionalPredicateAndWhitespace :  
+        // Regarding $optionalPredicateAndWhitespace :
         // Its really important to capture the optional predicate and trailing whitespace
-        // in one optional group because this affects how the pattern is repeatedly 
+        // in one optional group because this affects how the pattern is repeatedly
         // matched - the pattern does NOT include leading whitespace!
-        // Therefore, a match will only start with EITHER a leading '(' or the 
+        // Therefore, a match will only start with EITHER a leading '(' or the
         // first char from one of the OR'd predicates: 'A' 'O' 'N'
-        $optionalPredicateAndWhitespace = '(?:(?:AND|OR|NOT)[\s]*)?'; // occur 0 or 1 
-        $parethesisGroup = '\((?:\\\\.|[^()\\\\])+\)';   // occur 1 
-       
-        $patternMatchRepeat = '/' . $optionalPredicateAndWhitespace . $parethesisGroup . '/s'; 
-        
+        $optionalPredicateAndWhitespace = '(?:(?:AND|OR|NOT)[\s]*)?'; // occur 0 or 1
+        $parethesisGroup = '\((?:\\\\.|[^()\\\\])+\)';   // occur 1
+
+        $patternMatchRepeat = '/' . $optionalPredicateAndWhitespace . $parethesisGroup . '/s';
+
         // http://stackoverflow.com/questions/10208694/regex-to-parse-string-with-escaped-characters
-        
+
         /* $optionalPredicateAndWhitespace
          * /                   # start regex
          *   (?:               #    |start a new group but don't catpure group
          *      (?:            #         |start a new group but don't capture group
-         *         AND|OR|NOT  #         |  allow AND or OR or NOT 
+         *         AND|OR|NOT  #         |  allow AND or OR or NOT
          *      )              #         |close group
-         *      [\s]*          #         allow multiple whitespace 
-         *   )?                #    |close group, can occur zero or once (an optional group) 
+         *      [\s]*          #         allow multiple whitespace
+         *   )?                #    |close group, can occur zero or once (an optional group)
          */
         /* $parethesisGroup
-         * \(                  #     find first opening of '(' 
-         *      (?:            #     |      |start a new group but don't capture group 
+         * \(                  #     find first opening of '('
+         *      (?:            #     |      |start a new group but don't capture group
          *          \\\\.      #     |      |  allow any escaped char inc escaped parethesis \(  and escaped backslash \\
-         *            |        #     |      |     or 
+         *            |        #     |      |     or
          *          [^()\\\\]  #     |      |  allow any char except parenthesis or backslash in group
-         *      )+             #     |      |close group, must be one or more chars in group  
+         *      )+             #     |      |close group, must be one or more chars in group
          * \)                  #     find balanced closing ')'
-         * /s                  # end regex, /s is dotall mode - a dot metacharacter 
-         *                     # in the pattern matches all characters, including newlines. 
+         * /s                  # end regex, /s is dotall mode - a dot metacharacter
+         *                     # in the pattern matches all characters, including newlines.
          *                     # Without it, newlines are excluded
          */
-        // Note we don't capture any groups, therefore the regex captures the 
-        // whole (repeating) pattern that starts with an optional AND|OR|NOT and ends with a closing )  
+        // Note we don't capture any groups, therefore the regex captures the
+        // whole (repeating) pattern that starts with an optional AND|OR|NOT and ends with a closing )
         // Note, to escape a char we need to use 4 backslahses: http://php.net/manual/en/regexp.reference.escape.php
-     
+
         // preg_match_all
         // - Returns the number of full pattern matches (which might be zero),
-        // or FALSE if an error occurred. 
-        // - Default PREG_PATTERN_ORDER orders results so that $groups[0] is an 
-        // array of full pattern matches, $groups[1] is an array of strings 
-        // matched by the first parenthesized subgroup, and so on. Since we 
-        // are not capturing any sub-groups, only $groups[0] has matched values. 
+        // or FALSE if an error occurred.
+        // - Default PREG_PATTERN_ORDER orders results so that $groups[0] is an
+        // array of full pattern matches, $groups[1] is an array of strings
+        // matched by the first parenthesized subgroup, and so on. Since we
+        // are not capturing any sub-groups, only $groups[0] has matched values.
         $patternMatchCount = preg_match_all($patternMatchRepeat, $string, $groups);
         if($patternMatchCount === FALSE){
             throw new \InvalidArgumentException("This is not a valid extensions expression. Please see the wiki for information on valid expressions.
                     \nhttps://wiki.egi.eu/wiki/GOCDB/Release4/Development/ExtensibilityMechanism#PI_Examples\n\n");
         }
-        
-        // Returns all the values from the array and indexes the array numerically 
-        $matches = array_values($groups[0]); 
+
+        // Returns all the values from the array and indexes the array numerically
+        $matches = array_values($groups[0]);
         // Sample array, note that not all groups have a leading operator yet
         /*
          $matches[0] = "AND ( color: \) #888; )"
@@ -196,8 +196,8 @@ class ExtensionsQueryNormaliser {
          $matches[2] = "NOT ( body \( color=\= \( #333; \) )"
          $matches[3] = "( help\ me \(forest\) help me )"
          $matches[4] = "( color: blue;\(\)
- 
- 
+
+
           )"
          $matches[5] = "( color: blue;\(\) \ )"
          $matches[6] = "( \ )"
@@ -207,59 +207,59 @@ class ExtensionsQueryNormaliser {
          $matches[10] = "(\\)"
          $matches[11] = "NOT(\\////)"
         */
-     
-        // Foreach group, prepend an operator (if non is specified, use last 
-        // encountered operator) and trim leading/trailing parethesis chars  
+
+        // Foreach group, prepend an operator (if non is specified, use last
+        // encountered operator) and trim leading/trailing parethesis chars
         $lastEncounteredPredicate = 'AND';  //default if not specified
-        $normalizedKV = array(); 
+        $normalizedKV = array();
         foreach($matches as $match){
-            $firstChar = substr($match, 0, 1); 
+            $firstChar = substr($match, 0, 1);
             //echo $firstChar; // one of the following: ( A O N
             if($firstChar == '('){
-                $predicate = $lastEncounteredPredicate; 
+                $predicate = $lastEncounteredPredicate;
             } else if(strtolower($firstChar) == 'a'){
-                $predicate = 'AND'; 
+                $predicate = 'AND';
             } else if(strtolower($firstChar) == 'o'){
-                $predicate = 'OR';         
+                $predicate = 'OR';
             } else if(strtolower($firstChar) == 'n'){
-                $predicate = 'NOT';         
+                $predicate = 'NOT';
             } else {
-                throw new \InvalidArgumentException('Invalid expression, could not extract predicate'); 
+                throw new \InvalidArgumentException('Invalid expression, could not extract predicate');
             }
-            $lastEncounteredPredicate = $predicate; 
-            //echo " ".$predicate."\n"; 
-            
-            // Find the position of the first occurrence of '(' (zero offset) 
-            $openingParenthesisPos = strpos($match, '('); 
+            $lastEncounteredPredicate = $predicate;
+            //echo " ".$predicate."\n";
+
+            // Find the position of the first occurrence of '(' (zero offset)
+            $openingParenthesisPos = strpos($match, '(');
             if($openingParenthesisPos === FALSE){
-                throw new \InvalidArgumentException('Invalid expression, could not extract starting parenthesis'); 
+                throw new \InvalidArgumentException('Invalid expression, could not extract starting parenthesis');
             }
-            // extract just the '(xxxxxx)' part of the expression 
-            $keyValPair = substr($match, $openingParenthesisPos, strlen($match) ); 
-            // trim the leading and trailing parenthesis 
-            $keyValPairNoParenthesis = substr($keyValPair, 1, strlen($keyValPair)-2); 
-            //echo $predicate.' '.$keyValPairNoParenthesis."\n"; 
-          
-            // Returns a string with backslashes stripped off. (\' becomes ' and so on.) 
-            // Double backslashes (\\) are made into a single backslash (\). 
-            // todo 
-            //$keyValPairNoParenthesis = stripslashes($keyValPairNoParenthesis); 
-                    
+            // extract just the '(xxxxxx)' part of the expression
+            $keyValPair = substr($match, $openingParenthesisPos, strlen($match) );
+            // trim the leading and trailing parenthesis
+            $keyValPairNoParenthesis = substr($keyValPair, 1, strlen($keyValPair)-2);
+            //echo $predicate.' '.$keyValPairNoParenthesis."\n";
+
+            // Returns a string with backslashes stripped off. (\' becomes ' and so on.)
+            // Double backslashes (\\) are made into a single backslash (\).
+            // todo
+            //$keyValPairNoParenthesis = stripslashes($keyValPairNoParenthesis);
+
             // if($this->splitParethesisGroupOn != null)
-            // explode/split the k=v pair on the first occurrence of the '=' char 
-            
-             
-            // Validate the values of the key and value 
-            
-            // build expected/normalized array 
-            $pred_kv = array(); 
-            $pred_kv[] = $predicate; 
-            $pred_kv[] = $keyValPairNoParenthesis; 
-            $normalizedKV[] = $pred_kv; 
+            // explode/split the k=v pair on the first occurrence of the '=' char
+
+
+            // Validate the values of the key and value
+
+            // build expected/normalized array
+            $pred_kv = array();
+            $pred_kv[] = $predicate;
+            $pred_kv[] = $keyValPairNoParenthesis;
+            $normalizedKV[] = $pred_kv;
         }
-        // $normalizedKV sample. Note that the internal partheneis are escaped, 
-        // probably need to iterate the values and replace all '\(' '\)' with 
-        // '(' and ')' 
+        // $normalizedKV sample. Note that the internal partheneis are escaped,
+        // probably need to iterate the values and replace all '\(' '\)' with
+        // '(' and ')'
         /*
          Array
             (
@@ -340,7 +340,7 @@ class ExtensionsQueryNormaliser {
 
             )
          */
-        return $normalizedKV; 
+        return $normalizedKV;
     }
 
 }

--- a/lib/Gocdb_Services/PI/QueryBuilders/Helpers.php
+++ b/lib/Gocdb_Services/PI/QueryBuilders/Helpers.php
@@ -21,48 +21,48 @@ namespace org\gocdb\services;
 class Helpers {
 
     /**
-     * Takes a pre-built Doctrine query containing positional bind parameter 
-     * placeholders e.g. ':?15', and a 2D array that contains values for binding each parameter, 
+     * Takes a pre-built Doctrine query containing positional bind parameter
+     * placeholders e.g. ':?15', and a 2D array that contains values for binding each parameter,
      * then binds all the positional bind parameters in the query.
      * <p>
-     * In the bindValues array, each nested element is a child array where:  
+     * In the bindValues array, each nested element is a child array where:
      * <ol>
      *   <li>1st element is an int used to select the positional param.</li>
      *   <li>2nd element is the value to bind, has a value of mixed. </li>
      * </ol>
      * <code>
      * array(
-     *    array(10, 'some value'), 
-     *    array(11, 'another value'), 
+     *    array(10, 'some value'),
+     *    array(11, 'another value'),
      *    array(12, 'a, third, value')
-     * ); 
-     * </code>  
+     * );
+     * </code>
      *
-     * @param array $bindIdValues 2D array, see description above 
-     * @param \Doctrine\ORM\QueryBuilder $query        	
+     * @param array $bindIdValues 2D array, see description above
+     * @param \Doctrine\ORM\QueryBuilder $query
      * @return \Doctrine\ORM\QueryBuilder Updated with bind params bound
      */
     public function bindValuesToQuery($bindIdValues, $query) {
 
     foreach ($bindIdValues as $bindIdValue) {
         $query->setParameter($bindIdValue[0], $bindIdValue[1]);
-        
+
         // Check value is string not time/date object
         /*if (is_string($bindIdValue[1])) {
 
-        // Presence of a 3rd element in the bind array means the bind 
-        // value has to be exploded using the string stored in the 3rd 
-        // element, e.g. for multiple scopes this is a comma: 'EGI,wlcg,scopex' 
+        // Presence of a 3rd element in the bind array means the bind
+        // value has to be exploded using the string stored in the 3rd
+        // element, e.g. for multiple scopes this is a comma: 'EGI,wlcg,scopex'
         //if (count($bindIdValue) == 3 && strpos($bindIdValue[1], ',')) {
         //if (count($bindIdValue) == 3) {
         //    $explodedValuesArray = explode($bindIdValue[2], $bindIdValue[1]);
         //    $query->setParameter($bindIdValue[0], $explodedValuesArray);
         //} else {
-            // No 3rd element in bind array means bind the raw value 
+            // No 3rd element in bind array means bind the raw value
             // echo "Binding at: ".$values[0]. " With: ".$values[1]. "\n\n";
             $query->setParameter($bindIdValue[0], $bindIdValue[1]);
         //}
-        //If value was object bind it as is	
+        //If value was object bind it as is
         } else {
         $query->setParameter($bindIdValue[0], $bindIdValue[1]);
         }*/
@@ -71,7 +71,7 @@ class Helpers {
     }
 
     /**
-     * Ensure that $testParams only contain array keys that are supported as 
+     * Ensure that $testParams only contain array keys that are supported as
      * listed in $supportedParams, and that parameter values don't contain any
      * of the following chars: "'`
      * If an unsupported parameter is detected, then die with a message.
@@ -84,7 +84,7 @@ class Helpers {
      */
     public function validateParams($supportedParams, $testParams) {
     if (!is_array($supportedParams) || !is_array($testParams)) {
-        throw new \InvalidArgumentException('Invalid parameters passed to PI query'); 
+        throw new \InvalidArgumentException('Invalid parameters passed to PI query');
     }
 
     // Check the parameter keys are supoported
@@ -111,7 +111,7 @@ class Helpers {
     /**
      * Adds a new tag $tagName to $xml if $value isn't ""
      *
-     * @param $xml SimpleXMLElement        	
+     * @param $xml SimpleXMLElement
      * @param $tagName String
      *        	Name of the tag
      * @param $value String

--- a/lib/Gocdb_Services/PI/QueryBuilders/IExtensionsParser.php
+++ b/lib/Gocdb_Services/PI/QueryBuilders/IExtensionsParser.php
@@ -15,46 +15,46 @@
 namespace org\gocdb\services;
 
 /**
- * Used for parsing the value of 'extensions' URL parameter in the API. 
- * 
+ * Used for parsing the value of 'extensions' URL parameter in the API.
+ *
  * @author David Meredith
  */
 interface IExtensionsParser {
 
     /**
-     * Parse the given extensions query string and return a tokenised array. 
+     * Parse the given extensions query string and return a tokenised array.
      * <p>
-     * The format of the string is one or more <code>AND_OR_NOT_OPERATOR(key=value)</code> groups. 
+     * The format of the string is one or more <code>AND_OR_NOT_OPERATOR(key=value)</code> groups.
      * <p>
-     * The format of the query string must be as follows:  
+     * The format of the query string must be as follows:
      * <ul>
-     *   <li>For each group the AND_OR_NOT_OPERATOR is optional, but if specified must be one of 
+     *   <li>For each group the AND_OR_NOT_OPERATOR is optional, but if specified must be one of
      *      <code>AND</code>, <code>OR</code> or <code>NOT</code>.</li>
      *   <li>The key=value must be enclosed with a leading and trailing parenthesis.</li>
-     *   <li>The key=value string must contain one or more equals '=' chars 
+     *   <li>The key=value string must contain one or more equals '=' chars
      *   (the string is split on the first equals char moving from left to right)</li>
-     *   <li>The rules for allowed chars in the 'key' and 'value' parts are  
+     *   <li>The rules for allowed chars in the 'key' and 'value' parts are
      *   defined by the implementation.</li>
      * </ul>
      * <p>
-     * The format of the returned array is a two dimensional array. Each nested 
-     * array has two elements, the first being an operator string, the second 
-     * being the formatted key=value string.  If the query 
-     * string does not define a leading operator, <code>AND</code> is assumed. 
-     * For subsequent groups, if no OPERATOR is defined, then the last 
-     * encountered operator is used to populate the nested array element.  
+     * The format of the returned array is a two dimensional array. Each nested
+     * array has two elements, the first being an operator string, the second
+     * being the formatted key=value string.  If the query
+     * string does not define a leading operator, <code>AND</code> is assumed.
+     * For subsequent groups, if no OPERATOR is defined, then the last
+     * encountered operator is used to populate the nested array element.
      * <p>
-     * Each key=value string value is formatted as follows: 
+     * Each key=value string value is formatted as follows:
      * <ul>
      *   <li>The leading/trailing parenthesis are stripped off.</li>
-     *   <li>Backslashes are stripped out: (\' becomes ' and so on) while 
-     *   double backslashes (\\) are made into a single backslash (\) 
+     *   <li>Backslashes are stripped out: (\' becomes ' and so on) while
+     *   double backslashes (\\) are made into a single backslash (\)
      *   (<code>stripslashes($string)</code> is appled to each value) </li>
      * </ul>
-     * 
-     * <p> 
-     * Given the expression <code>(VO=Alice)(VO=Atlas)NOT(VO=LHCB)(VO=AAA)OR(VO=BBB)</code> 
-     * the following array is returned:  
+     *
+     * <p>
+     * Given the expression <code>(VO=Alice)(VO=Atlas)NOT(VO=LHCB)(VO=AAA)OR(VO=BBB)</code>
+     * the following array is returned:
      * <code>
      *    Array
      *    (
@@ -84,11 +84,11 @@ interface IExtensionsParser {
      *                [1] => VO=BBB
      *            )
      *    )
-     * </code> 
-     * 
+     * </code>
+     *
      * @param string $extensionsQuery
-     * @return array Array formatted as described above 
-     * @throws \InvalidArgumentException if query is invalid/can't be processed 
+     * @return array Array formatted as described above
+     * @throws \InvalidArgumentException if query is invalid/can't be processed
      */
-    public function parseQuery($extensionsQuery); 
+    public function parseQuery($extensionsQuery);
 }

--- a/lib/Gocdb_Services/PI/QueryBuilders/KeyValueValidator.php
+++ b/lib/Gocdb_Services/PI/QueryBuilders/KeyValueValidator.php
@@ -18,15 +18,15 @@ namespace org\gocdb\services;
 require_once __DIR__ . '/../../validation/IValidator.php';
 
 /**
- * Validator for a 'Key=Value' pair expressiosn (assumes no enclosing chars). 
- * Used to validate a k=v pairs in the 'extensions' URL parameter of the API.   
+ * Validator for a 'Key=Value' pair expressiosn (assumes no enclosing chars).
+ * Used to validate a k=v pairs in the 'extensions' URL parameter of the API.
  *
  * @author David Meredith
  */
 class KeyValueValidator implements \IValidator {
 
     /**
-     * @see \IValidator::supports($object) 
+     * @see \IValidator::supports($object)
      * @param string $object
      * @return boolean
      */
@@ -38,30 +38,30 @@ class KeyValueValidator implements \IValidator {
     }
 
     /**
-     * Validate the given 'key=value' pair and add new elements to the 
-     * given errors array if there are any validation errors. 
+     * Validate the given 'key=value' pair and add new elements to the
+     * given errors array if there are any validation errors.
      * <p>
-     * A k=v pair is valid if it follows the following rules: 
+     * A k=v pair is valid if it follows the following rules:
      * <ul>
-     *   <li>String contains one or more equals '=' chars 
+     *   <li>String contains one or more equals '=' chars
      *   (the key=val string is split on the first equals char moving left to right)</li>
      *   <li>The key=val pair has no enclosing chars, e.g. no leading/trailing parethesis</>
      *   <li>The key conforms to the regex: <code>/^([a-zA-Z0-9\s@_\-\[\]\+\.]{1,255})$/</code>
      *   (1 to 255 alpha numeric chars and selected chars)</li>
-     *   <li>The value conforms to the regex (any char 0 to 255 times including 
+     *   <li>The value conforms to the regex (any char 0 to 255 times including
      *     newline/whitespace): <code>/^([\s\S]{0,255})$/</code></li>
      * </ul>
-     * 
-     * @see \IValidator::validate($object, $errors)   
+     *
+     * @see \IValidator::validate($object, $errors)
      * @param string $keyValuePair
      * @param array $errors
-     * @return array Will be same size as given array if no errors 
-     * @throws \LogicException on coding errors 
+     * @return array Will be same size as given array if no errors
+     * @throws \LogicException on coding errors
      */
     public function validate($keyValuePair, $errors) {
          //<li>The value conforms to the regex: <code>/^([^'\";\(\)`]{0,255})$/</code>
          //(any char 0 to 255 times except <code>'";()`</code></li>
-         
+
         if (!is_array($errors)) {
             throw new \LogicException("Invalid errors array");
         }
@@ -73,37 +73,37 @@ class KeyValueValidator implements \IValidator {
         $keyregex = "/^([a-zA-Z0-9\s@_\-\[\]\+\.]{1,255})$/";
         // to be restrictive on what vals allowed, use:
         //$valregex = "/^([^'\";\(\)`]{0,255})$/";  //0 to allow for no input which will repsent wildcard
-        // any char 0 to 255 times 
+        // any char 0 to 255 times
         $valregex = "/^([\s\S]{0,255})$/";  //0 to allow for no input which will repsent wildcard
-        
-        $keyValuePair = trim($keyValuePair); 
+
+        $keyValuePair = trim($keyValuePair);
         if($keyValuePair == ''){
-            $errors[] = 'Invalid key=value pair, no content'; 
-            return $errors; 
+            $errors[] = 'Invalid key=value pair, no content';
+            return $errors;
         }
-        
+
         // check expression contains an '=' char to perform split on
         if (strpos($keyValuePair, '=') === FALSE) {
             $errors[] = 'Invalid key=value pair, missing = char';
             return $errors;
         }
 
-        // split k=v expression on the first occurence of '=' (to allow other '=' chars in value)  
+        // split k=v expression on the first occurence of '=' (to allow other '=' chars in value)
         $namevalueArray = explode('=', $keyValuePair, 2);
-        $key = $namevalueArray[0];  // could trim key so ' VOa' becomes 'VOa'  
-        $val = $namevalueArray[1];  // don't trim val, whitespace is valid part of value      
-        //print_r('['.$key.'] ['.$val."]\n"); 
-        // validate key 
+        $key = $namevalueArray[0];  // could trim key so ' VOa' becomes 'VOa'
+        $val = $namevalueArray[1];  // don't trim val, whitespace is valid part of value
+        //print_r('['.$key.'] ['.$val."]\n");
+        // validate key
         if (preg_match($keyregex, $key) != 1) {
             $errors[] = ('Invalid key=value pair, invalid key');
             return $errors;
         }
-        // validate value 
+        // validate value
         if (preg_match($valregex, $val) != 1) {
             $errors[] = ('Invalid key=value pair, invalid value');
             return $errors;
         }
-        return $errors; // will be empty/no elements added if validation passed 
+        return $errors; // will be empty/no elements added if validation passed
     }
 
 }

--- a/lib/Gocdb_Services/PI/QueryBuilders/ParameterBuilder.php
+++ b/lib/Gocdb_Services/PI/QueryBuilders/ParameterBuilder.php
@@ -3,10 +3,10 @@
 namespace org\gocdb\services;
 
 /*
- * Copyright 2011 STFC Licensed under the Apache License, Version 2.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
- * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 
- * Unless required by applicable law or agreed to in writing, software distributed under 
+ * Copyright 2011 STFC Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under
  * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
  * either express or implied. See the License for the specific language governing permissions
  * and limitations under the License.
@@ -44,7 +44,7 @@ class ParameterBuilder {
     return $this->qb;
     }
 
-    /** 
+    /**
      * Initialize variables, convert then store the new query
      * @param Array $parameters
      * @param QueryBuilder $qb
@@ -109,17 +109,17 @@ class ParameterBuilder {
     // http://www.doctrine-project.org/jira/browse/DDC-1683
     // http://stackoverflow.com/questions/11413752/doctrine2-and-postgres-invalid-input-syntax-for-boolean
     // Specifying TRUE instead of 1 works as expected, but specifying FALSE
-    // instead of 0 does not work as expected. This looks to be due to a 
-    // Doctrine bug related the one listed above. 
+    // instead of 0 does not work as expected. This looks to be due to a
+    // Doctrine bug related the one listed above.
     if (isset($parameters ['monitored'])) {
         if ($parameters['monitored'] == 'Y' || $parameters['monitored'] == 'y') {
-        // we can't bind a literal using the ? syntax so do it directly here  
+        // we can't bind a literal using the ? syntax so do it directly here
         $qb->andWhere($qb->expr()->eq('se.monitored', $qb->expr()->literal(true)));
         // below works, but is probably not DB agnostic
         //$qb->andWhere($qb->expr()->eq('se.monitored', '?'.++$bc ));
         //$this->binds[] = array($bc, 1);
         } else if ($parameters['monitored'] == 'N' || $parameters['monitored'] == 'n') {
-        // we can't bind a literal using the ? sytnax so do it directly here 
+        // we can't bind a literal using the ? sytnax so do it directly here
         $qb->andWhere($qb->expr()->eq('se.monitored', $qb->expr()->literal(false)));
         // below works, but is probably not DB agnostic
         //$qb->andWhere($qb->expr()->eq('se.monitored', '?'.++$bc ));

--- a/lib/Gocdb_Services/PI/QueryBuilders/ScopeQueryBuilder.php
+++ b/lib/Gocdb_Services/PI/QueryBuilders/ScopeQueryBuilder.php
@@ -1,29 +1,29 @@
 <?php
 namespace org\gocdb\services;
 /*
- * Copyright 2011 STFC Licensed under the Apache License, Version 2.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
- * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 
- * Unless required by applicable law or agreed to in writing, software distributed under 
+ * Copyright 2011 STFC Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under
  * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
  * either express or implied. See the License for the specific language governing permissions
  * and limitations under the License.
 */
 //use Doctrine\ORM\EntityManager;
-require_once __DIR__.'/../../Factory.php'; 
+require_once __DIR__.'/../../Factory.php';
 
-/** 
- * Appends new WHERE clauses with positional bind parameters to the given 
- * QueryBuilder for filtering a particular target entity by its associated scope tags. 
- * <p>  
+/**
+ * Appends new WHERE clauses with positional bind parameters to the given
+ * QueryBuilder for filtering a particular target entity by its associated scope tags.
+ * <p>
  * The updated Query
- * Builder and the new bind variables must then be fetched 
+ * Builder and the new bind variables must then be fetched
  * using the getQB() and getBinds() methods.
  * <p>
- * Example Queries shown belowm, + indicates the appended WHERE clauses:  
- * <p> 
+ * Example Queries shown belowm, + indicates the appended WHERE clauses:
+ * <p>
  * When a single scope or no scope is provided and a default scope is provided in local_info.xml:
- * <pre>   
+ * <pre>
  *    SELECT s, sc, sp
  *    FROM Site s
  *    LEFT JOIN s.siteProperties sp
@@ -34,15 +34,15 @@ require_once __DIR__.'/../../Factory.php';
  *    LEFT JOIN s.infrastructure i
  * +   WHERE s IN                     --('s' is passed to constructor as $tableType)
  * +       (SELECT tts
- * +        FROM Site tts             --('Site' is passed to constructor as $tId) 
+ * +        FROM Site tts             --('Site' is passed to constructor as $tId)
  * +        INNER JOIN tts.scopes sc2
  * +        WHERE sc2.name LIKE ?0)   --(?0 created from single scope value passed via $scopeParameter in constructor, e.g. 'EGI' )
  *    ORDER BY s.shortName ASC
- *  </pre> 
- * <p> 
+ *  </pre>
+ * <p>
  * When the user supplies multiple scopes and scope match = 'all' or default scope match = 'all'
  * eg scope=EGI,Prace,Local&scope_match=all:
- * <pre> 
+ * <pre>
  *    SELECT s, sc, sp
  *    FROM Site s
  *    LEFT JOIN s.siteProperties sp
@@ -61,10 +61,10 @@ require_once __DIR__.'/../../Factory.php';
  * +              WHERE sc2.name IN(?0))   --(?0 created from multiple scope values passed via $scopeParameter, e.g. 'EGI,Prace,Local')
  * +         GROUP BY tts.id HAVING COUNT(tts.id) = ?1)  --(?1 created by counting comma separated scopes)
  *    ORDER BY s.shortName ASC
- * </pre> 
+ * </pre>
  * When the user supplies multiple scopes  and scope match = any or default scope match = any
  * eg scope=EGI,Prace,Local&scope_match=any:
- * <pre>  
+ * <pre>
  *    SELECT s, sc, sp
  *    FROM Site s
  *    LEFT JOIN s.siteProperties sp
@@ -81,7 +81,7 @@ require_once __DIR__.'/../../Factory.php';
  * +       WHERE sc2.name IN(?1))    --(?1 created from multiple scope values passed via $scopeParameter, e.g. 'EGI,Prace,Local')
  *    ORDER BY s.shortName ASC
  * </pre>
- *   
+ *
  * When the user specifies 'scope=' which represents no scope specified so no sub query for scope at all:
  * <pre>
  *    SELECT s, sc, sp
@@ -96,7 +96,7 @@ require_once __DIR__.'/../../Factory.php';
  * </pre>
  *
  * @author James McCarthy
- * @author David Meredith 
+ * @author David Meredith
  */
 class ScopeQueryBuilder{
 
@@ -116,7 +116,7 @@ class ScopeQueryBuilder{
     }
 
     /**
-     * Get the updated query builder. 
+     * Get the updated query builder.
      * @return \Doctrine\ORM\QueryBuilder
      */
     public function getQB() {
@@ -124,14 +124,14 @@ class ScopeQueryBuilder{
     }
 
     /**
-     * 2D array of postitional bind parameter IDs to bindValue mappings for the 
-     * new WHERE clauses that are appended to the QueryBuilder.  
+     * 2D array of postitional bind parameter IDs to bindValue mappings for the
+     * new WHERE clauses that are appended to the QueryBuilder.
      * <p>
-     * Each outer element stores a child array that has two elements; 
-     * 1st element stores the parameterBindCounter (int) used for the positional bind param. 
+     * Each outer element stores a child array that has two elements;
+     * 1st element stores the parameterBindCounter (int) used for the positional bind param.
      * 2nd element stores the bindValue (mixed).
-     * 
-     * @return array counter-to-value mapping array or empty array    
+     *
+     * @return array counter-to-value mapping array or empty array
      */
     public function getBinds() {
         return $this->binds;
@@ -142,9 +142,9 @@ class ScopeQueryBuilder{
     }
 
     /**
-     * Get the current positional bind parameter value. 
-     * This value is needed if you need to add more positional bind params 
-     * to the query builder after using this class.  
+     * Get the current positional bind parameter value.
+     * This value is needed if you need to add more positional bind params
+     * to the query builder after using this class.
      * @return int Bind count
      */
     public function getBindCount() {
@@ -161,38 +161,38 @@ class ScopeQueryBuilder{
     }
 
     /**
-     * Appends new WHERE clauses with positional bind parameters to the 
-     * given QueryBuilder for filtering a target entity type by its associated scope tags. 
-     * <p> 
-     * The class takes a Doctrine {@link \Doctrine\ORM\QueryBuilder} which represents 
-     * the current query that will be appended/updated. This query may contain other 
-     * positional bind parameters - the query should NOT contain any named params. 
+     * Appends new WHERE clauses with positional bind parameters to the
+     * given QueryBuilder for filtering a target entity type by its associated scope tags.
      * <p>
-     * The constructor also takes the scope value(s) to filter on, the bind count which 
-     * is used to create new unique bind parameters, the name of the entity type and 
-     * the alias used in the query (these values should match the values already 
-     * used in the query).   
-     * <p>  
-     * The updated QueryBuilder and the new bind variables must then be fetched 
+     * The class takes a Doctrine {@link \Doctrine\ORM\QueryBuilder} which represents
+     * the current query that will be appended/updated. This query may contain other
+     * positional bind parameters - the query should NOT contain any named params.
+     * <p>
+     * The constructor also takes the scope value(s) to filter on, the bind count which
+     * is used to create new unique bind parameters, the name of the entity type and
+     * the alias used in the query (these values should match the values already
+     * used in the query).
+     * <p>
+     * The updated QueryBuilder and the new bind variables must then be fetched
      * using the getQB() and getBinds() methods.
-     * See class doc for example appended WHERE clauses.  
-     * 
-     * @param string $scopeParameter either null, a single scope tag value e.g. 'EGI' 
+     * See class doc for example appended WHERE clauses.
+     *
+     * @param string $scopeParameter either null, a single scope tag value e.g. 'EGI'
      *   or comma sep list 'EGI,EUDAT,SCOPEX'
-     * @param string $scopeMatch either null, 'any' or 'all' 
-     * @param \Doctrine\ORM\QueryBuilder $qb QueryBuilder instance to update with 
-     *   new WHERE clauses and postional bind params 
-     * @param \Doctrine\ORM\EntityManager $em EntityManager Used for creating the query 
-     * @param int $bc Current bind count, used to create new positional bind params 
+     * @param string $scopeMatch either null, 'any' or 'all'
+     * @param \Doctrine\ORM\QueryBuilder $qb QueryBuilder instance to update with
+     *   new WHERE clauses and postional bind params
+     * @param \Doctrine\ORM\EntityManager $em EntityManager Used for creating the query
+     * @param int $bc Current bind count, used to create new positional bind params
      *   (new bind params will be created by incrementing from this value)
-     * @param string $tableType The entity type name that owns the scopes used in the query, 
-     *   e.g. 'Site' or 'Service' (must be an {@see \IScopedEntity} implementation) 
-     * @param string $tId Alias of the entity type used in the query, e.g.   
+     * @param string $tableType The entity type name that owns the scopes used in the query,
+     *   e.g. 'Site' or 'Service' (must be an {@see \IScopedEntity} implementation)
+     * @param string $tId Alias of the entity type used in the query, e.g.
      *   's' for Site or 'se' for Service
      */
-    public function __construct($scopeParameter, $scopeMatch, 
-            \Doctrine\ORM\QueryBuilder $qb, \Doctrine\ORM\EntityManager $em, 
-            $bc, $tableType, $tId){                                
+    public function __construct($scopeParameter, $scopeMatch,
+            \Doctrine\ORM\QueryBuilder $qb, \Doctrine\ORM\EntityManager $em,
+            $bc, $tableType, $tId){
 
         $this->em = $em;
         $this->setQB($qb);
@@ -206,31 +206,31 @@ class ScopeQueryBuilder{
             $this->createSubQuery($scopeParameter, $scopeMatch);
         }
     }
-        
-    /** 
+
+    /**
      *  The TTS alias used in these statements refers to Table To Select,
-     *  a generic term to which means less inserting of unique names into the 
-     *  query when selecting from sites, ngis, services etc. 
+     *  a generic term to which means less inserting of unique names into the
+     *  query when selecting from sites, ngis, services etc.
      */
-        
+
     /**
      * Generates the sub query from the scope that will be appended
      * to the existing query
-     * 
-     * @param String $scopeParameters either null, a single scope tag value e.g. 
+     *
+     * @param String $scopeParameters either null, a single scope tag value e.g.
      *    'EGI' or comma sep list 'EGI,EUDAT,SCOPEX'
-     * @param String $scopeMatch either null, 'any' or 'all' 
+     * @param String $scopeMatch either null, 'any' or 'all'
      */
     private function createSubQuery($scopeParameters, $scopeMatch) {
-        // If user has specified "&scope=" as a parameter then don't add any 
-        // scope clause to the query - do nothing with scopes including no default 
+        // If user has specified "&scope=" as a parameter then don't add any
+        // scope clause to the query - do nothing with scopes including no default
         if ($scopeParameters != NULL) {
             $tId = $this->tId;
             $bc = $this->getBindCount();
             $tableType = $this->tableType;
             $qb = $this->getQB();
 
-            //If scopes does not contain a comma then it is not a list so do a standard query                
+            //If scopes does not contain a comma then it is not a list so do a standard query
             if (!strpos($scopeParameters, ',')) {
                 $qb2 = $this->em->createQueryBuilder();
                 $qb2->select('tts')
@@ -244,30 +244,30 @@ class ScopeQueryBuilder{
                 $this->binds[] = array($bc, $scopeParameters);
             } else {
                 //$scopeParameters Contains multiple scope tags, so construct a 'WHERE IN' query
-                // trim whitespace and leadind/trailing commas (if present) 
-                $scopeParameters = trim($scopeParameters); 
-                $scopeParameters = rtrim($scopeParameters, ','); 
-                $scopeParameters = ltrim($scopeParameters, ','); 
-                
+                // trim whitespace and leadind/trailing commas (if present)
+                $scopeParameters = trim($scopeParameters);
+                $scopeParameters = rtrim($scopeParameters, ',');
+                $scopeParameters = ltrim($scopeParameters, ',');
+
                 //If no scope match was provided get the default
                 if ($scopeMatch == null) {
                     $configService = \Factory::getConfigService();
                     $scopeMatch = $configService->getDefaultScopeMatch();
                 }
 
-                //If scope match was 'all' then construct query using HAVING and 
-                //GROUP BY clauses to ensure all scopes are matched 
+                //If scope match was 'all' then construct query using HAVING and
+                //GROUP BY clauses to ensure all scopes are matched
                 if ($scopeMatch == 'all') {
                     $qb2 = $this->em->createQueryBuilder();
                     $qb2->select('sc2.id')
                             ->from('Scope', 'sc2')
                             ->where($qb2->expr()->in('sc2.name', '?' . ++$bc));
-                    
-                    // Store bind name and value for later binding, e.g. 
+
+                    // Store bind name and value for later binding, e.g.
                     // $this->binds[] = array(15, array('EGI', 'WLCG' ,'Local'))
                     $scopesArray = explode(',', $scopeParameters);
                     $this->binds[] = array($bc, $scopesArray);
-                    
+
                     /* ------------IMPORTANT-------------------------------------------------
                      * We need this extra parent clause when performing a GROUP BY and HAVING.
                      * Without this doctrine will get confused when creating the SQL it sends
@@ -282,16 +282,16 @@ class ScopeQueryBuilder{
 
                     $qb1->groupBy('tts.id')
                             ->andHaving($qb1->expr()->eq($qb1->expr()->count('tts.id'), '?' . ++$bc));
-                    
+
                     // Count split terms and store, e.g. array(15, 3), is needed
-                    // for HAVING clause above 
-                    $this->binds[] = array($bc, count($scopesArray)); 
-                    
+                    // for HAVING clause above
+                    $this->binds[] = array($bc, count($scopesArray));
+
                     //Join sub-clause onto main query
                     $qb->andWhere($qb->expr()->in($tId, $qb1->getDQL()));
-                    
+
                 } else {
-                    // scope_match == 'any' so there is no need for an extra 
+                    // scope_match == 'any' so there is no need for an extra
                     // parent query as we aren't using HAVING and GROUP BY.
 
                     $qb2 = $this->em->createQueryBuilder();
@@ -299,8 +299,8 @@ class ScopeQueryBuilder{
                             ->from($tableType, 'tts')
                             ->innerJoin('tts.scopes', 'sc2')
                             ->where($qb->expr()->in('sc2.name', '?' . ++$bc));
-                    
-                    // bind the array of scope values 
+
+                    // bind the array of scope values
                     $this->binds[] = array($bc, explode(',', $scopeParameters));
 
                     //Join sub-clause onto main query
@@ -315,7 +315,7 @@ class ScopeQueryBuilder{
 
 
     /**
-     * When no scope is specified the default is set via defaultScope 
+     * When no scope is specified the default is set via defaultScope
      * which in turn is read from a local_info.xml file in config folder.
      */
     private function createDefaultSubQuery() {
@@ -344,8 +344,8 @@ class ScopeQueryBuilder{
     }
 
     /**
-     * Gets the name of the default scope from the config service 
-     * and returns it as a string value. 
+     * Gets the name of the default scope from the config service
+     * and returns it as a string value.
      * @return $scopes
      */
     private function defaultScope() {
@@ -360,10 +360,10 @@ class ScopeQueryBuilder{
     }
 
     /**
-     * This is a backup function incase the other function utilizing group by and having 
-     * breaks. This can be switched over to with a function name change and will use 
+     * This is a backup function incase the other function utilizing group by and having
+     * breaks. This can be switched over to with a function name change and will use
      * repeated AND/OR queries to filter by scope
-     * 
+     *
      * @param String $scopeParameters
      * @param String $scopeMatch
      */
@@ -442,7 +442,7 @@ class ScopeQueryBuilder{
          INNER JOIN tts1.scopes sc1
          WHERE sc1.name = ?2)
     ORDER BY s.shortName ASC
-    
+
 *
 *
 * &scope=EGI,Local&scope_match=all:

--- a/lib/Gocdb_Services/RetrieveAccount.php
+++ b/lib/Gocdb_Services/RetrieveAccount.php
@@ -21,17 +21,17 @@ require_once __DIR__ . '/AbstractEntityService.php';
  * @author David Meredith
  */
 class RetrieveAccount extends AbstractEntityService {
-     
+
     /**
      * Validates an account retrieval request
      * @param string $oldDn
      * @param string $email
      */
     public function validate($oldDn, $email) {
-        require_once __DIR__ . '/User.php'; 
-        $userService = new \org\gocdb\services\User(); 
-        $userService->setEntityManager($this->em); 
-        $user = $userService->getUserByPrinciple($oldDn); 
+        require_once __DIR__ . '/User.php';
+        $userService = new \org\gocdb\services\User();
+        $userService->setEntityManager($this->em);
+        $user = $userService->getUserByPrinciple($oldDn);
         if($user == null) {
             throw new \Exception("Can't find user with DN $oldDn");
         }
@@ -49,14 +49,14 @@ class RetrieveAccount extends AbstractEntityService {
 
 
         //get user from old dn and throw exception if they don't exist
-        require_once __DIR__ . '/User.php'; 
-        $userService = new \org\gocdb\services\User(); 
-        $userService->setEntityManager($this->em); 
-        $user = $userService->getUserByPrinciple($oldDn); 
+        require_once __DIR__ . '/User.php';
+        $userService = new \org\gocdb\services\User();
+        $userService->setEntityManager($this->em);
+        $user = $userService->getUserByPrinciple($oldDn);
         if($user == null) {
             throw new \Exception("Can't find user with DN $oldDn");
         }
-        
+
         //check the given email address matches the one given
         if(strcasecmp($user->getEmail(), $givenEmail)) {
             throw new \Exception("E-mail address doesn't match DN");
@@ -64,9 +64,9 @@ class RetrieveAccount extends AbstractEntityService {
 
         //Check the portal is not in read only mode, throws exception if it is. If portal is read only, but the user whos DN is being changed is an admin, we will still be able to proceed.
         $this->checkPortalIsNotReadOnlyOrUserIsAdmin($user);
-        
-        //check if there has already been a request for this dn, if there has, 
-        //remove it. This must be in a seperate try catch block to the new one, 
+
+        //check if there has already been a request for this dn, if there has,
+        //remove it. This must be in a seperate try catch block to the new one,
         //to prevent constraint violations
         $previousRequest = $this->getRetrieveAccountRequestByUserId($user->getId());
         if(!is_null($previousRequest)){
@@ -79,31 +79,31 @@ class RetrieveAccount extends AbstractEntityService {
                 $this->em->getConnection()->rollback();
                 $this->em->close();
                 throw $e;
-            }  
+            }
         }
-        
+
         //Generate confirmation code
         $code = $this->generateConfirmationCode($user->getCertificateDn());
-        
+
         $retrieveAccountReq = new \RetrieveAccountRequest($user, $code, $currentDn);
         //die('code ['.$code.']');
-        
+
         //apply change
         try {
             $this->em->getConnection()->beginTransaction();
             $this->em->persist($retrieveAccountReq);
             $this->em->flush();
-            
+
             //send email (before commit - if it fails we'll need a rollback)
             $this->sendConfirmationEmail($user, $code, $currentDn);
-            
+
             $this->em->getConnection()->commit();
         } catch(\Exception $ex){
             $this->em->getConnection()->rollback();
             $this->em->close();
             throw $ex;
         }
-        
+
     }
 
     private function generateConfirmationCode($userdn){
@@ -111,7 +111,7 @@ class RetrieveAccount extends AbstractEntityService {
         $confirm_hash = sha1($userdn.$confirm_code);
         return $confirm_hash;
     }
-    
+
     /**
      * Gets a retrieve account request from the database based on userid
      * @param integer $userId userid of the request to be retrieved
@@ -120,17 +120,17 @@ class RetrieveAccount extends AbstractEntityService {
     public function getRetrieveAccountRequestByUserId($userId){
         $dql = "SELECT r
                 FROM RetrieveAccountRequest r
-                JOIN r.user u 
+                JOIN r.user u
                 WHERE u.id = :id";
-        
+
         $request = $this->em
             ->createQuery($dql)
             ->setParameter('id', $userId)
             ->getOneOrNullResult();
-        
+
         return $request;
     }
-    
+
     /**
      * Gets a retrieve account request from the database based on the conformation code
      * @param string $code confirmation code of the request being retrieved
@@ -140,28 +140,28 @@ class RetrieveAccount extends AbstractEntityService {
         $dql = "SELECT r
                 FROM RetrieveAccountRequest r
                 WHERE r.confirmCode = :code";
-        
+
         $request = $this->em
             ->createQuery($dql)
             ->setParameter('code', $code)
             ->getOneOrNullResult();
-        
+
         return $request;
     }
-    
+
     /**
      * sends a confimation email to the user
-     * 
+     *
      * @param \User $user user who's dn is being changed
-     * @param type $confirmationCode genersted confirmation code 
+     * @param type $confirmationCode genersted confirmation code
      * @param type $newDn new dn for $user
      * @throws \Exception
      */
     private function sendConfirmationEmail(\User $user, $confirmationCode, $newDn){
         $portal_url = \Factory::getConfigService()->GetPortalURL();
-        //echo $portal_url; 
+        //echo $portal_url;
        //die();
-        
+
         $link = $portal_url."/index.php?Page_Type=User_Validate_DN_Change&c=".$confirmationCode;
         $subject = "Validation of changes on your GOCDB account";
         $body = "Dear GOCDB User,\n\n"
@@ -173,39 +173,39 @@ class RetrieveAccount extends AbstractEntityService {
             "\n\nIf you did not create this request in GOCDB, please immediately contact gocdb-admins@mailman.egi.eu" ;
             ;
         //If "sendmail_from" is set in php.ini, use second line ($headers = '';):
-        $headers = "From: no-reply@goc.egi.eu";           
+        $headers = "From: no-reply@goc.egi.eu";
         //$headers = "";
-        
+
         //mail command returns boolean. False if message not accepted for delivery.
         if (!mail($user->getEmail(), $subject, $body, $headers)){
             throw new \Exception("Unable to send email message");
         }
-        
+
         //echo $body;
     }
-    
+
     public function confirmAccountRetrieval ($code, $currentDn){
         //get the request
         $request = $this->getRetrieveAccountRequestByConfirmationCode($code);
-        
+
         //check there is a result
         if(is_null($request)){
             throw new \Exception("Confirmation URL invalid. If you have submitted multiple requests for the same account, please ensure you have used the link in the most recent email");
         }
-        
+
         $user = $request->getUser();
-        
+
         //Check the portal is not in read only mode, throws exception if it is. If portal is read only, but the user whos DN is being changed is an admin, we will still be able to proceed.
         $this->checkPortalIsNotReadOnlyOrUserIsAdmin($user);
-        
+
         //check the DN currently being used by the user is the one they want their account changed to
         if($currentDn != $request->getNewDn()){
             throw new Exception("Your current certificate DN does not match the one to which it was requested to link the user account. The link will only work once, if you have refreshed the page or clicked the link a second time you will see this messaage"); //TODO: reword
         }
-        
+
         //update user, remove request from table
         try{
-            $user->setCertificateDn($request->getNewDn()); 
+            $user->setCertificateDn($request->getNewDn());
             $this->em->getConnection()->beginTransaction();
             $this->em->merge($user);
             $this->em->remove($request);
@@ -216,6 +216,6 @@ class RetrieveAccount extends AbstractEntityService {
             $this->em->close();
             throw $e;
         }
-        
+
     }
 }

--- a/lib/Gocdb_Services/RoleActionAuthorisationService.php
+++ b/lib/Gocdb_Services/RoleActionAuthorisationService.php
@@ -22,200 +22,200 @@ require_once __DIR__ . '/RoleActionMappingService.php';
 /**
  * Context object to return the authorisation result from the service method:
  * {@see \org\gocdb\services\RoleActionAuthorisationService::authoriseAction($action, $targetEntity, $user)}
- * The object wraps a boolean that determines whether the action can be performed, 
- * and an array of roles that enable the action (or not).  
- * 
+ * The object wraps a boolean that determines whether the action can be performed,
+ * and an array of roles that enable the action (or not).
+ *
  * @author David Meredith
  */
 class AuthoriseActionResult {
-   private $grantingRoles = array(); 
-   private $grantAction = FALSE; 
+   private $grantingRoles = array();
+   private $grantAction = FALSE;
 
    public function setGrantingRoles($grantingRoles){
-       $this->grantingRoles = $grantingRoles; 
+       $this->grantingRoles = $grantingRoles;
    }
    public function setGrantAction($grantAction){
-       $this->grantAction = $grantAction; 
+       $this->grantAction = $grantAction;
    }
    /**
     * @return array {@see \Role} objects that grant the action, or an empty array.
     */
    public function getGrantingRoles(){
-       return $this->grantingRoles; 
+       return $this->grantingRoles;
    }
    /**
-    * Can the user perform the specified action? If the user is the gocdb admin, 
-    * True is always returned. 
-    * @return boolean True if the user can perform the action, otherwise False. 
+    * Can the user perform the specified action? If the user is the gocdb admin,
+    * True is always returned.
+    * @return boolean True if the user can perform the action, otherwise False.
     */
    public function getGrantAction(){
-       return $this->grantAction; 
+       return $this->grantAction;
    }
 }
 
 
 /**
- * Used to determine if a user can perform an action on an object by 
- * comparing the user's granted DB roles against the rules/roles defined in the 
- * role action mapping service. 
+ * Used to determine if a user can perform an action on an object by
+ * comparing the user's granted DB roles against the rules/roles defined in the
+ * role action mapping service.
  *
  * @author David Meredith
  */
 class RoleActionAuthorisationService  extends AbstractEntityService  {
 
-    private $roleActionMappingService; 
-    //private $roleService; 
-   
+    private $roleActionMappingService;
+    //private $roleService;
+
     /**
-     * Create a new instance.  
+     * Create a new instance.
      * @param org\gocdb\services\RoleActionMappingService $roleActionMappingService
      */
     public function __construct(RoleActionMappingService $roleActionMappingService /*, Role $roleService*/) {
         parent::__construct();
-        $this->roleActionMappingService = $roleActionMappingService; //new RoleActionMappingService(); 
-        //$this->roleService = $roleService; //new Role();  
+        $this->roleActionMappingService = $roleActionMappingService; //new RoleActionMappingService();
+        //$this->roleService = $roleService; //new Role();
     }
 
- 
+
     /**
-     * Analyse the user's roles to determine if they can perform the 
+     * Analyse the user's roles to determine if they can perform the
      * specified action over the target entity? Return a context object that
-     * wraps the authorisation result. If the user is the gocdb admin, 
-     * true is always returned as a param of context object result, otherwise 
-     * the result is determined from the user's roles. 
+     * wraps the authorisation result. If the user is the gocdb admin,
+     * true is always returned as a param of context object result, otherwise
+     * the result is determined from the user's roles.
      * <p>
      * The authorisation decisions are made by comparing a) the user's Roles that are
      * reachable from the target entity when ascending the domain graph with b) the
-     * role-action-mapping rules for the relevant project(s). The relevant 
-     * projects include those that are a parents/ancestors to the target entity.   
-     * 
-     * @param string $action The action the user wants to perform over the entity 
-     * @param \OwnedEntity $targetEntity The target entity for the action 
-     * @param \User $user The user who wants to peform the action on the entity 
-     * @return \org\gocdb\services\AuthoriseActionResult Context object that 
-     * wraps the result.  
-     * @throws \LogicException If role action mappings can't be resolved.  
+     * role-action-mapping rules for the relevant project(s). The relevant
+     * projects include those that are a parents/ancestors to the target entity.
+     *
+     * @param string $action The action the user wants to perform over the entity
+     * @param \OwnedEntity $targetEntity The target entity for the action
+     * @param \User $user The user who wants to peform the action on the entity
+     * @return \org\gocdb\services\AuthoriseActionResult Context object that
+     * wraps the result.
+     * @throws \LogicException If role action mappings can't be resolved.
      */
     public function authoriseAction($action, \OwnedEntity $targetEntity, $user){
         if (!is_string($action) || strlen(trim($action)) == 0) {
             throw new \LogicException('Invalid action');
-        } 
+        }
         if(is_null($user)){
-            return new AuthoriseActionResult();  
+            return new AuthoriseActionResult();
         }
          if(is_null($user->getId())){
-            return new AuthoriseActionResult(); 
+            return new AuthoriseActionResult();
         }
-        // If we limit the actions, then its hard to test using some sample 
-        // roleActionMapping files. Need to decide to include this.  
+        // If we limit the actions, then its hard to test using some sample
+        // roleActionMapping files. Need to decide to include this.
 //        if(!in_array($action, \Action::getAsArray())){
-//            throw new \LogicException('Coding Error - Invalid action not known'); 
-//        } 
+//            throw new \LogicException('Coding Error - Invalid action not known');
+//        }
 
-//         IGNORE THIS COMMENT BLOCK - DECLARING DIFFERENT ROLE ACTION MAPPINGS PER  
-//       PROJECT MAY BE NEEDED IN FUTURE, BUT RIGHT NOW IT ADDS UNNECESSARY COMPLEXITY.   
+//         IGNORE THIS COMMENT BLOCK - DECLARING DIFFERENT ROLE ACTION MAPPINGS PER
+//       PROJECT MAY BE NEEDED IN FUTURE, BUT RIGHT NOW IT ADDS UNNECESSARY COMPLEXITY.
 //       IF THE NEED ARISES, THIS STUFF WILL BE USEFUL:
 //       =======================================================================
-//       // Get a list of DB projects that are 'reachable' from the given entity 
-//       // by moving up the OwnedEntity hierarchy. 
-//       // Note, some objects don't come under the remit of a Project, e.g. 
-//       // ServiceGroups, so dbProjects may be empty (this is normal). 
-//       //$dbProjects = $this->getReachableProjectsFromOwnedEntity($targetEntity); 
+//       // Get a list of DB projects that are 'reachable' from the given entity
+//       // by moving up the OwnedEntity hierarchy.
+//       // Note, some objects don't come under the remit of a Project, e.g.
+//       // ServiceGroups, so dbProjects may be empty (this is normal).
+//       //$dbProjects = $this->getReachableProjectsFromOwnedEntity($targetEntity);
 //
-//        // TODO? 
-//        // iterate the dbProjects and exclude those that are not mapped in the 
+//        // TODO?
+//        // iterate the dbProjects and exclude those that are not mapped in the
 //        // roleActionMappings file
 //        foreach($dbProjects as $dbProj){
 //           if($this->roleActionMappingService->isProjectMapped($dbProj->getName())){
-//              $dbProjects[] = $dbProj;  
-//           } 
+//              $dbProjects[] = $dbProj;
+//           }
 //        }
-//        
+//
 //        if(count($dbProjects) > 0){
 //            // If there is an ancestor project, then we ignore the default role action mappings
 //            foreach ($dbProjects as $dbProject) {
-//                //print_r('reachable project: ['.$dbProject->getName()."] \n"); 
-//                // Lookup the role type mappings for this project (['RoleTypeName'] => 'overOwnedEntity'). 
-//                // throws LogicException if the dbProjectName does not exist in the 
-//                // mapping file! (not so with action or entity-type)  
-//                // For example, the following role-types over the specified object 
-//                // types could enable 'actionX': 
+//                //print_r('reachable project: ['.$dbProject->getName()."] \n");
+//                // Lookup the role type mappings for this project (['RoleTypeName'] => 'overOwnedEntity').
+//                // throws LogicException if the dbProjectName does not exist in the
+//                // mapping file! (not so with action or entity-type)
+//                // For example, the following role-types over the specified object
+//                // types could enable 'actionX':
 //                // array (
-//                //   ['Site Administrator'] => 'Site', 
-//                //   ['NGI Operations Manager'] => 'Ngi', 
+//                //   ['Site Administrator'] => 'Site',
+//                //   ['NGI Operations Manager'] => 'Ngi',
 //                //   ['Chief Operations Officer'] => 'Project'
-//                // );      
+//                // );
 //                $roleTypeMappingsForProj = $this->roleActionMappingService->
 //                        getRoleTypeNamesThatEnableActionOnTargetObjectType(
 //                        $action, $targetEntity->getType(), $dbProject->getName());
-//                //print_r('roleTypeMappings for reachable project: ['.$dbProject->getName()."] \n"); 
-//                //print_r($roleTypeMappingsForProj); 
-//                
-//                // If there are roles that enable the action, store the roles for the project 
+//                //print_r('roleTypeMappings for reachable project: ['.$dbProject->getName()."] \n");
+//                //print_r($roleTypeMappingsForProj);
+//
+//                // If there are roles that enable the action, store the roles for the project
 //                if (count($roleTypeMappingsForProj) > 0) {
 //                    $requiredRoleTypesPerProj[] = $roleTypeMappingsForProj;
 //                }
 //            }
 //        } else {
-//            // The entity dont come under a Project, e.g. the entity was 
-//            // Project agnostic like a ServiceGroup, or there was an instance of 
-//            // an orphan NGI or Site, therefore get the default RoleActionMappings. 
+//            // The entity dont come under a Project, e.g. the entity was
+//            // Project agnostic like a ServiceGroup, or there was an instance of
+//            // an orphan NGI or Site, therefore get the default RoleActionMappings.
 //            $requiredRoleTypesPerProj[] = $this->roleActionMappingService->
 //                    getRoleTypeNamesThatEnableActionOnTargetObjectType(
 //                        $action, $targetEntity->getType(), null);
-//            //print_r($requiredRoleTypesPerProj); // e.g. 
-//            // Array ( [0] => Array ( [Service Group Administrator] => ServiceGroup ) ) 
+//            //print_r($requiredRoleTypesPerProj); // e.g.
+//            // Array ( [0] => Array ( [Service Group Administrator] => ServiceGroup ) )
 //        }
 //       =======================================================================
 
 
-        
-        // Lookup+store the role type mappings that enable 
-        // the action on the specified entity type (mappings stored in RoleActionMappings XML). 
+
+        // Lookup+store the role type mappings that enable
+        // the action on the specified entity type (mappings stored in RoleActionMappings XML).
         $requiredRoleTypesPerProj = array();
         $requiredRoleTypesPerProj[] = $this->roleActionMappingService->
                     getRoleTypeNamesThatEnableActionOnTargetObjectType(
                         $action, $targetEntity->getType(), null);
 
-        // Get all the roles occurring over and above the entity. Note, in future it may be 
-        // necessary to introduce getUserRolesReachableFromEntityDESC($user, $entity) too 
-        // (or getUserRolesReachableFromEntity($user, $entity) to go up and down). 
-        // e.g. this would be needed IF we want to enable actions on parent objects from roles held over 
-        // child objects, e.g. consider the case where users with roles over sites/ngis 
-        // want to post comments on a Project's notifications-board - a user may need a role 
-        // over a child object to do this. 
-        $dbUserRoles = $this->getUserRolesReachableFromEntityASC($user, $targetEntity);  
-        
+        // Get all the roles occurring over and above the entity. Note, in future it may be
+        // necessary to introduce getUserRolesReachableFromEntityDESC($user, $entity) too
+        // (or getUserRolesReachableFromEntity($user, $entity) to go up and down).
+        // e.g. this would be needed IF we want to enable actions on parent objects from roles held over
+        // child objects, e.g. consider the case where users with roles over sites/ngis
+        // want to post comments on a Project's notifications-board - a user may need a role
+        // over a child object to do this.
+        $dbUserRoles = $this->getUserRolesReachableFromEntityASC($user, $targetEntity);
+
         //   Note, don't get all the user's roles in the project (to compare
-        //   with the role-action-mappings) because this would include roles that 
-        //   are not linerarly reachable from the entity, e.g. when authorising an 
+        //   with the role-action-mappings) because this would include roles that
+        //   are not linerarly reachable from the entity, e.g. when authorising an
         //   an action on an NGI, we wouldn't want to include Roles linked to another NGI!
-        //   in the same project. Therefore, doing the following would be wrong:  
+        //   in the same project. Therefore, doing the following would be wrong:
         //   foreach ($dbProjects as $dbProject) {
-        //      $rolesInProj = $this->getUserRolesByProject($user, $dbProject); 
+        //      $rolesInProj = $this->getUserRolesByProject($user, $dbProject);
         //      foreach($rolesInProj as $r){
         //           $dbUserRoles[] = $r
-        //      } 
+        //      }
         //   }
 
-        // Iterate the users roles and for each role determine if this role's type  
-        // and ownedEntity type match a role action mapping rule. If true, then 
-        // store that users's role in the grantingUserRoles array. 
+        // Iterate the users roles and for each role determine if this role's type
+        // and ownedEntity type match a role action mapping rule. If true, then
+        // store that users's role in the grantingUserRoles array.
         $grantingUserRoles = array();
         foreach ($dbUserRoles as $candidateUserRole) {
             foreach ($requiredRoleTypesPerProj as $requiredRoleTypesForProjX) {
-                //print_r("candidate granting role: [".$candidateUserRole->getRoleType()->getName()."]\n"); 
-                // Iterate required role types for proj X  
+                //print_r("candidate granting role: [".$candidateUserRole->getRoleType()->getName()."]\n");
+                // Iterate required role types for proj X
                 foreach ($requiredRoleTypesForProjX as $grantingRoleTypeName => $overEntityType) {
 
-                    // If user has a role with the same type name and 
-                    // over the same entity type, this role grants the action  
+                    // If user has a role with the same type name and
+                    // over the same entity type, this role grants the action
                     if ($candidateUserRole->getRoleType()->getName() == $grantingRoleTypeName &&
                             strtoupper($candidateUserRole->getOwnedEntity()->getType()) == strtoupper($overEntityType)) {
 
                         if (!in_array($candidateUserRole, $grantingUserRoles)) {
-                            //print_r("Adding role [".$candidateUserRole->getRoleType()->getName()."] over [".$candidateUserRole->getOwnedEntity()->getType()."]"); 
-                            //e.g. Adding role [Service Group Administrator] over [servicegroup] 
+                            //print_r("Adding role [".$candidateUserRole->getRoleType()->getName()."] over [".$candidateUserRole->getOwnedEntity()->getType()."]");
+                            //e.g. Adding role [Service Group Administrator] over [servicegroup]
                             $grantingUserRoles[] = $candidateUserRole;
                         }
                     }
@@ -223,95 +223,95 @@ class RoleActionAuthorisationService  extends AbstractEntityService  {
             }
         }
 
-        
-        //print_r("Granting User Roles size: [".count($grantingUserRoles)."]"); 
+
+        //print_r("Granting User Roles size: [".count($grantingUserRoles)."]");
         $grantResult = new AuthoriseActionResult();
-        $grantResult->setGrantingRoles($grantingUserRoles); 
+        $grantResult->setGrantingRoles($grantingUserRoles);
         if($user->isAdmin()){
-            $grantResult->setGrantAction(TRUE); 
+            $grantResult->setGrantAction(TRUE);
         } else {
             if(count($grantingUserRoles) > 0){
-                $grantResult->setGrantAction(TRUE); 
+                $grantResult->setGrantAction(TRUE);
             }
         }
-        return $grantResult; 
+        return $grantResult;
     }
 
     /**
-     * Get all the Roles that the user has DIRECTLY over the given OwnedEntity AND 
-     * over all the reachable parent and ancestor OwnedEntities encountered when 
-     * moving up through the domain model.  
-     * 
+     * Get all the Roles that the user has DIRECTLY over the given OwnedEntity AND
+     * over all the reachable parent and ancestor OwnedEntities encountered when
+     * moving up through the domain model.
+     *
      * @param \User $user
      * @param \OwnedEntity $ownedEntity
-     * @param string $roleStatus Role status, GRANTED by default 
-     * @return array {@see \Role} array  
+     * @param string $roleStatus Role status, GRANTED by default
+     * @return array {@see \Role} array
      */
-    public function getUserRolesReachableFromEntityASC(\User $user, \OwnedEntity $ownedEntity, 
+    public function getUserRolesReachableFromEntityASC(\User $user, \OwnedEntity $ownedEntity,
             $roleStatus = \RoleStatus::GRANTED){
-        $roles = array(); 
-        $this->getUserRolesReachableFromEntityAscRecurse($user, $ownedEntity, $roles, $roleStatus);  
-        return $roles;         
+        $roles = array();
+        $this->getUserRolesReachableFromEntityAscRecurse($user, $ownedEntity, $roles, $roleStatus);
+        return $roles;
     }
-    
-    private function getUserRolesReachableFromEntityAscRecurse(\User $user, 
+
+    private function getUserRolesReachableFromEntityAscRecurse(\User $user,
             \OwnedEntity $ownedEntity, &$roles, $roleStatus){
-        
-        $_roles = $this->getUserRolesOverEntity($ownedEntity, $user, $roleStatus);  
+
+        $_roles = $this->getUserRolesOverEntity($ownedEntity, $user, $roleStatus);
         foreach($_roles as $r){
-            $roles[] = $r; 
+            $roles[] = $r;
         }
-        $parentOEs = $ownedEntity->getParentOwnedEntities(); 
+        $parentOEs = $ownedEntity->getParentOwnedEntities();
         foreach($parentOEs as $parentOE){
             // recurse
-            $this->getUserRolesReachableFromEntityAscRecurse($user, $parentOE, $roles, $roleStatus);  
+            $this->getUserRolesReachableFromEntityAscRecurse($user, $parentOE, $roles, $roleStatus);
         }
     }
-    
+
 
     /**
-     * Get all {@see \Project}s that are reachable from the given ownedEntity 
-     * when moving up the domain model, e.g. Site->Ngi->Project. 
+     * Get all {@see \Project}s that are reachable from the given ownedEntity
+     * when moving up the domain model, e.g. Site->Ngi->Project.
      * <p>
-     * The ownedEntity therefore comes under the 'remit' of the returned projects. 
-     * 
-     * @param \OwnedEntity $ownedEntity Search up the domain graph from this entity 
-     * @return array of \Project entities 
+     * The ownedEntity therefore comes under the 'remit' of the returned projects.
+     *
+     * @param \OwnedEntity $ownedEntity Search up the domain graph from this entity
+     * @return array of \Project entities
      */
     public function getReachableProjectsFromOwnedEntity(\OwnedEntity $ownedEntity){
-        $projects = array(); 
+        $projects = array();
         if ($ownedEntity instanceof \Site) {
-            // maybe below line needs to be more 'defensive' ? not sure, the 
-            // role logic requires that a site is not an orphan and 
-            // checking that parents/ancestors are not null could mask problems.  
-            /* @var $ownedEntity \Site */ 
-            $projects = $ownedEntity->getNgi()->getProjects()->toArray(); 
-            
+            // maybe below line needs to be more 'defensive' ? not sure, the
+            // role logic requires that a site is not an orphan and
+            // checking that parents/ancestors are not null could mask problems.
+            /* @var $ownedEntity \Site */
+            $projects = $ownedEntity->getNgi()->getProjects()->toArray();
+
         } else if($ownedEntity instanceof \NGI) {
             /* @var $ownedEntity NGI */
-            $projects = $ownedEntity->getProjects()->toArray(); 
-            
+            $projects = $ownedEntity->getProjects()->toArray();
+
         } else if($ownedEntity instanceof \Project){
            $projects = array($ownedEntity);
-           
+
         } else {
             //throw new \LogicException('ownedEntity type is not a descendant '
-            //        . 'of Project ['.$ownedEntity->getType().']'); 
-            return array(); 
+            //        . 'of Project ['.$ownedEntity->getType().']');
+            return array();
         }
-        return $projects; 
+        return $projects;
     }
-    
+
 
     /**
-     * Get all the RoleType names that the user has DIRECTLY over the given entity,   
-     * and optionally limit the returned RoleType names to those with the specified  
+     * Get all the RoleType names that the user has DIRECTLY over the given entity,
+     * and optionally limit the returned RoleType names to those with the specified
      * RoleStatus (GRANTED by default).
-     * 
-     * @param \OwnedEntity $entity An entity that extends OwnedEntity (Site, NGI, ServiceGroup, Project) 
+     *
+     * @param \OwnedEntity $entity An entity that extends OwnedEntity (Site, NGI, ServiceGroup, Project)
      * @param \User $user
      * @param string $roleStatus
-     * @return array of {@see \Role}s 
+     * @return array of {@see \Role}s
      */
     public function getUserRolesOverEntity(\OwnedEntity $entity, \User $user, $roleStatus = \RoleStatus::GRANTED) {
         if ($user->getId() == null || $entity->getId() == null) {
@@ -320,8 +320,8 @@ class RoleActionAuthorisationService  extends AbstractEntityService  {
         //$entityClassName= get_class($entity);
         require_once __DIR__.'/OwnedEntity.php';
         $OwnedEntityService = new \org\gocdb\services\OwnedEntity();
-        $entityClassName = $OwnedEntityService->getOwnedEntityDerivedClassName($entity); 
-        //$entityClassName = $entity->getType(); // DQL is case sensitive for class names and field names, so can't use this 
+        $entityClassName = $OwnedEntityService->getOwnedEntityDerivedClassName($entity);
+        //$entityClassName = $entity->getType(); // DQL is case sensitive for class names and field names, so can't use this
 
         $dql = "SELECT r
             FROM Role r
@@ -332,15 +332,15 @@ class RoleActionAuthorisationService  extends AbstractEntityService  {
             AND o.id = :entityId
             AND r.status = :roleStatus
             AND o INSTANCE OF $entityClassName";
-        
+
         /* @var $query \Doctrine\ORM\Query */
         $query = $this->em->createQuery($dql)
                 ->setParameter('userId', $user->getId())
                 ->setParameter('roleStatus', $roleStatus)
                 ->setParameter('entityId', $entity->getId());
         $roles = $query->getResult();
-        return $roles; 
+        return $roles;
     }
 
-    
+
 }

--- a/lib/Gocdb_Services/RoleActionMappingService.php
+++ b/lib/Gocdb_Services/RoleActionMappingService.php
@@ -17,16 +17,16 @@ namespace org\gocdb\services;
 //require_once __DIR__ . '/AbstractEntityService.php';
 
 /**
- * Service for querying the Role-Action mapping definitions defined in a 
- * RoleActionMappings.xml file. 
+ * Service for querying the Role-Action mapping definitions defined in a
+ * RoleActionMappings.xml file.
  * <p>
  * The role action mappings xml file and its XSD can be configured for non-default
- * locations. The XSD defines the TNS specified by <code>ROLE_ACTION_MAPPING_NS</code>. 
+ * locations. The XSD defines the TNS specified by <code>ROLE_ACTION_MAPPING_NS</code>.
  * <p>
- * The mappings file is used to define which {@see \RoleType}s enable which actions on  
- * a target object(s) on a per-project basis. The role type names specified in 
- * the XML mappings file (mapped as <code>//RoleActionMapping/RoleNames/Role</code>) 
- * need to already exist in the DB as {@see \RoleType} entities.     
+ * The mappings file is used to define which {@see \RoleType}s enable which actions on
+ * a target object(s) on a per-project basis. The role type names specified in
+ * the XML mappings file (mapped as <code>//RoleActionMapping/RoleNames/Role</code>)
+ * need to already exist in the DB as {@see \RoleType} entities.
  *
  * @author David Meredith
  */
@@ -38,7 +38,7 @@ class RoleActionMappingService /* extends AbstractEntityService */ {
     const ROLE_ACTION_MAPPING_NS = 'http://goc.egi.eu/2015/03/spec1.0_r1';
 
     /**
-     * Service for querying the Role-Action mappings defined in the RoleActionMappingRules XML file. 
+     * Service for querying the Role-Action mappings defined in the RoleActionMappingRules XML file.
      */
     function __construct() {
         //parent::__construct();
@@ -47,31 +47,31 @@ class RoleActionMappingService /* extends AbstractEntityService */ {
     }
 
     /**
-     * Set the path to the XML role action mapping file, the default is: 
+     * Set the path to the XML role action mapping file, the default is:
      * <code>GOCDB_HOME/config/RoleActionMappingsSchema.xsd</code>
-     * @param string $xmlDocPath Path to role action mapping file. 
+     * @param string $xmlDocPath Path to role action mapping file.
      */
     public function setRoleActionMappingsXmlPath($xmlDocPath) {
         $this->roleActionMappingsXmlPath = $xmlDocPath;
     }
 
     /**
-     * Set the path to the XSD schema for the role action mapping file, the default is: 
+     * Set the path to the XSD schema for the role action mapping file, the default is:
      * <code>GOCDB_HOME/config/RoleActionMappingsSchema.xsd</code>
-     * @param string $xsdDocPath Path to XSD schema  
+     * @param string $xsdDocPath Path to XSD schema
      */
     public function setRoleActionMappingsXsdPath($xsdDocPath) {
         $this->roleActionMappingsXsdPath = $xsdDocPath;
     }
 
     /**
-     * Validate the XML file located at $roleActionMappingsXmlPath with the XSD 
-     * located at $roleActionMappingsXsdPath. 
-     * 
-     * @return array an array with LibXMLError objects if there are any errors 
+     * Validate the XML file located at $roleActionMappingsXmlPath with the XSD
+     * located at $roleActionMappingsXsdPath.
+     *
+     * @return array an array with LibXMLError objects if there are any errors
      * or an empty array otherwise.
-     * @throws \LogicException if XML/XSD fiels can't be loaded 
-     * @throws \Exception If the role action mapping file is invalid against its XSD.  
+     * @throws \LogicException if XML/XSD fiels can't be loaded
+     * @throws \Exception If the role action mapping file is invalid against its XSD.
      */
     public function validateRoleActionMappingFileAgainstXsd() {
         // http://stackoverflow.com/questions/12368453/domdocumentschemavalidate-throwing-warning-errors
@@ -81,135 +81,135 @@ class RoleActionMappingService /* extends AbstractEntityService */ {
             throw new \LogicException("Couldn't load RoleActionMappings file, "
             . "invalid roleActionMappingsXmlPath: [$this->roleActionMappingsXmlPath]");
         }
-        return $this->_validateRoleActionMappingFileAgainstXsd($xml);  
+        return $this->_validateRoleActionMappingFileAgainstXsd($xml);
     }
 
     private function _validateRoleActionMappingFileAgainstXsd(\DOMDocument $xml){
         if (!$xml->schemaValidate($this->roleActionMappingsXsdPath)) {
             return libxml_get_errors();
         }
-        return array(); 
+        return array();
     }
 
 
     /**
-     * Load and validate the role actions xml file referenced from $roleActionMappingsXmlPath; 
+     * Load and validate the role actions xml file referenced from $roleActionMappingsXmlPath;
      * @return \DOMDocument
      * @throws \LogicException
      */
     private function loadRoleActionsXmlFile(){
         //http://stackoverflow.com/questions/12368453/domdocumentschemavalidate-throwing-warning-errors
-        //libxml_use_internal_errors(true); 
-        // load file 
+        //libxml_use_internal_errors(true);
+        // load file
         $roleActionMapXmlDom = new \DOMDocument();
         if (FALSE === $roleActionMapXmlDom->load($this->roleActionMappingsXmlPath)) {
             throw new \LogicException("Couldn't load RoleActionMappings file, "
             . "invalid roleActionMappingsXmlPath: [$this->roleActionMappingsXmlPath].");
         }
-        
-        $errors = $this->_validateRoleActionMappingFileAgainstXsd($roleActionMapXmlDom); 
+
+        $errors = $this->_validateRoleActionMappingFileAgainstXsd($roleActionMapXmlDom);
         if(count($errors) > 0){
             throw new \LogicException("Invalid RoleActionMappingsFile "
                     . "[$this->roleActionMappingsXmlPath], use libxml_get_errors() "
-                    . "for error details."); 
+                    . "for error details.");
         }
-        return $roleActionMapXmlDom; 
+        return $roleActionMapXmlDom;
     }
 
 
     /**
-     * Query the role action mapping rules for the list of actions that are  
-     * enabled over different target object types by possession of a Role with 
+     * Query the role action mapping rules for the list of actions that are
+     * enabled over different target object types by possession of a Role with
      * the specified type.
      * <p>
-     * Each element in the returned 2D array is a child array that holds two 
-     * strings of the form: <code>array('ENABLED_ACTION', 'TargetObjectType')</code>.  
-     * For example: 
+     * Each element in the returned 2D array is a child array that holds two
+     * strings of the form: <code>array('ENABLED_ACTION', 'TargetObjectType')</code>.
+     * For example:
      * <code>
      *   $resultArray[0] = array('ACTION_EDIT_OBJECT', 'Site');
      *   $resultArray[1] = array('ACTION_GRANT_ROLE, 'Site');
      *   $resultArray[2] = array('ACTION_GRANT_ROLE, 'Ngi');
-     * </code> 
-     *   
-     * @param string $targetRoleTypeName The name of a role type, e.g. 'Site Administrator' 
-     * @return array 2D array, each element holds a 2 element string array  
+     * </code>
+     *
+     * @param string $targetRoleTypeName The name of a role type, e.g. 'Site Administrator'
+     * @return array 2D array, each element holds a 2 element string array
      */
     public function getEnabledActionsForRoleType($targetRoleTypeName){
-        // load file 
-        $roleActionMapXmlDom = $this->loadRoleActionsXmlFile(); 
-        
-        // create xpath and register namespace  
+        // load file
+        $roleActionMapXmlDom = $this->loadRoleActionsXmlFile();
+
+        // create xpath and register namespace
         $xpath = new \DOMXPath($roleActionMapXmlDom);
         $xpath->registerNamespace("goc", RoleActionMappingService::ROLE_ACTION_MAPPING_NS);
-        
-        // get the <RoleActionMapping> element
-        $roleActionMapping = $this->getRoleActionMapping($xpath); 
 
-        // Iterate all the <Role> elements and get the value 'id' attribute value 
-        // of the <Role> element corresponds to the given targetRoleTypeName 
-        // 
+        // get the <RoleActionMapping> element
+        $roleActionMapping = $this->getRoleActionMapping($xpath);
+
+        // Iterate all the <Role> elements and get the value 'id' attribute value
+        // of the <Role> element corresponds to the given targetRoleTypeName
+        //
          /* @var $roleNamesList DOMNodeList */
-        $roleNamesList = $xpath->query("goc:RoleNames", $roleActionMapping);  
+        $roleNamesList = $xpath->query("goc:RoleNames", $roleActionMapping);
         $roleId = NULL;
         foreach ($roleNamesList as $roleNames) {
-            //print_r($roleNames->nodeValue); 
+            //print_r($roleNames->nodeValue);
             //$over = $roleNames->getAttribute('over');
             $roles = $xpath->query("goc:Role", $roleNames);
             foreach ($roles as $role) {
-                //print_r($role->nodeValue); 
+                //print_r($role->nodeValue);
                 if($role->nodeValue == $targetRoleTypeName){
-                    // get the Role id and break 
-                    $roleId = $role->getAttribute('id'); 
-                    break; 
+                    // get the Role id and break
+                    $roleId = $role->getAttribute('id');
+                    break;
                 }
             }
-        } 
-        
-        // if the roleId wasn't found, then return an emtpy array - this means the 
-        // targetRoleTypeName isn't configured/defined in the role action mappings file, 
-        // which is perfectly normal e.g. to remove privilages for legacy role types.  
-        if($roleId == NULL){
-            return array(); 
         }
-        //print_r("roleId: ".$roleId."<br>"); 
+
+        // if the roleId wasn't found, then return an emtpy array - this means the
+        // targetRoleTypeName isn't configured/defined in the role action mappings file,
+        // which is perfectly normal e.g. to remove privilages for legacy role types.
+        if($roleId == NULL){
+            return array();
+        }
+        //print_r("roleId: ".$roleId."<br>");
 
         // xpath query all the <RoleMapping> elements that reference the $roleId
         /* @var $roleMappings DOMNodeList */
         $roleMappings = $xpath->query(
-                "goc:RoleMapping[goc:Roles/goc:RoleRef[@idRef='$roleId']]",  
+                "goc:RoleMapping[goc:Roles/goc:RoleRef[@idRef='$roleId']]",
                 $roleActionMapping);
 
-        // collect results 
-        $enabledActionsOnTargets = array(); 
+        // collect results
+        $enabledActionsOnTargets = array();
 
         foreach($roleMappings as $roleMapping){
             /* @var $enabledActions DOMNodeList */
-            $enabledActions = $xpath->query("goc:EnabledActions", $roleMapping); 
+            $enabledActions = $xpath->query("goc:EnabledActions", $roleMapping);
             foreach($enabledActions as $enabledAction){
                 /* @var $actions DOMNodeList */
-                $actions = $xpath->query("goc:Actions/goc:Action", $enabledAction); 
+                $actions = $xpath->query("goc:Actions/goc:Action", $enabledAction);
                 /* @var $targets DOMNodeList */
-                $targets = $xpath->query("goc:Target", $enabledAction);        
+                $targets = $xpath->query("goc:Target", $enabledAction);
                 foreach($actions as $action){
                     foreach($targets as $target){
-                       $enabledActionsOnTargets[] = array($action->nodeValue, $target->nodeValue);  
+                       $enabledActionsOnTargets[] = array($action->nodeValue, $target->nodeValue);
                     }
                 }
             }
         }
-        return $enabledActionsOnTargets; 
+        return $enabledActionsOnTargets;
     }
 
     /**
      * Return all of the Role type names defined for the named project.
      * <p>
-     * Note, the projectName is ignored and is nullable - the same role type names  
+     * Note, the projectName is ignored and is nullable - the same role type names
      * are returned for all projects (in future, different role types may need
-     * to be declared for differnt projects, but this is not yet implemented). 
-     * <p> 
-     * Returns an associative array where keys map to unique role type names 
-     * {@see \RoleType::getName()} and values define the name of the 
-     * {@see \OwnedEntity::getType()} type that the role is over. For example: 
+     * to be declared for differnt projects, but this is not yet implemented).
+     * <p>
+     * Returns an associative array where keys map to unique role type names
+     * {@see \RoleType::getName()} and values define the name of the
+     * {@see \OwnedEntity::getType()} type that the role is over. For example:
      * <code>
      *   $resultArray['Site Adminstrator'] = 'Site';
      *   $resultArray['Site Security Officer'] = 'Site';
@@ -217,133 +217,133 @@ class RoleActionMappingService /* extends AbstractEntityService */ {
      *   $resultArray['Service Group Administrator'] = 'ServiceGroup';
      *   ...
      * </code>
-     * Note, array values are NOT the target object type over which actions are enabled.     
-     * <p> 
-     * Keys are looked up from: <code>//RoleActionMapping/RoleNames/Role</code>.  
+     * Note, array values are NOT the target object type over which actions are enabled.
      * <p>
-     * Values are looked up from: <code>//RoleActionMapping/RoleNames[@over]</code>. 
-     * 
-     * @param string $projectName Currently ignored and is nullable 
-     * @return array Associative array of unique Role type names (keys) and the 
-     *   owned object type the role is over (value) 
-     * @throws \LogicException if XSD/XML files can't be loaded, 
-     *   or if the role action mappings can't be resolved.  
-     * @throws \Exception If the role action mapping file is invalid against its XSD.  
+     * Keys are looked up from: <code>//RoleActionMapping/RoleNames/Role</code>.
+     * <p>
+     * Values are looked up from: <code>//RoleActionMapping/RoleNames[@over]</code>.
+     *
+     * @param string $projectName Currently ignored and is nullable
+     * @return array Associative array of unique Role type names (keys) and the
+     *   owned object type the role is over (value)
+     * @throws \LogicException if XSD/XML files can't be loaded,
+     *   or if the role action mappings can't be resolved.
+     * @throws \Exception If the role action mapping file is invalid against its XSD.
      */
     public function getRoleTypeNamesForProject($projectName) {
-        //$projectName = 'WLCG'; //'EGI'; 
+        //$projectName = 'WLCG'; //'EGI';
         if ($projectName !== NULL && (!is_string($projectName) || strlen(trim($projectName)) == 0)) {
             throw new \LogicException('Invalid projectName');
         }
 
-        // Load file 
+        // Load file
         //http://stackoverflow.com/questions/12368453/domdocumentschemavalidate-throwing-warning-errors
-        //libxml_use_internal_errors(true); 
-         $roleActionMapXmlDom = $this->loadRoleActionsXmlFile(); 
+        //libxml_use_internal_errors(true);
+         $roleActionMapXmlDom = $this->loadRoleActionsXmlFile();
 
         $xpath = new \DOMXPath($roleActionMapXmlDom);
         $xpath->registerNamespace("goc", RoleActionMappingService::ROLE_ACTION_MAPPING_NS);
 
         // In future, may need to fetch different role action mappings on a per
-        // project basis - needs finishing if required.  
-        //$roleActionMapping = $this->getRoleActionMappingForProject($xpath, $projectName);  
-        $roleActionMapping = $this->getRoleActionMapping($xpath); 
-        //print_r($roleActionMapping); 
+        // project basis - needs finishing if required.
+        //$roleActionMapping = $this->getRoleActionMappingForProject($xpath, $projectName);
+        $roleActionMapping = $this->getRoleActionMapping($xpath);
+        //print_r($roleActionMapping);
 
         $roleNamesOver = array();
          /* @var $roleNamesList DOMNodeList */
-        $roleNamesList = $xpath->query("goc:RoleNames", $roleActionMapping);  
+        $roleNamesList = $xpath->query("goc:RoleNames", $roleActionMapping);
         foreach ($roleNamesList as $roleNames) {
-            //print_r($roleNames->nodeValue); 
+            //print_r($roleNames->nodeValue);
             $over = $roleNames->getAttribute('over');
             $roles = $xpath->query("goc:Role", $roleNames);
             foreach ($roles as $role) {
-                //print_r("[".$role->getAttribute('id'). "] [".$role->nodeValue."] [".$over."]\n");  
+                //print_r("[".$role->getAttribute('id'). "] [".$role->nodeValue."] [".$over."]\n");
                if (!array_key_exists($role->nodeValue, $roleNamesOver)) {
-                    $roleNamesOver[$role->nodeValue] = $over; // associative array 
+                    $roleNamesOver[$role->nodeValue] = $over; // associative array
                 } else {
                     throw new \LogicException("Duplicate Role value detected.");
-                } 
+                }
             }
-        } 
+        }
         return $roleNamesOver;
     }
 
     /**
-     * Return the Role type names that enable the specified action on the target 
-     * object type. 
+     * Return the Role type names that enable the specified action on the target
+     * object type.
      * <p>
-     * Note, the projectName param is ignored and is nullable - the same results  
+     * Note, the projectName param is ignored and is nullable - the same results
      * are returned for all projects (in future, different role types may need
-     * to be declared for differnt projects, but this is not yet implemented). 
+     * to be declared for differnt projects, but this is not yet implemented).
      * <p>
-     * Returns an associative array where keys map to unique role type names 
-     * {@see \RoleType::getName()} and values define the name of the 
-     * {@see \OwnedEntity::getType()} type that the role is over. For example: 
-     * <code> 
-     *   $resultArray['Site Administrator'] => 'Site'; 
-     *   $resultArray['NGI Operations Manager']  => 'Ngi';    
-     *   $resultArray['Chief Operations Officer'] => 'Project'; 
+     * Returns an associative array where keys map to unique role type names
+     * {@see \RoleType::getName()} and values define the name of the
+     * {@see \OwnedEntity::getType()} type that the role is over. For example:
+     * <code>
+     *   $resultArray['Site Administrator'] => 'Site';
+     *   $resultArray['NGI Operations Manager']  => 'Ngi';
+     *   $resultArray['Chief Operations Officer'] => 'Project';
      *   ...
      * </code>
      *
      * @param string $action The type of action, case-insensitive, matches to element value:
      *   <code>//RoleActionMapping/RoleMapping/EnabledActions/Actions</code>
-     * @param string $objectType The type of entity, case-insensitive, matches to element value: 
+     * @param string $objectType The type of entity, case-insensitive, matches to element value:
      *   <code>//RoleMapping/EnabledActions/Target</code>
-     * @param string $projectName Currently ignored and is nullable. 
-     * @return array Associative array where Role type names are keys and the 
-     * owned object type the role applies over is the value. Can be empty if no roles map to the requested action.  
-     * @throws \LogicException If role action mappings can't be resolved, or if the XML/XSD files are logically invalid.  
+     * @param string $projectName Currently ignored and is nullable.
+     * @return array Associative array where Role type names are keys and the
+     * owned object type the role applies over is the value. Can be empty if no roles map to the requested action.
+     * @throws \LogicException If role action mappings can't be resolved, or if the XML/XSD files are logically invalid.
      */
     public function getRoleTypeNamesThatEnableActionOnTargetObjectType($action, $objectType, $projectName) {
-        // fail early 
+        // fail early
         if (!is_string($action) || strlen(trim($action)) == 0) {
             throw new \LogicException('Invalid action');
         }
         if (!is_string($objectType) || strlen(trim($objectType)) == 0) {
             throw new \LogicException('Invalid entityType');
         }
-        
-//         IGNORE THIS COMMENT BLOCK - DECLARING DIFFERENT ROLE ACTION MAPPINGS PER  
-//       PROJECT MAY BE NEEDED IN FUTURE, BUT RIGHT NOW IT ADDS UNNECESSARY COMPLEXITY.   
+
+//         IGNORE THIS COMMENT BLOCK - DECLARING DIFFERENT ROLE ACTION MAPPINGS PER
+//       PROJECT MAY BE NEEDED IN FUTURE, BUT RIGHT NOW IT ADDS UNNECESSARY COMPLEXITY.
 //       IF THE NEED ARISES, THIS STUFF WILL BE USEFUL:
 //       =======================================================================
 //       if ($projectName !== NULL && (!is_string($projectName) || strlen(trim($projectName)) == 0)) {
 //            throw new \LogicException('Invalid projectName');
 //       }
-//     * The returned Role type names (keys) are looked up from:  
-//     * </code>RoleActionMapping/RoleNames/Role</code> for the specified project. 
-//     * The returned object-type names that the roles are over (values) are looked up from: 
+//     * The returned Role type names (keys) are looked up from:
+//     * </code>RoleActionMapping/RoleNames/Role</code> for the specified project.
+//     * The returned object-type names that the roles are over (values) are looked up from:
 //     * <code>RoleActionMapping/RoleNames[@over]</code> for the specified project.
-//     *         
-//     * @param string $projectName The projectName, case-insensitive, nullable, 
+//     *
+//     * @param string $projectName The projectName, case-insensitive, nullable,
 //     * if specified it matches to element value:
-//     *   <code>//RoleActionMapping/TargetProject</code>. 
-//     * If null, the default RoleActionMapping is queried. 
+//     *   <code>//RoleActionMapping/TargetProject</code>.
+//     * If null, the default RoleActionMapping is queried.
 //       =======================================================================
 
         // Upper case the parameters so we can perform case-insensitive matches
-        // when reading the XML file 
+        // when reading the XML file
         $entityTypeU = strtoupper($objectType);
         $actionU = strtoupper($action);
 
-        // Lets not use simplexml, DOMXPath is more powerful 
+        // Lets not use simplexml, DOMXPath is more powerful
         //$xml = simplexml_load_file($this->roleActionMappingsXmlPath);
-        //$xml->registerXPathNamespace('goc', RoleActionMappingService::ROLE_ACTION_MAPPING_NS); 
-        //$roleActionMapping = $xml->xpath("//goc:RoleActionMapping"); 
+        //$xml->registerXPathNamespace('goc', RoleActionMappingService::ROLE_ACTION_MAPPING_NS);
+        //$roleActionMapping = $xml->xpath("//goc:RoleActionMapping");
 
-        // load dom 
-        $roleActionMapXmlDom  = $roleActionMapXmlDom = $this->loadRoleActionsXmlFile(); 
+        // load dom
+        $roleActionMapXmlDom  = $roleActionMapXmlDom = $this->loadRoleActionsXmlFile();
 
-        // create xpath 
+        // create xpath
         $xpath = new \DOMXPath($roleActionMapXmlDom);
         $xpath->registerNamespace("goc", RoleActionMappingService::ROLE_ACTION_MAPPING_NS);
 
         // In future, may need to fetch different role action mappings on a per
-        // project basis - needs finishing if required. 
-        //$roleActionMapping = $this->getRoleActionMappingForProject($xpath, $projectName);  
-        $roleActionMapping = $this->getRoleActionMapping($xpath);  
+        // project basis - needs finishing if required.
+        //$roleActionMapping = $this->getRoleActionMappingForProject($xpath, $projectName);
+        $roleActionMapping = $this->getRoleActionMapping($xpath);
 
         /* @var $roleMappings DOMNodeList */
         $roleMappings = $xpath->query(
@@ -351,120 +351,120 @@ class RoleActionMappingService /* extends AbstractEntityService */ {
                 . "translate(text(), 'abcdefghijklmnopqrstuvwxyz', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ')]]", $roleActionMapping);
 
         //foreach ($roleMappings as $roleMapping) { print_r("[" . $roleMapping->nodeValue . "]\n"); }
-        // Iterate RoleMapping elements and identify/collect those that have a child 
+        // Iterate RoleMapping elements and identify/collect those that have a child
         // 'EnabledActions' element that groups together BOTH the required  Target $entityType
-        // AND the required $action listed in <Actions> e.g. 
-        // if $action = ACtion_EDIT_OBJECT and $entityType = SERviceGroup a 
-        // conforming element would be: 
-        // 
+        // AND the required $action listed in <Actions> e.g.
+        // if $action = ACtion_EDIT_OBJECT and $entityType = SERviceGroup a
+        // conforming element would be:
+        //
         //  <EnabledActions>
         //      <Actions>
         //            <Action>ACTION_EDIT_OBJECT</Action>
         //            <Action>ACTION_GRANT_ROLE</Action>
         //            <Action>ACTION_REJECT_ROLE</Action>
-        //            <Action>ACTION_REVOKE_ROLE</Action> 
-        //      </Actions>      
-        //      <Target>SERviceGroup</Target> 
-        //  </EnabledActions> 
-        // 
+        //            <Action>ACTION_REVOKE_ROLE</Action>
+        //      </Actions>
+        //      <Target>SERviceGroup</Target>
+        //  </EnabledActions>
+        //
         $inScopeRoleMappings = array();
         foreach ($roleMappings as $roleMapping) {
             //print_r("[" . $roleMapping->nodeValue . "]\n");
             // Filter the child <EnabledActions> to those that have the required <Target> entityType
             $enabledActionsNodes = $xpath->query(
-                    "goc:EnabledActions[goc:Target['$entityTypeU'=" // .'text()', 
+                    "goc:EnabledActions[goc:Target['$entityTypeU'=" // .'text()',
                     . "translate(text(), 'abcdefghijklmnopqrstuvwxyz', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ')]]", $roleMapping);
 
-            // Filter the <EnabledActions> to those that have the required <Action>    
+            // Filter the <EnabledActions> to those that have the required <Action>
             foreach ($enabledActionsNodes as $enabledAction) {
-                $actionsNodes = $xpath->query("goc:Actions", $enabledAction);  
+                $actionsNodes = $xpath->query("goc:Actions", $enabledAction);
                 foreach ($actionsNodes as $actionsNode){
-                    //print_r($actionsNode); 
-                    $actionsUpper = array(); 
-                    $actionNodes = $xpath->query('goc:Action', $actionsNode); 
+                    //print_r($actionsNode);
+                    $actionsUpper = array();
+                    $actionNodes = $xpath->query('goc:Action', $actionsNode);
                     foreach($actionNodes as $actionNode){
-                        //print_r($actionNode); 
-                        $actionVal = trim($actionNode->nodeValue); 
-                        //print_r($actionVal); 
-                        $actionsUpper[] = strtoupper($actionVal); 
+                        //print_r($actionNode);
+                        $actionVal = trim($actionNode->nodeValue);
+                        //print_r($actionVal);
+                        $actionsUpper[] = strtoupper($actionVal);
                     }
-                    //print_r($actionsUpper); 
-                    // Collect this RoleMapping, it has required action and target 
+                    //print_r($actionsUpper);
+                    // Collect this RoleMapping, it has required action and target
                     if(in_array($actionU, $actionsUpper)){
                         $inScopeRoleMappings[] = $roleMapping;
-                        //print_r($explodedActions);  
+                        //print_r($explodedActions);
                     }
                 }
-//                // when actions were listed as a single text node value using comma sep list e.g.  
+//                // when actions were listed as a single text node value using comma sep list e.g.
 //                //  <Actions>ACtion_EDIT_OBJECT,ACTION_GRANT_ROLE, ACTION_REJECT_ROLE, ACTION_REVOKE_ROLE</Actions>
 //                $actionsNodes = $xpath->query('goc:Actions[text()]', $enabledAction);
 //                foreach ($actionsTextNodes as $actionsText) {
-//                    //print_r($actionsText->nodeValue. "\n");  
+//                    //print_r($actionsText->nodeValue. "\n");
 //                    $explodedActionsMixedCase = explode(",", $actionsText->nodeValue);
 //                    $explodedActionsNotTrimmed = array_map('strtoupper', $explodedActionsMixedCase);
 //                    $explodedActions = array_map('trim', $explodedActionsNotTrimmed);
-//                    //print_r($explodedActions);  
-//                    // Collect this RoleMapping, it has required action and target 
+//                    //print_r($explodedActions);
+//                    // Collect this RoleMapping, it has required action and target
 //                    if (in_array($actionU, $explodedActions)) {
 //                        $inScopeRoleMappings[] = $roleMapping;
-//                        //print_r($explodedActions); 
+//                        //print_r($explodedActions);
 //                    }
 //                }
             }
         }
 
-        // collect the idRef val from RoleRef elements (these role Ids enable 
-        // the specifed actions on the target object. 
+        // collect the idRef val from RoleRef elements (these role Ids enable
+        // the specifed actions on the target object.
         $enablingRoleIds = array();
-        foreach ($inScopeRoleMappings as $inScopeRoleMapping) { 
-           $roleRef_Elements = $xpath->query("goc:Roles/goc:RoleRef", $inScopeRoleMapping);  
+        foreach ($inScopeRoleMappings as $inScopeRoleMapping) {
+           $roleRef_Elements = $xpath->query("goc:Roles/goc:RoleRef", $inScopeRoleMapping);
            foreach($roleRef_Elements as $roleRef){
-               $idRef_Att = $roleRef->getAttribute('idRef'); 
-               $enablingRoleIds[] = $idRef_Att;  
+               $idRef_Att = $roleRef->getAttribute('idRef');
+               $enablingRoleIds[] = $idRef_Att;
            }
         }
 
-        // Remove duplicates, its possible that someone specified two duplicate 
-        // <RoleRef> elements in a <Roles>, e.g: 
+        // Remove duplicates, its possible that someone specified two duplicate
+        // <RoleRef> elements in a <Roles>, e.g:
         // <Roles>
         //    <RoleRef idRef="RA"/>
         //    <RoleRef idRef="RA"/>
         //    <RoleRef idRef="RB"/>
         // <Roles>
-        $enablingRoleIds = array_unique($enablingRoleIds); 
-        //print_r($enablingRoleIds); 
+        $enablingRoleIds = array_unique($enablingRoleIds);
+        //print_r($enablingRoleIds);
         //return $enablingRoleIds;
 
-       
-        $enablingRoleNamesOver = array(); 
-        $roleNamesList = $xpath->query("goc:RoleNames", $roleActionMapping);  
+
+        $enablingRoleNamesOver = array();
+        $roleNamesList = $xpath->query("goc:RoleNames", $roleActionMapping);
         foreach ($roleNamesList as $roleNames) {
-            //print_r($roleNames->nodeValue); 
+            //print_r($roleNames->nodeValue);
             $over = $roleNames->getAttribute('over');
             $roles = $xpath->query("goc:Role", $roleNames);
             foreach ($roles as $role) {
-                //print_r("[".$role->getAttribute('id'). "] [".$role->nodeValue."] [".$over."]\n");  
+                //print_r("[".$role->getAttribute('id'). "] [".$role->nodeValue."] [".$over."]\n");
                 if (in_array($role->getAttribute('id'), $enablingRoleIds)) {
                     if (!array_key_exists($role->nodeValue, $enablingRoleNamesOver)) {
-                        $enablingRoleNamesOver[$role->nodeValue] = $over; // associative array 
+                        $enablingRoleNamesOver[$role->nodeValue] = $over; // associative array
                     } else {
                         throw new \LogicException("Duplicate Role value detected.");
                     }
                 }
             }
         }
-        return $enablingRoleNamesOver; 
+        return $enablingRoleNamesOver;
     }
 
 
     /**
-     * Get the (single) RoleActionMapping element from the XML file. 
+     * Get the (single) RoleActionMapping element from the XML file.
      * @param \DOMXPath $xpath
-     * @return DOMNode The RoleActionMapping element 
+     * @return DOMNode The RoleActionMapping element
      * @throws \LogicException
      */
     private function getRoleActionMapping(\DOMXPath $xpath) {
-        // Query for Single/Default RoleActionMapping element 
+        // Query for Single/Default RoleActionMapping element
         $roleActionMappings = $xpath->query(
                 "/goc:RoleActionMappingRules/goc:RoleActionMapping");
 
@@ -486,44 +486,44 @@ class RoleActionMappingService /* extends AbstractEntityService */ {
         return $roleActionMapping;
     }
 
-    
+
 
     /**
-     * NOT NEEDED (YET) - DECLARING DIFFERENT ROLE ACTION MAPPINGS PER PROJECT MAY BE 
-     * NEEDED IN FUTURE, BUT RIGHT NOW IT ADDS UNNECESSARY COMPLEXITY.   
-     * 
-     * Get the (single) RoleActionMapping element for the optional projectName. 
+     * NOT NEEDED (YET) - DECLARING DIFFERENT ROLE ACTION MAPPINGS PER PROJECT MAY BE
+     * NEEDED IN FUTURE, BUT RIGHT NOW IT ADDS UNNECESSARY COMPLEXITY.
+     *
+     * Get the (single) RoleActionMapping element for the optional projectName.
      * <p>
-     * Returns either a RoleActionMapping that specifies the named project 
+     * Returns either a RoleActionMapping that specifies the named project
      * using a nested TargetProject child element, or the default RoleActionMapping
-     * that applies to all projects (if defined). If null is specified for the 
-     * projectName, then the default RoleActionMapping is returned (if defined).    
-     * 
+     * that applies to all projects (if defined). If null is specified for the
+     * projectName, then the default RoleActionMapping is returned (if defined).
+     *
      * @param \DOMXPath $xpath
-     * @param string $projectName case-insensitive, nullable  
-     * @return DOMNode The RoleActionMapping element 
-     * @throws \LogicException If a RoleActionMapping element can't be resolved  
+     * @param string $projectName case-insensitive, nullable
+     * @return DOMNode The RoleActionMapping element
+     * @throws \LogicException If a RoleActionMapping element can't be resolved
      */
     /*private function getRoleActionMappingForProject(\DOMXPath $xpath, $projectName){
-        $roleActionMappings = NULL; 
-        
-        if($projectName !== NULL){
-            $projectNameU = strtoupper($projectName); 
+        $roleActionMappings = NULL;
 
-            // Query for all RoleMapping elements where there is a child 
+        if($projectName !== NULL){
+            $projectNameU = strtoupper($projectName);
+
+            // Query for all RoleMapping elements where there is a child
             // 'EnabledActions/Target' element with a text val == $entity type
-            // This version is case-sensitive version: 
+            // This version is case-sensitive version:
             //$roleMappings = $xpath->query("goc:RoleMapping[goc:EnabledActions/goc:Target[text()='$entityType']]", $roleActionMapping);
-            
-            // Use xpath to populate the roleActionMappings array with 
-            // the relevant elements for the requested action 
-            // First, query for any RoleActionMapping elements for the named project 
-            // i.e. those that have a child <TargetProject> with text value == $projectName 
-            // 
-            // Next comment-line shows case-sensitive version: 
+
+            // Use xpath to populate the roleActionMappings array with
+            // the relevant elements for the requested action
+            // First, query for any RoleActionMapping elements for the named project
+            // i.e. those that have a child <TargetProject> with text value == $projectName
+            //
+            // Next comment-line shows case-sensitive version:
             // $roleActionMappings = $xpath->query("/goc:RoleActionMappingRules/goc:RoleActionMapping[goc:TargetProject[text()='$projectName']]");
-            // Need to use translate() with XPath1.0 in order to perform a 
-            // case-insensitive comparison, see: 
+            // Need to use translate() with XPath1.0 in order to perform a
+            // case-insensitive comparison, see:
             // http://stackoverflow.com/questions/2893551/case-insensitive-matching-in-xpath
             $roleActionMappings = $xpath->query(
                     "/goc:RoleActionMappingRules/goc:RoleActionMapping"
@@ -536,34 +536,34 @@ class RoleActionMappingService /* extends AbstractEntityService */ {
 
             //print_r("ram Size: ".($roleActionMappings->length));
             //foreach($roleActionMappings as $ram){
-            //    print_r("[".$ram->nodeValue."]\n");     
-            //} 
+            //    print_r("[".$ram->nodeValue."]\n");
+            //}
 
             if ($roleActionMappings->length > 1) {
                 throw new \LogicException("There are multiple RoleActionMapping elements for the "
                 . "specified project when there should only be one - please check "
                 . "your RoleActionMapping XML file.", 20);
             }
-            
-            // Lets not throw if a RAM can't be found for the project because 
-            // its plausable that old/legacy Projects exist in the DB but are 
-            // not mapped in the XML file. In this scenario, attempt to  
-            // query the default RAM instead. 
+
+            // Lets not throw if a RAM can't be found for the project because
+            // its plausable that old/legacy Projects exist in the DB but are
+            // not mapped in the XML file. In this scenario, attempt to
+            // query the default RAM instead.
 //            if ($roleActionMappings->length == 0) {
 //                throw new \LogicException("Can't find a RoleActionMapping elements for the "
 //                . "specified project [$projectName] - please check "
 //                . "your RoleActionMapping XML file.", 20);
 //            }
-        } 
+        }
 
-        // 0 or 1 roleActionMapping DOMNodes 
+        // 0 or 1 roleActionMapping DOMNodes
         if ($roleActionMappings !== NULL && $roleActionMappings->length == 1) {
             $roleActionMapping = $roleActionMappings->item(0);
-            //print_r($roleActionMapping->nodeValue); 
+            //print_r($roleActionMapping->nodeValue);
         } else {
             // 0 found for specified project
-            // Fallback to Query for any Default RoleActionMapping elements that have no 
-            // child <TargetProject> nodes (used as default) 
+            // Fallback to Query for any Default RoleActionMapping elements that have no
+            // child <TargetProject> nodes (used as default)
             $roleActionMappings = $xpath->query(
                     "/goc:RoleActionMappingRules/goc:RoleActionMapping[not (goc:TargetProject)]");
 
@@ -584,7 +584,7 @@ class RoleActionMappingService /* extends AbstractEntityService */ {
             throw new \LogicException("Couldn't find a RoleActionMapping element for "
             . "specified project [$projectName] - check your RoleActionMapping XML file.", 30);
         }
-        return $roleActionMapping; 
+        return $roleActionMapping;
     }*/
 
 }

--- a/lib/Gocdb_Services/RoleConstants.php
+++ b/lib/Gocdb_Services/RoleConstants.php
@@ -33,7 +33,7 @@ class RoleStatus {
 }
 
 /**
- * Class for defining enum vals for role type definitions. 
+ * Class for defining enum vals for role type definitions.
  * <p>
  * @deprecated since version 5.5 RoleTypes are now defined in role action mapping xml file
  * Note, these enums should NOT be referenced from within the DB entities (entities
@@ -42,37 +42,37 @@ class RoleStatus {
  */
 class RoleTypeName {
 
-    const GOCDB_ADMIN = 'GOCDB_ADMIN'; 
-    
-    // Roles for Sites 
+    const GOCDB_ADMIN = 'GOCDB_ADMIN';
+
+    // Roles for Sites
     const SITE_ADMIN = 'Site Administrator'; // C
-    
+
     const SITE_SECOFFICER = 'Site Security Officer'; // C'
     const SITE_OPS_DEP_MAN = 'Site Operations Deputy Manager'; // C'
     const SITE_OPS_MAN = 'Site Operations Manager'; // C'
-    
-    // Roles for NGIs 
+
+    // Roles for NGIs
     const REG_FIRST_LINE_SUPPORT = 'Regional First Line Support'; // D
     const REG_STAFF_ROD = 'Regional Staff (ROD)'; // D
-    
+
     const NGI_SEC_OFFICER = 'NGI Security Officer'; // D'
     const NGI_OPS_DEP_MAN = 'NGI Operations Deputy Manager'; // D'
     const NGI_OPS_MAN = 'NGI Operations Manager'; // D'
-    
+
     // Roles for Projects
     const COD_STAFF = 'COD Staff'; // E
     const COD_ADMIN = 'COD Administrator'; // E
     const EGI_CSIRT_OFFICER = 'EGI CSIRT Officer'; // E
     const COO = 'Chief Operations Officer'; // E
-    
+
     // Roles for ServiceGroups
     const SERVICEGROUP_ADMIN = 'Service Group Administrator'; // ServiceGroupC'
-    
-    // "Other" roles that have slipped by us (see AddRoleTypes.php) 
-    const CIC_STAFF = 'CIC Staff'; // Pretty sure this role is not required anymore: https://rt.egi.eu/rt/Ticket/Display.html?id=931 
+
+    // "Other" roles that have slipped by us (see AddRoleTypes.php)
+    const CIC_STAFF = 'CIC Staff'; // Pretty sure this role is not required anymore: https://rt.egi.eu/rt/Ticket/Display.html?id=931
     const REG_STAFF = 'Regional Staff';
 
-    
+
     /*public static function getRoleTypeClass($roleName) {
         if ($roleName == RoleTypeName::SITE_ADMIN) {
             return 'C';
@@ -87,7 +87,7 @@ class RoleTypeName {
             return "D";
         }
         if ($roleName == RoleTypeName::NGI_SEC_OFFICER ||
-                $roleName == RoleTypeName::NGI_OPS_DEP_MAN || 
+                $roleName == RoleTypeName::NGI_OPS_DEP_MAN ||
                 $roleName == RoleTypeName::NGI_OPS_MAN ) {
             return "D'";
         }
@@ -123,37 +123,37 @@ class RoleTypeName {
 }
 
 /**
- * Define a list of different actions that apply over a target object. 
+ * Define a list of different actions that apply over a target object.
  * <p>
- * A user's granted Role enables a particular action over the target object. 
- * For example, RoleTypeName::SITE_OPS_DEP_MAN enables the ObjectAction::ACTION_EDIT_CERT_STATUS action. 
+ * A user's granted Role enables a particular action over the target object.
+ * For example, RoleTypeName::SITE_OPS_DEP_MAN enables the ObjectAction::ACTION_EDIT_CERT_STATUS action.
  */
 class Action {
-   
-    // Generic actions that can apply to a particular target object. 
-    const EDIT_OBJECT = 'ACTION_EDIT_OBJECT'; 
-    const READ_OBJECT = 'ACTION_READ_OBJECT'; 
-    const DELETE_OBJECT = 'ACTION_DELETE_OBJECT'; 
-    const GRANT_ROLE = 'ACTION_GRANT_ROLE'; 
-    const REJECT_ROLE = 'ACTION_REJECT_ROLE'; 
-    const REVOKE_ROLE = 'ACTION_REVOKE_ROLE'; 
-  
+
+    // Generic actions that can apply to a particular target object.
+    const EDIT_OBJECT = 'ACTION_EDIT_OBJECT';
+    const READ_OBJECT = 'ACTION_READ_OBJECT';
+    const DELETE_OBJECT = 'ACTION_DELETE_OBJECT';
+    const GRANT_ROLE = 'ACTION_GRANT_ROLE';
+    const REJECT_ROLE = 'ACTION_REJECT_ROLE';
+    const REVOKE_ROLE = 'ACTION_REVOKE_ROLE';
+
     // Actions that apply to NGIs
-    const NGI_ADD_SITE = 'ACTION_NGI_ADD_SITE'; // maybe EDIT_OBJECT will be sufficient 
-    
-    // Actions that apply to Sites 
-    const SITE_ADD_SERVICE = 'ACTION_SITE_ADD_SERVICE'; 
-    const SITE_DELETE_SERVICE = 'ACTION_SITE_DELETE_SERVICE'; 
-    const SITE_EDIT_CERT_STATUS = 'ACTION_SITE_EDIT_CERT_STATUS'; 
-    
+    const NGI_ADD_SITE = 'ACTION_NGI_ADD_SITE'; // maybe EDIT_OBJECT will be sufficient
+
+    // Actions that apply to Sites
+    const SITE_ADD_SERVICE = 'ACTION_SITE_ADD_SERVICE';
+    const SITE_DELETE_SERVICE = 'ACTION_SITE_DELETE_SERVICE';
+    const SITE_EDIT_CERT_STATUS = 'ACTION_SITE_EDIT_CERT_STATUS';
+
     // Actions that apply to Service
     //const SE_ADD_DOWNTIME = 'ACTION_SE_ADD_DOWNTIME';
-    
+
     /**
      * private constructor to limit instantiation
      */
     private function __construct() {
-    } 
+    }
 
     /**
      * Get an associative array of the class constants. Array keys are the constant

--- a/lib/Gocdb_Services/Scope.php
+++ b/lib/Gocdb_Services/Scope.php
@@ -24,21 +24,21 @@ require_once __DIR__ . '/Config.php';
  * @author George Ryall
  */
 class Scope extends AbstractEntityService{
-    protected $configService; 
+    protected $configService;
 
     function __construct() {
         parent::__construct();
-        $this->configService = new Config(); 
+        $this->configService = new Config();
     }
 
 
     /**
-     * Set the Conifg service used by this class. 
+     * Set the Conifg service used by this class.
      * <p>
      * Used to override the default Conf service created on class construction.
-     *  
+     *
      * @param \org\gocdb\services\Config $configService
-     */    
+     */
     public function setConfigService(Config $configService){
         $this->configService = $configService;
     }
@@ -59,52 +59,52 @@ class Scope extends AbstractEntityService{
      */
 
     /**
-     * Get either all scopes in the database or the scopes with the specified ids. 
-     * @param mixed $scopeIdArray Array of scope IDs as ints or null 
+     * Get either all scopes in the database or the scopes with the specified ids.
+     * @param mixed $scopeIdArray Array of scope IDs as ints or null
      * @return array An array of Scope objects
      */
     public function getScopes($scopeIdArray = NULL) {
-        // Note: empty array is converted to null by non-strict equal '==' comparison. 
+        // Note: empty array is converted to null by non-strict equal '==' comparison.
         // Use is_null() or '===' if there is possible of getting empty array.
         if($scopeIdArray === NULL){
-            // get all scopes in the DB by default 
+            // get all scopes in the DB by default
             $dql = "SELECT s from Scope s ORDER BY s.name";
             $query = $this->em->createQuery($dql);
             return $query->getResult();
-            
+
         } else if(count($scopeIdArray) > 0){
-            $dql = "SELECT s from Scope s WHERE s.id IN(:scopeIdArray) ORDER BY s.name"; 
+            $dql = "SELECT s from Scope s WHERE s.id IN(:scopeIdArray) ORDER BY s.name";
             $query = $this->em->createQuery($dql)->setParameter('scopeIdArray', $scopeIdArray);
             return $query->getResult();
         } else {
-            return array(); 
+            return array();
         }
     }
 
 
     /**
      * Return a new filtered array by filtering the given $scopeArray or all of the
-     * {@see \Scope}s in the DB according to the associative $filterParams. 
+     * {@see \Scope}s in the DB according to the associative $filterParams.
      * <p>
      * Supported parameters in $filterParams include:
      * <ul>
-     *   <li>'excludeDefault' => boolean (if true, exclude scopes that have a 
+     *   <li>'excludeDefault' => boolean (if true, exclude scopes that have a
      *       default value listed in the 'local_info.xml' config file</li>
      *   <li>'excludeNonDefault' => boolean (if true exclude scopes that are not default)</li>
-     *   <li>'excludeReserved' => boolean (if true, exclude 'reserved' scopes, 
+     *   <li>'excludeReserved' => boolean (if true, exclude 'reserved' scopes,
      *      i.e. those that are listed as reserved in the the 'local_info.xml' config file</li>
-     *   <li>'excludeNonReserved' => boolean (if true, exclude 'normal' scopes, 
+     *   <li>'excludeNonReserved' => boolean (if true, exclude 'normal' scopes,
      *     i.e. those that are not listed as reserved in the the 'local_info.xml' config file</li>
      * </ul>
-     * 
-     * @param array $filterParams Associative array 
-     * @param mixed $scopeArray Array of {@see \Scope} entities or null to filter 
-     *   all scopes in the DB.   
-     * @return array New array of \Scope instances 
+     *
+     * @param array $filterParams Associative array
+     * @param mixed $scopeArray Array of {@see \Scope} entities or null to filter
+     *   all scopes in the DB.
+     * @return array New array of \Scope instances
      */
     public function getScopesFilterByParams(array $filterParams, $scopeArray) {
-        // The filterParams array can be extended with new key/val pairs. E.g.  
-        // 'excludeProvided' => array(of Scope instances to filter/exclude) from results 
+        // The filterParams array can be extended with new key/val pairs. E.g.
+        // 'excludeProvided' => array(of Scope instances to filter/exclude) from results
 
         if (!is_null($scopeArray)) {
             //Check that each entity scope is a scope
@@ -113,13 +113,13 @@ class Scope extends AbstractEntityService{
                     throw new \InvalidArgumentException("object is not an instance of Scope.");
                 }
             }
-            $allScopes = $scopeArray; 
+            $allScopes = $scopeArray;
         } else {
-            $allScopes = $this->getScopes(); 
+            $allScopes = $this->getScopes();
         }
-        
+
         // Check the parameter keys are supoported
-        $supportedParams = array('excludeNonDefault', 'excludeDefault', 'excludeReserved', 'excludeNonReserved'); 
+        $supportedParams = array('excludeNonDefault', 'excludeDefault', 'excludeReserved', 'excludeNonReserved');
     $testParamKeys = array_keys($filterParams);
     foreach ($testParamKeys as $key) {
         // if givenkey is not defined in supportedkeys it is unsupported
@@ -127,49 +127,49 @@ class Scope extends AbstractEntityService{
         throw new \InvalidArgumentException('Unsupported parameter key');
         }
     }
-        
+
         $defaultScopeName = $this->configService->getDefaultScopeName();
 
         if (isset($filterParams['excludeNonDefault']) && $filterParams['excludeNonDefault'] == TRUE) {
             foreach ($allScopes as $scope) {
                 if ($scope->getName() != $defaultScopeName) {
-                    unset($allScopes[array_search($scope, $allScopes)]); 
+                    unset($allScopes[array_search($scope, $allScopes)]);
                 }
             }
         }
         if (isset($filterParams['excludeDefault']) && $filterParams['excludeDefault'] == TRUE) {
             foreach ($allScopes as $scope) {
                 if ($scope->getName() == $defaultScopeName) {
-                    unset($allScopes[array_search($scope, $allScopes)]); 
+                    unset($allScopes[array_search($scope, $allScopes)]);
                 }
             }
         }
         if(isset($filterParams['excludeReserved']) && $filterParams['excludeReserved'] == TRUE){
-            $reservedScopes = $this->configService->getReservedScopeList(); 
+            $reservedScopes = $this->configService->getReservedScopeList();
             foreach ($allScopes as $scope) {
                 foreach($reservedScopes as $rs){
                    if($scope->getName() == $rs){
-                       unset($allScopes[array_search($scope, $allScopes)]); 
+                       unset($allScopes[array_search($scope, $allScopes)]);
                    }
                 }
             }
         }
         if(isset($filterParams['excludeNonReserved']) && $filterParams['excludeNonReserved'] == TRUE){
-            $reservedScopes = $this->configService->getReservedScopeList(); 
+            $reservedScopes = $this->configService->getReservedScopeList();
             foreach ($allScopes as $scope) {
-                $isReserved = false; 
+                $isReserved = false;
                 foreach($reservedScopes as $rs){
                    if($scope->getName() == $rs){
-                       $isReserved = true; 
-                       break; 
+                       $isReserved = true;
+                       break;
                    }
                 }
                 if(!$isReserved){
-                   unset($allScopes[array_search($scope, $allScopes)]);  
+                   unset($allScopes[array_search($scope, $allScopes)]);
                 }
             }
         }
-        return $allScopes;  
+        return $allScopes;
     }
 
     /**
@@ -182,14 +182,14 @@ class Scope extends AbstractEntityService{
                      ->setParameter('id', $id);
         return $query->getSingleResult();
     }
-    
+
     /**
      * Finds all sites with a given scope tag
-     * @param \Scope $scope 
+     * @param \Scope $scope
      * @return array collection of sites with specified scope
      */
     public function getSitesFromScope(\Scope $scope){
-        $dql = "SELECT si 
+        $dql = "SELECT si
                 FROM Site si
                 JOIN si.scopes sc
                 WHERE sc.id = :id
@@ -201,11 +201,11 @@ class Scope extends AbstractEntityService{
 
      /**
      * Finds all NGIs with a given scope tag
-     * @param \Scope $scope 
+     * @param \Scope $scope
      * @return array collection of NGIs with specified scope
      */
     public function getNgisFromScope(\Scope $scope){
-        $dql = "SELECT n 
+        $dql = "SELECT n
                 FROM NGI n
                 JOIN n.scopes sc
                 WHERE sc.id = :id
@@ -214,14 +214,14 @@ class Scope extends AbstractEntityService{
                           ->setParameter(":id", $scope->getId());
         return $query->getResult();
     }
-    
+
      /**
      * Finds all Service Groups with a given scope tag
-     * @param \Scope $scope 
+     * @param \Scope $scope
      * @return array collection of service groups with specified scope
      */
     public function getServiceGroupsFromScope(\Scope $scope){
-        $dql = "SELECT sg 
+        $dql = "SELECT sg
                 FROM ServiceGroup sg
                 JOIN sg.scopes sc
                 WHERE sc.id = :id
@@ -230,10 +230,10 @@ class Scope extends AbstractEntityService{
                           ->setParameter(":id", $scope->getId());
         return $query->getResult();
     }
-    
+
      /**
      * Finds all services with a given scope tag
-     * @param \Scope $scope 
+     * @param \Scope $scope
      * @return array collection of services with specified scope
      */
     public function getServicesFromScope(\Scope $scope){
@@ -246,14 +246,14 @@ class Scope extends AbstractEntityService{
                           ->setParameter(":id", $scope->getId());
         return $query->getResult();
     }
-    
+
     /**
-     * Deletes a scope. throws an error if the scope is in use, unless $inUse 
-     * Overide is set to true 
-     * 
+     * Deletes a scope. throws an error if the scope is in use, unless $inUse
+     * Overide is set to true
+     *
      * @param \scope $scope         Scope to be deleted
      * @param \User $user           User doing the deltion
-     * @param boolean $inUseOveride If true, then the fact the scope is currently in use is ignored.   
+     * @param boolean $inUseOveride If true, then the fact the scope is currently in use is ignored.
      * @throws \Exception
      */
     public function deleteScope(\scope $scope, \User $user= null, $inUseOveride=false){
@@ -262,14 +262,14 @@ class Scope extends AbstractEntityService{
 
         //Throws exception if user is not an administrator
         $this->checkUserIsAdmin($user);
-        
+
         // get details of entities currently using this scope
         $ngis = $this->getNgisFromScope($scope);
         $sites =$this->getSitesFromScope($scope);
         $serviceGroups = $this->getServiceGroupsFromScope($scope);
         $services = $this->getServicesFromScope($scope);
-               
-        
+
+
         if (!$inUseOveride){
             //check to see if there are NGIs, Sites, Service Groups, & services
             // with this scope tag. If there are, throw exception.
@@ -286,7 +286,7 @@ class Scope extends AbstractEntityService{
               throw new Exception("This scope tag is still applied to one or more NGIs. ". $scope->getName() ."can not be deleted until these links are removed");
             }
         }
-        
+
         //Start a transaction
         $this->em->getConnection()->beginTransaction();
         try {
@@ -320,7 +320,7 @@ class Scope extends AbstractEntityService{
             throw $e;
         }
     }
-    
+
     /**
      * Adds a new scope
      * @param array $values array containing the name of the new scope
@@ -334,7 +334,7 @@ class Scope extends AbstractEntityService{
 
         //Throws exception if user is not an administrator
         $this->checkUserIsAdmin($user);
-        
+
         //Check the values are actually there, the name is unique and validate the values as per the GOCDB schema
         $this->validate($values, true);
 
@@ -346,7 +346,7 @@ class Scope extends AbstractEntityService{
             //set name
             $scope->setName($values['Name']);
             $scope->setDescription($values['Description']);
-            
+
             $this->em->persist($scope);
             $this->em->flush();
             $this->em->getConnection()->commit();
@@ -354,11 +354,11 @@ class Scope extends AbstractEntityService{
             $this->em->getConnection()->rollback();
             $this->em->close();
             throw $e;
-        }        
+        }
 
         return $scope;
     }
-    
+
     /**
      * Edit an existing scope
      * @param \Scope $scope the scope to be changed
@@ -373,7 +373,7 @@ class Scope extends AbstractEntityService{
 
         //Throws exception if user is not an administrator
         $this->checkUserIsAdmin($user);
-        
+
         //Validate the values as per the GOCDB schema and check values are present and valid and check the name is unique, if it has changed.
         $this->validate($newValues, false, $scope->getName());
 
@@ -383,7 +383,7 @@ class Scope extends AbstractEntityService{
             //set name
             $scope->setName($newValues['Name']);
             $scope->setDescription($newValues['Description']);
-            
+
             $this->em->merge($scope);
             $this->em->flush();
             $this->em->getConnection()->commit();
@@ -391,27 +391,27 @@ class Scope extends AbstractEntityService{
             $this->em->getConnection()->rollback();
             $this->em->close();
             throw $e;
-        }        
+        }
 
         return $scope;
     }
 
-    
-    
+
+
     /**
-     * Returns a 2D array - each element wraps an associative array for every 
-     * Scope in the DB; each child array nests a Scope and a boolean to indicate if 
-     * the Scope appears in the given array.  
+     * Returns a 2D array - each element wraps an associative array for every
+     * Scope in the DB; each child array nests a Scope and a boolean to indicate if
+     * the Scope appears in the given array.
      * <p>
-     * Used to provide checkboxes for scope selection when editing 
+     * Used to provide checkboxes for scope selection when editing
      * exisiting entities in the web portal
      * <p>
-     * Each element nests a child associative array; 
+     * Each element nests a child associative array;
      * array( 'scope' => {@see \Scope}, 'applied' => boolean )
-     * 
-     * @param array $entityScopes \Scope objects 
-     * @return array 2D Array - elements are associative arrays containing the \Scope and a boolean   
-     * @throws \LogicException if given collection does not contain {@see \Scope} instances.  
+     *
+     * @param array $entityScopes \Scope objects
+     * @return array 2D Array - elements are associative arrays containing the \Scope and a boolean
+     * @throws \LogicException if given collection does not contain {@see \Scope} instances.
      */
     public function getAllScopesMarkProvided($entityScopes){
         //Check that each entity scope is a scope
@@ -420,7 +420,7 @@ class Scope extends AbstractEntityService{
                 throw new \LogicException("object is not a scope.");
             }
         }
-        
+
         //create an array containing scopes that can be applied to an entity
         // and wheter or not they appear in the $entityScopes list
         $scopeArray=array();
@@ -434,30 +434,30 @@ class Scope extends AbstractEntityService{
             }
             $scopeArray[]=$innerArray;
         }
-        
+
         return $scopeArray;
     }
-    
+
     /**
-     * Returns a 2D array - each element wraps an associative array for every 
-     * Scope in the DB; each child array nests a Scope and a boolean to indicate if 
-     * the Scope is a default scope.  
+     * Returns a 2D array - each element wraps an associative array for every
+     * Scope in the DB; each child array nests a Scope and a boolean to indicate if
+     * the Scope is a default scope.
      * <p>
-     * Used to provide checkboxes for scope selection when adding new entities in the web portal. 
+     * Used to provide checkboxes for scope selection when adding new entities in the web portal.
      * <p>
-     * Each element nests a 2D child associative array; 
+     * Each element nests a 2D child associative array;
      * array( 'scope' => {@see \Scope}, 'applied' => boolean )
-     * 
-     * @return array 2D Array - elements are associative arrays containing the \Scope and a boolean  
+     *
+     * @return array 2D Array - elements are associative arrays containing the \Scope and a boolean
      */
     public function getAllScopesMarkDefault(){
         //create an array containing scopes that can be applied to an entity
         // and wheter or not they appear in the $entityScopes list
         $scopeArray=array();
         $scopes = $this->getScopes();
-        
+
         $defaultScopeName = $this->configService->getDefaultScopeName();
-        
+
         foreach ($scopes as $scope) {
             $innerArray = array('scope'=>$scope, 'applied' => false);
             if ($scope->getName() == $defaultScopeName){
@@ -485,15 +485,15 @@ class Scope extends AbstractEntityService{
         else {
             return false;
         }
-        
+
     }
-    
+
     /**
      * Performs some basic checks on the values aray and then validates the user
      * inputted scope type data against the data in the gocdb_schema.xml.
      * @param array $scopeData containing all the fields for a GOCDB scope object
      * @param boolean $scopeIsNew true if the values are for a new scope
-     * @param string $oldScopeName name of the sope before this cvhange. Only 
+     * @param string $oldScopeName name of the sope before this cvhange. Only
      *                             relevant if scopeIsNew = false
      * @throws \Exception If the project's data can't be
      *                    validated. The \Exception message will contain a human
@@ -539,4 +539,4 @@ class Scope extends AbstractEntityService{
         }
     }
 
-}      
+}

--- a/lib/Gocdb_Services/Search.php
+++ b/lib/Gocdb_Services/Search.php
@@ -20,24 +20,24 @@ namespace org\gocdb\services;
  * @author David Meredith
  */
 class Search {
-    private $em; 
+    private $em;
 
     public function __construct() {
     }
 
     /**
-     * Set the EntityManager instance used by all service methods. 
+     * Set the EntityManager instance used by all service methods.
      * @param \Doctrine\ORM\EntityManager $em
      */
     public function setEntityManager(\Doctrine\ORM\EntityManager $em){
-        $this->em = $em;  
+        $this->em = $em;
     }
-    
+
     /**
-     * @return \Doctrine\ORM\EntityManager 
+     * @return \Doctrine\ORM\EntityManager
      */
     public function getEntityManager(){
-        return $this->em; 
+        return $this->em;
     }
 
     /*

--- a/lib/Gocdb_Services/SecurityContextSource.php
+++ b/lib/Gocdb_Services/SecurityContextSource.php
@@ -1,23 +1,23 @@
 <?php
 
 /**
- * Storage for an external security context object that may be set to 
- * authenticate users. This object is queried from within the 
- * 'htdocs/web_portal/components/Get_User_Principle.php' to see 
- * if a security context has been set for the current request.    
- * The context would need to be set before the Gocdb front 
- * controller is invoked. 
+ * Storage for an external security context object that may be set to
+ * authenticate users. This object is queried from within the
+ * 'htdocs/web_portal/components/Get_User_Principle.php' to see
+ * if a security context has been set for the current request.
+ * The context would need to be set before the Gocdb front
+ * controller is invoked.
  *
  * @author David Meredith
  */
 class SecurityContextSource {
-    private static $context = null; 
+    private static $context = null;
 
     public static function setContext($context){
-        self::$context = $context; 
+        self::$context = $context;
     }
     public static function getContext(){
-        return self::$context; 
+        return self::$context;
     }
 }
 

--- a/lib/Gocdb_Services/ServiceGroup.php
+++ b/lib/Gocdb_Services/ServiceGroup.php
@@ -14,7 +14,7 @@ namespace org\gocdb\services;
 require_once __DIR__ . '/AbstractEntityService.php';
 require_once __DIR__ . '/Role.php';
 require_once __DIR__ . '/RoleConstants.php';
-require_once __DIR__ . '/RoleActionAuthorisationService.php'; 
+require_once __DIR__ . '/RoleActionAuthorisationService.php';
 require_once __DIR__.  '/Scope.php';
 require_once __DIR__.  '/Config.php';
 
@@ -27,7 +27,7 @@ require_once __DIR__.  '/Config.php';
  * @author George Ryall
  */
 class ServiceGroup extends AbstractEntityService{
-    
+
     /*
      * All the public service methods in a service facade are typically atomic -
      * they demarcate the tx boundary at the start and end of the method
@@ -44,34 +44,34 @@ class ServiceGroup extends AbstractEntityService{
      */
 
     private $roleActionAuthorisationService;
-    private $scopeService; 
-    private $configService; 
+    private $scopeService;
+    private $configService;
 
     function __construct(/*$roleActionAuthorisationService*/) {
         parent::__construct();
         //$this->roleActionAuthorisationService = $roleActionAuthorisationService;
-         $this->configService = new Config(); 
+         $this->configService = new Config();
     }
 
     /**
-     * Set class dependency (REQUIRED). 
-     * @todo Mandatory objects should be injected via constructor. 
+     * Set class dependency (REQUIRED).
+     * @todo Mandatory objects should be injected via constructor.
      * @param \org\gocdb\services\Scope $scopeService
      */
     public function setScopeService(Scope $scopeService){
-        $this->scopeService = $scopeService; 
+        $this->scopeService = $scopeService;
     }
 
     /**
-     * Set class dependency (REQUIRED). 
-     * @todo Mandatory objects should be injected via constructor. 
+     * Set class dependency (REQUIRED).
+     * @todo Mandatory objects should be injected via constructor.
      * @param \org\gocdb\services\RoleActionAuthorisationService $roleActionAuthService
      */
     public function setRoleActionAuthorisationService(RoleActionAuthorisationService $roleActionAuthService){
-        $this->roleActionAuthorisationService = $roleActionAuthService; 
+        $this->roleActionAuthorisationService = $roleActionAuthService;
     }
-    
-    
+
+
 
     /**
      * Finds a single service group by ID and returns its entity
@@ -91,17 +91,17 @@ class ServiceGroup extends AbstractEntityService{
     }
 
     /**
-     * Return all {@see \ServiceGroup}s that satisfy the specfied filter parameters. 
-     * <p>  
-     * $filterParams defines an associative array of optional parameters for 
-     * filtering the serviceGroups. The supported Key => Value pairs include: 
+     * Return all {@see \ServiceGroup}s that satisfy the specfied filter parameters.
+     * <p>
+     * $filterParams defines an associative array of optional parameters for
+     * filtering the serviceGroups. The supported Key => Value pairs include:
      * <ul>
      *   <li>'scope' => 'String,comma,sep,list,of,scopes,e.g.,egi,wlcg'</li>
      *   <li>'service_group_name' => String name of service group</li>
      *   <li>'scope_match' => String 'any' or 'all' </li>
      *   <li>'extensions' => String extensions expression to filter custom key=value pairs</li>
      * <ul>
-     * 
+     *
      * @param array $filterParams
      * @return array ServiceGroup array
      */
@@ -115,10 +115,10 @@ class ServiceGroup extends AbstractEntityService{
     }
 
     /**
-     * Returns an array of all Service Group entities and joined scopes. 
+     * Returns an array of all Service Group entities and joined scopes.
      * @param string $scope Scope name
      * @param string $keyname ServiceGroup extension property key name
-     * @param string $keyvalue ServiceGroup extension property key value 
+     * @param string $keyvalue ServiceGroup extension property key value
      * @return array An array of ServiceGroup objects
      */
     public function getServiceGroups($scope = NULL, $keyname = NULL, $keyvalue = NULL) {
@@ -156,7 +156,7 @@ class ServiceGroup extends AbstractEntityService{
     /**
      * Returns the downtimes linked to a service group.
      * @param integer $id Service Group ID
-     * @param integer $dayLimit Limit to downtimes that are only $dayLimit old (can be null) 
+     * @param integer $dayLimit Limit to downtimes that are only $dayLimit old (can be null)
      */
     public function getDowntimes($id, $dayLimit) {
         if($dayLimit != null) {
@@ -237,38 +237,38 @@ class ServiceGroup extends AbstractEntityService{
         }
         $this->validate($newValues['SERVICEGROUP']);
 
-        // EDIT SCOPE TAGS: 
+        // EDIT SCOPE TAGS:
         // collate selected scopeIds (reserved and non-reserved)
-        $scopeIdsToApply = array(); 
+        $scopeIdsToApply = array();
         foreach($newValues['Scope_ids'] as $sid){
-            $scopeIdsToApply[] = $sid; 
+            $scopeIdsToApply[] = $sid;
         }
         foreach($newValues['ReservedScope_ids'] as $sid){
-            $scopeIdsToApply[] = $sid; 
+            $scopeIdsToApply[] = $sid;
         }
-        $selectedScopesToApply = $this->scopeService->getScopes($scopeIdsToApply); 
+        $selectedScopesToApply = $this->scopeService->getScopes($scopeIdsToApply);
         // Check Reserved scopes
-        // When normal users EDIT the site, the selected scopeIds should 
+        // When normal users EDIT the site, the selected scopeIds should
         // be checked to prevent users manually crafting a POST request in an attempt
-        // to select reserved scopes, this is unlikely but it is a possible hack. 
-        // 
-        // Note, on edit we also don't want to enforce cascading of parent NGI scopes to the site,  
-        // as we need to allow an admin to de-select a site's reserved scopes 
-        // (which is a perfectly valid requirement) and prevent re-cascading 
-        // when the user next edits the site! 
+        // to select reserved scopes, this is unlikely but it is a possible hack.
+        //
+        // Note, on edit we also don't want to enforce cascading of parent NGI scopes to the site,
+        // as we need to allow an admin to de-select a site's reserved scopes
+        // (which is a perfectly valid requirement) and prevent re-cascading
+        // when the user next edits the site!
         if (!$user->isAdmin()) {
             $selectedReservedScopes = $this->scopeService->getScopesFilterByParams(
-                    array('excludeNonReserved' => true), $selectedScopesToApply);  
-            
+                    array('excludeNonReserved' => true), $selectedScopesToApply);
+
             $existingReservedScopes = $this->scopeService->getScopesFilterByParams(
-                    array('excludeNonReserved' => true), $sg->getScopes()->toArray()); 
-            
+                    array('excludeNonReserved' => true), $sg->getScopes()->toArray());
+
             if(count($selectedReservedScopes) != count($existingReservedScopes)) {
-                throw new \Exception("The reserved Scope count does not match the ServiceGroups existing scope count "); 
+                throw new \Exception("The reserved Scope count does not match the ServiceGroups existing scope count ");
             }
             foreach($selectedReservedScopes as $sc){
                 if(!in_array($sc, $existingReservedScopes)){
-                    throw new \Exception("A reserved Scope Tag was selected that is not already assigned to the ServiceGroup"); 
+                    throw new \Exception("A reserved Scope Tag was selected that is not already assigned to the ServiceGroup");
                 }
             }
         }
@@ -308,7 +308,7 @@ class ServiceGroup extends AbstractEntityService{
 //                $sg->addScope($scope);
 //            }
             foreach($selectedScopesToApply as $scope){
-                $sg->addScope($scope); 
+                $sg->addScope($scope);
             }
 
             $this->em->merge($sg);
@@ -322,8 +322,8 @@ class ServiceGroup extends AbstractEntityService{
         return $sg;
     }
 
-    
-    
+
+
 
     /**
      * Validates the user inputted service group data against the
@@ -375,7 +375,7 @@ class ServiceGroup extends AbstractEntityService{
     /**
      * Removes a service from a service group
      * @param \ServiceGroup $sg The service group
-     * @param \Service $se The service 
+     * @param \Service $se The service
      */
     public function removeService(\ServiceGroup $sg, \Service $se, \User $user = null) {
         //Check the portal is not in read only mode, throws exception if it is
@@ -416,7 +416,7 @@ class ServiceGroup extends AbstractEntityService{
         //Check the portal is not in read only mode, throws exception if it is
         $this->checkPortalIsNotReadOnlyOrUserIsAdmin($user);
 
-        // Any registered user can create a service group. 
+        // Any registered user can create a service group.
 
         if (is_null($user)) {
             throw new \Exception("Unregistered users can't create service groups.");
@@ -428,18 +428,18 @@ class ServiceGroup extends AbstractEntityService{
         $this->validate($values['SERVICEGROUP']);
         $this->uniqueCheck($values['SERVICEGROUP']['NAME']);
 
-        // ADD SCOPE TAGS: 
+        // ADD SCOPE TAGS:
         // collate selected reserved and non-reserved scopeIds
-        $allSelectedScopeIds = array(); 
+        $allSelectedScopeIds = array();
         foreach($values['Scope_ids'] as $sid){
-            $allSelectedScopeIds[] = $sid; 
+            $allSelectedScopeIds[] = $sid;
         }
         // only admin can add reserved scopes as unlike sites/serivces,
-        // the reserved scopes can't be inherited from a parent. 
+        // the reserved scopes can't be inherited from a parent.
         if($user->isAdmin()){
-            // if user is admin, allow them to add any reserved scope tag 
+            // if user is admin, allow them to add any reserved scope tag
             foreach($values['ReservedScope_ids'] as $sid){
-                $allSelectedScopeIds[] = $sid; 
+                $allSelectedScopeIds[] = $sid;
             }
         }
 
@@ -510,13 +510,13 @@ class ServiceGroup extends AbstractEntityService{
      * @param \User $user
      * @param $isTest when unit testing this allows for true to be supplied and this method
      * will not attempt to archive the sg which can easily cause errors for sg objects without
-     * a full set of information  
+     * a full set of information
      */
     public function deleteServiceGroup(\ServiceGroup $sg, \User $user = null, $isTest=false) {
         require_once __DIR__ . '/../DAOs/ServiceGroupDAO.php';
         //Check the portal is not in read only mode, throws exception if it is
         $this->checkPortalIsNotReadOnlyOrUserIsAdmin($user);
-        
+
         if ($this->roleActionAuthorisationService->authoriseAction(
                 \Action::EDIT_OBJECT, $sg, $user)->getGrantAction() == FALSE) {
             throw new \Exception("You don't have permission over this service group.");
@@ -527,8 +527,8 @@ class ServiceGroup extends AbstractEntityService{
             $sgDAO = new \ServiceGroupDAO;
             $sgDAO->setEntityManager($this->em);
             // TODO If this SG contains siteless services, delete them
-            
-            //Archive site - if this is a test then don't archive            
+
+            //Archive site - if this is a test then don't archive
             if($isTest==false){
                 //Create entry in Audit table
                 $sgDAO->addServiceGroupToArchive($sg, $user);
@@ -543,7 +543,7 @@ class ServiceGroup extends AbstractEntityService{
             throw $e;
         }
     }
-    
+
     private function checkNumberOfScopes($scopeIds){
         require_once __DIR__ . '/Config.php';
         $configService = new \org\gocdb\services\Config();
@@ -552,9 +552,9 @@ class ServiceGroup extends AbstractEntityService{
             throw new \Exception("A service group must have at least " . $minumNumberOfScopes . " scope(s) assigned to it.");
         }
     }
-    
+
     /**
-     * This method will check that a user has edit permissions over a service 
+     * This method will check that a user has edit permissions over a service
      * group before allowing a user to add, edit or delete a site property.
      *
      * @param \User $user
@@ -564,13 +564,13 @@ class ServiceGroup extends AbstractEntityService{
     public function validatePropertyActions(\User $user, \ServiceGroup $sg){
         // Check to see whether the user has a role that covers this site
 //        if(count($this->authorize Action(\Action::EDIT_OBJECT, $sg, $user))==0){
-//            throw new \Exception("You don't have permission over $sg");  
+//            throw new \Exception("You don't have permission over $sg");
 //        }
         if($this->roleActionAuthorisationService->authoriseAction(\Action::EDIT_OBJECT, $sg, $user)->getGrantAction()==FALSE){
             throw new \Exception("You don't have permission over ". $sg->getName());
         }
     }
-    
+
     /** TODO
      * Before adding or editing a key pair check that the keyname is not a reserved keyname
      *
@@ -595,7 +595,7 @@ class ServiceGroup extends AbstractEntityService{
 
         $existingProperties = $serviceGroup->getServiceGroupProperties();
 
-        //Check to see if adding the new properties will exceed the max limit 
+        //Check to see if adding the new properties will exceed the max limit
         //defined in local_info.xml, and throw an exception if so
         $extensionLimit = $this->configService->getExtensionsLimit();
         if (sizeof($existingProperties) + sizeof($propArr) > $extensionLimit){
@@ -607,7 +607,7 @@ class ServiceGroup extends AbstractEntityService{
             foreach ($propArr as $i => $prop) {
                 $key = $prop[0];
                 $value = $prop[1];
-                //Check that we are not trying to add an existing key, and skip if we are, 
+                //Check that we are not trying to add an existing key, and skip if we are,
                 //unless the user has selected the prevent overwrite mode
 
                 foreach ($existingProperties as $existProp) {
@@ -673,33 +673,33 @@ class ServiceGroup extends AbstractEntityService{
             throw $e;
         }
     }
-    
+
     /**
-     * Edits a service group property. 
-     * A check is performed to confirm the given property is from the parent 
+     * Edits a service group property.
+     * A check is performed to confirm the given property is from the parent
      * serviceGroup, and an exception is thrown if not.
      *
      * @param \ServiceGroup $serviceGroup
      * @param \User $user
      * @param \ServiceGroupProperty $prop
      * @param array $newValues
-     *        	
+     *
      */
     public function editServiceGroupProperty(\ServiceGroup $serviceGroup,\User $user,\ServiceGroupProperty $prop, $newValues) {
         // Check the portal is not in read only mode, throws exception if it is
         $this->checkPortalIsNotReadOnlyOrUserIsAdmin ( $user );
-    
+
         $this->validate($newValues['SERVICEGROUPPROPERTIES'], 'servicegroupproperty');
-        
+
         $keyname = $newValues ['SERVICEGROUPPROPERTIES'] ['NAME'];
         $keyvalue = $newValues ['SERVICEGROUPPROPERTIES'] ['VALUE'];
-        
-        $this->checkNotReserved($user, $serviceGroup, $keyname);        
-         
+
+        $this->checkNotReserved($user, $serviceGroup, $keyname);
+
         $this->em->getConnection ()->beginTransaction ();
-    
+
         try {
-            //Check that the prop is from the sg 
+            //Check that the prop is from the sg
             if ($prop->getParentServiceGroup() != $serviceGroup) {
                 $id = $prop->getId();
                 throw new \Exception("Property {$id} does not belong to the specified ServiceGroup");
@@ -707,7 +707,7 @@ class ServiceGroup extends AbstractEntityService{
             // Set the site propertys new member variables
             $prop->setKeyName ($keyname);
             $prop->setKeyValue ($keyvalue);
-    
+
             $this->em->merge ( $prop );
             $this->em->flush ();
             $this->em->getConnection ()->commit ();

--- a/lib/Gocdb_Services/ServiceService.php
+++ b/lib/Gocdb_Services/ServiceService.php
@@ -24,7 +24,7 @@ require_once __DIR__ . '/Config.php';
  * The public API methods are atomic and transactional.
  *
  * @todo Implement the ServiceEndpont interface when ready.
- *      
+ *
  * @author John Casson
  * @author David Meredith
  * @author George Ryall
@@ -39,7 +39,7 @@ class ServiceService extends AbstractEntityService {
         // $this->roleActionAuthorisationService = $roleActionAuthorisationService;
         $this->configService = new Config ();
     }
-    
+
     /**
      * Set class dependency (REQUIRED).
      *
@@ -49,7 +49,7 @@ class ServiceService extends AbstractEntityService {
     public function setRoleActionAuthorisationService(RoleActionAuthorisationService $roleActionAuthService) {
         $this->roleActionAuthorisationService = $roleActionAuthService;
     }
-    
+
     /**
      * Set class dependency (REQUIRED).
      *
@@ -59,7 +59,7 @@ class ServiceService extends AbstractEntityService {
     public function setScopeService(Scope $scopeService) {
         $this->scopeService = $scopeService;
     }
-    
+
     /**
      * Finds a single service by ID and returns its entity
      *
@@ -69,20 +69,20 @@ class ServiceService extends AbstractEntityService {
     public function getService($id) {
         $dql = "SELECT s FROM Service s
                 WHERE s.id = :id";
-        
+
         $service = $this->em->createQuery ( $dql )->setParameter ( 'id', $id )->getSingleResult ();
-        
+
         return $service;
     }
     public function getEndpoint($id) {
         $dql = "SELECT el FROM EndpointLocation el
                 WHERE el.id = :id";
-        
+
         $endpoint = $this->em->createQuery ( $dql )->setParameter ( 'id', $id )->getSingleResult ();
-        
+
         return $endpoint;
     }
-    
+
     /**
      * Return all {@link \Service} entities that satisfy the specfied search parameters.
      * <p>
@@ -104,12 +104,12 @@ class ServiceService extends AbstractEntityService {
      * @return type array graph or object graph of {@link \Service} entities
      */
     public function getSes($term = null, $serviceType = null, $production = null, $monitored = null, $scope = null, $ngi = null, $certStatus = null, $showClosed = null, $servKeyNames = null, $servKeyValues = null, $startRecord = null, $endRecord = null, $returnArray = false) {
-        
+
         // this method needs to be dropped in favor of getServicesFilterByParams,
         // but it is still needed when adding services to serviceGroups.
         return $this->getServicesHelper ( $term, $serviceType, $production, $monitored, $scope, $ngi, $certStatus, $showClosed, $servKeyNames, $servKeyValues, $startRecord, $endRecord, $returnArray, false );
     }
-    
+
     /**
      * Count the number of {@link \Service} entities that satisfy the specified
      * search parameters.
@@ -118,7 +118,7 @@ class ServiceService extends AbstractEntityService {
     public function getSesCount($term = null, $serviceType = null, $production = null, $monitored = null, $scope = null, $ngi = null, $certStatus = null, $showClosed = null, $servKeyNames = null, $servKeyValues = null, $startRecord = null, $endRecord = null, $returnArray = false) {
         return $this->getServicesHelper ( $term, $serviceType, $production, $monitored, $scope, $ngi, $certStatus, $showClosed, $servKeyNames, $servKeyValues, $startRecord, $endRecord, $returnArray, true );
     }
-    
+
     private function getServicesHelper($term = null, $serviceType = null, $production = null, $monitored = null, $scope = null, $ngi = null, $certStatus = null, $showClosed = null, $servKeyNames = null, $servKeyValues = null, $startRecord = null, $endRecord = null, $returnArray = false, $count = false) {
         // this method can be dropped when getSes and getSesCount have been dropped.
         if ($production == "TRUE") {
@@ -126,83 +126,83 @@ class ServiceService extends AbstractEntityService {
         } else if ($production == "FALSE") {
             $production = "0";
         }
-        
+
         if ($monitored == "TRUE") {
             $monitored = "1";
         } else if ($monitored == "FALSE") {
             $monitored = "0";
         }
-        
+
         $qb = $this->em->createQueryBuilder ();
-        
+
         if ($count) {
             $qb->select ( 'count(DISTINCT se)' );
         } else {
             $qb->select ( 'DISTINCT se', 'si', 'st', 'cs', 'n' );
         }
-        
+
         $qb->from ( 'Service', 'se' )->leftjoin ( 'se.serviceType', 'st' )->leftjoin ( 'se.scopes', 's' )->leftjoin ( 'se.parentSite', 'si' )->leftjoin ( 'si.certificationStatus', 'cs' )->leftjoin ( 'si.ngi', 'n' )->orderBy ( 'se.hostName' );
-        
+
         // For use with search function, convert all terms to upper and do a like query
         if ($term != null && $term != '%%') {
             $qb->andWhere ( $qb->expr ()->orX ( $qb->expr ()->like ( $qb->expr ()->upper ( 'se.hostName' ), ':term' ), $qb->expr ()->like ( $qb->expr ()->upper ( 'se.description' ), ':term' ) ) )->setParameter ( ':term', strtoupper ( $term ) );
         }
-        
+
         if ($serviceType != null && $serviceType != '%%') {
             $qb->andWhere ( $qb->expr ()->like ( $qb->expr ()->upper ( 'st.name' ), ':serviceType' ) )->setParameter ( ':serviceType', strtoupper ( $serviceType ) );
         }
-        
+
         if ($production != null && $production != '%%') {
             $qb->andWhere ( $qb->expr ()->like ( $qb->expr ()->upper ( 'se.production' ), ':production' ) )->setParameter ( ':production', $production );
         }
-        
+
         if ($monitored != null && $monitored != '%%') {
             $qb->andWhere ( $qb->expr ()->like ( $qb->expr ()->upper ( 'se.monitored' ), ':monitored' ) )->setParameter ( ':monitored', $monitored );
         }
-        
+
         if ($scope != null && $scope != '%%') {
             $qb->andWhere ( $qb->expr ()->like ( 's.name', ':scope' ) )->setParameter ( ':scope', $scope );
         }
-        
+
         if ($certStatus != null && $certStatus != '%%') {
             $qb->andWhere ( $qb->expr ()->like ( 'cs.name', ':certStatus' ) )->setParameter ( ':certStatus', $certStatus );
         }
-        
+
         if ($showClosed != 1) {
             $qb->andWhere ( $qb->expr ()->not ( $qb->expr ()->like ( 'cs.name', ':closed' ) ) )->setParameter ( ':closed', 'Closed' );
         }
-        
+
         if ($ngi != null && $ngi != '%%') {
             $qb->andWhere ( $qb->expr ()->like ( 'n.name', ':ngi' ) )->setParameter ( ':ngi', $ngi );
         }
-        
+
         if ($servKeyNames != null && $servKeyNames != '%%') {
             if ($servKeyValues == null || $servKeyValues == '') {
                 $servKeyValues = '%%';
             }
-            
+
             $sQ = $this->em->createQueryBuilder ();
             $sQ->select ( 'se1' . '.id' )->from ( 'Service', 'se1' )->join ( 'se1.serviceProperties', 'sp' )->andWhere ( $sQ->expr ()->andX ( $sQ->expr ()->eq ( 'sp.keyName', ':keyname' ), $sQ->expr ()->like ( 'sp.keyValue', ':keyvalue' ) ) );
-            
+
             $qb->andWhere ( $qb->expr ()->in ( 'se', $sQ->getDQL () ) );
             $qb->setParameter ( ':keyname', $servKeyNames )->setParameter ( ':keyvalue', $servKeyValues );
         }
-        
+
         $query = $qb->getQuery ();
-        
+
         if ($count) {
             $count = $query->getSingleScalarResult ();
             return $count;
         } else {
-            
+
             if (! empty ( $startRecord )) {
                 $query->setFirstResult ( $startRecord );
             }
-            
+
             if (! empty ( $endRecord )) {
                 $query->setMaxResults ( $endRecord );
             }
-            
+
             if ($returnArray) {
                 $results = $query->getResult ( \Doctrine\ORM\Query::HYDRATE_ARRAY );
                 return $results;
@@ -213,16 +213,16 @@ class ServiceService extends AbstractEntityService {
             // print_r($results);
         }
     }
-    
+
     public function getAllSesJoinParentSites() {
-        $dql = "SELECT se, st, si 
+        $dql = "SELECT se, st, si
             FROM Service se
             JOIN se.serviceType st
             JOIN se.parentSite si";
         $query = $this->em->createQuery ( $dql );
         return $query->getResult ();
     }
-    
+
     /**
      * Return all {@link \Service} entities OR a count of the services that
      * satisfy the specfied filter parameters.
@@ -268,7 +268,7 @@ class ServiceService extends AbstractEntityService {
         $maxResults = null;
         $returnArray = false;
         $count = false;
-        
+
         if (isset ( $filterParams ['searchTerm'] )) {
             $searchTerm = $filterParams ['searchTerm'];
         }
@@ -323,36 +323,36 @@ class ServiceService extends AbstractEntityService {
         if (isset ( $filterParams ['count'] ) && $filterParams ['count'] != null) {
             $count = $filterParams ['count'];
         }
-        
+
         // bind count - used to create positional bind params.
         $bc = - 1;
         $qb = $this->em->createQueryBuilder ();
-        
+
         if ($count) {
             $qb->select ( 'count(DISTINCT se)' );
         } else {
             $qb->select ( 'DISTINCT se', 'si', 'st', 'cs', 'n' );
         }
-        
+
         $qb->from ( 'Service', 'se' )->leftjoin ( 'se.serviceType', 'st' )->leftjoin ( 'se.scopes', 's' )->leftjoin ( 'se.parentSite', 'si' )->leftjoin ( 'si.certificationStatus', 'cs' )->leftjoin ( 'si.ngi', 'n' )->orderBy ( 'se.hostName' );
-        
+
         // For use with search function, convert all terms to upper and do a like query
         if ($searchTerm != null) {
             $qb->andWhere ( $qb->expr ()->orX ( $qb->expr ()->like ( $qb->expr ()->upper ( 'se.hostName' ), '?' . ++ $bc ), $qb->expr ()->like ( $qb->expr ()->upper ( 'se.description' ), '?' . $bc ) ) )->setParameter ( $bc, strtoupper ( $searchTerm ) );
         }
-        
+
         if ($serviceType != null) {
             $qb->andWhere ( $qb->expr ()->like ( $qb->expr ()->upper ( 'st.name' ), '?' . ++ $bc ) )->setParameter ( $bc, strtoupper ( $serviceType ) );
         }
-        
+
         if ($production != null) {
             $qb->andWhere ( $qb->expr ()->like ( $qb->expr ()->upper ( 'se.production' ), '?' . ++ $bc ) )->setParameter ( $bc, $production );
         }
-        
+
         if ($monitored != null) {
             $qb->andWhere ( $qb->expr ()->like ( $qb->expr ()->upper ( 'se.monitored' ), '?' . ++ $bc ) )->setParameter ( $bc, $monitored );
         }
-        
+
         // Create WHERE clauses for multiple scopes using positional bind params
         if ($scope != null) {
             require_once __DIR__ . '/PI/QueryBuilders/ScopeQueryBuilder.php';
@@ -370,35 +370,35 @@ class ServiceService extends AbstractEntityService {
                 $qb->setParameter ( $bindIdValue [0], $bindIdValue [1] ); // , \Doctrine\DBAL\Types\Type::STRING );
             }
         }
-        
+
         if ($certStatus != null) {
             $qb->andWhere ( $qb->expr ()->like ( 'cs.name', '?' . ++ $bc ) )->setParameter ( $bc, $certStatus );
         }
-        
+
         if ($showClosed) {
             // don't add the extra where clause
         } else {
             // add a where clause to drop Closed certStatus, i.e. 'WHERE cs.name IS NOT LIKE Closed'
             $qb->andWhere ( $qb->expr ()->not ( $qb->expr ()->like ( 'cs.name', '?' . ++ $bc ) ) )->setParameter ( $bc, 'Closed' );
         }
-        
+
         if ($ngi != null) {
             $qb->andWhere ( $qb->expr ()->like ( 'n.name', '?' . ++ $bc ) )->setParameter ( $bc, $ngi );
         }
-        
+
         if ($servKeyNames != null) {
             if ($servKeyValue == null || $servKeyValue == '') {
                 $servKeyValue = '%%';
             }
             $sQ = $this->em->createQueryBuilder ();
             $sQ->select ( 'se_p1' . '.id' )->from ( 'Service', 'se_p1' )->join ( 'se_p1.serviceProperties', 'sp' )->andWhere ( $sQ->expr ()->andX ( $sQ->expr ()->eq ( 'sp.keyName', '?' . ++ $bc ), $sQ->expr ()->like ( 'sp.keyValue', '?' . ++ $bc ) ) );
-            
+
             $qb->andWhere ( $qb->expr ()->in ( 'se', $sQ->getDQL () ) );
             $qb->setParameter ( $bc - 1, $servKeyNames )->setParameter ( $bc, $servKeyValue );
         }
-        
+
         $query = $qb->getQuery ();
-        
+
         if ($count) {
             $count = $query->getSingleScalarResult ();
             return $count;
@@ -419,7 +419,7 @@ class ServiceService extends AbstractEntityService {
             // print_r($results);
         }
     }
-    
+
     /**
      * Returns the downtimes linked to a Service.
      *
@@ -432,21 +432,21 @@ class ServiceService extends AbstractEntityService {
             $dayLimit = new \DateTime ();
             $dayLimit->sub ( $di );
         }
-        
+
         // Simplified and updated query for MEPs model by JM&DM - 18/06/2014
-        $dql = "SELECT d  
+        $dql = "SELECT d
                 FROM Downtime d
                 JOIN d.services se
-                WHERE se.id = :id 
+                WHERE se.id = :id
                 AND ( :dayLimit IS NULL OR d.startDate > :dayLimit)
                 ORDER BY d.startDate DESC";
-        
+
         $downtimes = $this->em->createQuery ( $dql )->setParameter ( 'id', $id )->setParameter ( 'dayLimit', $dayLimit )->getResult ();
-        
+
         // $downtimes = $this->getService($id)->getDowntimes();
         return $downtimes;
     }
-    
+
     /**
      * Returns all service types
      *
@@ -458,7 +458,7 @@ class ServiceService extends AbstractEntityService {
         $types = $this->em->createQuery ( $dql )->getResult ();
         return $types;
     }
-    
+
     /**
      * Updates a Service.
      * Returns the updated SE
@@ -493,17 +493,17 @@ class ServiceService extends AbstractEntityService {
      */
     public function editService(\Service $se, $newValues, \User $user = null) {
         require_once __DIR__ . '/../../htdocs/web_portal/components/Get_User_Principle.php';
-        
+
         // Check the portal is not in read only mode, throws exception if it is
         $this->checkPortalIsNotReadOnlyOrUserIsAdmin ( $user );
-        
+
         // Authorise the change
         if ($this->roleActionAuthorisationService->authoriseAction ( \Action::EDIT_OBJECT, $se->getParentSite (), $user )->getGrantAction () == FALSE) {
             throw new \Exception ( "You do not have permission over this service." );
         }
-        
+
         $st = $this->getServiceType ( $newValues ['serviceType'] );
-        
+
         $this->validate ( $newValues ['SE'], 'service' );
         $this->validateEndpointUrl ( $newValues ['endpointUrl'] );
         $this->uniqueCheck ( $newValues ['SE'] ['HOSTNAME'], $st, $se->getParentSite () );
@@ -513,7 +513,7 @@ class ServiceService extends AbstractEntityService {
                 throw new \Exception ( "If Production flat is set to True, Monitored flag must also be True (except for VOMS and emi.ARGUS)" );
             }
         }
-        
+
         // EDIT SCOPE TAGS:
         // collate selected scopeIds (reserved and non-reserved)
         $scopeIdsToApply = array ();
@@ -524,23 +524,23 @@ class ServiceService extends AbstractEntityService {
             $scopeIdsToApply [] = $sid;
         }
         $selectedScopesToApply = $this->scopeService->getScopes ( $scopeIdsToApply );
-        
+
         // If not admin, Check user edits to the service's Reserved scopes:
         // Required to prevent users manually crafting a POST request in an attempt
         // to select reserved scopes, this is unlikely but it is a possible hack.
         if (! $user->isAdmin ()) {
             $selectedReservedScopes = $this->scopeService->getScopesFilterByParams ( array (
-                    'excludeNonReserved' => true 
+                    'excludeNonReserved' => true
             ), $selectedScopesToApply );
-            
+
             $existingReservedScopes = $this->scopeService->getScopesFilterByParams ( array (
-                    'excludeNonReserved' => true 
+                    'excludeNonReserved' => true
             ), $se->getScopes ()->toArray () );
-            
+
             $existingReservedScopesParent = $this->scopeService->getScopesFilterByParams ( array (
-                    'excludeNonReserved' => true 
+                    'excludeNonReserved' => true
             ), $se->getParentSite ()->getScopes ()->toArray () );
-            
+
             foreach ( $selectedReservedScopes as $sc ) {
                 // Reserved scopes must already be assigned to se or parent
                 if (! in_array ( $sc, $existingReservedScopes ) && ! in_array ( $sc, $existingReservedScopesParent )) {
@@ -548,7 +548,7 @@ class ServiceService extends AbstractEntityService {
                 }
             }
         }
-        
+
         // Check no changes to Reserved scopes (if not admin):
         // When normal users EDIT the service, the selected scopeIds should
         // be checked to prevent users manually crafting a POST request in an attempt
@@ -576,60 +576,60 @@ class ServiceService extends AbstractEntityService {
          * }
          * }
          */
-        
+
         // check there are the required number of optional scopes specified
         $this->checkNumberOfScopes ( $this->scopeService->getScopesFilterByParams ( array (
-                'excludeReserved' => true 
+                'excludeReserved' => true
         ), $selectedScopesToApply ) );
-        
+
         // Explicity demarcate our tx boundary
         $this->em->getConnection ()->beginTransaction ();
         try {
             // Set the service's member variables
             $se->setHostName ( $newValues ['SE'] ['HOSTNAME'] );
             $se->setDescription ( $newValues ['SE'] ['DESCRIPTION'] );
-            
+
             if ($newValues ['PRODUCTION_LEVEL'] == "Y") {
                 $prod = true;
             } else {
                 $prod = false;
             }
             $se->setProduction ( $prod );
-            
+
             if ($newValues ['BETA'] == "Y") {
                 $beta = true;
             } else {
                 $beta = false;
             }
             $se->setBeta ( $beta );
-            
+
             if ($newValues ['IS_MONITORED'] == "Y") {
                 $monitored = true;
             } else {
                 $monitored = false;
             }
             $se->setMonitored ( $monitored );
-            
+
             $se->setDn ( $newValues ['SE'] ['HOST_DN'] );
             $se->setIpAddress ( $newValues ['SE'] ['HOST_IP'] );
             $se->setIpV6Address ( $newValues ['SE'] ['HOST_IP_V6'] );
             $se->setOperatingSystem ( $newValues ['SE'] ['HOST_OS'] );
             $se->setArchitecture ( $newValues ['SE'] ['HOST_ARCH'] );
             $se->setEmail ( $newValues ['SE'] ['EMAIL'] );
-            
+
             $se->setServiceType ( $st );
-            
+
             // $el = $se->getEndpointLocations()->first();
             // $el->setUrl($newValues['endpointUrl']);
             $se->setUrl ( $newValues ['endpointUrl'] );
-            
+
             // Update the service's scope
             // firstly remove all existing scope links
             $scopes = $se->getScopes ();
             foreach ( $scopes as $s ) {
                 $se->removeScope ( $s );
             }
-            
+
             // find then link each scope specified to the site
             // foreach ($scopeIdsToApply as $scopeId) {
             // $dql = "SELECT s FROM Scope s WHERE s.id = ?1";
@@ -641,7 +641,7 @@ class ServiceService extends AbstractEntityService {
             foreach ( $selectedScopesToApply as $scope ) {
                 $se->addScope ( $scope );
             }
-            
+
             $this->em->merge ( $se );
             // $this->em->merge($el);
             $this->em->flush ();
@@ -653,7 +653,7 @@ class ServiceService extends AbstractEntityService {
         }
         return $se;
     }
-    
+
     /*
      * Get an array of Role names granted to the user that permit the requested
      * action on the given Service.
@@ -718,7 +718,7 @@ class ServiceService extends AbstractEntityService {
      * return array_unique($enablingRoles);
      * }
      */
-    
+
     /**
      * Validates user inputted service data against the
      * checks in the gocdb_schema.xml.
@@ -739,7 +739,7 @@ class ServiceService extends AbstractEntityService {
                 throw new \Exception ( $error );
             }
         }
-        
+
         // Apply additional logic for validation that can't be captured solely using gocdb_schema.xml
         if (! empty ( $se_data ['HOST_IP_V6'] )) {
             require_once __DIR__ . '/validation/IPv6Validator.php';
@@ -751,7 +751,7 @@ class ServiceService extends AbstractEntityService {
             }
         }
     }
-    
+
     /**
      * Validates the user inputted service data against the
      * checks in the gocdb_schema.xml.
@@ -770,7 +770,7 @@ class ServiceService extends AbstractEntityService {
             throw new \Exception ( "Invalid URL: $endpoint_url" );
         }
     }
-    
+
     /**
      * Array
      * (
@@ -799,29 +799,29 @@ class ServiceService extends AbstractEntityService {
      * @param org\gocdb\services\User $user The user adding the SE
      */
     public function addService($values, \User $user = null) {
-        
+
         // get the parent site
         $dql = "SELECT s from Site s WHERE s.id = :id";
         /* @var $site \Site */
         $site = $this->em->createQuery ( $dql )->setParameter ( 'id', $values ['hostingSite'] )->getSingleResult ();
         // get the service type
         $st = $this->getServiceType ( $values ['serviceType'] );
-        
+
         if ($this->roleActionAuthorisationService->authoriseAction ( \Action::SITE_ADD_SERVICE, $site, $user )->getGrantAction () == FALSE) {
             throw new \Exception ( "You don't have permission to add a service to this site." );
         }
-        
+
         $this->validate ( $values ['SE'], 'service' );
         $this->validateEndpointUrl ( $values ['endpointUrl'] );
         $this->uniqueCheck ( $values ['SE'] ['HOSTNAME'], $st, $site );
-        
+
         // validate production/monitored combination
         if ($st != 'VOMS' && $st != 'emi.ARGUS') {
             if ($values ['PRODUCTION_LEVEL'] == "Y" && $values ['IS_MONITORED'] != "Y") {
                 throw new \Exception ( "If Production flag is set to True, Monitored flag must also be True (except for VOMS and emi.ARGUS)" );
             }
         }
-        
+
         // ADD SCOPE TAGS:
         // collate selected reserved and non-reserved scopeIds.
         // Note, Reserved scopes can be inherited from the parent Site.
@@ -832,21 +832,21 @@ class ServiceService extends AbstractEntityService {
         foreach ( $values ['ReservedScope_ids'] as $sid ) {
             $allSelectedScopeIds [] = $sid;
         }
-        
+
         $selectedScopesToApply = $this->scopeService->getScopes ( $allSelectedScopeIds );
-        
+
         // If not admin, check that requested reserved scopes are already implemented by the parent Site.
         // Required to prevent users manually crafting a POST request in an attempt
         // to select reserved scopes, this is unlikely but it is a possible hack.
         if (! $user->isAdmin ()) {
             $selectedReservedScopes = $this->scopeService->getScopesFilterByParams ( array (
-                    'excludeNonReserved' => true 
+                    'excludeNonReserved' => true
             ), $selectedScopesToApply );
-            
+
             $existingReservedScopesParent = $this->scopeService->getScopesFilterByParams ( array (
-                    'excludeNonReserved' => true 
+                    'excludeNonReserved' => true
             ), $site->getScopes ()->toArray () );
-            
+
             foreach ( $selectedReservedScopes as $sc ) {
                 // Reserved scopes must already be assigned to parent
                 if (! in_array ( $sc, $existingReservedScopesParent )) {
@@ -854,37 +854,37 @@ class ServiceService extends AbstractEntityService {
                 }
             }
         }
-        
+
         // check there are the required number of OPTIONAL scopes specified
         $this->checkNumberOfScopes ( $values ['Scope_ids'] );
-        
+
         $this->em->getConnection ()->beginTransaction ();
         try {
             $se = new \Service ();
             $se->setParentSiteDoJoin ( $site );
             $se->setServiceType ( $st );
-            
+
             // Set production
             if ($values ['PRODUCTION_LEVEL'] == "Y") {
                 $se->setProduction ( true );
             } else {
                 $se->setProduction ( false );
             }
-            
+
             // Set Beta
             if ($values ['BETA'] == "Y") {
                 $se->setBeta ( true );
             } else {
                 $se->setBeta ( false );
             }
-            
+
             // Set monitored
             if ($values ['IS_MONITORED'] == "Y") {
                 $se->setMonitored ( true );
             } else {
                 $se->setMonitored ( false );
             }
-            
+
             // Set the scopes
             // foreach ($allSelectedScopeIds as $scopeId) {
             // $dql = "SELECT s FROM Scope s WHERE s.id = :id";
@@ -896,7 +896,7 @@ class ServiceService extends AbstractEntityService {
             foreach ( $selectedScopesToApply as $scope ) {
                 $se->addScope ( $scope );
             }
-            
+
             $se->setDn ( $values ['SE'] ['HOST_DN'] );
             $se->setIpAddress ( $values ['SE'] ['HOST_IP'] );
             $se->setOperatingSystem ( $values ['SE'] ['HOST_OS'] );
@@ -905,7 +905,7 @@ class ServiceService extends AbstractEntityService {
             $se->setDescription ( $values ['SE'] ['DESCRIPTION'] );
             $se->setEmail ( $values ['SE'] ['EMAIL'] );
             $se->setUrl ( $values ['endpointUrl'] );
-            
+
             $this->em->persist ( $se );
             $this->em->flush ();
             $this->em->getConnection ()->commit ();
@@ -916,7 +916,7 @@ class ServiceService extends AbstractEntityService {
         }
         return $se;
     }
-    
+
     /**
      * Does a newly submitted SE have the same hostname+service type
      * as an existing service linked to another site.
@@ -941,12 +941,12 @@ class ServiceService extends AbstractEntityService {
                 AND st.id = :stId
                 AND s.id != :siteId";
         $ses = $this->em->createQuery ( $dql )->setParameter ( 'hostName', $hostName )->setParameter ( 'stId', $serviceType->getId () )->setParameter ( 'siteId', $site->getId () )->getResult ();
-        
+
         if (sizeof ( $ses ) != 0) {
             throw new \Exception ( "A $serviceType service named $hostName already exists." );
         }
     }
-    
+
     /**
      * Check that if if the selected scope for this SE is EGI, the parent site
      * is also EGI
@@ -960,12 +960,12 @@ class ServiceService extends AbstractEntityService {
         if ($scope->getName () != 'EGI') {
             return;
         }
-        
+
         if ($site->getScopes ()->first ()->getName () != "EGI") {
             throw new \Exception ( "For this service to be EGI scoped, $site must also be EGI scoped." );
         }
     }
-    
+
     /**
      * Gets a service type by ID
      *
@@ -977,7 +977,7 @@ class ServiceService extends AbstractEntityService {
         $st = $this->em->createQuery ( $dql )->setParameter ( 'id', $id )->getSingleResult ();
         return $st;
     }
-    
+
     /**
      *
      * @return array of all properties for a service
@@ -987,7 +987,7 @@ class ServiceService extends AbstractEntityService {
         $properties = $this->em->createQuery ( $dql )->setParameter ( 'ID', $id )->getOneOrNullResult ();
         return $properties;
     }
-    
+
     /**
      *
      * @return a single service property or null if not found
@@ -997,7 +997,7 @@ class ServiceService extends AbstractEntityService {
         $property = $this->em->createQuery ( $dql )->setParameter ( 'ID', $id )->getOneOrNullResult ();
         return $property;
     }
-    
+
     /**
      *
      * @return a single service property or null if not foud
@@ -1007,7 +1007,7 @@ class ServiceService extends AbstractEntityService {
         $property = $this->em->createQuery ( $dql )->setParameter ( 'ID', $id )->getOneOrNullResult ();
         return $property;
     }
-    
+
     /**
      * This method will check that a user has edit permissions over a service before allowing a user to add, edit or delete
      * any service information.
@@ -1025,7 +1025,7 @@ class ServiceService extends AbstractEntityService {
             throw new \Exception ( "You don't have permission over service." );
         }
     }
-    
+
     /**
      * TODO
      * Before adding or editing a key pair check that the keyname is not a reserved keyname
@@ -1035,7 +1035,7 @@ class ServiceService extends AbstractEntityService {
     private function checkNotReserved(\User $user, \Service $service, $keyname) {
         // TODO Function: This function is called but not yet filled out with an action
     }
-    
+
     /**
      * Adds key value pairs to a service
      *
@@ -1049,24 +1049,24 @@ class ServiceService extends AbstractEntityService {
         // Check the portal is not in read only mode, throws exception if it is
         $this->checkPortalIsNotReadOnlyOrUserIsAdmin ( $user );
         // throw new \Exception(var_dump($propArr));
-        
+
         $this->validateAddEditDeleteActions ( $user, $service );
-        
+
         $existingProperties = $service->getServiceProperties ();
-        
+
         // Check to see if adding the new properties will exceed the max limit defined in local_info.xml, and throw an exception if so
         $extensionLimit = \Factory::getConfigService ()->getExtensionsLimit ();
         if (sizeof ( $existingProperties ) + sizeof ( $propArr ) > $extensionLimit) {
             throw new \Exception ( "Property(s) could not be added due to the property limit of $extensionLimit" );
         }
-        
+
         $this->em->getConnection ()->beginTransaction ();
         try {
             foreach ( $propArr as $i => $prop ) {
                 $key = $prop [0];
                 $value = $prop [1];
                 // Check that we are not trying to add an existing key, and skip if we are, unless the user has selected the prevent overwrite mode
-                
+
                 foreach ( $existingProperties as $existProp ) {
                     if ($existProp->getKeyName () == $key && $existProp->getKeyValue () == $value) {
                         if ($preventOverwrite == false) {
@@ -1076,14 +1076,14 @@ class ServiceService extends AbstractEntityService {
                         }
                     }
                 }
-                
+
                 $this->checkNotReserved ( $user, $service, $key );
-                
+
                 // validate key value
                 $validateArray ['NAME'] = $key;
                 $validateArray ['VALUE'] = $value;
                 $this->validate ( $validateArray, 'serviceproperty' );
-                
+
                 $serviceProperty = new \ServiceProperty ();
                 $serviceProperty->setKeyName ( $key );
                 $serviceProperty->setKeyValue ( $value );
@@ -1091,7 +1091,7 @@ class ServiceService extends AbstractEntityService {
                 $service->addServicePropertyDoJoin ( $serviceProperty );
                 $this->em->persist ( $serviceProperty );
             }
-            
+
             $this->em->flush ();
             $this->em->getConnection ()->commit ();
         } catch ( \Exception $e ) {
@@ -1100,7 +1100,7 @@ class ServiceService extends AbstractEntityService {
             throw $e;
         }
     }
-    
+
     /**
      * Adds a key value pair to a service endpoint
      *
@@ -1114,24 +1114,24 @@ class ServiceService extends AbstractEntityService {
         // Check the portal is not in read only mode, throws exception if it is
         $this->checkPortalIsNotReadOnlyOrUserIsAdmin ( $user );
         // throw new \Exception(var_dump($propArr));
-        
+
         $this->validateAddEditDeleteActions ( $user, $endpoint->getService () );
-        
+
         $existingProperties = $endpoint->getEndpointProperties ();
-        
+
         // Check to see if adding the new properties will exceed the max limit defined in local_info.xml, and throw an exception if so
         $extensionLimit = \Factory::getConfigService ()->getExtensionsLimit ();
         if (sizeof ( $existingProperties ) + sizeof ( $propArr ) > $extensionLimit) {
             throw new \Exception ( "Property(s) could not be added due to the property limit of $extensionLimit" );
         }
-        
+
         $this->em->getConnection ()->beginTransaction ();
         try {
             foreach ( $propArr as $i => $prop ) {
                 $key = $prop [0];
                 $value = $prop [1];
                 // Check that we are not trying to add an existing key, and skip if we are, unless the user has selected the prevent overwrite mode
-                
+
                 foreach ( $existingProperties as $existProp ) {
                     if ($existProp->getKeyName () == $key && $existProp->getKeyValue () == $value) {
                         if ($preventOverwrite == false) {
@@ -1141,22 +1141,22 @@ class ServiceService extends AbstractEntityService {
                         }
                     }
                 }
-                
+
                 $this->checkNotReserved ( $user, $endpoint->getService (), $key );
-                
+
                 // validate key value
                 $validateArray ['NAME'] = $key;
                 $validateArray ['VALUE'] = $value;
                 $validateArray ['ENDPOINTID'] = $endpoint->getId ();
                 $this->validate ( $validateArray, 'endpointproperty' );
-                
+
                 $property = new \EndpointProperty ();
                 $property->setKeyName ( $key );
                 $property->setKeyValue ( $value );
                 $endpoint->addEndpointPropertyDoJoin ( $property );
                 $this->em->persist ( $property );
             }
-            
+
             $this->em->flush ();
             $this->em->getConnection ()->commit ();
         } catch ( \Exception $e ) {
@@ -1165,7 +1165,7 @@ class ServiceService extends AbstractEntityService {
             throw $e;
         }
     }
-    
+
     /**
      * Deletes service properties
      *
@@ -1177,7 +1177,7 @@ class ServiceService extends AbstractEntityService {
         // Check the portal is not in read only mode, throws exception if it is
         $this->checkPortalIsNotReadOnlyOrUserIsAdmin ( $user );
         $this->validateAddEditDeleteActions ( $user, $service );
-        
+
         $this->em->getConnection ()->beginTransaction ();
         try {
             foreach ( $propArr as $prop ) {
@@ -1187,7 +1187,7 @@ class ServiceService extends AbstractEntityService {
                     $id = $prop->getId ();
                     throw new \Exception ( "Property {$id} does not belong to the specified service" );
                 }
-                
+
                 // Service is the owning side so remove elements from service.
                 $service->getServiceProperties ()->removeElement ( $prop );
                 // Once relationship is removed delete the actual element
@@ -1201,7 +1201,7 @@ class ServiceService extends AbstractEntityService {
             throw $e;
         }
     }
-    
+
     /**
      * Deletes the given EndpointProperties in the array from their parent Endpoints (if set).
      * If the parent Endpoint has not been set (<code>$prop->getParentEndpoint()</code> returns null
@@ -1214,23 +1214,23 @@ class ServiceService extends AbstractEntityService {
     public function deleteEndpointProperties(\User $user, array $propArr) {
         // Check the portal is not in read only mode, throws exception if it is
         $this->checkPortalIsNotReadOnlyOrUserIsAdmin ( $user );
-        
+
         $this->em->getConnection ()->beginTransaction ();
-        
+
         try {
             foreach ( $propArr as $prop ) {
-                
+
                 // check endpoint property has an parent endpoint
                 $endpoint = $prop->getParentEndpoint ();
                 if ($endpoint == null) {
                     $id = $prop->getId ();
                     throw new \Exception ( "Property {$id} does not have a parent endpoint" );
                 }
-                
+
                 // check user has permissions over the service associated with the endpoint
                 $service = $endpoint->getService ();
                 $this->validateAddEditDeleteActions ( $user, $service );
-                
+
                 // EndointLocation is the owning side so remove elements from endpoint.
                 $endpoint->getEndpointProperties ()->removeElement ( $prop );
                 // Once relationship is removed delete the actual element
@@ -1244,7 +1244,7 @@ class ServiceService extends AbstractEntityService {
             throw $e;
         }
     }
-    
+
     /**
      * Edits an existing service property that already belongs to the service.
      *
@@ -1264,7 +1264,7 @@ class ServiceService extends AbstractEntityService {
         $keyname = $newValues ['SERVICEPROPERTIES'] ['NAME'];
         $keyvalue = $newValues ['SERVICEPROPERTIES'] ['VALUE'];
         $this->checkNotReserved ( $user, $service, $keyname );
-        
+
         $this->em->getConnection ()->beginTransaction ();
         try {
             // Check that the prop is from the service
@@ -1275,7 +1275,7 @@ class ServiceService extends AbstractEntityService {
             // Set the service propertys new member variables
             $prop->setKeyName ( $keyname );
             $prop->setKeyValue ( $keyvalue );
-            
+
             $this->em->merge ( $prop );
             $this->em->flush ();
             $this->em->getConnection ()->commit ();
@@ -1285,7 +1285,7 @@ class ServiceService extends AbstractEntityService {
             throw $ex;
         }
     }
-    
+
     /**
      * Edits an existing endpoint property that already belongs to the endpoint.
      *
@@ -1306,7 +1306,7 @@ class ServiceService extends AbstractEntityService {
         $keyname = $newValues ['ENDPOINTPROPERTIES'] ['NAME'];
         $keyvalue = $newValues ['ENDPOINTPROPERTIES'] ['VALUE'];
         $this->checkNotReserved ( $user, $service, $keyname );
-        
+
         $this->em->getConnection ()->beginTransaction ();
         try {
             // Check that the prop is from the endpoint
@@ -1314,11 +1314,11 @@ class ServiceService extends AbstractEntityService {
                 $id = $prop->getId ();
                 throw new \Exception ( "Property {$id} does not belong to the specified service endpoint" );
             }
-            
+
             // Set the service propertys new member variables
             $prop->setKeyName ( $keyname );
             $prop->setKeyValue ( $keyvalue );
-            
+
             $this->em->merge ( $prop );
             $this->em->flush ();
             $this->em->getConnection ()->commit ();
@@ -1328,7 +1328,7 @@ class ServiceService extends AbstractEntityService {
             throw $ex;
         }
     }
-    
+
     /**
      * Deletes a service
      *
@@ -1343,26 +1343,26 @@ class ServiceService extends AbstractEntityService {
         require_once __DIR__ . '/../DAOs/ServiceDAO.php';
         // Check the portal is not in read only mode, throws exception if it is
         $this->checkPortalIsNotReadOnlyOrUserIsAdmin ( $user );
-        
+
         if ($this->roleActionAuthorisationService->authoriseAction ( \Action::EDIT_OBJECT, $s->getParentSite (), $user )->getGrantAction () == FALSE) {
             throw new \Exception ( "You don't have permission to delete service." );
         }
-        
+
         $this->em->getConnection ()->beginTransaction ();
         try {
             $serviceDAO = new \ServiceDAO ();
             $serviceDAO->setEntityManager ( $this->em );
-            
+
             // Archive site - if this is a test then don't archive
             if ($isTest == false) {
                 // Create entry in audit table
                 $serviceDAO->addServiceToArchive ( $s, $user );
             }
-            
+
             // Break links with downtimes and remove downtimes only associated
             // with this service, then remove service
             $serviceDAO->removeService ( $s );
-            
+
             $this->em->flush ();
             $this->em->getConnection ()->commit ();
         } catch ( \Exception $e ) {
@@ -1371,7 +1371,7 @@ class ServiceService extends AbstractEntityService {
             throw $e;
         }
     }
-    
+
     /**
      * Move the service to the given site.
      *
@@ -1386,9 +1386,9 @@ class ServiceService extends AbstractEntityService {
     public function moveService(\Service $Service, \Site $Site, \User $user = null) {
         // Throws exception if user is not an administrator
         $this->checkUserIsAdmin ( $user );
-        
+
         $this->em->getConnection ()->beginTransaction (); // suspend auto-commit
-        
+
         try {
             // If the site or service have no ID - throw logic exception
             $site_id = $Site->getId ();
@@ -1399,22 +1399,22 @@ class ServiceService extends AbstractEntityService {
             if (empty ( $Service_id )) {
                 throw new \LogicException ( 'Service has no ID' );
             }
-            
+
             // find old site
             $old_Site = $Service->getParentSite ();
-            
+
             // If the Site has changed, then we move the service.
             if ($old_Site != $Site) {
-                
+
                 // Remove the service from the old site if it has an old site
                 if (! empty ( $old_Site )) {
-                    
+
                     $old_Site->getServices ()->removeElement ( $Service );
                 }
-                
+
                 // Add Service to new Site
                 $Site->addServiceDoJoin ( $Service );
-                
+
                 // persist
                 $this->em->merge ( $Site );
                 $this->em->merge ( $old_Site );
@@ -1427,7 +1427,7 @@ class ServiceService extends AbstractEntityService {
             throw $e;
         }
     }
-    
+
     /**
      * Adds an endpoint to a service
      *
@@ -1440,18 +1440,18 @@ class ServiceService extends AbstractEntityService {
         // Check the portal is not in read only mode, throws exception if it is
         $this->checkPortalIsNotReadOnlyOrUserIsAdmin ( $user );
         $this->validate ( $values ['SERVICEENDPOINT'], 'endpoint' );
-        
+
         $name = $values ['SERVICEENDPOINT'] ['NAME'];
         $url = $values ['SERVICEENDPOINT'] ['URL'];
         $serviceID = $values ['SERVICEENDPOINT'] ['SERVICE'];
         $service = $this->getService ( $serviceID );
-        
+
         if ($values ['SERVICEENDPOINT'] ['INTERFACENAME'] != '') {
             $interfaceName = $values ['SERVICEENDPOINT'] ['INTERFACENAME'];
         } else {
             $interfaceName = ( string ) $service->getServiceType ();
         }
-        
+
         if (empty ( $name )) {
             throw new \Exception ( "An endpoint must have a name." );
         }
@@ -1464,7 +1464,7 @@ class ServiceService extends AbstractEntityService {
                 throw new \Exception ( "Please provide a unique name for this endpoint." );
             }
         }
-        
+
         $this->em->getConnection ()->beginTransaction ();
         try {
             $endpoint = new \EndpointLocation ();
@@ -1474,7 +1474,7 @@ class ServiceService extends AbstractEntityService {
             $service = $this->em->find ( "Service", $serviceID );
             $service->addEndpointLocationDoJoin ( $endpoint );
             $this->em->persist ( $endpoint );
-            
+
             $this->em->flush ();
             $this->em->getConnection ()->commit ();
         } catch ( \Exception $e ) {
@@ -1484,7 +1484,7 @@ class ServiceService extends AbstractEntityService {
         }
         return $endpoint;
     }
-    
+
     /**
      * Update the given endpoint with the given newValues.
      *
@@ -1498,7 +1498,7 @@ class ServiceService extends AbstractEntityService {
     public function editEndpoint(\Service $service, \User $user, \EndpointLocation $endpoint, $newValues) {
         // Check the portal is not in read only mode, throws exception if it is
         $this->checkPortalIsNotReadOnlyOrUserIsAdmin ( $user );
-        
+
         $name = $newValues ['SERVICEENDPOINT'] ['NAME'];
         $url = $newValues ['SERVICEENDPOINT'] ['URL'];
         if ($newValues ['SERVICEENDPOINT'] ['INTERFACENAME'] != '') {
@@ -1507,16 +1507,16 @@ class ServiceService extends AbstractEntityService {
             $interfaceName = ( string ) $service->getServiceType ();
         }
         $description = $newValues ['SERVICEENDPOINT'] ['DESCRIPTION'];
-        
+
         $this->validate ( $newValues ['SERVICEENDPOINT'], 'endpoint' );
-        
+
         if (empty ( $name )) {
             throw new \Exception ( "An endpoint must have a name." );
         }
         if (filter_var ( $url, FILTER_VALIDATE_URL ) === FALSE) {
             throw new \Exception ( "An endpoint must have a valid url." );
         }
-        
+
         // check endpoint's name is unique under the service
         foreach ( $service->getEndpointLocations () as $endpointL ) {
             // exclude itself
@@ -1524,9 +1524,9 @@ class ServiceService extends AbstractEntityService {
                 throw new \Exception ( "Please provide a unique name for this endpoint." );
             }
         }
-        
+
         $this->em->getConnection ()->beginTransaction ();
-        
+
         try {
             // Set the endpoints new member variables
             $endpoint->setName ( $name );
@@ -1542,10 +1542,10 @@ class ServiceService extends AbstractEntityService {
             throw $ex;
         }
     }
-    
-    
+
+
     /**
-     * User deletes the given endpoint. 
+     * User deletes the given endpoint.
      * @param \EndpointLocation $endpoint
      * @param \User $user
      * @throws Exception
@@ -1557,13 +1557,13 @@ class ServiceService extends AbstractEntityService {
         $service = $endpoint->getService ();
         // check user has permission to edit endpoint's service
         $this->validateAddEditDeleteActions ( $user, $service );
-        
+
         $this->em->getConnection ()->beginTransaction ();
         try {
             $serviceDAO = new \ServiceDAO ();
             $serviceDAO->setEntityManager ( $this->em );
             $serviceDAO->removeEndpoint ( $endpoint );
-            
+
             $this->em->flush ();
             $this->em->getConnection ()->commit ();
         } catch ( \Exception $e ) {
@@ -1572,8 +1572,8 @@ class ServiceService extends AbstractEntityService {
             throw $e;
         }
     }
-    
-    
+
+
     private function checkNumberOfScopes($scopeIds) {
         require_once __DIR__ . '/Config.php';
         $configService = new \org\gocdb\services\Config ();
@@ -1582,7 +1582,7 @@ class ServiceService extends AbstractEntityService {
             throw new \Exception ( "A service must have at least " . $minumNumberOfScopes . " optional scope(s)  assigned to it." );
         }
     }
-    
+
     /**
      * For a given service, returns an array containing the names of all the
      * scopes that service has as keys and a boolean as value.
@@ -1596,21 +1596,21 @@ class ServiceService extends AbstractEntityService {
         $parentSite = $service->getParentSite ();
         $parentScopes = $parentSite->getScopes ();
         $childScopes = $service->getScopes ();
-        
+
         $parentScopesNames = array ();
         foreach ( $parentScopes as $parentScope ) {
             $parentScopesNames [] = $parentScope->getName ();
         }
-        
+
         $childScopesNames = array ();
         foreach ( $childScopes as $childScope ) {
             $childScopesNames [] = $childScope->getName ();
         }
-        
+
         $sharedScopesNames = array_intersect ( $childScopesNames, $parentScopesNames );
-        
+
         $scopeNamesNotShared = array_diff ( $childScopesNames, $parentScopesNames );
-        
+
         $ScopeNamesAndParentShareInfo = array ();
         foreach ( $sharedScopesNames as $sharedScopesName ) {
             $ScopeNamesAndParentShareInfo [$sharedScopesName] = true;
@@ -1618,10 +1618,10 @@ class ServiceService extends AbstractEntityService {
         foreach ( $scopeNamesNotShared as $scopeNameNotShared ) {
             $ScopeNamesAndParentShareInfo [$scopeNameNotShared] = false;
         }
-        
+
         // can be replaced with ksort($ScopeNamesAndParentShareInfo, SORT_NATURAL); in php>=5.5
         uksort ( $ScopeNamesAndParentShareInfo, 'strcasecmp' );
-        
+
         return $ScopeNamesAndParentShareInfo;
     }
 }

--- a/lib/Gocdb_Services/ServiceType.php
+++ b/lib/Gocdb_Services/ServiceType.php
@@ -22,7 +22,7 @@ include_once __DIR__ . '/AbstractEntityService.php';
  * @author David Meredith
  */
 class ServiceType extends AbstractEntityService{
-    
+
     /*
      * All the public service methods in a service facade are typically atomic -
      * they demarcate the tx boundary at the start and end of the method
@@ -48,7 +48,7 @@ class ServiceType extends AbstractEntityService{
         $query = $this->em->createQuery($dql);
         return $query->getResult();
     }
-    
+
      /**
      * Finds a single service type by ID and returns its entity
      * @param int $id the service type ID
@@ -62,10 +62,10 @@ class ServiceType extends AbstractEntityService{
             ->createQuery($dql)
             ->setParameter('id', $id)
             ->getSingleResult();
-        
+
         return $serviceType;
     }
-    
+
     /**
      * Finds and returns all services which have the service type with
      * the input id.
@@ -73,14 +73,14 @@ class ServiceType extends AbstractEntityService{
      */
     public function getServices($id) {
         $dql = "SELECT se FROM Service se
-                JOIN se.serviceType st 
+                JOIN se.serviceType st
                 WHERE st.id = :id";
         $services =  $this->em->createQuery($dql)
                             ->setParameter('id', $id)
                             ->getResult();
         return $services;
     }
-    
+
         /**
      * Deletes a downtime
      * @param \Downtime $dt
@@ -89,10 +89,10 @@ class ServiceType extends AbstractEntityService{
     public function deleteServiceType(\ServiceType $serviceType, \User $user = null) {
         //Check the portal is not in read only mode, throws exception if it is
         $this->checkPortalIsNotReadOnlyOrUserIsAdmin($user);
-        
+
         //Throws exception if user is not an administrator
         $this->checkUserIsAdmin($user);
-        
+
         //Start a transaction
         $this->em->getConnection()->beginTransaction();
         try {
@@ -110,10 +110,10 @@ class ServiceType extends AbstractEntityService{
             throw $e;
         }
     }
-    
+
     /**
-     * 
-     * @param array $newValues array containing the name and description for the 
+     *
+     * @param array $newValues array containing the name and description for the
      *                        new service type
      * @param \user $user   User adding the service type, used for permissions check
      * @return \org\gocdb\services\ServiceType returns created service type
@@ -124,15 +124,15 @@ class ServiceType extends AbstractEntityService{
 
         //Throws exception if user is not an administrator
         $this->checkUserIsAdmin($user);
-        
+
         //Check the values are actually there, then validate the values as per the GOCDB schema
         $this->validate($values);
-        
+
         //check the name is unique
         if(!$this->serviceTypeNameIsUnique($values['Name'])){
             throw new \Exception("Service type names must be unique, '".$values['Name']."' is already in use");
         }
-        
+
 
         //Start transaction
         $this->em->getConnection()->beginTransaction(); // suspend auto-commit
@@ -143,7 +143,7 @@ class ServiceType extends AbstractEntityService{
             $serviceType->setName($values['Name']);
             //set description
             $serviceType->setDescription($values['Description']);
-            
+
             $this->em->persist($serviceType);
             $this->em->flush();
             $this->em->getConnection()->commit();
@@ -151,11 +151,11 @@ class ServiceType extends AbstractEntityService{
             $this->em->getConnection()->rollback();
             $this->em->close();
             throw $e;
-        }        
+        }
 
         return $serviceType;
     }
-    
+
     /**
      * Edit a service type
      * @param \ServiceType $serviceType service type to be altered
@@ -167,18 +167,18 @@ class ServiceType extends AbstractEntityService{
     public function editServiceType(\ServiceType $serviceType, $newValues, \User $user = null){
         //Throws exception if user is not an administrator
         $this->checkUserIsAdmin($user);
-        
+
         //Validate the values as per the GOCDB schema and check values are present and valid.
         $this->validate($newValues);
-        
+
         //check the name is unique, if it has changed
         if($newValues['Name']!=$serviceType->getName()){
             if(!$this->serviceTypeNameIsUnique($newValues['Name'])){
                 throw new \Exception("Service type names must be unique, '".$newValues['Name']."' is already in use");
             }
         }
-        
-   
+
+
         //Start transaction
         $this->em->getConnection()->beginTransaction(); // suspend auto-commit
         try {
@@ -186,7 +186,7 @@ class ServiceType extends AbstractEntityService{
             $serviceType->setName($newValues['Name']);
             //set description
             $serviceType->setDescription($newValues['Description']);
-            
+
             $this->em->merge($serviceType);
             $this->em->flush();
             $this->em->getConnection()->commit();
@@ -194,14 +194,14 @@ class ServiceType extends AbstractEntityService{
             $this->em->getConnection()->rollback();
             $this->em->close();
             throw $e;
-        }        
+        }
 
         return $serviceType;
     }
 
 
-    
-    
+
+
     /**
      * Returns true if the name given is not currently in use for a service type
      * @param type $name potential service type name
@@ -219,13 +219,13 @@ class ServiceType extends AbstractEntityService{
         else {
             return false;
         }
-        
+
     }
-    
+
     /**
      * Performs some basic checks on the values aray and then validates the user
      * inputted service type data against the data in the gocdb_schema.xml.
-     * @param array $serviceTypeData containing all the fields for a GOCDB 
+     * @param array $serviceTypeData containing all the fields for a GOCDB
      *                               service type object
      * @throws \Exception If the project's data can't be
      *                    validated. The \Exception message will contain a human
@@ -233,33 +233,33 @@ class ServiceType extends AbstractEntityService{
      * @return null */
     private function validate($serviceTypeData) {
         require_once __DIR__.'/Validate.php';
-        
+
         //check values are there
         if(!((array_key_exists('Name',$serviceTypeData)) and (array_key_exists('Description',$serviceTypeData)))){
             throw new \Exception("A name and description for the service type must be specified");
-        }    
-        
+        }
+
         //check values are strings
         if(!((is_string($serviceTypeData['Name'])) and (is_string($serviceTypeData['Description'])))){
             throw new \Exception("The new service type name and description must be valid strings");
         }
-                     
+
         //check that the name is not null
         if(empty($serviceTypeData['Name'])){
             throw new \Exception("A name must be specified for the Service Type");
         }
-        
+
         //check that the description is not null
         if(empty($serviceTypeData['Description'])){
             throw new \Exception("A description must be specified for the Service Type");
         }
- 
-        
+
+
         //remove the ID from the values file if present (which it may be for an edit)
         if(array_key_exists("ID",$serviceTypeData)){
             unset($serviceTypeData["ID"]);
         }
-               
+
         $serv = new \org\gocdb\services\Validate();
         foreach ($serviceTypeData as $field => $value) {
             $valid = $serv->validate('service_type', strtoupper($field), $value);
@@ -269,6 +269,6 @@ class ServiceType extends AbstractEntityService{
             }
         }
     }
-}   
+}
 
 

--- a/lib/Gocdb_Services/Site.php
+++ b/lib/Gocdb_Services/Site.php
@@ -13,9 +13,9 @@ namespace org\gocdb\services;
  */
 require_once __DIR__ . '/AbstractEntityService.php';
 require_once __DIR__ . '/Role.php';
-require_once __DIR__ . '/RoleConstants.php'; 
-require_once __DIR__ . '/NGI.php'; 
-require_once __DIR__ . '/RoleActionAuthorisationService.php'; 
+require_once __DIR__ . '/RoleConstants.php';
+require_once __DIR__ . '/NGI.php';
+require_once __DIR__ . '/RoleActionAuthorisationService.php';
 require_once __DIR__.  '/Scope.php';
 require_once __DIR__.  '/Config.php';
 
@@ -30,36 +30,36 @@ require_once __DIR__.  '/Config.php';
  * @author James McCarthy
  */
 class Site extends AbstractEntityService{
-   
+
     private $roleActionAuthorisationService;
-    private $scopeService; 
-    private $configService; 
-     
+    private $scopeService;
+    private $configService;
+
     function __construct(/*$roleActionAuthorisationService, $scopeService*/) {
         parent::__construct();
         //$this->roleActionAuthorisationService = $roleActionAuthorisationService;
-        //$this->scopeService = $scopeService; 
-        $this->configService = new Config(); 
+        //$this->scopeService = $scopeService;
+        $this->configService = new Config();
     }
 
     /**
-     * Set class dependency (REQUIRED). 
-     * @todo Mandatory objects should be injected via constructor. 
+     * Set class dependency (REQUIRED).
+     * @todo Mandatory objects should be injected via constructor.
      * @param \org\gocdb\services\RoleActionAuthorisationService $roleActionAuthService
      */
     public function setRoleActionAuthorisationService(RoleActionAuthorisationService $roleActionAuthService){
-        $this->roleActionAuthorisationService = $roleActionAuthService; 
+        $this->roleActionAuthorisationService = $roleActionAuthService;
     }
 
     /**
-     * Set class dependency (REQUIRED). 
-     * @todo Mandatory objects should be injected via constructor. 
+     * Set class dependency (REQUIRED).
+     * @todo Mandatory objects should be injected via constructor.
      * @param \org\gocdb\services\Scope $scopeService
      */
     public function setScopeService(Scope $scopeService){
-        $this->scopeService = $scopeService; 
+        $this->scopeService = $scopeService;
     }
-    
+
     /*
      * Since all the service methods in a service facade are atomic and fully
      * isolated, we can call getNewConnection(TRUE|FALSE) from within the
@@ -130,7 +130,7 @@ class Site extends AbstractEntityService{
         $this->checkPortalIsNotReadOnlyOrUserIsAdmin($user);
 
         if($user == null){
-            throw new \Exception("Null user can't edit site"); 
+            throw new \Exception("Null user can't edit site");
         }
         // Check to see whether the user has a role that covers this site
         //$this->edit Authorization($site, $user);
@@ -139,55 +139,55 @@ class Site extends AbstractEntityService{
                 \Action::EDIT_OBJECT, $site, $user)->getGrantAction()==FALSE){
             throw new \Exception("You don't have permission over ". $site->getShortName());
         }
-        
+
         $this->validate($newValues['Site'], 'site');
         // TODO: Check the sitename is unique (reusable code in addSite())
-       
-        // EDIT SCOPE TAGS: 
+
+        // EDIT SCOPE TAGS:
         // collate selected scopeIds (reserved and non-reserved)
-        $scopeIdsToApply = array(); 
+        $scopeIdsToApply = array();
         foreach($newValues['Scope_ids'] as $sid){
-            $scopeIdsToApply[] = $sid; 
+            $scopeIdsToApply[] = $sid;
         }
         foreach($newValues['ReservedScope_ids'] as $sid){
-            $scopeIdsToApply[] = $sid; 
+            $scopeIdsToApply[] = $sid;
         }
-        $selectedScopesToApply = $this->scopeService->getScopes($scopeIdsToApply); 
-        
-        // If not admin, Check user edits to the site's Reserved scopes: 
+        $selectedScopesToApply = $this->scopeService->getScopes($scopeIdsToApply);
+
+        // If not admin, Check user edits to the site's Reserved scopes:
         // Required to prevent users manually crafting a POST request in an attempt
-        // to select reserved scopes, this is unlikely but it is a possible hack. 
-        // Site can only have reserved tags that are already assigned or assigned to the parent. 
+        // to select reserved scopes, this is unlikely but it is a possible hack.
+        // Site can only have reserved tags that are already assigned or assigned to the parent.
         if (!$user->isAdmin()) {
             $selectedReservedScopes = $this->scopeService->getScopesFilterByParams(
-                    array('excludeNonReserved' => true), $selectedScopesToApply);  
-            
+                    array('excludeNonReserved' => true), $selectedScopesToApply);
+
             $existingReservedScopes = $this->scopeService->getScopesFilterByParams(
-                    array('excludeNonReserved' => true), $site->getScopes()->toArray()); 
-            
+                    array('excludeNonReserved' => true), $site->getScopes()->toArray());
+
             $existingReservedScopesParent = $this->scopeService->getScopesFilterByParams(
-                    array('excludeNonReserved' => true), $site->getNgi()->getScopes()->toArray()); 
-            
+                    array('excludeNonReserved' => true), $site->getNgi()->getScopes()->toArray());
+
             foreach($selectedReservedScopes as $sc){
-                // Reserved scopes must already be assigned to site or parent 
+                // Reserved scopes must already be assigned to site or parent
                 if(!in_array($sc, $existingReservedScopes) && !in_array($sc, $existingReservedScopesParent)){
                     throw new \Exception("A reserved Scope Tag was selected that is "
-                            . "not assigned to the Site or to the Parent NGI");  
+                            . "not assigned to the Site or to the Parent NGI");
                 }
             }
         }
-        
+
         //check there are the required number of optional scopes specified
         $this->checkNumberOfScopes($this->scopeService->getScopesFilterByParams(
                array('excludeReserved' => true), $selectedScopesToApply));
 
         // check childServiceScopeAction is a known value
         if($newValues['childServiceScopeAction'] != 'noModify' &&
-                $newValues['childServiceScopeAction'] != 'inherit' && 
+                $newValues['childServiceScopeAction'] != 'inherit' &&
                 $newValues['childServiceScopeAction'] != 'override' ){
-            throw new \Exception("Invalid scope update action"); 
+            throw new \Exception("Invalid scope update action");
         }
-        
+
         $this->em->getConnection()->beginTransaction();
         try {
             // Set the site's member variables
@@ -210,7 +210,7 @@ class Site extends AbstractEntityService{
             $site->setEmergencyEmail($newValues['Site']['EMERGENCYEMAIL']);
             $site->setAlarmEmail($newValues['Site']['EMERGENCYEMAIL']);
             $site->setHelpdeskEmail($newValues['Site']['HELPDESKEMAIL']);
-            $site->setTimezoneId($newValues['Site']['TIMEZONE']); 
+            $site->setTimezoneId($newValues['Site']['TIMEZONE']);
 
             // update the target infrastructure
             $dql = "SELECT i FROM Infrastructure i WHERE i.name = :name";
@@ -233,10 +233,10 @@ class Site extends AbstractEntityService{
 
             // Link the requested scopes to the site
             foreach($selectedScopesToApply as $scope){
-                $site->addScope($scope); 
+                $site->addScope($scope);
             }
 
-            // Remove reserved scopes from child services that are not applied on site 
+            // Remove reserved scopes from child services that are not applied on site
             $siteReservedScopes = $this->scopeService->getScopesFilterByParams(
                     array('excludeNonReserved' => true), $site->getScopes()->toArray());
             foreach ($site->getServices() as $service) {
@@ -250,48 +250,48 @@ class Site extends AbstractEntityService{
             }
 
 
-            // Optionally update the child service scopes 
+            // Optionally update the child service scopes
             if($newValues['childServiceScopeAction'] == 'noModify'){
-                // do nothing to child service scopes, leave intact         
+                // do nothing to child service scopes, leave intact
             } else if($newValues['childServiceScopeAction'] == 'inherit'){
-                // iterate each child service and ensure it has all the site scopes 
+                // iterate each child service and ensure it has all the site scopes
                 $services = $site->getServices();
                 /* @var $service \Service */
                 foreach($services as $service){
-                    // for this service, see if it has each siteScope, if not add it  
+                    // for this service, see if it has each siteScope, if not add it
                     foreach($site->getScopes() as $siteScope){
-                        $addScope = true; 
+                        $addScope = true;
                         foreach($service->getScopes() as $servScope){
                             if($siteScope == $servScope){
-                                $addScope = false; 
-                                break; 
+                                $addScope = false;
+                                break;
                             }
                         }
                         if($addScope){
-                           $service->addScope($siteScope);  
+                           $service->addScope($siteScope);
                         }
                     }
                 }
-                
+
             } else if($newValues['childServiceScopeAction'] == 'override'){
-                // force child service scopes to be same as site 
+                // force child service scopes to be same as site
                 $services = $site->getServices();
                 /* @var $service \Service */
                 foreach($services as $service){
                     // remove all service's existing scopes
                     foreach($service->getScopes() as $servScope){
-                        $service->removeScope($servScope); 
+                        $service->removeScope($servScope);
                     }
-                    // add all site scopes 
+                    // add all site scopes
                     foreach($site->getScopes() as $siteScope){
-                        $service->addScope($siteScope); 
+                        $service->addScope($siteScope);
                     }
                 }
-                        
+
             } else {
-                throw new \Exception("Invalid scope update action");         
+                throw new \Exception("Invalid scope update action");
             }
-            
+
             // get / set the country
             $dql = "SELECT c FROM Country c WHERE c.name = ?1";
             $country = $this->em->createQuery($dql)
@@ -299,7 +299,7 @@ class Site extends AbstractEntityService{
                              ->getSingleResult();
             $site->setCountry($country);
 
-            // deprecated 
+            // deprecated
 //            $dql = "SELECT t FROM Timezone t WHERE t.name = ?1";
 //            $timezone = $this->em->createQuery($dql)
 //                            ->setParameter(1, $newValues['Timezone'])
@@ -320,9 +320,9 @@ class Site extends AbstractEntityService{
 
     /**
      * Validates the user inputted site data against the
-     * checks in the gocdb_schema.xml and applies additional logic checks 
-     * that can't be described in the gocdb_schema.xml. 
-     *  
+     * checks in the gocdb_schema.xml and applies additional logic checks
+     * that can't be described in the gocdb_schema.xml.
+     *
      * @param array $site_data containing all the fields for a GOCDB_SITE
      *                       object
      * @throws \Exception if the site data can't be
@@ -332,7 +332,7 @@ class Site extends AbstractEntityService{
      */
     private function validate($site_data, $type) {
         require_once __DIR__.'/Validate.php';
-        $serv = new \org\gocdb\services\Validate(); 
+        $serv = new \org\gocdb\services\Validate();
         foreach($site_data as $field => $value) {
             $valid = $serv->validate($type, $field, $value);
             if(!$valid) {
@@ -348,19 +348,19 @@ class Site extends AbstractEntityService{
             $errors = array();
             $errors = $validator->validate($site_data['IP_V6_RANGE'], $errors);
             if (count($errors) > 0) {
-                throw new \Exception($errors[0]); // show the first message. 
+                throw new \Exception($errors[0]); // show the first message.
             }
         }
     }
-  
+
     /**
-     * Return all {@see \Site}s that satisfy the specfied filter parameters. 
-     * <p>  
-     * $filterParams defines an associative array of optional parameters for 
-     * filtering the sites. The supported Key => Value pairs include: 
+     * Return all {@see \Site}s that satisfy the specfied filter parameters.
+     * <p>
+     * $filterParams defines an associative array of optional parameters for
+     * filtering the sites. The supported Key => Value pairs include:
      * <ul>
      *   <li>'sitename' => String site name</li>
-     *   <li>'roc' => String name of parent NGI/ROC</li> 
+     *   <li>'roc' => String name of parent NGI/ROC</li>
      *   <li>'country' => String country name</li>
      *   <li>'certification_status' => String certification status value e.g. 'Certified'</li>
      *   <li>'exclude_certification_status' => String exclude sites with this certification status</li>
@@ -369,35 +369,35 @@ class Site extends AbstractEntityService{
      *   <li>'scope_match' => String 'any' or 'all' </li>
      *   <li>'extensions' => String extensions expression to filter custom key=value pairs</li>
      * <ul>
-     * 
+     *
      * @param array $filterParams
      * @return array Site array
      */
     public function getSitesFilterByParams($filterParams){
-        require_once __DIR__.'/PI/GetSite.php'; 
-        $getSite = new GetSite($this->em); 
-        //$params = array('sitename' => 'GRIDOPS-GOCDB');  
-        //$params = array('scope' => 'EGI,DAVE', 'sitename' => 'GRIDOPS-GOCDB');          
-        //$params = array('scope' => 'EGI,Local', 'scope_match' => 'any', 'exclude_certification_status' => 'Closed');  
-        //$params = array('scope' => 'EGI,Local', 'scope_match' => 'all');  
-        //$params = array('scope' => 'EGI,DAVE', 'scope_match' => 'all');  
-        //$params = array('extensions' => '(aaa=123)(dave=\(someVal with parethesis\))(test=test)'); 
-        $getSite->validateParameters($filterParams); 
-        $getSite->createQuery(); 
-        $sites = $getSite->executeQuery(); 
-        return $sites; 
+        require_once __DIR__.'/PI/GetSite.php';
+        $getSite = new GetSite($this->em);
+        //$params = array('sitename' => 'GRIDOPS-GOCDB');
+        //$params = array('scope' => 'EGI,DAVE', 'sitename' => 'GRIDOPS-GOCDB');
+        //$params = array('scope' => 'EGI,Local', 'scope_match' => 'any', 'exclude_certification_status' => 'Closed');
+        //$params = array('scope' => 'EGI,Local', 'scope_match' => 'all');
+        //$params = array('scope' => 'EGI,DAVE', 'scope_match' => 'all');
+        //$params = array('extensions' => '(aaa=123)(dave=\(someVal with parethesis\))(test=test)');
+        $getSite->validateParameters($filterParams);
+        $getSite->createQuery();
+        $sites = $getSite->executeQuery();
+        return $sites;
     }
 
-    
+
     /**
-     * Returns all Sites filtered by the given parameters with the following  
-     * joined relations: CertificationStatus, Scope, NGI, Infrastructure. 
-     * 
+     * Returns all Sites filtered by the given parameters with the following
+     * joined relations: CertificationStatus, Scope, NGI, Infrastructure.
+     *
      * Sites are matched using SQL 'like' statements so you can for e.g. specify
-     * $ngiName = '%_ngi' to select all Sites whose parent NGI's name ends in '_ngi'.   
-     * All parametes are nullable. Null params are not used for filtering results.   
-     * 
-     * @param string $ngiName NGI name   
+     * $ngiName = '%_ngi' to select all Sites whose parent NGI's name ends in '_ngi'.
+     * All parametes are nullable. Null params are not used for filtering results.
+     *
+     * @param string $ngiName NGI name
      * @param string $prodStatus Production status/target infrastructure, usually Test or Production
      * @param string $certStatus Certification status value (Certified, Uncertified, Candidate, Suspended, Closed)
      * @param string $scopeName Name of a scope value
@@ -405,57 +405,57 @@ class Site extends AbstractEntityService{
      * @param integer $siteId Site id or null
      * @param string $siteExtPropKeyName Site extension property name
      * @param string $siteExtPropKeyValue Site extension property value
-     * @return array An array of site objects with joined entities. 
+     * @return array An array of site objects with joined entities.
      */
     public function getSitesBy(
             $ngiName=NULL, $prodStatus=NULL, $certStatus=NULL,
-            $scopeName=NULL, $showClosed=NULL, $siteId=NULL, 
+            $scopeName=NULL, $showClosed=NULL, $siteId=NULL,
             $siteExtPropKeyName=NULL, $siteExtPropKeyValue=NULL) {
 
         $qb = $this->em->createQueryBuilder();
         $qb ->select('DISTINCT s', 'sc', 'n', 'i')
             ->from('Site', 's')
-            ->leftjoin('s.certificationStatus', 'cs')            
-            ->leftjoin('s.scopes', 'sc')    
-            ->leftjoin('s.ngi', 'n')    
+            ->leftjoin('s.certificationStatus', 'cs')
+            ->leftjoin('s.scopes', 'sc')
+            ->leftjoin('s.ngi', 'n')
             ->leftjoin('s.infrastructure', 'i')
             ->orderBy('s.shortName');
-        
+
         if($scopeName != null && $scopeName != '%%'){
             $qb->andWhere($qb->expr()->like('sc.name', ':scope'))
                 ->setParameter(':scope', $scopeName);
         }
-        
+
         if($ngiName != null && $ngiName != '%%'){
             $qb->andWhere($qb->expr()->like('n.name', ':ngi'))
                 ->setParameter(':ngi', $ngiName);
         }
-        
+
         if($prodStatus != null && $prodStatus != '%%'){
             $qb->andWhere($qb->expr()->like('i.name', ':prodStatus'))
                 ->setParameter(':prodStatus', $prodStatus);
         }
-        
+
         if($certStatus != null && $certStatus != '%%'){
             $qb ->andWhere($qb->expr()->like('cs.name', ':certStatus'))
                 ->setParameter(':certStatus', $certStatus);
         }
-        
+
         if($siteId != null && $siteId != '%%'){
             $qb->andWhere($qb->expr()->like('s.id', ':siteId'))
                 ->setParameter(':siteId', $siteId);
         }
-        
+
         if($showClosed != 1){
             $qb->andWhere( $qb->expr()->not($qb->expr()->like('cs.name', ':closed')))
-                ->setParameter(':closed', 'Closed');            
+                ->setParameter(':closed', 'Closed');
         }
-        
+
         if($siteExtPropKeyName != null && $siteExtPropKeyName != '%%'){
             if($siteExtPropKeyValue == null || $siteExtPropKeyValue == ''){
                 $siteExtPropKeyValue='%%';
             }
-        
+
             $sQ = $this->em->createQueryBuilder();
             $sQ ->select('s1'.'.id')
             ->from('Site', 's1')
@@ -463,19 +463,19 @@ class Site extends AbstractEntityService{
             ->andWhere($sQ->expr()->andX(
                     $sQ->expr()->eq('sp.keyName', ':keyname'),
                     $sQ->expr()->like('sp.keyValue', ':keyvalue')));
-        
+
             $qb ->andWhere($qb->expr()->in('s', $sQ->getDQL()));
             $qb ->setParameter(':keyname', $siteExtPropKeyName)
             ->setParameter(':keyvalue', $siteExtPropKeyValue);
-        
+
         }
-        
+
         $query = $qb->getQuery();
         $sites = $query->execute();
 
         return $sites;
     }
-    
+
     /**
      * @return array of all properties for a site
      */
@@ -484,7 +484,7 @@ class Site extends AbstractEntityService{
         $properties = $this->em->createQuery ( $dql )->setParameter ( 'ID', $id )->getOneOrNullResult ();
         return $properties;
     }
-    
+
     /**
      * @return a single site property
      */
@@ -493,13 +493,13 @@ class Site extends AbstractEntityService{
         $property = $this->em->createQuery ( $dql )->setParameter ( 'ID', $id )->getOneOrNullResult ();
         return $property;
     }
-    
+
     /**
      *  @return array of NGIs
      */
     public function getNGIs() {
         $dql = "SELECT n from NGI n";
-        $ngis = $this->em 
+        $ngis = $this->em
             ->createQuery($dql)
             ->getResult();
         return $ngis;
@@ -511,7 +511,7 @@ class Site extends AbstractEntityService{
      */
     public function getCertStatuses() {
         $dql = "SELECT c from CertificationStatus c";
-        $certStatuses = $this->em 
+        $certStatuses = $this->em
             ->createQuery($dql)
             ->getResult();
         return $certStatuses;
@@ -528,7 +528,7 @@ class Site extends AbstractEntityService{
             ->getResult();
         return $prodStatuses;
     }
-    
+
     /**
      *  Return doctrine production status entity from name
      *  @return production status with sepcified name, throws error if multiple results
@@ -549,7 +549,7 @@ class Site extends AbstractEntityService{
     public function getCountries() {
             $dql = "SELECT c from Country c
                             ORDER BY c.name";
-            $countries = $this->em 
+            $countries = $this->em
                     ->createQuery($dql)
                     ->getResult();
             return $countries;
@@ -640,7 +640,7 @@ class Site extends AbstractEntityService{
     public function addSite($values, \User $user =null) {
         //Check the portal is not in read only mode, throws exception if it is
         $this->checkPortalIsNotReadOnlyOrUserIsAdmin($user);
-        
+
         if(is_null($user)){
             throw new Exception("Unregistered users may not add new sites");
         }
@@ -650,48 +650,48 @@ class Site extends AbstractEntityService{
         $parentNgi = $this->em->createQuery("SELECT n FROM NGI n WHERE n.id = :id")
                 ->setParameter('id', $values['NGI'])
                 ->getSingleResult(); // throws NonUniqueResultException throws, NoResultException
-        
+
         if(!$user->isAdmin()){
-            // Check that user has permission to add site to the chosen NGI 
+            // Check that user has permission to add site to the chosen NGI
             if(!$this->roleActionAuthorisationService->authoriseAction(
                     \Action::NGI_ADD_SITE, $parentNgi, $user)->getGrantAction()){
                 throw new \Exception("You do not have permission to add a new site to the selected NGI"
-                        . " To add a new site you require a managing role over an NGI"); 
+                        . " To add a new site you require a managing role over an NGI");
             }
         }
 
-        
+
         // do as much validation before starting a new db tx
         // check the site object data is valid
         $this->validate($values['Site'], 'site');
         $this->uniqueCheck($values['Site']['SHORT_NAME']);
 
-        // ADD SCOPE TAGS: 
+        // ADD SCOPE TAGS:
         // collate selected reserved and non-reserved scopeIds
-        $allSelectedScopeIds = array(); 
+        $allSelectedScopeIds = array();
         foreach($values['Scope_ids'] as $sid){
-            $allSelectedScopeIds[] = $sid; 
+            $allSelectedScopeIds[] = $sid;
         }
         foreach($values['ReservedScope_ids'] as $sid){
-            $allSelectedScopeIds[] = $sid; 
+            $allSelectedScopeIds[] = $sid;
         }
-       
-        $selectedScopesToApply = $this->scopeService->getScopes($allSelectedScopeIds); 
-        
-        // If not admin, check that requested reserved scopes are already implemented by the parent NGI. 
+
+        $selectedScopesToApply = $this->scopeService->getScopes($allSelectedScopeIds);
+
+        // If not admin, check that requested reserved scopes are already implemented by the parent NGI.
         // Required to prevent users manually crafting a POST request in an attempt
-        // to select reserved scopes, this is unlikely but it is a possible hack. 
+        // to select reserved scopes, this is unlikely but it is a possible hack.
         if (!$user->isAdmin()) {
             $selectedReservedScopes = $this->scopeService->getScopesFilterByParams(
-                    array('excludeNonReserved' => true), $selectedScopesToApply);  
-            
+                    array('excludeNonReserved' => true), $selectedScopesToApply);
+
             $existingReservedScopesParent = $this->scopeService->getScopesFilterByParams(
-                    array('excludeNonReserved' => true), $parentNgi->getScopes()->toArray()); 
-            
+                    array('excludeNonReserved' => true), $parentNgi->getScopes()->toArray());
+
             foreach($selectedReservedScopes as $sc){
-                // Reserved scopes must already be assigned to parent 
+                // Reserved scopes must already be assigned to parent
                 if(!in_array($sc, $existingReservedScopesParent)){
-                    throw new \Exception("A reserved Scope Tag was selected that is not assigned to the Parent NGI");  
+                    throw new \Exception("A reserved Scope Tag was selected that is not assigned to the Parent NGI");
                 }
             }
         }
@@ -702,15 +702,15 @@ class Site extends AbstractEntityService{
         // Populate the entity
         try {
             /* Create a PK for this site
-             * This is persisted/flushed (but not committed) before the site 
+             * This is persisted/flushed (but not committed) before the site
              * so the PK is set by the database.
-             * If the site insertion fails the PK can still be rolled back.  
+             * If the site insertion fails the PK can still be rolled back.
              */
             $this->em->getConnection()->beginTransaction();
             $pk = new \PrimaryKey();
             $this->em->persist($pk);
             // flush synchronizes the in-memory state of managed objects with the database
-            // but we can still rollback 
+            // but we can still rollback
             $this->em->flush();
             //$this->em->getConnection()->commit();
             //$this->em->getConnection()->beginTransaction();
@@ -726,7 +726,7 @@ class Site extends AbstractEntityService{
             $site->setLatitude($values['Site']['LATITUDE']);
             $site->setLongitude($values['Site']['LONGITUDE']);
             $site->setCsirtEmail($values['Site']['CSIRTEMAIL']);
-            $site->setIpRange($values['Site']['IP_RANGE']);                    
+            $site->setIpRange($values['Site']['IP_RANGE']);
             $site->setIpV6Range($values['Site']['IP_V6_RANGE']);
             $site->setDomain($values['Site']['DOMAIN']);
             $site->setLocation($values['Site']['LOCATION']);
@@ -735,8 +735,8 @@ class Site extends AbstractEntityService{
             $site->setEmergencyEmail($values['Site']['EMERGENCYEMAIL']);
             $site->setHelpdeskEmail($values['Site']['HELPDESKEMAIL']);
             $site->setTimezoneId($values['Site']['TIMEZONE']);
-                    
-            // join the site to the parent NGI 
+
+            // join the site to the parent NGI
             $site->setNgiDoJoin($parentNgi);
 
             // get the target infrastructure
@@ -747,29 +747,29 @@ class Site extends AbstractEntityService{
             $site->setInfrastructure($inf);
 
             // get the cert status
-            if(!isset($values['Certification_Status']) || 
+            if(!isset($values['Certification_Status']) ||
                     $values['Certification_Status'] == null || $values['Certification_Status'] == ''){
                 throw new \LogicException(
-                        "Missing seed data - No certification status values in the DB (required data)"); 
+                        "Missing seed data - No certification status values in the DB (required data)");
             }
             $dql = "SELECT c FROM CertificationStatus c WHERE c.id = :id";
             $certStatus = $this->em->createQuery($dql)
                     ->setParameter('id', $values['Certification_Status'])
                     ->getSingleResult();
             $site->setCertificationStatus($certStatus);
-            $now = new \DateTime('now',  new \DateTimeZone('UTC')); 
-            $site->setCertificationStatusChangeDate($now); 
+            $now = new \DateTime('now',  new \DateTimeZone('UTC'));
+            $site->setCertificationStatusChangeDate($now);
 
-            // create a new CertStatusLog 
-            $certLog = new \CertificationStatusLog(); 
-            $certLog->setAddedBy($user->getCertificateDn()); 
-            $certLog->setNewStatus($certStatus->getName()); 
-            $certLog->setOldStatus(null); 
-            $certLog->setAddedDate($now); 
-            $certLog->setReason('Initial creation'); 
-            $this->em->persist($certLog); 
-            $site->addCertificationStatusLog($certLog); 
-            
+            // create a new CertStatusLog
+            $certLog = new \CertificationStatusLog();
+            $certLog->setAddedBy($user->getCertificateDn());
+            $certLog->setNewStatus($certStatus->getName());
+            $certLog->setOldStatus(null);
+            $certLog->setAddedDate($now);
+            $certLog->setReason('Initial creation');
+            $this->em->persist($certLog);
+            $site->addCertificationStatusLog($certLog);
+
 
             // Set the scopes
 //            foreach($allSelectedScopeIds as $scopeId){
@@ -780,9 +780,9 @@ class Site extends AbstractEntityService{
 //                $site->addScope($scope);
 //            }
             foreach($selectedScopesToApply as $scope){
-                $site->addScope($scope); 
+                $site->addScope($scope);
             }
-            
+
             // get the country
             $dql = "SELECT c FROM Country c WHERE c.id = :id";
             $country = $this->em->createQuery($dql)
@@ -790,16 +790,16 @@ class Site extends AbstractEntityService{
                     ->getSingleResult();
             $site->setCountry($country);
 
-                    // deprecated - don't use the lookup DB entity  
+                    // deprecated - don't use the lookup DB entity
 //                    $dql = "SELECT t FROM Timezone t WHERE t.id = :id";
 //                    $timezone = $this->em->createQuery($dql)
 //                            ->setParameter('id', $values['Timezone'])
 //                            ->getSingleResult();
 //                    $site->setTimezone($timezone);
-                    
+
             $this->em->persist($site);
             // flush synchronizes the in-memory state of managed objects with the database
-            // but we can still rollback 
+            // but we can still rollback
             $this->em->flush();
             $this->em->getConnection()->commit();
         } catch(\Exception $ex){
@@ -827,12 +827,12 @@ class Site extends AbstractEntityService{
             throw new \Exception("A site named " . $shortName . " already exists.");
         }
     }
-    
+
     /*
      * Moves a site to a new NGI. Site to NGI is a many to one
      * relationship, so moving the site from one NGI removes it
      * from the other.
-     * 
+     *
      * @param \site $site site to be moved
      * @param \NGI $NGI NGI to which $site is to be moved
      * @return null
@@ -843,7 +843,7 @@ class Site extends AbstractEntityService{
 
         //Throws exception if user is not an administrator
         $this->checkUserIsAdmin($user);
-        
+
         $this->em->getConnection()->beginTransaction(); // suspend auto-commit
         try {
             //If the NGI or site have no ID - throw logic exception
@@ -860,15 +860,15 @@ class Site extends AbstractEntityService{
 
             //If the NGI has changed, then we move the site.
             if ($old_NGI != $NGI) {
-                   
+
                  //Remove the site from the old NGI FIRST if it has an old NGI
                 if (!empty($old_NGI)) {
                     $old_NGI->getSites()->removeElement($Site);
                 }
                 //Add site to new NGI
                 $NGI->addSiteDoJoin($Site);
-                //$Site->setNgiDoJoin($NGI); 
-               
+                //$Site->setNgiDoJoin($NGI);
+
                 //persist
                 $this->em->merge($NGI);
                 $this->em->merge($old_NGI);
@@ -882,7 +882,7 @@ class Site extends AbstractEntityService{
             throw $e;
         }
     }
-    
+
     private function checkNumberOfScopes(array $myArray){
         require_once __DIR__ . '/Config.php';
         $configService = new \org\gocdb\services\Config();
@@ -890,14 +890,14 @@ class Site extends AbstractEntityService{
         if(sizeof($myArray)<$minumNumberOfScopes){
             throw new \Exception("A site must have at least " . $minumNumberOfScopes . " optional scope(s) assigned to it.");
         }
-    }   
+    }
 
     /**
      * Delete a site. Only available to admins.
      * @param \Site $s site for deletion
      * @param \User $user user doing the deleting
-     * @param $logSiteAndServicesInArchive Archive the site and its services or not.  
-     * Useful for testing - an incomplete site or its service can easily cause errors when archiving.  
+     * @param $logSiteAndServicesInArchive Archive the site and its services or not.
+     * Useful for testing - an incomplete site or its service can easily cause errors when archiving.
      * @throws \Exception
      */
     public function deleteSite(\Site $s, \User $user =null, $logSiteAndServicesInArchive=true) {
@@ -905,22 +905,22 @@ class Site extends AbstractEntityService{
         require_once __DIR__ . '/../DAOs/ServiceDAO.php';
         //Check the portal is not in read only mode, throws exception if it is
         $this->checkPortalIsNotReadOnlyOrUserIsAdmin($user);
-        
+
         //Throws exception if user is not an administrator
         $this->checkUserIsAdmin($user);
-        
+
         $this->em->getConnection()->beginTransaction();
         try {
             $siteDAO = new \SiteDAO();
             $siteDAO->setEntityManager($this->em);
             $serviceDAO = new \ServiceDAO();
             $serviceDAO->setEntityManager($this->em);
-            
-            //Archive site 
+
+            //Archive site
             if($logSiteAndServicesInArchive){
                 $siteDAO->addSiteToArchive($s, $user);
             }
-            
+
             //delete each child service
             foreach($s->getServices() as $service){
                 if($logSiteAndServicesInArchive){
@@ -933,7 +933,7 @@ class Site extends AbstractEntityService{
 
             //remove the site
             $siteDAO->removeSite($s);
-            
+
             $this->em->flush();
             $this->em->getConnection()->commit();
         } catch (\Exception $e) {
@@ -942,13 +942,13 @@ class Site extends AbstractEntityService{
             throw $e;
         }
     }
-    
+
     /**
-     * This method will check that a user has edit permissions over a site before allowing a user to add, edit or delete 
-     * a site property. 
-     * 
+     * This method will check that a user has edit permissions over a site before allowing a user to add, edit or delete
+     * a site property.
+     *
      * @param \User $user
-     * @param \Site $site         
+     * @param \Site $site
      * @throws \Exception
      */
     public function validatePropertyActions(\User $user, \Site $site) {
@@ -1060,12 +1060,12 @@ class Site extends AbstractEntityService{
             throw $e;
         }
     }
-        
+
     /**
      * Edit a site's property. A check is performed to confirm the given property
      * is from the parent site specified by the request, and an exception is thrown if this is
-     * not the case.  
-     * 
+     * not the case.
+     *
      * @param \Site $site
      * @param \User $user
      * @param \SiteProperty $prop
@@ -1074,31 +1074,31 @@ class Site extends AbstractEntityService{
      */
     public function editSiteProperty(\Site $site,\User $user,\SiteProperty $prop, $newValues) {
         // Check the portal is not in read only mode, throws exception if it is
-        $this->checkPortalIsNotReadOnlyOrUserIsAdmin ( $user );            
-        
+        $this->checkPortalIsNotReadOnlyOrUserIsAdmin ( $user );
+
         //Validate User to perform this action
         $this->validatePropertyActions($user, $site);
-        
+
         $this->validate($newValues['SITEPROPERTIES'], 'siteproperty');
-        
+
         $keyname=$newValues ['SITEPROPERTIES'] ['NAME'];
         $keyvalue=$newValues ['SITEPROPERTIES'] ['VALUE'];
 
         //$this->checkNotReserved($user, $site, $keyname);
-        
+
         $this->em->getConnection()->beginTransaction();
-    
+
         try {
-            //Check that the prop is from the site 
+            //Check that the prop is from the site
             if ($prop->getParentSite() != $site){
                 $id = $prop->getId();
                 throw new \Exception("Property {$id} does not belong to the specified site");
             }
-                    
+
             // Set the site propertys new member variables
             $prop->setKeyName ( $keyname );
             $prop->setKeyValue ( $keyvalue );
-                    
+
             $this->em->merge ( $prop );
             $this->em->flush ();
             $this->em->getConnection ()->commit ();
@@ -1108,11 +1108,11 @@ class Site extends AbstractEntityService{
             throw $ex;
         }
     }
-        
+
     /**
-     * For a given site, returns an array containing the names of all the 
-     * scopes that site has as keys and a boolean as value. The bool is true 
-     * if the scope is shared with the parent ngi, false if not. 
+     * For a given site, returns an array containing the names of all the
+     * scopes that site has as keys and a boolean as value. The bool is true
+     * if the scope is shared with the parent ngi, false if not.
      * @param \Service $service
      * @return associative array
      */
@@ -1120,21 +1120,21 @@ class Site extends AbstractEntityService{
         $parentNgi = $site->getNgi();
         $parentScopes = $parentNgi->getScopes();
         $childScopes = $site->getScopes();
-        
+
         $parentScopesNames = array();
         foreach($parentScopes as $parentScope){
             $parentScopesNames[] =$parentScope->getName();
         }
-        
+
         $childScopesNames = array();
         foreach($childScopes as $childScope){
             $childScopesNames[] =$childScope->getName();
         }
-        
+
         $sharedScopesNames = array_intersect($childScopesNames, $parentScopesNames);
-        
+
         $scopeNamesNotShared = array_diff($childScopesNames, $parentScopesNames);
-        
+
         $ScopeNamesAndParentShareInfo = array();
         foreach($sharedScopesNames as $sharedScopesName){
             $ScopeNamesAndParentShareInfo[$sharedScopesName]=true;
@@ -1142,13 +1142,13 @@ class Site extends AbstractEntityService{
         foreach($scopeNamesNotShared as $scopeNameNotShared){
             $ScopeNamesAndParentShareInfo[$scopeNameNotShared]=false;
         }
-        
+
         //can be replaced with ksort($ScopeNamesAndParentShareInfo, SORT_NATURAL); in php>=5.5
         uksort($ScopeNamesAndParentShareInfo, 'strcasecmp');
-        
+
         return $ScopeNamesAndParentShareInfo;
     }
-    
+
     /**
      * Returns those sites which have valid longitudes and latitudes specified
      * and are not closed
@@ -1156,11 +1156,11 @@ class Site extends AbstractEntityService{
      */
     public function getSitesWithGeoInfo() {
             //Note - we remove any site with 0,0 as it's location, as we have no
-        //sites in the middle of the pacific ocean. We also remove sites with 
+        //sites in the middle of the pacific ocean. We also remove sites with
         //invaid (too large) longs and lats (these are legacy values, new values
-        // entered through the webportal have to be within expected range, 
+        // entered through the webportal have to be within expected range,
         // historical values may not)
-        $dql = "SELECT s 
+        $dql = "SELECT s
                 FROM Site s
                 JOIN s.certificationStatus c
                 WHERE s.latitude IS NOT NULL
@@ -1178,14 +1178,14 @@ class Site extends AbstractEntityService{
 
         return $sites;
     }
-    
+
     /*
      * @return string xml string containing information required by google maps js
      */
     public function getGoogleMapXMLString(){
         $sites = $this->getSitesWithGeoInfo();
         $portalUrl = $this->configService->GetPortalURL();
-        
+
         $xml = new \SimpleXMLElement("<map></map>");
                 foreach($sites as $site) {
             $xmlSite = $xml->addChild('Site');
@@ -1205,7 +1205,7 @@ class Site extends AbstractEntityService{
                 $dom_sxe = $dom->appendChild($dom_sxe);
                 $dom->formatOutput = true;
                 $xmlString = $dom->saveXML();
-        
+
         return $xmlString;
     }
 }

--- a/lib/Gocdb_Services/User.php
+++ b/lib/Gocdb_Services/User.php
@@ -23,7 +23,7 @@ require_once __DIR__ . '/../Doctrine/entities/User.php';
  * @author George Ryall
  */
 class User extends AbstractEntityService{
-    
+
     /*
      * All the public service methods in a service facade are typically atomic -
      * they demarcate the tx boundary at the start and end of the method
@@ -55,17 +55,17 @@ class User extends AbstractEntityService{
      */
     public function getUserByPrinciple($userPrinciple){
        if(empty($userPrinciple)){
-           return null; 
-       } 
+           return null;
+       }
        $dql = "SELECT u from User u WHERE u.certificateDn = :certDn";
        $user = $this->em->createQuery($dql)
                   ->setParameter(":certDn", $userPrinciple)
                   ->getOneOrNullResult();
        return $user;
     }
-    
+
     /**
-     * Updates the users last login time to the current time in UTC. 
+     * Updates the users last login time to the current time in UTC.
      * @param \User $user
      */
     public function updateLastLoginTime(\User $user){
@@ -86,10 +86,10 @@ class User extends AbstractEntityService{
     }
 
     /**
-     * Find sites a user has a role over with the specified role status. 
+     * Find sites a user has a role over with the specified role status.
      * @param \User $user The user
      * @param string $roleStatus Optional role status string @see \RoleStatus (default is GRANTED)
-     * @return array of \Site objects or emtpy array  
+     * @return array of \Site objects or emtpy array
      */
     public function getSitesFromRoles(\User $user, $roleStatus = \RoleStatus::GRANTED) {
         $dql = "SELECT r FROM Role r
@@ -119,10 +119,10 @@ class User extends AbstractEntityService{
     }
 
     /**
-     * Find NGIs a user has a role over with the specified role status.  
+     * Find NGIs a user has a role over with the specified role status.
      * @param \User $user
      * @param string $roleStatus Optional role status string @see \RoleStatus (default is GRANTED)
-     * @return array of \NGI objects or empty array 
+     * @return array of \NGI objects or empty array
      */
     public function getNgisFromRoles(\User $user, $roleStatus = \RoleStatus::GRANTED) {
         $dql = "SELECT r FROM Role r
@@ -151,11 +151,11 @@ class User extends AbstractEntityService{
     }
 
     /**
-     * Find service groups a user has a role over with the specified role status.  
+     * Find service groups a user has a role over with the specified role status.
      * @param \User $user
      * @param string $roleStatus Optional role status string @see \RoleStatus (default is GRANTED)
-     * @return array of \ServiceGroup objects or empty array 
-     */ 
+     * @return array of \ServiceGroup objects or empty array
+     */
     public function getSGroupsFromRoles(\User $user, $roleStatus = \RoleStatus::GRANTED) {
         $dql = "SELECT r FROM Role r
                 INNER JOIN r.user u
@@ -182,12 +182,12 @@ class User extends AbstractEntityService{
 
         return $sGroups;
     }
-    
+
     /**
-     * Find Projects a user has a role over with the specified role status.  
+     * Find Projects a user has a role over with the specified role status.
      * @param \User $user
      * @param string $roleStatus Optional role status string @see \RoleStatus (default is GRANTED)
-     * @return array of \Project objects or empty array 
+     * @return array of \Project objects or empty array
      */
     public function getProjectsFromRoles(\User $user, $roleStatus = \RoleStatus::GRANTED) {
         $dql = "SELECT r FROM Role r
@@ -266,8 +266,8 @@ class User extends AbstractEntityService{
         }
         return $user;
     }
-    
-    
+
+
     /**
      * Check to see if the current user has permission to edit a user entity
      * @param org\gocdb\services\User $user The user being edited or deleted
@@ -279,7 +279,7 @@ class User extends AbstractEntityService{
         if(is_null($currentUser)){
             throw new \Exception("unregistered users may not edit users");
         }
-        
+
         if($currentUser->isAdmin()) {
             return;
         }
@@ -300,8 +300,8 @@ class User extends AbstractEntityService{
      *                   readable description of which field failed validation.
      * @return null */
     private function validateUser($userData) {
-        require_once __DIR__ .'/Validate.php'; 
-        $serv = new \org\gocdb\services\Validate(); 
+        require_once __DIR__ .'/Validate.php';
+        $serv = new \org\gocdb\services\Validate();
         foreach($userData as $field => $value) {
             $valid = $serv->validate('user', $field, $value);
             if(!$valid) {
@@ -343,7 +343,7 @@ class User extends AbstractEntityService{
             $user->setEmail($values['EMAIL']);
             $user->setTelephone($values['TELEPHONE']);
             $user->setCertificateDn($values['CERTIFICATE_DN']);
-            $user->setAdmin(false); 
+            $user->setAdmin(false);
             $this->em->persist($user);
             $this->em->flush();
             $this->em->getConnection()->commit();
@@ -354,7 +354,7 @@ class User extends AbstractEntityService{
         }
         return $user;
     }
-    
+
     /**
      * Update a user's DN
      * @param \User $user user to have DN updated
@@ -366,21 +366,21 @@ class User extends AbstractEntityService{
     public function editUserDN(\User $user, $dn, \User $currentUser = null){
         //Authorisation - only GOCDB Admins shoud be able to change DNs (Throws exception if not)
         $this->checkUserIsAdmin($currentUser);
-        
+
         //Check the DN is changed
         if($dn == $user->getCertificateDn()) {
             throw new \Exception("The specified certificate DN is the same as the current DN");
         }
-        
+
         //Check the DN is unique (if not null)
         if(!is_null($this->getUserByPrinciple($dn))) {
             throw new \Exception("DN is already registered in GOCDB");
         }
-        
+
         //Validate the DN
         $dnInAnArray['CERTIFICATE_DN']= $dn;
         $this->validateUser($dnInAnArray);
-        
+
         //Explicity demarcate our tx boundary
         $this->em->getConnection()->beginTransaction();
         try {
@@ -416,7 +416,7 @@ class User extends AbstractEntityService{
             throw $e;
         }
     }
-    
+
     /**
      * Returns all users in GOCDB or those matching optional criteria note
      * forename and surname are handled case insensitivly
@@ -446,9 +446,9 @@ class User extends AbstractEntityService{
 
         return $users;
     }
-    
+
     /**
-     * Changes the isAdmin user property. 
+     * Changes the isAdmin user property.
      * @param \User $user           The user who's admin status is to change
      * @param \User $currentUser    The user making the change, who themselvess must be an admin
      * @param boolean $isAdmin      The new property. This must be boolean true or false.
@@ -459,17 +459,17 @@ class User extends AbstractEntityService{
 
         //Throws exception if the current user is not an administrator - only admins can make admins
         $this->checkUserIsAdmin($user);
-                 
+
         //Check that $isAdmin is boolean
         if(!is_bool($isAdmin)){
             throw new \Exception("the setUserAdmin function takes on boolean values for isAdmin");
         }
-        
+
         //Check user is not changing themselves - prevents lone admin acidentally demoting themselves
         if($user==$currentUser){
             throw new \Exception("To ensure there is always at least one administrator, you may not demote yourself, please ask another administrator to do it");
         }
-        
+
         //Actually make the change
         $this->em->getConnection()->beginTransaction();
         try {
@@ -482,6 +482,6 @@ class User extends AbstractEntityService{
             $this->em->close();
             throw $e;
         }
-        
+
     }*/
 }

--- a/lib/Gocdb_Services/Validate.php
+++ b/lib/Gocdb_Services/Validate.php
@@ -35,7 +35,7 @@ class Validate {
     {
         //Check the length of the field value, if too long, throws exception
         $this->checkFieldLength($Object_Name, $Field_Name, $Field_Value);
-        
+
         $RegEx = $this->Get_Field_value($Object_Name, $Field_Name, 'regex');
         // If there are no checks to perform then $Field_Value must be valid
         if(count($RegEx) == 0)
@@ -47,7 +47,7 @@ class Validate {
 
         return true;
     }
-    
+
     /**
      * Checks the length of inputs against the length specified in the schema.
      * @throws \Exception

--- a/lib/Gocdb_Services/validation/IPv6Validator.php
+++ b/lib/Gocdb_Services/validation/IPv6Validator.php
@@ -2,41 +2,41 @@
 require_once __DIR__.'/IValidator.php';
 
 /**
- * Validator for IPv6 address ranges. 
+ * Validator for IPv6 address ranges.
  *
- * @author David Meredith  
+ * @author David Meredith
  */
 class IPv6Validator implements IValidator {
-   
+
     /**
-     * Determine if the given object type can be validated by this class. 
+     * Determine if the given object type can be validated by this class.
      * @param string $object
      * @return boolean
      */
     public function supports($object) {
-       return is_string($object);   
+       return is_string($object);
     }
 
     /**
-     * Validate the given ipv6 address, errors are added to the $errors array. 
-     * @param string $ipaddr IPv6 address with optional /int prefix  
-     * @param array $errors 
-     * @return array Errors array, if ip is valid, the no extra errors are added. 
+     * Validate the given ipv6 address, errors are added to the $errors array.
+     * @param string $ipaddr IPv6 address with optional /int prefix
+     * @param array $errors
+     * @return array Errors array, if ip is valid, the no extra errors are added.
      * @throws \LogicException if given params are not of expected type
      */
     public function validate($ipaddr, $errors) {
         if(!is_array($errors)){
-            throw new \LogicException('$errors object is not an array'); 
+            throw new \LogicException('$errors object is not an array');
         }
         if(!is_string($ipaddr)){
-            throw new \LogicException('Ip address is not a string'); 
+            throw new \LogicException('Ip address is not a string');
         }
         $cx = strpos($ipaddr, '/');
         if ($cx) {
             $subnet = intval((substr($ipaddr, $cx + 1)));
             if($subnet == 0){
-              $errors[] = 'Invalid IPv6 netmask'; 
-              return $errors; 
+              $errors[] = 'Invalid IPv6 netmask';
+              return $errors;
             }
             $ipaddr = substr($ipaddr, 0, $cx);
         } else {
@@ -46,10 +46,10 @@ class IPv6Validator implements IValidator {
         //$isValid = filter_var('2001:adb8:85a3:7334', FILTER_VALIDATE_IP, array('flags' => FILTER_FLAG_IPV6, FILTER_FLAG_NO_PRIV_RANGE, FILTER_FLAG_NO_RES_RANGE) );
         $validIpAddr = filter_var($ipaddr, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6);
         if ($validIpAddr != FALSE) {
-            return $errors; // filter_val did not return false, so return 
+            return $errors; // filter_val did not return false, so return
         } else {
-            $errors[] = 'Invalid IPv6 address range'; 
-            return $errors; 
+            $errors[] = 'Invalid IPv6 address range';
+            return $errors;
         }
     }
 

--- a/lib/Gocdb_Services/validation/IValidator.php
+++ b/lib/Gocdb_Services/validation/IValidator.php
@@ -1,29 +1,29 @@
 <?php
 
 /**
- * Generic validator interface for validating objects. 
- * The interface defines a method to determine the supported object type 
- * targeted for validation and the subsequent validate method.   
- * 
- * @author David Meredith  
+ * Generic validator interface for validating objects.
+ * The interface defines a method to determine the supported object type
+ * targeted for validation and the subsequent validate method.
+ *
+ * @author David Meredith
  */
 interface IValidator {
   /**
-   * Determine if the given object can be validated. 
-   * @param mixed $object The object targed for validation.  
+   * Determine if the given object can be validated.
+   * @param mixed $object The object targed for validation.
    * @return boolean true if supported otherwise false
-   */  
-  public function supports($object); 
-  
+   */
+  public function supports($object);
+
   /**
    * Validate the target object. Validation error strings will be added to the
-   * given errors array (the array must exist). If there are no 
-   * errors, the size of the array will not be changed. 
-   * 
-   * @param mixed $object validate the given object 
-   * @param array $errors add error strings to the given array 
-   * @return array the errors array 
+   * given errors array (the array must exist). If there are no
+   * errors, the size of the array will not be changed.
+   *
+   * @param mixed $object validate the given object
+   * @param array $errors add error strings to the given array
+   * @return array the errors array
    * @throws \LogicException if given params are not of expected type
    */
-  public function validate($object, $errors); 
+  public function validate($object, $errors);
 }

--- a/resources/ApplyScopeTagsToSitesAndServicesRunner.php
+++ b/resources/ApplyScopeTagsToSitesAndServicesRunner.php
@@ -14,20 +14,20 @@
  */
 
 /**
- * CLI script to join a batch of scopes to a list of Sites. 
+ * CLI script to join a batch of scopes to a list of Sites.
  * <p>
- * You need to update the $requestedScopeNames and $requestedSiteNames arrays 
- * to specify which sites/scopes you want to link. Note, the sites and scopes 
- * must already be added to the DB. 
- * 
- * @author David Meredith 
+ * You need to update the $requestedScopeNames and $requestedSiteNames arrays
+ * to specify which sites/scopes you want to link. Note, the sites and scopes
+ * must already be added to the DB.
+ *
+ * @author David Meredith
  */
 require_once dirname(__FILE__) . "/../lib/Doctrine/bootstrap.php";
 require dirname(__FILE__) . '/../lib/Doctrine/bootstrap_doctrine.php';
 require_once __DIR__ . '/../lib/Gocdb_Services/Scope.php';
 require_once __DIR__ . '/../lib/Gocdb_Services/Site.php';
 
-// Specify a list of Scopes that you want to add to the sites/services. 
+// Specify a list of Scopes that you want to add to the sites/services.
 //$requestedScopeNames = array('DAVE', 'Local', 'EGI'); //'wlcg', 'cms');
 
 // Specify a list of Site Names to add the scopes
@@ -43,7 +43,7 @@ require_once __DIR__ . '/../lib/Gocdb_Services/Site.php';
 //'INFN-LNL-2', 'INFN-T1', 'INFN-TORINO', 'INFN-TRIESTE', 'ITEP', 'JINR-LCG2', 'JP-HIROSHIMA-WLCG', 'KR-KISTI-GSDC-01', 'NCP-LCG2', 'NDGF-T1', 'NIHAM',
 //'NIKHEF-ELPROD', 'PK-CIIT', 'PSNC', 'RAL-LCG2', 'RO-07-NIPNE', 'RO-13-ISS', 'RRC-KI', 'RRC-KI-T1', 'RU-Protvino-IHEP', 'RU-SPbSU', 'Ru-Troitsk-INR-LCG2', 'SAMPA',
 //'SARA-MATRIX', 'SE-SNIC-T2', 'SUPERCOMPUTO-UNAM', 'T2-TH-CUNSTDA', 'T2-TH-SUT', 'UA-BITP', 'UA-ISMA', 'UA-KNU', 'UKI-SOUTHGRID-BHAM-HEP', 'UKI-SOUTHGRID-OX-HEP', 'WUT',
-//'ZA-CHPC', 'praguelcg2', 'ru-Moscow-MEPHI-LCG2', 'ru-PNPI'); 
+//'ZA-CHPC', 'praguelcg2', 'ru-Moscow-MEPHI-LCG2', 'ru-PNPI');
 
 //$requestedScopeNames = array('wlcg', 'lhcb');
 //$requestedSiteNames = array( 'AUVERGRID', 'CBPF', 'CERN-PROD', 'CSCS-LCG2', 'CYFRONET-LCG2', 'DESY-HH', 'DESY-ZN', 'FZK-LCG2', 'GRIF', 'ICM', 'IL-TAU-HEP',
@@ -52,9 +52,9 @@ require_once __DIR__ . '/../lib/Gocdb_Services/Site.php';
 //'RU-Protvino-IHEP', 'RU-SPbSU', 'Ru-Troitsk-INR-LCG2', 'SAMPA', 'SARA-MATRIX', 'TECHNION-HEP', 'UB-LCG2', 'UKI-LT2-Brunel', 'UKI-LT2-IC-HEP', 'UKI-LT2-QMUL', 'UKI-LT2-RHUL',
 //'UKI-NORTHGRID-LANCS-HEP', 'UKI-NORTHGRID-LIV-HEP', 'UKI-NORTHGRID-MAN-HEP', 'UKI-NORTHGRID-SHEF-HEP', 'UKI-SCOTGRID-DURHAM', 'UKI-SCOTGRID-ECDF', 'UKI-SCOTGRID-GLASGOW',
 //'UKI-SOUTHGRID-BHAM-HEP', 'UKI-SOUTHGRID-BRIS-HEP', 'UKI-SOUTHGRID-CAM-HEP', 'UKI-SOUTHGRID-OX-HEP', 'UKI-SOUTHGRID-RALPP', 'USC-LCG2', 'WEIZMANN-LCG2', 'pic', 'ru-PNPI',
-//); 
+//);
 
-//$requestedScopeNames = array('wlcg', 'cms'); 
+//$requestedScopeNames = array('wlcg', 'cms');
 //$requestedSiteNames = array(
 //'CERN-PROD', 'FZK-LCG2', 'pic', 'IN2P3-CC', 'INFN-T1', 'JINR-T1', 'RAL-LCG2', 'Hephy-Vienna', 'BEgrid-ULB-VUB', 'BelGrid-UCL', 'CSCS-LCG2',
 //'BEIJING-LCG2', 'DESY-HH', 'RWTH-Aachen', 'T2_Estonia', 'CIEMAT-LCG2', 'IFCA-LCG2', 'FI_HIP_T2', 'IN2P3-CC-T2', 'GRIF', 'IN2P3-IRES',
@@ -62,23 +62,23 @@ require_once __DIR__ . '/../lib/Gocdb_Services/Site.php';
 //'NCBJ-CIS', 'ICM', 'NCG-INGRID-PT', 'RU-Protvino-IHEP', 'Ru-Troitsk-INR-LCG2', 'ITEP', 'JINR-LCG2', 'ru-PNPI', 'RRC-KI', 'ru-Moscow-SINP-LCG2', 'T2-TH-CUNSTDA',
 //'TR-03-METU', 'Kharkov-KIPT-LCG2', 'UKI-LT2-Brunel', 'UKI-LT2-IC-HEP', 'UKI-SOUTHGRID-BRIS-HEP', 'UKI-SOUTHGRID-RALPP',
 ////'IFRU',
-//); 
+//);
 
 // set the $requestesSiteNames by including the file
-//require __DIR__ . '/ApplyScopeTagsToSites_SiteValues.php'; 
-//$requestedSiteNames = $requestedSiteNames2; 
+//require __DIR__ . '/ApplyScopeTagsToSites_SiteValues.php';
+//$requestedSiteNames = $requestedSiteNames2;
 
-//$requestedScopeNames = array('wlcg', 'atlas'); 
-//$requestedSiteNames = array(); 
+//$requestedScopeNames = array('wlcg', 'atlas');
+//$requestedSiteNames = array();
 
 
-$requestedScopeNames = array('tier1'); 
+$requestedScopeNames = array('tier1');
 $requestedSiteNames = array( 'TRIUMF-LCG2', 'IN2P3-CC', 'FZK-LCG2', 'INFN-T1', 'NIKHEF-ELPROD',
 'SARA-MATRIX', 'NDGF-T1', 'KR-KISTI-GSDC-01', 'RRC-KI-T1', 'JINR-T1', 'pic', 'Taiwan-LCG2',
-'RAL-LCG2', 'USCMS-FNAL-WC1', 'BNL-ATLAS'); 
+'RAL-LCG2', 'USCMS-FNAL-WC1', 'BNL-ATLAS');
 
 
-//$requestedScopeNames = array('tier2'); 
+//$requestedScopeNames = array('tier2');
 //$requestedSiteNames = array( 'Australia-ATLAS', 'HEPHY-UIBK', 'Hephy-Vienna', 'BEgrid-ULB-VUB', 'BelGrid-UCL',
 //'CA-MCGILL-CLUMEQ-T2', 'CA-SCINET-T2', 'CA-VICTORIA-WESTGRID-T2', 'SFU-LCG2', 'BEIJING-LCG2', 'praguelcg2', 'T2_Estonia',
 //'FI_HIP_T2', 'IN2P3-CC-T2', 'IN2P3-CPPM', 'GRIF', 'IN2P3-IRES', 'IN2P3-LAPP', 'IN2P3-LPC', 'IN2P3-LPSC', 'IN2P3-SUBATECH',
@@ -93,10 +93,10 @@ $requestedSiteNames = array( 'TRIUMF-LCG2', 'IN2P3-CC', 'FZK-LCG2', 'INFN-T1', '
 //'UNIBE-LHEP', 'TW-FTT', 'T2-TH-CUNSTDA', 'T2-TH-SUT', 'TR-03-METU', 'TR-10-ULAKBIM', 'UKI-LT2-Brunel', 'UKI-LT2-IC-HEP', 'UKI-LT2-QMUL',
 //'UKI-LT2-RHUL', 'UKI-LT2-UCL-HEP', 'UKI-NORTHGRID-LANCS-HEP', 'UKI-NORTHGRID-LIV-HEP', 'UKI-NORTHGRID-MAN-HEP', 'UKI-NORTHGRID-SHEF-HEP', 'UKI-SCOTGRID-DURHAM',
 //'UKI-SCOTGRID-ECDF', 'UKI-SCOTGRID-GLASGOW', 'EFDA-JET', 'UKI-SOUTHGRID-BHAM-HEP', 'UKI-SOUTHGRID-BRIS-HEP', 'UKI-SOUTHGRID-CAM-HEP', 'UKI-SOUTHGRID-OX-HEP',
-//'UKI-SOUTHGRID-RALPP', 'UKI-SOUTHGRID-SUSX', 'Kharkov-KIPT-LCG2', 'UA-BITP', 'UA-ISMA', 'UA-KNU',); 
+//'UKI-SOUTHGRID-RALPP', 'UKI-SOUTHGRID-SUSX', 'Kharkov-KIPT-LCG2', 'UA-BITP', 'UA-ISMA', 'UA-KNU',);
 
-// specify '--force' to actually execute the changes, otherwise script will 
-// only show which sites will be updated with which scopes 
+// specify '--force' to actually execute the changes, otherwise script will
+// only show which sites will be updated with which scopes
 $forceOrShow = "--show";
 $commandLineArgValid = false;
 if (isset($argv[1])) {
@@ -112,28 +112,28 @@ if (!$commandLineArgValid) {
 
 
 
-// Setp connection and services 
+// Setp connection and services
 $em = $entityManager;
 $scopeService = new org\gocdb\services\Scope();
 $scopeService->setEntityManager($em);
 $siteService = new org\gocdb\services\Site();
 $siteService->setEntityManager($em);
 
-echo "Checking for duplicates in requested sites/scopes \n"; 
+echo "Checking for duplicates in requested sites/scopes \n";
 if(count($requestedSiteNames) !== count(array_unique($requestedSiteNames))){
 //    $uarr = array_unique($requestedSiteNames);
 //    $dups = var_dump(array_diff($requestedSiteNames, array_diff($uarr, array_diff_assoc($requestedSiteNames, $uarr))));
 //    foreach($dups as $dup){
-//	echo "$dups\n"; 
+//	echo "$dups\n";
 //    }
-    die("ERROR - Requested sites has a duplicate entry\n"); 
+    die("ERROR - Requested sites has a duplicate entry\n");
 }
 if(count($requestedScopeNames) !== count(array_unique($requestedScopeNames))){
-    die("ERROR - Requested scope has a duplicate entry\n"); 
+    die("ERROR - Requested scope has a duplicate entry\n");
 }
 
 
-// Nasty shortcut just to extract all the GOCDB names from the site name list 
+// Nasty shortcut just to extract all the GOCDB names from the site name list
 if ($forceOrShow == '--listSiteNames') {
     foreach ($requestedSiteNames as $requestedSiteName) {
     $filterParams = array('sitename' => $requestedSiteName);
@@ -141,16 +141,16 @@ if ($forceOrShow == '--listSiteNames') {
     if (count($siteArray) == 0) {
         //die("ERROR - Requested Site does not exist in the DB [" . $requestedSiteName . "]\n");
     } else {
-        echo $siteArray[0]->getShortName()."\n"; 
+        echo $siteArray[0]->getShortName()."\n";
     }
     }
-    die('done'); 
+    die('done');
 }
 
 
 
-// Check that the requested scopes actually exist in the DB and populate  
-// the 'targetScopesToAdd' array. 
+// Check that the requested scopes actually exist in the DB and populate
+// the 'targetScopesToAdd' array.
 echo "Checking the requested Scopes exist in the DB\n";
 $allScopes = $scopeService->getScopes();
 $targetScopesToAdd = array();
@@ -169,12 +169,12 @@ foreach ($requestedScopeNames as $requestedScopeName) {
     die("Requested scope don't exist [" . $requestedScopeName . "]\n");
     }
 }
-echo "Scopes OK\n"; 
+echo "Scopes OK\n";
 
 
 
 
-// Check that the requested sites exist in the DB. 
+// Check that the requested sites exist in the DB.
 echo "Checking requested Sites exist in the DB\n";
 foreach ($requestedSiteNames as $requestedSiteName) {
     $filterParams = array('sitename' => $requestedSiteName);
@@ -188,10 +188,10 @@ echo "Sites OK\n";
 // If true, the target scopes will be added to each Site's child services.
 $applyScopeToChildSites = true;
 
-// Run all updates in tx to rollback if issue occurs 
+// Run all updates in tx to rollback if issue occurs
 $em->getConnection()->beginTransaction();
 try {
-// Get Site instance, see if it is missing a targetScope  
+// Get Site instance, see if it is missing a targetScope
     foreach ($requestedSiteNames as $requestedSiteName) {
     $filterParams = array('sitename' => $requestedSiteName);
     $siteArray = $siteService->getSitesFilterByParams($filterParams);
@@ -203,7 +203,7 @@ try {
     foreach ($targetScopesToAdd as $addTargetScope) {
         $addScope = true;
 
-        // Iterate Site's scopes and determine if it already has the targetScope 
+        // Iterate Site's scopes and determine if it already has the targetScope
         /* @var $siteScope \Scope */
         foreach ($siteScopes as $siteScope) {
         if ($siteScope->getName() == $addTargetScope->getName()) {
@@ -212,7 +212,7 @@ try {
             break;
         }
         }
-        // Site don't have scope, so add it and echo 
+        // Site don't have scope, so add it and echo
         if ($addScope) {
         echo ' +' . $addTargetScope->getName();
         //if ($forceOrShow == '--force') {
@@ -222,28 +222,28 @@ try {
         }
         // Iterate child services scopes and see if each is missing the targetScope
         if ($applyScopeToChildSites) {
-        //echo "\n\tSEs: (".$addTargetScope->getName(); 
+        //echo "\n\tSEs: (".$addTargetScope->getName();
         /* @var $se \Service */
         foreach ($site->getServices() as $se) {
             $addSeScope = true;
             $seScopes = $se->getScopes();
             foreach ($seScopes as $seScope) {
             if ($seScope->getName() == $addTargetScope->getName()) {
-                // the service already has the scope, so break 
+                // the service already has the scope, so break
                 $addSeScope = false;
                 break;
             }
             }
-            // Service don't have scope, so add it 
+            // Service don't have scope, so add it
             if ($addSeScope) {
-            //echo ' +'.$se->getHostName().',';  	
+            //echo ' +'.$se->getHostName().',';
             //if ($forceOrShow == '--force') {
                 $se->addScope($addTargetScope);
-                $em->persist($se); 
+                $em->persist($se);
             //}
             }
         }
-        //echo ')'; 
+        //echo ')';
         }
     }
     echo "\n";
@@ -253,11 +253,11 @@ try {
     $em->flush();
     $em->getConnection()->commit();
     }
-    
+
 } catch (\Exception $e) {
     $em->getConnection()->rollback();
     $em->close();
-    echo $e->getMessage(); 
+    echo $e->getMessage();
 }
 
 

--- a/resources/QueryPopulateSSO_UsernameRunner.php
+++ b/resources/QueryPopulateSSO_UsernameRunner.php
@@ -14,14 +14,14 @@
  */
 
 /*
- * Script to query and update each user's EGI SSO user name value in the 
- * DB (User->username1). Note, the EGI SSO username is NOT used as a the 
- * user's unique principle string in the DB and so does not need to be unique. 
- * The transaction is committed only after updating 
- * all the username values in the DB (either all usernames are updated or none). 
+ * Script to query and update each user's EGI SSO user name value in the
+ * DB (User->username1). Note, the EGI SSO username is NOT used as a the
+ * user's unique principle string in the DB and so does not need to be unique.
+ * The transaction is committed only after updating
+ * all the username values in the DB (either all usernames are updated or none).
  * <p>
- * This script is usually ran from an external cron.hourly. 
- * 
+ * This script is usually ran from an external cron.hourly.
+ *
  * @author David Meredith
  */
 require_once dirname(__FILE__) . "/../lib/Doctrine/bootstrap.php";
@@ -33,7 +33,7 @@ $em = $entityManager;
 $dql = "SELECT u FROM User u";
 $users = $entityManager->createQuery($dql)->getResult();
 
-echo "Starting update of EGI SSO usernames at: ".date('D, d M Y H:i:s')."\n"; 
+echo "Starting update of EGI SSO usernames at: ".date('D, d M Y H:i:s')."\n";
 $count = 0;
 foreach ($users as $user) {
     ++$count;
@@ -47,7 +47,7 @@ foreach ($users as $user) {
         curl_setopt($ch, CURLOPT_PROXYPORT, 8080);
         curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 2);
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true); //return result instead of outputting it
-        curl_setopt($ch, CURLOPT_TIMEOUT, 3); //3secs 
+        curl_setopt($ch, CURLOPT_TIMEOUT, 3); //3secs
         $ssousername = trim(curl_exec($ch));
         //if(curl_errno($ch)){ // error occured. //}
         //$info = curl_getinfo($ch);
@@ -59,16 +59,16 @@ foreach ($users as $user) {
             $ssousername = null;
         }
         //echo $count . ' ' . $user->getCertificateDn() . "  " . $ssousername . "\n";
-        //echo $count.",";   
+        //echo $count.",";
         if($ssousername != null){
-          $user->setUsername1($ssousername); 
-          $em->persist($user); 
+          $user->setUsername1($ssousername);
+          $em->persist($user);
           //$em->flush();
         }
     }
 }
 $em->flush();
-echo "Completed ok: ".date('D, d M Y H:i:s'); 
+echo "Completed ok: ".date('D, d M Y H:i:s');
 
 function cleanDN($dn) {
     return trim(str_replace(' ', '%20', $dn));

--- a/tests/DoctrineTestSuite1.php
+++ b/tests/DoctrineTestSuite1.php
@@ -19,7 +19,7 @@ require_once __DIR__ . '/unit/lib/Gocdb_Services/ScopeServiceTest.php';
 
 /**
  * TestSuite designed to run the main doctrine tests
- * @author David Meredith <david.meredith@stfc.ac.uk> 
+ * @author David Meredith <david.meredith@stfc.ac.uk>
  */
 class DoctrineTestSuite1 {
     public static function suite() {

--- a/tests/doctrine/DoctrineCleanInsert1Test.php
+++ b/tests/doctrine/DoctrineCleanInsert1Test.php
@@ -2,34 +2,34 @@
 
 //require_once 'PHPUnit/Extensions/Database/TestCase.php';
 //require_once 'PHPUnit/Extensions/Database/DataSet/DefaultDataSet.php';
-require_once dirname(__FILE__) . '/TestUtil.php'; 
+require_once dirname(__FILE__) . '/TestUtil.php';
 
-use Doctrine\ORM\EntityManager; 
+use Doctrine\ORM\EntityManager;
 require_once dirname(__FILE__) . "/bootstrap.php";
-        
+
 
 /**
  * This test case truncates the test database (a clean insert with no seed data)
- * and performs subsequent CRUD operations using Doctrine ORM. 
- * Usage: 
+ * and performs subsequent CRUD operations using Doctrine ORM.
+ * Usage:
  * Run the recreate.sh to create the sample database first (create tables etc), then run:
  * '$phpunit TestDoctrineCleanInsert1.php'
  * <p>
- * Note, this class shows the correct usage of the Doctrine ORM under certain 
- * conditions rather than testing the overlying GOCDB DAO and Service layers.  
- * 
+ * Note, this class shows the correct usage of the Doctrine ORM under certain
+ * conditions rather than testing the overlying GOCDB DAO and Service layers.
+ *
  * @author David Meredith <david.meredith@stfc.ac.uk>
- * @author Johnn Casson <john.casson@stfc.ac.uk> 
+ * @author Johnn Casson <john.casson@stfc.ac.uk>
  */
 class DoctrineCleanInsert1Test extends PHPUnit_Extensions_Database_TestCase {
 
-   private $em; 
-   private $egiScope; 
-   private $localScope; 
-   private $eudatScope; 
-   
+   private $em;
+   private $egiScope;
+   private $localScope;
+   private $eudatScope;
+
     /**
-     * Overridden. 
+     * Overridden.
      */
     public static function setUpBeforeClass() {
         parent::setUpBeforeClass();
@@ -37,29 +37,29 @@ class DoctrineCleanInsert1Test extends PHPUnit_Extensions_Database_TestCase {
         echo "\n\n-------------------------------------------------\n";
         echo "Executing DoctrineCleanInsert1Test. . .\n";
     }
-    
+
     /**
      * Overridden. Returns the test database connection.
      * @return PHPUnit_Extensions_Database_DB_IDatabaseConnection
      */
     protected function getConnection() {
         require_once dirname(__FILE__) . '/bootstrap_pdo.php';
-        return getConnectionToTestDB(); 
+        return getConnectionToTestDB();
     }
 
     /**
-     * Overridden. Returns the test dataset.  
-     * Defines how the initial state of the database should look before each test is executed. 
+     * Overridden. Returns the test dataset.
+     * Defines how the initial state of the database should look before each test is executed.
      * @return PHPUnit_Extensions_Database_DataSet_IDataSet
      */
-    protected function getDataSet() { 
+    protected function getDataSet() {
         return $this->createFlatXMLDataSet(dirname(__FILE__) . '/truncateDataTables.xml');
         // Use below to return an empty data set if we don't want to truncate and seed
         //return new PHPUnit_Extensions_Database_DataSet_DefaultDataSet();
     }
 
     /**
-     * Overridden. 
+     * Overridden.
      */
     protected function getSetUpOperation() {
         // CLEAN_INSERT is default
@@ -67,14 +67,14 @@ class DoctrineCleanInsert1Test extends PHPUnit_Extensions_Database_TestCase {
         //return PHPUnit_Extensions_Database_Operation_Factory::UPDATE();
         //return PHPUnit_Extensions_Database_Operation_Factory::NONE();
         //
-        // Issue a DELETE from <table> which is more portable than a 
-        // TRUNCATE table <table> (some DBs require high privileges for truncate statements 
+        // Issue a DELETE from <table> which is more portable than a
+        // TRUNCATE table <table> (some DBs require high privileges for truncate statements
         // and also do not allow truncates across tables with FK contstraints e.g. Oracle)
         return PHPUnit_Extensions_Database_Operation_Factory::DELETE_ALL();
     }
 
     /**
-     * Overridden. 
+     * Overridden.
      */
     protected function getTearDownOperation() {
         // NONE is default
@@ -86,18 +86,18 @@ class DoctrineCleanInsert1Test extends PHPUnit_Extensions_Database_TestCase {
      * This method is called before each test method is executed.
      */
     protected function setUp() {
-        parent::setUp();            
-        $this->em = $this->createEntityManager();		
+        parent::setUp();
+        $this->em = $this->createEntityManager();
     }
-    
+
     /**
-     * @todo Still need to setup connection to different databases. 
+     * @todo Still need to setup connection to different databases.
      * @return EntityManager
      */
     private function createEntityManager(){
         //require dirname(__FILE__).'/../bootstrap.php';
         require dirname(__FILE__).'/bootstrap_doctrine.php';
-        return $entityManager; 
+        return $entityManager;
     }
 
     /**
@@ -113,128 +113,128 @@ class DoctrineCleanInsert1Test extends PHPUnit_Extensions_Database_TestCase {
             //print $tableName->getName() . "\n";
             $sql = "SELECT * FROM ".$tableName->getName();
             $result = $con->createQueryTable('results_table', $sql);
-            //echo 'row count: '.$result->getRowCount() ; 
-            if($result->getRowCount() != 0) 
+            //echo 'row count: '.$result->getRowCount() ;
+            if($result->getRowCount() != 0)
                 throw new RuntimeException("Invalid fixture. Table has rows: ".$tableName->getName());
         }
     }
-    
+
 //    public function testSimpleAssert(){
 //        print __METHOD__ . "\n";
-//        $this->assertTrue(2 == 2); 
+//        $this->assertTrue(2 == 2);
 //    }
-   
+
     public function testAssertTestEntityMangersAreDifferent(){
         print __METHOD__ . "\n";
-        $em1 = $this->createEntityManager(); 
-        $em2 = $this->createEntityManager(); 
-        // Below asserts that two variables do not have the same type and value. 
+        $em1 = $this->createEntityManager();
+        $em2 = $this->createEntityManager();
+        // Below asserts that two variables do not have the same type and value.
         // Used on objects, it asserts that two variables do not reference the same object.
-        $this->assertNotSame($em1, $em2); 
+        $this->assertNotSame($em1, $em2);
         if($em1 === $em2){
-            $this->fail();  
+            $this->fail();
         }
     }
 
 
     public function testJoinServicesToSite_RefetchSiteLazyLoadSEs() {
         print __METHOD__ . "\n";
-        // create a sinlge site and add 3 service endpoints 
+        // create a sinlge site and add 3 service endpoints
         $n = 3;
-        $site = TestUtil::createSampleSite('site' . $n);     
-        $this->em->persist($site); 
+        $site = TestUtil::createSampleSite('site' . $n);
+        $this->em->persist($site);
         for ($i = 0; $i < $n; $i++) {
             $se = TestUtil::createSampleService("serv" . $i);
             $site->addServiceDoJoin($se);
             $se->setParentSiteDoJoin($site);
-            $this->em->persist($se);   
+            $this->em->persist($se);
         }
         $seCount = count($site->getServices());
         $this->assertTrue($seCount == $n);
         $this->em->flush();
-        $this->em->clear(); 
-        $this->em->close(); 
+        $this->em->clear();
+        $this->em->close();
 
         $em2 = $this->createEntityManager();
-        $refetchedSite = $em2->getRepository('Site')->findOneBy(array('shortName' => 'site' . $n)); 
-        $this->assertNotNull($refetchedSite); 
-        $em2->clear(); 
-        $em2->close();  
+        $refetchedSite = $em2->getRepository('Site')->findOneBy(array('shortName' => 'site' . $n));
+        $this->assertNotNull($refetchedSite);
+        $em2->clear();
+        $em2->close();
         // close causes all managed entities ($refetchedSite) to become detached
-        // and the em2 can't be used again. 
-        
+        // and the em2 can't be used again.
+
                                                 /** Why the following works **/
         /* When doctrine fetches an entity its default is to lazy load related entities - it does
-         * not directly hydrate them it creates a proxy. Although the entity manager is closed the 
-         * code below is able to get the service count, name and parent site. This is because when 
+         * not directly hydrate them it creates a proxy. Although the entity manager is closed the
+         * code below is able to get the service count, name and parent site. This is because when
          * doctrine creates a proxy the proxy also contains an instance of the EntityManager and it's
          * dependancies which can then be used when the proxy is called to hydrate the entity and provide
-         * the required data. 
-         */	
-        
-        
-        $seList = $refetchedSite->getServices(); 
+         * the required data.
+         */
+
+
+        $seList = $refetchedSite->getServices();
         /*foreach($seList as $se){
-            print $se->getId().' '.$se->getHostName()."\n"; 
+            print $se->getId().' '.$se->getHostName()."\n";
         }*/
-        $this->assertCount(3, $seList); 
+        $this->assertCount(3, $seList);
     }
-    
-    
+
+
     /**
      * @link http://stackoverflow.com/questions/7877987/read-objects-persisted-but-not-yet-flushed-with-doctrine issue with doctrine
      */
     public function testShowDoctrineReadFailiureUntilCommitted(){
         print __METHOD__ . "\n";
         $n = 1;
-        // create a new site and persist (but do not flush yet) 
+        // create a new site and persist (but do not flush yet)
         $site = TestUtil::createSampleSite('site' . $n/*, 'pk' . $n*/);
-        $this->em->beginTransaction(); 
+        $this->em->beginTransaction();
         $this->em->persist($site);
-        // After persist, Doctrine querying does not return our site until we flush, hence we get 0 
-        // returned from our repository. 
-        $this->assertEquals(0, count($this->em->getRepository('Site')->findOneBy(array('shortName' => 'site' . $n)))); 
-        // When we flush or commit we get one. 
-        $this->em->commit(); 
+        // After persist, Doctrine querying does not return our site until we flush, hence we get 0
+        // returned from our repository.
+        $this->assertEquals(0, count($this->em->getRepository('Site')->findOneBy(array('shortName' => 'site' . $n))));
+        // When we flush or commit we get one.
+        $this->em->commit();
         $this->em->flush();
         $this->assertEquals(1, count($this->em->getRepository('Site')->findOneBy(array('shortName' => 'site' . $n))));
     }
 
-    
+
     /**
-     * Show how BiDirectional relationships must be correctly managed in 
-     * userland/application code. (See Doctrine the tutorial: 
-     * "Consistency of bi-directional references on the inverse side of a 
-     * relation have to be managed in userland application code. Doctrine 
-     * cannot magically update your collections to be consistent."). 
+     * Show how BiDirectional relationships must be correctly managed in
+     * userland/application code. (See Doctrine the tutorial:
+     * "Consistency of bi-directional references on the inverse side of a
+     * relation have to be managed in userland application code. Doctrine
+     * cannot magically update your collections to be consistent.").
      */
     public function testShowBiDirectionalJoinConsitencyManagement() {
         print __METHOD__ . "\n";
         $ngi = TestUtil::createSampleNGI('myngi');
         $site = TestUtil::createSampleSite('mysite'/*, 'pk1'*/);
 
-        // Important: 
-        // The inverse side of a bi-directional relationship MUST be correctly managed. 
-        // If  $ngi->addSiteDoJoin($site) is not called (try commenting out next line), 
-        // the commented out assertion on next line would fail as $ngi->getSites() 
-        // will return 0 when running in same TX. 
+        // Important:
+        // The inverse side of a bi-directional relationship MUST be correctly managed.
+        // If  $ngi->addSiteDoJoin($site) is not called (try commenting out next line),
+        // the commented out assertion on next line would fail as $ngi->getSites()
+        // will return 0 when running in same TX.
         // "$siteCount = $ngi->getSites(); $this->assertTrue($siteCount == 1);"
         $ngi->addSiteDoJoin($site);
-        //$site->setNgiDoJoin($ngi);  // optional, calling this does no harm. 
-        
-        // Important: 
-        // Similarly, two invocations of "$ngi->addSiteDoJoin($site)" in the same TX  
-        // will add two sites to NGI causing getSites() to return 2 ! 
+        //$site->setNgiDoJoin($ngi);  // optional, calling this does no harm.
+
+        // Important:
+        // Similarly, two invocations of "$ngi->addSiteDoJoin($site)" in the same TX
+        // will add two sites to NGI causing getSites() to return 2 !
         // (looks like Doctrine's ArrayCollection can
-        // only distinguish object instances based on obj FK ID). 
+        // only distinguish object instances based on obj FK ID).
 
         $this->em->persist($site); // is now managed
-        $this->em->persist($ngi);  // is now managed      
-        $siteCount = count($ngi->getSites()); //echo('siteCount: '.$siteCount); 
+        $this->em->persist($ngi);  // is now managed
+        $siteCount = count($ngi->getSites()); //echo('siteCount: '.$siteCount);
         $this->assertTrue($siteCount == 1);
         $this->em->flush();
 
-        // start new TX 
+        // start new TX
         $this->em = $this->createEntityManager();
         $this->assertTrue(
                 count($this->em->getRepository('NGI')->
@@ -246,210 +246,210 @@ class DoctrineCleanInsert1Test extends PHPUnit_Extensions_Database_TestCase {
         $result = $testConn->createQueryTable('results_table', "SELECT * FROM Sites");
         $this->assertTrue($result->getRowCount() == 1);
 
-        // Assert that the FK joins worked as expected. 
-        $result = $testConn->createQueryTable('results_table', 
+        // Assert that the FK joins worked as expected.
+        $result = $testConn->createQueryTable('results_table',
                 "SELECT * FROM NGIs inner join Sites on NGIs.id = Sites.ngi_id");
         $this->assertTrue($result->getRowCount() == 1);
     }
 
     public function testJoinServicesToSite() {
         print __METHOD__ . "\n";
-         
+
         $n = 3;
-        $site = TestUtil::createSampleSite('site' . $n/*, 'pk' . $n*/);     
-        $this->em->persist($site); 
+        $site = TestUtil::createSampleSite('site' . $n/*, 'pk' . $n*/);
+        $this->em->persist($site);
         for ($i = 0; $i < $n; $i++) {
             $se = TestUtil::createSampleService("serv" . $i);
             $site->addServiceDoJoin($se);
-            // below is ok but not striclty required. 
+            // below is ok but not striclty required.
             $se->setParentSiteDoJoin($site);
-            $this->em->persist($se);   
+            $this->em->persist($se);
         }
         $seCount = count($site->getServices());
         //print 'debug '.$seCount."\n";
         $this->assertTrue($seCount == $n);
         $this->em->flush();
-        
-        // with same connection 
+
+        // with same connection
         $this->assertTrue(count($this->em->getRepository('Site')->
                         findOneBy(array('shortName' => 'site' . $n))->getServices()) == $n);
 
-        // start new connection  
-        $this->em->close(); 
+        // start new connection
+        $this->em->close();
         $this->em = $this->createEntityManager();
         $this->assertTrue(count($this->em->getRepository('Site')->
                         findOneBy(array('shortName' => 'site' . $n))->getServices()) == $n);
     }
-    
+
     public function testJoinCertStatusLogToSite(){
-       print __METHOD__ . "\n"; 
+       print __METHOD__ . "\n";
        $n = 3;
-       $site = TestUtil::createSampleSite('mysite1');     
-       $this->em->persist($site);  
+       $site = TestUtil::createSampleSite('mysite1');
+       $this->em->persist($site);
        for ($i = 0; $i < $n; $i++) {
-          $certLog = new \CertificationStatusLog(); 
-          $certLog->setAddedBy("/some/dn_$i"); 
-          $this->em->persist($certLog); 
-          $site->addCertificationStatusLog($certLog); 
-       } 
-       $this->em->merge($site); 
-       $logCount = count($site->getCertificationStatusLog()); 
+          $certLog = new \CertificationStatusLog();
+          $certLog->setAddedBy("/some/dn_$i");
+          $this->em->persist($certLog);
+          $site->addCertificationStatusLog($certLog);
+       }
+       $this->em->merge($site);
+       $logCount = count($site->getCertificationStatusLog());
        $this->assertTrue($logCount == $n);
        $this->em->flush();
 
-       // start new connection  
-       $this->em->close(); 
+       // start new connection
+       $this->em->close();
        $this->em = $this->createEntityManager();
-      
-       // fetch the site and check that the logs are present 
-       $siteRefetched = $this->em->getRepository('Site')->findOneBy(array('shortName' => 'mysite1'));  
+
+       // fetch the site and check that the logs are present
+       $siteRefetched = $this->em->getRepository('Site')->findOneBy(array('shortName' => 'mysite1'));
        $this->assertTrue(count($siteRefetched->getCertificationStatusLog()) == $n);
 
-       // check that the cascade delete removes all the certStatusLogs too 
-       $this->em->remove($siteRefetched); 
-       $this->em->flush(); 
+       // check that the cascade delete removes all the certStatusLogs too
+       $this->em->remove($siteRefetched);
+       $this->em->flush();
 
         $testConn = $this->getConnection();
-        $result = $testConn->createQueryTable('results_table', 
+        $result = $testConn->createQueryTable('results_table',
                 "SELECT CertificationStatusLogs.id FROM CertificationStatusLogs");
         $this->assertTrue($result->getRowCount() == 0);
 
-        // check deletion of cert log don't delete site 
-        
+        // check deletion of cert log don't delete site
+
     }
-    
-    
+
+
     /**
-     * Ensure that a Site may have many scope associations 
+     * Ensure that a Site may have many scope associations
      */
     public function testSiteScopeMultiplicity(){
         print __METHOD__ . "\n";
-        $this->createAndPersistScopes();  
+        $this->createAndPersistScopes();
         $n = 1;
-        $this->em->beginTransaction(); 
+        $this->em->beginTransaction();
         $site = TestUtil::createSampleSite('site' . $n/*, 'pk' . $n*/);
-        $site->addScope($this->localScope); 
+        $site->addScope($this->localScope);
         $site->addScope($this->egiScope);
         $site->addScope($this->eudatScope);
         $this->em->persist($site);
-        $this->em->commit(); 
+        $this->em->commit();
         $this->em->flush();
     }
-    
+
     /**
-     * Ensure that a SE may have many scope associations 
+     * Ensure that a SE may have many scope associations
      */
     public function testSEScopeMultiplicity(){
         print __METHOD__ . "\n";
-        $this->createAndPersistScopes();  
-        $this->em->beginTransaction(); 
+        $this->createAndPersistScopes();
+        $this->em->beginTransaction();
         $se = TestUtil::createSampleService("serv");
-        $se->addScope($this->localScope); 
+        $se->addScope($this->localScope);
         $se->addScope($this->egiScope);
         $se->addScope($this->eudatScope);
         $this->em->persist($se);
-        $this->em->commit(); 
+        $this->em->commit();
         $this->em->flush();
     }
-    
+
 
     public function testJoinSiteToScopes(){
         print __METHOD__ . "\n";
-        $this->createAndPersistScopes();  
-        $n = 1; // TODO - change this to 3 and un-comment the add egiScope and eudatScope lines below 
+        $this->createAndPersistScopes();
+        $n = 1; // TODO - change this to 3 and un-comment the add egiScope and eudatScope lines below
         $site = TestUtil::createSampleSite('site' . $n/*, 'pk' . $n*/);
-        $site->addScope($this->localScope); 
+        $site->addScope($this->localScope);
         //$site->addScope($this->egiScope);
-        //$site->addScope($this->eudatScope); 
-        
-        $this->em->persist($site);  
+        //$site->addScope($this->eudatScope);
+
+        $this->em->persist($site);
         $this->em->flush();
         $this->assertTrue(count($site->getScopes()) == $n);
-        
+
         $testConn = $this->getConnection();
-        $result = $testConn->createQueryTable('results_table', 
-                "SELECT sites.id FROM sites 
-                    inner join sites_scopes 
-                    on sites.id = sites_scopes.site_id 
-                    inner join scopes 
+        $result = $testConn->createQueryTable('results_table',
+                "SELECT sites.id FROM sites
+                    inner join sites_scopes
+                    on sites.id = sites_scopes.site_id
+                    inner join scopes
                     on scopes.id = sites_scopes.scope_id");
         $this->assertTrue($result->getRowCount() == $n);
     }
-   
+
 
     public function testJoinServiceToScopes() {
         print __METHOD__ . "\n";
-        $n = 1; // TODO - change this to 3 and un-comment the add egiScope and eudatScope lines below  
-        $this->createAndPersistScopes(); 
+        $n = 1; // TODO - change this to 3 and un-comment the add egiScope and eudatScope lines below
+        $this->createAndPersistScopes();
         $se = TestUtil::createSampleService("serv");
-        $se->addScope($this->egiScope); 
+        $se->addScope($this->egiScope);
         //$se->addScope($this->localScope);
         //$se->addScope($this->eudatScope);
         $this->assertTrue(count($se->getScopes()) == $n);
         $this->em->persist($se);
         $this->em->flush();
         $this->assertTrue(count($se->getScopes()) == $n);
-        
+
         $testConn = $this->getConnection();
-        $result = $testConn->createQueryTable('results_table', 
-                "SELECT Services.id FROM Services 
-                    inner join Services_Scopes 
-                    on Services.id = Services_Scopes.service_id 
-                    inner join Scopes 
+        $result = $testConn->createQueryTable('results_table',
+                "SELECT Services.id FROM Services
+                    inner join Services_Scopes
+                    on Services.id = Services_Scopes.service_id
+                    inner join Scopes
                     on Scopes.id = Services_Scopes.scope_id");
         $this->assertTrue($result->getRowCount() == $n);
     }
-  
+
     /**
-     * Add multiple endpointLocations to a single Service 
+     * Add multiple endpointLocations to a single Service
      */
     public function testJoinServiceToManyEndpointLocations(){
         print __METHOD__ . "\n";
         $n = 3; // we will want to be able to add many endpointLocations to a service
         $se = TestUtil::createSampleService("myservicehostname");
-        $this->em->persist($se); 
+        $this->em->persist($se);
         for ($i = 0; $i < $n; $i++) {
             $el = TestUtil::createSampleEndpointLocation();
-            $se->addEndpointLocationDoJoin($el); 
-            // below is ok but not striclty required. 
-            //$el->setServiceDoJoin($se); 
-            $this->em->persist($el);   
+            $se->addEndpointLocationDoJoin($el);
+            // below is ok but not striclty required.
+            //$el->setServiceDoJoin($se);
+            $this->em->persist($el);
         }
-        $elCount = count($se->getEndpointLocations());  
+        $elCount = count($se->getEndpointLocations());
         $this->assertTrue($elCount == $n);
         // flush is the line that throws the expected exe
         $this->em->flush();
-        
-        // in same TX 
+
+        // in same TX
         $this->assertTrue(count($this->em->getRepository('Service')->
                         findOneBy(array('hostName' => 'myservicehostname'))->getEndpointLocations()) == $n);
-        
-         // start new TX 
-        $this->em->close(); 
+
+         // start new TX
+        $this->em->close();
         $this->em = $this->createEntityManager();
         $this->assertTrue(count($this->em->getRepository('Service')->
                         findOneBy(array('hostName' => 'myservicehostname'))->getEndpointLocations()) == $n);
-        
+
     }
-   
+
     /**
-     * Test that rollback works as expected by creating a site, adding services, 
-     * persisting then calling rollback (note am not flushing or commiting) and 
+     * Test that rollback works as expected by creating a site, adding services,
+     * persisting then calling rollback (note am not flushing or commiting) and
      * checking that there are no sites and servcies in the DB.
      */
     public function testRollback() {
         print __METHOD__ . "\n";
         $n = 3;
         $site = TestUtil::createSampleSite('site' . $n/*, 'pk' . $n*/);
-        // need to start new TX to do a later rollback. 
+        // need to start new TX to do a later rollback.
         $this->em->beginTransaction();
         $this->em->persist($site); // is now managed
         for ($i = 0; $i < $n; $i++) {
             $se = TestUtil::createSampleService("serv" . $i);
             $site->addServiceDoJoin($se);
-            // below is ok but not striclty required. 
+            // below is ok but not striclty required.
             $se->setParentSiteDoJoin($site);
-            $this->em->persist($se);  // is now managed 
+            $this->em->persist($se);  // is now managed
         }
         $seCount = count($site->getServices());
         //print 'debug '.$seCount."\n";
@@ -462,14 +462,14 @@ class DoctrineCleanInsert1Test extends PHPUnit_Extensions_Database_TestCase {
         $result = $testConn->createQueryTable('results_table', "SELECT * FROM Services");
         $this->assertTrue($result->getRowCount() == 0);
     }
-    
-    
+
+
     /**
      * Tests asserts that we shouldn't be able to delete a site with child services
-     * because we do not use a cascade-delete rule when deleting the site. We 
-     * first have to delete the services that holds the FK to the site (one site 
-     * to many services). 
-     * 
+     * because we do not use a cascade-delete rule when deleting the site. We
+     * first have to delete the services that holds the FK to the site (one site
+     * to many services).
+     *
      * @expectedException \Doctrine\DBAL\DBALException
      */
     public function testExpectedFK_ViolationOnSiteDeleteWithoutCascade(){
@@ -479,76 +479,76 @@ class DoctrineCleanInsert1Test extends PHPUnit_Extensions_Database_TestCase {
         $this->em->persist($site); // is now managed
         for ($i = 0; $i < $n; $i++) {
             $se = TestUtil::createSampleService("serv" . $i);
-            $site->addServiceDoJoin($se);  
-            // below is ok but not striclty required. 
+            $site->addServiceDoJoin($se);
+            // below is ok but not striclty required.
             $se->setParentSiteDoJoin($site);
-            $this->em->persist($se);  // is now managed 
+            $this->em->persist($se);  // is now managed
         }
         $this->em->flush();
-              
-        // start new TX 
-        $this->em->close(); 
+
+        // start new TX
+        $this->em->close();
         $this->em = $this->createEntityManager();
         $refetchedSite = $this->em->getRepository('Site')->findOneBy(array('shortName' => 'site' . $n));
-        $this->assertTrue($refetchedSite->getShortName() == 'site'.$n); 
-        
-        // Now try to delete site. 
-        // We expect a FK violation wrapped as a DBALException. 
+        $this->assertTrue($refetchedSite->getShortName() == 'site'.$n);
+
+        // Now try to delete site.
+        // We expect a FK violation wrapped as a DBALException.
         // If the fail statement is called below, then it could be an issue with
-        // with the DB. For example, Sqlite with Doctrine does not enforce FK constraints ! 
+        // with the DB. For example, Sqlite with Doctrine does not enforce FK constraints !
         // see: http://stackoverflow.com/a/4599894
         //try {
-            // We shouldn't be able to remove the site as we need to remove the 
-            // services first as we have no cascade-delete option set. 
-            $this->em->remove($refetchedSite); 
+            // We shouldn't be able to remove the site as we need to remove the
+            // services first as we have no cascade-delete option set.
+            $this->em->remove($refetchedSite);
             $this->em->flush();
-            $this->fail('Should not get to this point - DBALException expected'); 
+            $this->fail('Should not get to this point - DBALException expected');
         //} catch (Exception $ex){
-        //    print_r('yup, and exception was thrown dave'.$ex); 
+        //    print_r('yup, and exception was thrown dave'.$ex);
         //}
-        
+
     }
-   
+
 
     /**
-     * Assert that deletion of an OwnedEntity superclass will delete its joined 
-     * extending class (e.g. Site and NGI). 
+     * Assert that deletion of an OwnedEntity superclass will delete its joined
+     * extending class (e.g. Site and NGI).
      */
     public function testCascadeDeleteFromOwnedEntity(){
         print __METHOD__ . "\n";
-        // create and commit a new site 
+        // create and commit a new site
         $s = TestUtil::createSampleSite("SITENAME"/*, "PK01"*/);
         $this->em->persist($s);
-        $this->em->flush(); 
+        $this->em->flush();
 
-        // lookup the site's super class (OwnedEntity) 
-        $siteID = $s->getId(); 
+        // lookup the site's super class (OwnedEntity)
+        $siteID = $s->getId();
         $ownedEntity = $this->em->find("OwnedEntity", $siteID);
-        $this->assertNotNull($ownedEntity); 
-        $this->assertTrue($ownedEntity instanceof OwnedEntity); 
-        $this->assertEquals($siteID, $ownedEntity->getId()); 
-       
-        // remove the super class - this should cascade delete the site 
-        $this->em->remove($ownedEntity); 
-        $this->em->flush(); 
-          
+        $this->assertNotNull($ownedEntity);
+        $this->assertTrue($ownedEntity instanceof OwnedEntity);
+        $this->assertEquals($siteID, $ownedEntity->getId());
+
+        // remove the super class - this should cascade delete the site
+        $this->em->remove($ownedEntity);
+        $this->em->flush();
+
         // Assert that the super class was deleted and site was cascade deleted
         // first using doctrine
         $siteAgain = $this->em->find("Site", $siteID);
-        $this->assertNull($siteAgain); 
-        $ownedEntityAgain = $this->em->find("OwnedEntity", $siteID); 
-        $this->assertNull($ownedEntityAgain); 
-        // second using separate db connection 
+        $this->assertNull($siteAgain);
+        $ownedEntityAgain = $this->em->find("OwnedEntity", $siteID);
+        $this->assertNull($ownedEntityAgain);
+        // second using separate db connection
         $testConn = $this->getConnection();
         $result = $testConn->createQueryTable('results_table', "SELECT * FROM OwnedEntities");
-        $this->assertTrue($result->getRowCount() == 0); 
+        $this->assertTrue($result->getRowCount() == 0);
         $result = $testConn->createQueryTable('results_table', "SELECT * FROM Sites");
-        $this->assertTrue($result->getRowCount() == 0); 
+        $this->assertTrue($result->getRowCount() == 0);
     }
 
 
     /**
-     * @expectedException \Doctrine\ORM\ORMInvalidArgumentException 
+     * @expectedException \Doctrine\ORM\ORMInvalidArgumentException
      */
     public function testShowMergeIsRequiredBetweenDifferentPersistenceCtxt(){
         print __METHOD__ . "\n";
@@ -556,27 +556,27 @@ class DoctrineCleanInsert1Test extends PHPUnit_Extensions_Database_TestCase {
         $u = TestUtil::createSampleUser("Test", "Testing", "/c=test");
         $regFLSupportRT = TestUtil::createSampleRoleType(RoleTypeName::REG_FIRST_LINE_SUPPORT/*, RoleTypeClass::REGIONAL_USER*/);
         $this->em->persist($u);
-        $this->em->persist($regFLSupportRT); 
+        $this->em->persist($regFLSupportRT);
         $this->em->flush();
 
-        // If we create a new $this->em as below, we would need to merge detatched $u 
-        // and $regFLSupportRT entities back into this persistence context 
-        // before we can call a persist again (a persist on these entities 
-        // called either by a CASCADE or direct call)! 
-        $this->em = $this->createEntityManager(); // simply requires bootstrap_doctrine.php 
-        //$u = $this->em->merge($u);  
+        // If we create a new $this->em as below, we would need to merge detatched $u
+        // and $regFLSupportRT entities back into this persistence context
+        // before we can call a persist again (a persist on these entities
+        // called either by a CASCADE or direct call)!
+        $this->em = $this->createEntityManager(); // simply requires bootstrap_doctrine.php
+        //$u = $this->em->merge($u);
         //$regFLSupportRT = $this->em->merge($regFLSupportRT);
 
         // Create new NGI
         $n = TestUtil::createSampleNGI("MYNGI");
         $this->em->persist($n);
-        
-        $roleNgi = TestUtil::createSampleRole($u, $regFLSupportRT, $n, RoleStatus::GRANTED); 
+
+        $roleNgi = TestUtil::createSampleRole($u, $regFLSupportRT, $n, RoleStatus::GRANTED);
         $this->em->persist($roleNgi);
-        // the flush below is what causes the expected exception 
+        // the flush below is what causes the expected exception
         $this->em->flush();
     }
-    
+
 
     public function testSiteV4PK(){
         print __METHOD__ . "\n";
@@ -584,337 +584,337 @@ class DoctrineCleanInsert1Test extends PHPUnit_Extensions_Database_TestCase {
         $pk = new \PrimaryKey();
         $this->em->persist($pk);
         // Below line is interesting - Oracle returns a value for $pk->getId()
-        // (i.e. before flush) while MySQL does not return a value until the 
+        // (i.e. before flush) while MySQL does not return a value until the
         // flush. Either way, the subsequent rollback causes the PK to be removed
-        // which is the required behaviour.     
-        //$this->assertEmpty($pk->getId()); 
-        //print "the pk is before: [".$pk->getId()."]\n"; 
-        
+        // which is the required behaviour.
+        //$this->assertEmpty($pk->getId());
+        //print "the pk is before: [".$pk->getId()."]\n";
+
         $this->em->flush(); // sync in-memory state with db so that the pk Id has a value
-        //print "the pk is after: [".$pk->getId()."]\n"; 
-        // We expect after the flush the pk to have an id value  
-        $this->assertNotEmpty($pk->getId()); 
+        //print "the pk is after: [".$pk->getId()."]\n";
+        // We expect after the flush the pk to have an id value
+        $this->assertNotEmpty($pk->getId());
         $site = new \Site();
         $site->setPrimaryKey($pk->getId() . "G0");
-        $site->setShortName('testshortname'); 
-        $this->em->persist($site); 
-        $this->em->flush(); 
+        $site->setShortName('testshortname');
+        $this->em->persist($site);
+        $this->em->flush();
 
-        // Rollback so that we don't commit the new pks and site to the DB 
-        //$this->em->getConnection()->commit();  
-        $this->em->getConnection()->rollback();  
+        // Rollback so that we don't commit the new pks and site to the DB
+        //$this->em->getConnection()->commit();
+        $this->em->getConnection()->rollback();
 
         $testConn = $this->getConnection();
         $result = $testConn->createQueryTable('results_table', "SELECT * FROM Sites");
-        $this->assertTrue($result->getRowCount() == 0); 
+        $this->assertTrue($result->getRowCount() == 0);
         $result = $testConn->createQueryTable('results_table', "SELECT * FROM PrimaryKeys");
-        $this->assertTrue($result->getRowCount() == 0); 
+        $this->assertTrue($result->getRowCount() == 0);
     }
 
- 
+
     /**
-     * Assert that the onDelete="CASCADE" FK mapping defined on 'EndpointLocation.service' 
-     * attribute does actually cascade delete a services endpoints when those 
-     * endpoints don't have any other joined associations, e.g. with Downtimes.  
+     * Assert that the onDelete="CASCADE" FK mapping defined on 'EndpointLocation.service'
+     * attribute does actually cascade delete a services endpoints when those
+     * endpoints don't have any other joined associations, e.g. with Downtimes.
      */
     public function testServiceToEndpointCascadeDelete_WithNoDTs(){
         print __METHOD__ . "\n";
-        // create a linked entity graph as below: 
-        // 
-        //     se        (1 service) 
+        // create a linked entity graph as below:
+        //
+        //     se        (1 service)
         //    / | \
-        // el1 el2 el3   (3 endpoints) 
-        
-        $se = TestUtil::createSampleService('service1'); 
-        $el1 = TestUtil::createSampleEndpointLocation(); 
-        $el2 = TestUtil::createSampleEndpointLocation(); 
-        $el3 = TestUtil::createSampleEndpointLocation(); 
-        $se->addEndpointLocationDoJoin($el1); 
-        $se->addEndpointLocationDoJoin($el2); 
-        $se->addEndpointLocationDoJoin($el3); 
-        
-        // persist and flush 
+        // el1 el2 el3   (3 endpoints)
+
+        $se = TestUtil::createSampleService('service1');
+        $el1 = TestUtil::createSampleEndpointLocation();
+        $el2 = TestUtil::createSampleEndpointLocation();
+        $el3 = TestUtil::createSampleEndpointLocation();
+        $se->addEndpointLocationDoJoin($el1);
+        $se->addEndpointLocationDoJoin($el2);
+        $se->addEndpointLocationDoJoin($el3);
+
+        // persist and flush
         $this->em->persist($se);
         $this->em->persist($el1);
         $this->em->persist($el2);
         $this->em->persist($el3);
-        $this->em->flush(); 
+        $this->em->flush();
 
-        // Delete the service, and assert the endpoints are cascade deleted too ! 
-        // Impt: This should work because we have NOT joined any downtimes to the 
-        // endpoints and so the cascade is free to work at the DB level using 
-        // the onDelete="CASCADE" FK mapping defined on 'EndpointLocation.service' attribute. 
+        // Delete the service, and assert the endpoints are cascade deleted too !
+        // Impt: This should work because we have NOT joined any downtimes to the
+        // endpoints and so the cascade is free to work at the DB level using
+        // the onDelete="CASCADE" FK mapping defined on 'EndpointLocation.service' attribute.
         // see: See: http://docs.doctrine-project.org/en/2.0.x/reference/working-with-objects.html#removing-entities
-        // 
-        $this->em->remove($se); 
-        $this->em->flush(); 
+        //
+        $this->em->remove($se);
+        $this->em->flush();
 
-        // Assert that there are still three EndpointLocations and one Downtimes in the database 
+        // Assert that there are still three EndpointLocations and one Downtimes in the database
         $testConn = $this->getConnection();
         $result = $testConn->createQueryTable('results_table', "SELECT * FROM EndpointLocations");
-        $this->assertTrue($result->getRowCount() == 0); 
+        $this->assertTrue($result->getRowCount() == 0);
         $result = $testConn->createQueryTable('results_table', "SELECT * FROM Downtimes");
-        $this->assertTrue($result->getRowCount() == 0); 
+        $this->assertTrue($result->getRowCount() == 0);
         $result = $testConn->createQueryTable('results_table', "SELECT * FROM Services");
-        $this->assertTrue($result->getRowCount() == 0); 
+        $this->assertTrue($result->getRowCount() == 0);
         $result = $testConn->createQueryTable('results_table', "SELECT * FROM Downtimes_EndpointLocations");
-        $this->assertTrue($result->getRowCount() == 0); 
-    } 
+        $this->assertTrue($result->getRowCount() == 0);
+    }
 
     /**
-     * Assert that the onDelete="CASCADE" FK mapping defined on 'EndpointLocation.service' 
-     * annotation fails due to a FK violation exception caused by the endpoint's 
+     * Assert that the onDelete="CASCADE" FK mapping defined on 'EndpointLocation.service'
+     * annotation fails due to a FK violation exception caused by the endpoint's
      * association to a downtime (this relationship would need to be deleted first
-     * to allow the endpoint to be deleted cleanly by the cascade).  
-     * 
+     * to allow the endpoint to be deleted cleanly by the cascade).
+     *
      * @expectedException \Doctrine\DBAL\DBALException
      */
     public function testExpectedFK_ViolationOnServiceToEndpointCascadeDelete_WithDTs(){
          print __METHOD__ . "\n";
-        // create a linked entity graph as beow: 
-        // 
-        //     se        (1 service) 
-        //    /  
-        // el1           (1 endpoints) 
-        //    \  
-        //     dt1       (1 downtime)  
-        
-        $se = TestUtil::createSampleService('service1'); 
-        $el1 = TestUtil::createSampleEndpointLocation(); 
-        $se->addEndpointLocationDoJoin($el1); 
-        
-        $dt1 = new Downtime(); 
-        $dt1->setDescription('downtime description'); 
-        $dt1->setSeverity("WARNING"); 
-        $dt1->setClassification("UNSCHEDULED"); 
-        
-        $dt1->addEndpointLocation($el1); 
-        
-        // persist and flush 
+        // create a linked entity graph as beow:
+        //
+        //     se        (1 service)
+        //    /
+        // el1           (1 endpoints)
+        //    \
+        //     dt1       (1 downtime)
+
+        $se = TestUtil::createSampleService('service1');
+        $el1 = TestUtil::createSampleEndpointLocation();
+        $se->addEndpointLocationDoJoin($el1);
+
+        $dt1 = new Downtime();
+        $dt1->setDescription('downtime description');
+        $dt1->setSeverity("WARNING");
+        $dt1->setClassification("UNSCHEDULED");
+
+        $dt1->addEndpointLocation($el1);
+
+        // persist and flush
         $this->em->persist($se);
         $this->em->persist($el1);
         $this->em->persist($dt1);
         $this->em->flush();
 
-        // Assert that there are expected EndpointLocations and one Downtimes in the database 
+        // Assert that there are expected EndpointLocations and one Downtimes in the database
         $testConn = $this->getConnection();
         $result = $testConn->createQueryTable('results_table', "SELECT * FROM EndpointLocations");
-        $this->assertTrue($result->getRowCount() == 1); 
+        $this->assertTrue($result->getRowCount() == 1);
         $result = $testConn->createQueryTable('results_table', "SELECT * FROM Downtimes");
-        $this->assertTrue($result->getRowCount() == 1); 
+        $this->assertTrue($result->getRowCount() == 1);
         $result = $testConn->createQueryTable('results_table', "SELECT * FROM Downtimes_EndpointLocations");
-        $this->assertTrue($result->getRowCount() == 1); 
+        $this->assertTrue($result->getRowCount() == 1);
 
-        // Try and delete the service 
-        // We expect a FK violation wrapped as a DBALException. 
+        // Try and delete the service
+        // We expect a FK violation wrapped as a DBALException.
         // If the fail statement is called below, then it could be an issue with
-        // with the DB. For example, Sqlite with Doctrine does not enforce FK constraints ! 
+        // with the DB. For example, Sqlite with Doctrine does not enforce FK constraints !
         // see: http://stackoverflow.com/a/4599894
         //try {
-            // We shouldn't be able to remove the site as we need to remove the 
-            // services first as we have no cascade-delete option set. 
+            // We shouldn't be able to remove the site as we need to remove the
+            // services first as we have no cascade-delete option set.
             $this->em->remove($se);
             $this->em->flush();
-            $this->fail('Should not get to this point - DBALException expected'); 
+            $this->fail('Should not get to this point - DBALException expected');
         //} catch (Exception $ex){
-        //    print_r('yup, and exception was thrown dave'.$ex); 
+        //    print_r('yup, and exception was thrown dave'.$ex);
         //}
     }
 
     /**
-     * Show how Bidirectional relationships must be correctly managed in 
-     * userland/application code. (See Doctrine the tutorial: 
-     * "Consistency of bi-directional references on the inverse side of a 
-     * relation have to be managed in userland application code. Doctrine 
-     * cannot magically update your collections to be consistent."). 
+     * Show how Bidirectional relationships must be correctly managed in
+     * userland/application code. (See Doctrine the tutorial:
+     * "Consistency of bi-directional references on the inverse side of a
+     * relation have to be managed in userland application code. Doctrine
+     * cannot magically update your collections to be consistent.").
      */
     public function testDowntimeEndpoint_BidirectionalJoinConsistencyManagement(){
         print __METHOD__ . "\n";
-        // create a linked entity graph as beow: 
-        // 
-        //     se        (1 service) 
+        // create a linked entity graph as beow:
+        //
+        //     se        (1 service)
         //    / | \
-        // el1 el2 el3   (3 endpoints) 
+        // el1 el2 el3   (3 endpoints)
         //    \ | /
-        //     dt1       (1 downtime)  
-        
-        $se = TestUtil::createSampleService('service1'); 
-        $el1 = TestUtil::createSampleEndpointLocation(); 
-        $el2 = TestUtil::createSampleEndpointLocation(); 
-        $el3 = TestUtil::createSampleEndpointLocation(); 
-        $se->addEndpointLocationDoJoin($el1); 
-        $se->addEndpointLocationDoJoin($el2); 
-        $se->addEndpointLocationDoJoin($el3); 
-        
-        $dt1 = new Downtime(); 
-        $dt1->setDescription('downtime description'); 
-        $dt1->setSeverity("WARNING"); 
-        $dt1->setClassification("UNSCHEDULED"); 
-        
-        $dt1->addEndpointLocation($el1); 
-        $dt1->addEndpointLocation($el2); 
-        $dt1->addEndpointLocation($el3); 
-        
-        // persist and flush 
+        //     dt1       (1 downtime)
+
+        $se = TestUtil::createSampleService('service1');
+        $el1 = TestUtil::createSampleEndpointLocation();
+        $el2 = TestUtil::createSampleEndpointLocation();
+        $el3 = TestUtil::createSampleEndpointLocation();
+        $se->addEndpointLocationDoJoin($el1);
+        $se->addEndpointLocationDoJoin($el2);
+        $se->addEndpointLocationDoJoin($el3);
+
+        $dt1 = new Downtime();
+        $dt1->setDescription('downtime description');
+        $dt1->setSeverity("WARNING");
+        $dt1->setClassification("UNSCHEDULED");
+
+        $dt1->addEndpointLocation($el1);
+        $dt1->addEndpointLocation($el2);
+        $dt1->addEndpointLocation($el3);
+
+        // persist and flush
         $this->em->persist($se);
         $this->em->persist($el1);
         $this->em->persist($el2);
         $this->em->persist($el3);
         $this->em->persist($dt1);
         $this->em->flush();
-        
-        // Now delete the relationship between dt1 and el1 + el2 using OWNING 
-        // SIDE ONLY; since downtime is the OWNING side we must remove el1 + el2 
-        // from downtime to actually delete the relationships in the DB 
-        // (on the subsequent flush). Since we have only removed the relationship 
-        // on the downtime side, our in-mem entity model is now inconsistent ! 
-        $dt1->getEndpointLocations()->removeElement($el1);  
-        //$el1->getDowntimes()->removeElement($dt1); 
-        $dt1->getEndpointLocations()->removeElement($el2);  
-        //$el2->getDowntimes()->removeElement($dt1); 
-        
+
+        // Now delete the relationship between dt1 and el1 + el2 using OWNING
+        // SIDE ONLY; since downtime is the OWNING side we must remove el1 + el2
+        // from downtime to actually delete the relationships in the DB
+        // (on the subsequent flush). Since we have only removed the relationship
+        // on the downtime side, our in-mem entity model is now inconsistent !
+        $dt1->getEndpointLocations()->removeElement($el1);
+        //$el1->getDowntimes()->removeElement($dt1);
+        $dt1->getEndpointLocations()->removeElement($el2);
+        //$el2->getDowntimes()->removeElement($dt1);
+
         $this->em->flush();
-        
-        // Entity model in DB now looks like this: 
+
+        // Entity model in DB now looks like this:
         //     se
         //    / | \
         // el1 el2 el3
         //        /
-        //     dt1      (note FKs/relationships have been removed)  
-       
-        // Assert that there are still three EndpointLocations and one Downtimes in the database 
+        //     dt1      (note FKs/relationships have been removed)
+
+        // Assert that there are still three EndpointLocations and one Downtimes in the database
         $testConn = $this->getConnection();
         $result = $testConn->createQueryTable('results_table', "SELECT * FROM EndpointLocations");
-        $this->assertTrue($result->getRowCount() == 3); 
+        $this->assertTrue($result->getRowCount() == 3);
         $result = $testConn->createQueryTable('results_table', "SELECT * FROM Downtimes");
-        $this->assertTrue($result->getRowCount() == 1); 
+        $this->assertTrue($result->getRowCount() == 1);
         $result = $testConn->createQueryTable('results_table', "SELECT * FROM Downtimes_EndpointLocations");
-        $this->assertTrue($result->getRowCount() == 1); 
+        $this->assertTrue($result->getRowCount() == 1);
 
-        // Assert that our in-mem entity model is now inconsistent with DB 
-        // when VIEWED FROM THE ENDPOINT SIDE. 
-        $this->assertEquals(1, count($el1->getDowntimes())); 
-        $this->assertEquals(1, count($el2->getDowntimes())); 
+        // Assert that our in-mem entity model is now inconsistent with DB
+        // when VIEWED FROM THE ENDPOINT SIDE.
+        $this->assertEquals(1, count($el1->getDowntimes()));
+        $this->assertEquals(1, count($el2->getDowntimes()));
         $this->assertEquals(1, count($el3->getDowntimes()));
 
-        // Assert that our in-mem entity model is consistent with DB 
-        // when VIEWED FROM THE DOWNTIME SIDE: 
-        // dt1 still has el3 linked (as expected) but not el1 or el2.  
-        // Note we use first() method to fetch first array collection entry! 
-        // (calling get(0) would not work as expected because the collection 
-        // is a map so array key values are preserved - el3 was added 3rd so it 
-        // preserves its zero-offset key value of 2).  
-        $this->assertEquals(1, count($dt1->getEndpointLocations())); 
-        $this->assertSame($el3, $dt1->getEndpointLocations()->first()); 
-        $this->assertSame($el3, $dt1->getEndpointLocations()->get(2)); 
-       
-        // Next lines keep our in-mem inverse side consistent with DB. If we 
-        // didn't do this, then our first assertion on the following lines below 
-        // would fail! This shows that you have to keep your bi-directional 
-        // relationships consistent in userland/application code, doctrine 
-        // won't do this for you! 
-        $el1->getDowntimes()->removeElement($dt1); 
-        $el2->getDowntimes()->removeElement($dt1); 
-        
-        // After updating the 'in-memory' entity model, check that el1 and el2 
-        // have no linked downtimes while el3 still has dt linked.  
-        // This mirrors what we have in the DB. 
-        $this->assertEquals(0, count($el1->getDowntimes())); 
-        $this->assertEquals(0, count($el2->getDowntimes())); 
-        $this->assertEquals(1, count($el3->getDowntimes())); 
-        
+        // Assert that our in-mem entity model is consistent with DB
+        // when VIEWED FROM THE DOWNTIME SIDE:
+        // dt1 still has el3 linked (as expected) but not el1 or el2.
+        // Note we use first() method to fetch first array collection entry!
+        // (calling get(0) would not work as expected because the collection
+        // is a map so array key values are preserved - el3 was added 3rd so it
+        // preserves its zero-offset key value of 2).
+        $this->assertEquals(1, count($dt1->getEndpointLocations()));
+        $this->assertSame($el3, $dt1->getEndpointLocations()->first());
+        $this->assertSame($el3, $dt1->getEndpointLocations()->get(2));
+
+        // Next lines keep our in-mem inverse side consistent with DB. If we
+        // didn't do this, then our first assertion on the following lines below
+        // would fail! This shows that you have to keep your bi-directional
+        // relationships consistent in userland/application code, doctrine
+        // won't do this for you!
+        $el1->getDowntimes()->removeElement($dt1);
+        $el2->getDowntimes()->removeElement($dt1);
+
+        // After updating the 'in-memory' entity model, check that el1 and el2
+        // have no linked downtimes while el3 still has dt linked.
+        // This mirrors what we have in the DB.
+        $this->assertEquals(0, count($el1->getDowntimes()));
+        $this->assertEquals(0, count($el2->getDowntimes()));
+        $this->assertEquals(1, count($el3->getDowntimes()));
+
         // our collection key value is still same
-        $this->assertSame($el3, $dt1->getEndpointLocations()->get(2)); 
+        $this->assertSame($el3, $dt1->getEndpointLocations()->get(2));
     }
-   
+
 
 
     private function createAndPersistScopes(){
-        $this->egiScope = new Scope(); 
-        $this->egiScope->setName('EGI'); 
-        $this->egiScope->setDescription('The egi project'); 
-        
-        $this->localScope = new Scope(); 
-        $this->localScope->setDescription('Local scope means no project'); 
-        $this->localScope->setName('Local'); 
-        
-        $this->eudatScope = new Scope(); 
-        $this->eudatScope->setName('EUDAT'); 
-        $this->eudatScope->setDescription('The eudat project'); 
-        
-        $this->em->persist($this->egiScope); 
+        $this->egiScope = new Scope();
+        $this->egiScope->setName('EGI');
+        $this->egiScope->setDescription('The egi project');
+
+        $this->localScope = new Scope();
+        $this->localScope->setDescription('Local scope means no project');
+        $this->localScope->setName('Local');
+
+        $this->eudatScope = new Scope();
+        $this->eudatScope->setName('EUDAT');
+        $this->eudatScope->setDescription('The eudat project');
+
+        $this->em->persist($this->egiScope);
         $this->em->persist($this->localScope);
         $this->em->persist($this->eudatScope);
     }
 
-    
-    // below two tests have now been deprecated, but they are good to keep 
+
+    // below two tests have now been deprecated, but they are good to keep
     // commented out because they are still useful to explain join behaviour
     /*public function testNgiSiteNotJoined(){
         print __METHOD__ . "\n";
-        $this->doNgiSiteJoins(false); 
+        $this->doNgiSiteJoins(false);
     }
     public function testNgiSiteJoined(){
         print __METHOD__ . "\n";
-        $this->doNgiSiteJoins(true); 
+        $this->doNgiSiteJoins(true);
     }*/
-    
+
     /**
-     * Helper function to show that setting the join/assocition is only set 
-     * on one side of a bi-directional relationship. If $setJoinCorrectly is 
-     * true, then the newly created sites will be joined to the NGIs. If false, 
-     * then the the join will not be set. 
-     * 
-     * @deprecated since the entity model was updated, but good to keep for reference. 
+     * Helper function to show that setting the join/assocition is only set
+     * on one side of a bi-directional relationship. If $setJoinCorrectly is
+     * true, then the newly created sites will be joined to the NGIs. If false,
+     * then the the join will not be set.
+     *
+     * @deprecated since the entity model was updated, but good to keep for reference.
      * @param boolean $setJoinCorrectly
      */
-    /*private function doNgiSiteJoins($setJoinCorrectly) {   
-        $n = 1; 
+    /*private function doNgiSiteJoins($setJoinCorrectly) {
+        $n = 1;
         for ($i = 0; $i < $n; $i++) {
             $ngi = $this->createSampleNGI('ngi' . $i);
             $site = $this->createSampleSite('site' . $i, 'pk' . $i);
             if ($setJoinCorrectly) {
-                // This will set the join/association 
+                // This will set the join/association
                 $site->setNgiDoJoin($ngi);
-                // 
+                //
                 // **Note** setNgiDoJoin() MUST have the following definition for this test to work as expected:
-                // 
+                //
                 //   public function setNgiDoJoin(NGI $ngi) {
-            //       $this->ngi = $ngi;  
-                //       $ngi->addSiteNoJoin($this);    
+            //       $this->ngi = $ngi;
+                //       $ngi->addSiteNoJoin($this);
             //   }
             } else {
-                // This will NOT set the join/association (only setting on the inverse side) 
-                $ngi->addSiteNoJoin($site); 
-                // 
-                // **Note** addSiteNoJoin() MUST have the following definition for this test to work as expected: 
-                // 
+                // This will NOT set the join/association (only setting on the inverse side)
+                $ngi->addSiteNoJoin($site);
+                //
+                // **Note** addSiteNoJoin() MUST have the following definition for this test to work as expected:
+                //
                 //   public function addSiteNoJoin(Site $site) {
-        //       $this->sites[] = $site; 
+        //       $this->sites[] = $site;
             //   }
-            }          
+            }
             $this->em->persist($site); // is now managed
             $this->em->persist($ngi);  // is now managed
-            $this->assertTrue($this->em->contains($site)); 
-            $this->assertTrue($this->em->contains($ngi)); 
+            $this->assertTrue($this->em->contains($site));
+            $this->assertTrue($this->em->contains($ngi));
         }
         $this->em->flush(); // commit
-           
-        // Do not trust what Doctrine tells us and assert the rows have 
-        // actually been added using test connection 
-        $testConn = $this->getConnection(); 
+
+        // Do not trust what Doctrine tells us and assert the rows have
+        // actually been added using test connection
+        $testConn = $this->getConnection();
         $result = $testConn->createQueryTable('results_table', "SELECT * FROM NGIs");
-        $this->assertTrue($result->getRowCount() == $n);     
+        $this->assertTrue($result->getRowCount() == $n);
         $result = $testConn->createQueryTable('results_table', "SELECT * FROM Sites");
         $this->assertTrue($result->getRowCount() == $n);
-        
-        // Assert that the FK joins worked as expected. 
-        $result = $testConn->createQueryTable('results_table', 
+
+        // Assert that the FK joins worked as expected.
+        $result = $testConn->createQueryTable('results_table',
                 "SELECT * FROM NGIs inner join Sites on NGIs.id = Sites.ngi_id");
         if($setJoinCorrectly) {
             $this->assertTrue($result->getRowCount() == $n);
         } else {
-            $this->assertTrue($result->getRowCount() == 0); 
+            $this->assertTrue($result->getRowCount() == 0);
         }
     }*/
 }

--- a/tests/doctrine/DowntimeServiceEndpointTest1.php
+++ b/tests/doctrine/DowntimeServiceEndpointTest1.php
@@ -13,8 +13,8 @@ require_once dirname(__FILE__) . '/../../lib/Gocdb_Services/ServiceService.php';
 require_once dirname(__FILE__) . '/../../lib/DAOs/ServiceDAO.php';
 
 /**
- * Service, EndpointLocation and Downtime cascade deletion tests. 
- * 
+ * Service, EndpointLocation and Downtime cascade deletion tests.
+ *
  * @author David Meredith
  */
 class DowntimeServiceEndpointTest1 extends PHPUnit_Extensions_Database_TestCase {
@@ -26,7 +26,7 @@ class DowntimeServiceEndpointTest1 extends PHPUnit_Extensions_Database_TestCase 
     //private $eudatScope;
 
     /**
-     * Overridden. 
+     * Overridden.
      */
     public static function setUpBeforeClass() {
         parent::setUpBeforeClass();
@@ -44,8 +44,8 @@ class DowntimeServiceEndpointTest1 extends PHPUnit_Extensions_Database_TestCase 
     }
 
     /**
-     * Overridden. Returns the test dataset.  
-     * Defines how the initial state of the database should look before each test is executed. 
+     * Overridden. Returns the test dataset.
+     * Defines how the initial state of the database should look before each test is executed.
      * @return PHPUnit_Extensions_Database_DataSet_IDataSet
      */
     protected function getDataSet() {
@@ -55,7 +55,7 @@ class DowntimeServiceEndpointTest1 extends PHPUnit_Extensions_Database_TestCase 
     }
 
     /**
-     * Overridden. 
+     * Overridden.
      */
     protected function getSetUpOperation() {
         // CLEAN_INSERT is default
@@ -63,14 +63,14 @@ class DowntimeServiceEndpointTest1 extends PHPUnit_Extensions_Database_TestCase 
         //return PHPUnit_Extensions_Database_Operation_Factory::UPDATE();
         //return PHPUnit_Extensions_Database_Operation_Factory::NONE();
         //
-        // Issue a DELETE from <table> which is more portable than a 
-        // TRUNCATE table <table> (some DBs require high privileges for truncate statements 
+        // Issue a DELETE from <table> which is more portable than a
+        // TRUNCATE table <table> (some DBs require high privileges for truncate statements
         // and also do not allow truncates across tables with FK contstraints e.g. Oracle)
         return PHPUnit_Extensions_Database_Operation_Factory::DELETE_ALL();
     }
 
     /**
-     * Overridden. 
+     * Overridden.
      */
     protected function getTearDownOperation() {
         // NONE is default
@@ -87,7 +87,7 @@ class DowntimeServiceEndpointTest1 extends PHPUnit_Extensions_Database_TestCase 
     }
 
     /**
-     * @todo Still need to setup connection to different databases. 
+     * @todo Still need to setup connection to different databases.
      * @return EntityManager
      */
     private function createEntityManager() {
@@ -109,39 +109,39 @@ class DowntimeServiceEndpointTest1 extends PHPUnit_Extensions_Database_TestCase 
             //print $tableName->getName() . "\n";
             $sql = "SELECT * FROM " . $tableName->getName();
             $result = $con->createQueryTable('results_table', $sql);
-            //echo 'row count: '.$result->getRowCount() ; 
+            //echo 'row count: '.$result->getRowCount() ;
             if ($result->getRowCount() != 0)
                 throw new RuntimeException("Invalid fixture. Table has rows: " . $tableName->getName());
         }
     }
 
     /**
-     * Delete service1 and ensure the DAO cascade deletes the service's 
+     * Delete service1 and ensure the DAO cascade deletes the service's
      * joined endpoints and downtimes, leaving downtimes that are either reachable
-     * from other services and any orphan downtimes that were never joined 
-     * to the service in the first place. 
+     * from other services and any orphan downtimes that were never joined
+     * to the service in the first place.
      */
     public function testServiceDAO_removeServiceAndJoinedDTs() {
         print __METHOD__ . "\n";
         include __DIR__ . '/resources/sampleFixtureData4.php';
 
         // Remove Service
-        // Impt: When deleting a service, we can't rely solely on the 
-        // 'onDelete=cascade' defined on the 'EndpointLocation->service' 
-        // to correctly cascade-delete the EL. This is because downtimes can also be linked 
-        // to the EL.  Therefore, if we don't invoke an $em->remove() on the EL 
-        // (either via cascade="remove" or manually invoking em->remove() on each EL), 
-        // Doctrine will not have flagged the EL as removed and so will not automatically delete the 
-        // relevant row(s) in 'DOWNTIMES_ENDPOINTLOCATIONS' join table. 
-        // This would cause a FK integrity/violation constraint exception 
-        // on the 'DOWNTIMES_ENDPOINTLOCATIONS.ENDPOINTLOCATION_ID' FK column. 
+        // Impt: When deleting a service, we can't rely solely on the
+        // 'onDelete=cascade' defined on the 'EndpointLocation->service'
+        // to correctly cascade-delete the EL. This is because downtimes can also be linked
+        // to the EL.  Therefore, if we don't invoke an $em->remove() on the EL
+        // (either via cascade="remove" or manually invoking em->remove() on each EL),
+        // Doctrine will not have flagged the EL as removed and so will not automatically delete the
+        // relevant row(s) in 'DOWNTIMES_ENDPOINTLOCATIONS' join table.
+        // This would cause a FK integrity/violation constraint exception
+        // on the 'DOWNTIMES_ENDPOINTLOCATIONS.ENDPOINTLOCATION_ID' FK column.
         // This is why we need to do a managed delete using the ServiceDAO
         $serviceDao = new ServiceDAO();
         $serviceDao->setEntityManager($this->em);
         $serviceDao->removeService($service1);
         $this->em->flush();
 
-        // use DB connection to check data has been deleted  
+        // use DB connection to check data has been deleted
         $con = $this->getConnection();
         $result = $con->createQueryTable('results_table', "SELECT * FROM EndpointLocations");
         $this->assertTrue($result->getRowCount() == 2);
@@ -150,10 +150,10 @@ class DowntimeServiceEndpointTest1 extends PHPUnit_Extensions_Database_TestCase 
     }
 
     /**
-     * Delete service2 and ensure the DAO cascade deletes the service's 
+     * Delete service2 and ensure the DAO cascade deletes the service's
      * joined endpoints and downtimes, leaving downtimes that are either reachable
-     * from other services and any orphan downtimes that were never joined 
-     * to the service in the first place. 
+     * from other services and any orphan downtimes that were never joined
+     * to the service in the first place.
      */
     public function testServiceDAO_removeService2AndJoinedDTs() {
         print __METHOD__ . "\n";
@@ -164,7 +164,7 @@ class DowntimeServiceEndpointTest1 extends PHPUnit_Extensions_Database_TestCase 
         $serviceDao->removeService($service2);
         $this->em->flush();
 
-        // use DB connection to check data has been deleted  
+        // use DB connection to check data has been deleted
         $con = $this->getConnection();
         $result = $con->createQueryTable('results_table', "SELECT * FROM EndpointLocations");
         $this->assertTrue($result->getRowCount() == 2);
@@ -173,8 +173,8 @@ class DowntimeServiceEndpointTest1 extends PHPUnit_Extensions_Database_TestCase 
     }
 
     /**
-     * Delete both services and enure the DAO cascade deletes both servcies 
-     * joined endpoints and downtimes, leaving only the sites and the single orphan downtime. 
+     * Delete both services and enure the DAO cascade deletes both servcies
+     * joined endpoints and downtimes, leaving only the sites and the single orphan downtime.
      */
     public function testServiceDAO_removeService1And2AndJoinedDTs() {
         print __METHOD__ . "\n";
@@ -186,18 +186,18 @@ class DowntimeServiceEndpointTest1 extends PHPUnit_Extensions_Database_TestCase 
         $serviceDao->removeService($service1);
         $this->em->flush();
 
-        // use DB connection to check data has been deleted  
+        // use DB connection to check data has been deleted
         $con = $this->getConnection();
         $result = $con->createQueryTable('results_table', "SELECT * FROM EndpointLocations");
         $this->assertTrue($result->getRowCount() == 0);
         $result = $con->createQueryTable('results_table', "SELECT * FROM Downtimes");
         $this->assertTrue($result->getRowCount() == 1); // orphanDT
         $result = $con->createQueryTable('results_table', "SELECT * FROM Sites");
-        $this->assertTrue($result->getRowCount() == 2); // site1 and site2 
+        $this->assertTrue($result->getRowCount() == 2); // site1 and site2
     }
 
     /**
-     * Delete site1 and ensure only site2 and the orphan downtime remain.  
+     * Delete site1 and ensure only site2 and the orphan downtime remain.
      */
     public function testSiteService_removeSite() {
         print __METHOD__ . "\n";
@@ -211,19 +211,19 @@ class DowntimeServiceEndpointTest1 extends PHPUnit_Extensions_Database_TestCase 
         $siteService->setEntityManager($this->em);
         $siteService->deleteSite($site1, $adminUser, false);
 
-        // use DB connection to check data has been deleted  
+        // use DB connection to check data has been deleted
         $con = $this->getConnection();
         $result = $con->createQueryTable('results_table', "SELECT * FROM EndpointLocations");
         $this->assertTrue($result->getRowCount() == 0);
         $result = $con->createQueryTable('results_table', "SELECT * FROM Downtimes");
-        $this->assertTrue($result->getRowCount() == 1); // orphanDT  
+        $this->assertTrue($result->getRowCount() == 1); // orphanDT
         $result = $con->createQueryTable('results_table', "SELECT * FROM Sites");
-        $this->assertTrue($result->getRowCount() == 1); // site2 
+        $this->assertTrue($result->getRowCount() == 1); // site2
     }
 
     /**
-     * Delete the parent NGI and ensure all sites, servcies, endponts and downtimes  
-     * are deleted leaving only the orphan dowmtime. 
+     * Delete the parent NGI and ensure all sites, servcies, endponts and downtimes
+     * are deleted leaving only the orphan dowmtime.
      */
     public function testNgiService_removeNgi() {
         print __METHOD__ . "\n";
@@ -237,58 +237,58 @@ class DowntimeServiceEndpointTest1 extends PHPUnit_Extensions_Database_TestCase 
         $ngiService->setEntityManager($this->em);
         $ngiService->deleteNgi($ngi, $adminUser, FALSE);
 
-        // use DB connection to check data has been deleted  
+        // use DB connection to check data has been deleted
         $con = $this->getConnection();
         $result = $con->createQueryTable('results_table', "SELECT * FROM EndpointLocations");
         $this->assertTrue($result->getRowCount() == 0);
         $result = $con->createQueryTable('results_table', "SELECT * FROM Downtimes");
-        $this->assertTrue($result->getRowCount() == 1); // orphanDT  
+        $this->assertTrue($result->getRowCount() == 1); // orphanDT
         $result = $con->createQueryTable('results_table', "SELECT * FROM Sites");
-        $this->assertTrue($result->getRowCount() == 0); // site2 
+        $this->assertTrue($result->getRowCount() == 0); // site2
     }
 
 
     /**
-     * Test the <code>$serviceDAO->removeEndpoint($endpoint)</code> method.   
-     */ 
+     * Test the <code>$serviceDAO->removeEndpoint($endpoint)</code> method.
+     */
     public function testServiceDAORemoveEndpoint(){
         print __METHOD__ . "\n";
-        // create a linked entity graph as beow: 
-        // 
-        //      se -----|    (1 service) 
+        // create a linked entity graph as beow:
+        //
+        //      se -----|    (1 service)
         //     / | \    |
-        //  el1 el2 el3 |    (3 endpoints) 
+        //  el1 el2 el3 |    (3 endpoints)
         //  |  \ | /    |
-        // dt0  dt1 ----|    (1 downtime)  
-        
-        $dt1 = new Downtime(); 
-        $dt1->setDescription('downtime description'); 
-        $dt1->setSeverity("WARNING"); 
-        $dt1->setClassification("UNSCHEDULED"); 
+        // dt0  dt1 ----|    (1 downtime)
 
-        $dt0 = new Downtime(); 
-        $dt0->setDescription('downtime description'); 
-        $dt0->setSeverity("WARNING"); 
-        $dt0->setClassification("UNSCHEDULED"); 
-         
-        $se = TestUtil::createSampleService('service1'); 
-        $el1 = TestUtil::createSampleEndpointLocation(); 
-        $el2 = TestUtil::createSampleEndpointLocation(); 
-        $el3 = TestUtil::createSampleEndpointLocation(); 
-        $se->addEndpointLocationDoJoin($el1); 
-        $se->addEndpointLocationDoJoin($el2); 
-        $se->addEndpointLocationDoJoin($el3); 
-        //$se->_addDowntime($dt1); // we don't call this in client code !  
-       
-        $dt1->addEndpointLocation($el1); 
-        $dt1->addEndpointLocation($el2); 
-        $dt1->addEndpointLocation($el3); 
-        $dt1->addService($se); 
+        $dt1 = new Downtime();
+        $dt1->setDescription('downtime description');
+        $dt1->setSeverity("WARNING");
+        $dt1->setClassification("UNSCHEDULED");
 
-        $dt0->addEndpointLocation($el1); 
-        //$dt0->addService($se); // note we don't add this relationship for purposes of the test 
-        
-        // persist and flush 
+        $dt0 = new Downtime();
+        $dt0->setDescription('downtime description');
+        $dt0->setSeverity("WARNING");
+        $dt0->setClassification("UNSCHEDULED");
+
+        $se = TestUtil::createSampleService('service1');
+        $el1 = TestUtil::createSampleEndpointLocation();
+        $el2 = TestUtil::createSampleEndpointLocation();
+        $el3 = TestUtil::createSampleEndpointLocation();
+        $se->addEndpointLocationDoJoin($el1);
+        $se->addEndpointLocationDoJoin($el2);
+        $se->addEndpointLocationDoJoin($el3);
+        //$se->_addDowntime($dt1); // we don't call this in client code !
+
+        $dt1->addEndpointLocation($el1);
+        $dt1->addEndpointLocation($el2);
+        $dt1->addEndpointLocation($el3);
+        $dt1->addService($se);
+
+        $dt0->addEndpointLocation($el1);
+        //$dt0->addService($se); // note we don't add this relationship for purposes of the test
+
+        // persist and flush
         $this->em->persist($se);
         $this->em->persist($el1);
         $this->em->persist($el2);
@@ -297,89 +297,89 @@ class DowntimeServiceEndpointTest1 extends PHPUnit_Extensions_Database_TestCase 
         $this->em->persist($dt0);
         $this->em->flush();
 
-        // create DAO to test 
+        // create DAO to test
         $serviceDao = new ServiceDAO();
         $serviceDao->setEntityManager($this->em);
-        
-        // remove first endpoint causing dt0 to be orphaned 
-        $serviceDao->removeEndpoint($el1); 
-        $this->em->flush(); 
 
-        // Assert expected object graph 
-        //     se -----|   (1 service) 
+        // remove first endpoint causing dt0 to be orphaned
+        $serviceDao->removeEndpoint($el1);
+        $this->em->flush();
+
+        // Assert expected object graph
+        //     se -----|   (1 service)
         //      | \    |
-        //     el2 el3 |   (2 endpoints) 
+        //     el2 el3 |   (2 endpoints)
         //      | /    |
-        // dt0 dt1-----|   (2 downtime)  
-        // 
+        // dt0 dt1-----|   (2 downtime)
+        //
         $testConn = $this->getConnection();
         $result = $testConn->createQueryTable('results_table', "SELECT * FROM EndpointLocations");
-        $this->assertTrue($result->getRowCount() == 2); 
+        $this->assertTrue($result->getRowCount() == 2);
         $result = $testConn->createQueryTable('results_table', "SELECT * FROM Downtimes");
-        $this->assertTrue($result->getRowCount() == 2); 
+        $this->assertTrue($result->getRowCount() == 2);
         $result = $testConn->createQueryTable('results_table', "SELECT * FROM Downtimes_EndpointLocations");
-        $this->assertTrue($result->getRowCount() == 2); 
+        $this->assertTrue($result->getRowCount() == 2);
 
-         // Assert expected object graph in ORM Mem 
-        $this->assertEquals(1, count($el2->getDowntimes())); 
-        $this->assertEquals(1, count($el3->getDowntimes())); 
-        $this->assertEquals(2, count($se->getEndpointLocations())); 
-        $this->assertEquals(1, count($se->getDowntimes())); 
-        $this->assertEquals(2, count($dt1->getEndpointLocations())); 
-        $this->assertEquals(1, count($dt1->getServices())); 
-
-        // remove another el  
-        $serviceDao->removeEndpoint($el2); 
-        $this->em->flush();  
-       
-        // Assert expected object graph in DB 
-        //     se -----| (1 service) 
-        //       \     |
-        //        el3  | (1 endpoints) 
-        //        /    |
-        // dt0 dt1-----| (2 downtime)   
-        // 
-        $testConn = $this->getConnection();
-        $result = $testConn->createQueryTable('results_table', "SELECT * FROM EndpointLocations");
-        $this->assertTrue($result->getRowCount() == 1); 
-        $result = $testConn->createQueryTable('results_table', "SELECT * FROM Downtimes");
-        $this->assertTrue($result->getRowCount() == 2); 
-        $result = $testConn->createQueryTable('results_table', "SELECT * FROM Downtimes_EndpointLocations");
-        $this->assertTrue($result->getRowCount() == 1); 
-      
-        // Assert expected object graph in ORM Mem 
-        $this->assertEquals(1, count($el3->getDowntimes())); 
-        $this->assertEquals(1, count($se->getEndpointLocations())); 
-        $this->assertEquals(1, count($se->getDowntimes())); 
-        $this->assertEquals(1, count($dt1->getEndpointLocations())); 
+         // Assert expected object graph in ORM Mem
+        $this->assertEquals(1, count($el2->getDowntimes()));
+        $this->assertEquals(1, count($el3->getDowntimes()));
+        $this->assertEquals(2, count($se->getEndpointLocations()));
+        $this->assertEquals(1, count($se->getDowntimes()));
+        $this->assertEquals(2, count($dt1->getEndpointLocations()));
         $this->assertEquals(1, count($dt1->getServices()));
 
-        // remove another el 
-        $serviceDao->removeEndpoint($el3); 
-        $this->em->flush();  
+        // remove another el
+        $serviceDao->removeEndpoint($el2);
+        $this->em->flush();
 
-         // Assert expected object graph in DB 
-        //     se -----| (1 service) 
-        //             |
-        //             | (1 endpoints) 
-        //             |
-        // dt0 dt1-----| (2 downtime)   
-        // 
+        // Assert expected object graph in DB
+        //     se -----| (1 service)
+        //       \     |
+        //        el3  | (1 endpoints)
+        //        /    |
+        // dt0 dt1-----| (2 downtime)
+        //
         $testConn = $this->getConnection();
         $result = $testConn->createQueryTable('results_table', "SELECT * FROM EndpointLocations");
-        $this->assertTrue($result->getRowCount() == 0); 
+        $this->assertTrue($result->getRowCount() == 1);
         $result = $testConn->createQueryTable('results_table', "SELECT * FROM Downtimes");
-        $this->assertTrue($result->getRowCount() == 2); 
+        $this->assertTrue($result->getRowCount() == 2);
         $result = $testConn->createQueryTable('results_table', "SELECT * FROM Downtimes_EndpointLocations");
-        $this->assertTrue($result->getRowCount() == 0); 
-      
-        // Assert expected object graph in ORM Mem 
-        $this->assertEquals(0, count($se->getEndpointLocations())); 
-        $this->assertEquals(1, count($se->getDowntimes())); 
-        $this->assertEquals(0, count($dt1->getEndpointLocations())); 
+        $this->assertTrue($result->getRowCount() == 1);
+
+        // Assert expected object graph in ORM Mem
+        $this->assertEquals(1, count($el3->getDowntimes()));
+        $this->assertEquals(1, count($se->getEndpointLocations()));
+        $this->assertEquals(1, count($se->getDowntimes()));
+        $this->assertEquals(1, count($dt1->getEndpointLocations()));
+        $this->assertEquals(1, count($dt1->getServices()));
+
+        // remove another el
+        $serviceDao->removeEndpoint($el3);
+        $this->em->flush();
+
+         // Assert expected object graph in DB
+        //     se -----| (1 service)
+        //             |
+        //             | (1 endpoints)
+        //             |
+        // dt0 dt1-----| (2 downtime)
+        //
+        $testConn = $this->getConnection();
+        $result = $testConn->createQueryTable('results_table', "SELECT * FROM EndpointLocations");
+        $this->assertTrue($result->getRowCount() == 0);
+        $result = $testConn->createQueryTable('results_table', "SELECT * FROM Downtimes");
+        $this->assertTrue($result->getRowCount() == 2);
+        $result = $testConn->createQueryTable('results_table', "SELECT * FROM Downtimes_EndpointLocations");
+        $this->assertTrue($result->getRowCount() == 0);
+
+        // Assert expected object graph in ORM Mem
+        $this->assertEquals(0, count($se->getEndpointLocations()));
+        $this->assertEquals(1, count($se->getDowntimes()));
+        $this->assertEquals(0, count($dt1->getEndpointLocations()));
         $this->assertEquals(1, count($dt1->getServices()));
     }
-   
+
 
 
 }

--- a/tests/doctrine/ExtensionProps_IPIQuery_Test1.php
+++ b/tests/doctrine/ExtensionProps_IPIQuery_Test1.php
@@ -18,13 +18,13 @@ require_once dirname(__FILE__) . '/../../lib/Gocdb_Services/Factory.php';
 
 
 /**
- * Creates selected <code>IPIQuery</code> objects that perform queries on 
- * entity objects that own extension properties. Assert that the query objects return 
- * the expected number of entities when querying against known fixture data using 
- * different extension queries. 
+ * Creates selected <code>IPIQuery</code> objects that perform queries on
+ * entity objects that own extension properties. Assert that the query objects return
+ * the expected number of entities when querying against known fixture data using
+ * different extension queries.
  * <p>
- * Covers the following IPIQuery objects: GetSite 
- * 
+ * Covers the following IPIQuery objects: GetSite
+ *
  * @author David Meredith
  */
 class ExtensionProps_IPIQuery_Test1 extends PHPUnit_Extensions_Database_TestCase {
@@ -32,7 +32,7 @@ class ExtensionProps_IPIQuery_Test1 extends PHPUnit_Extensions_Database_TestCase
     private $em;
 
     /**
-     * Overridden. 
+     * Overridden.
      */
     public static function setUpBeforeClass() {
         parent::setUpBeforeClass();
@@ -50,8 +50,8 @@ class ExtensionProps_IPIQuery_Test1 extends PHPUnit_Extensions_Database_TestCase
     }
 
     /**
-     * Overridden. Returns the test dataset.  
-     * Defines how the initial state of the database should look before each test is executed. 
+     * Overridden. Returns the test dataset.
+     * Defines how the initial state of the database should look before each test is executed.
      * @return PHPUnit_Extensions_Database_DataSet_IDataSet
      */
     protected function getDataSet() {
@@ -61,7 +61,7 @@ class ExtensionProps_IPIQuery_Test1 extends PHPUnit_Extensions_Database_TestCase
     }
 
     /**
-     * Overridden. 
+     * Overridden.
      */
     protected function getSetUpOperation() {
         // CLEAN_INSERT is default
@@ -69,14 +69,14 @@ class ExtensionProps_IPIQuery_Test1 extends PHPUnit_Extensions_Database_TestCase
         //return PHPUnit_Extensions_Database_Operation_Factory::UPDATE();
         //return PHPUnit_Extensions_Database_Operation_Factory::NONE();
         //
-        // Issue a DELETE from <table> which is more portable than a 
-        // TRUNCATE table <table> (some DBs require high privileges for truncate statements 
+        // Issue a DELETE from <table> which is more portable than a
+        // TRUNCATE table <table> (some DBs require high privileges for truncate statements
         // and also do not allow truncates across tables with FK contstraints e.g. Oracle)
         return PHPUnit_Extensions_Database_Operation_Factory::DELETE_ALL();
     }
 
     /**
-     * Overridden. 
+     * Overridden.
      */
     protected function getTearDownOperation() {
         // NONE is default
@@ -113,7 +113,7 @@ class ExtensionProps_IPIQuery_Test1 extends PHPUnit_Extensions_Database_TestCase
             //print $tableName->getName() . "\n";
             $sql = "SELECT * FROM " . $tableName->getName();
             $result = $con->createQueryTable('results_table', $sql);
-            //echo 'row count: '.$result->getRowCount() ; 
+            //echo 'row count: '.$result->getRowCount() ;
             if ($result->getRowCount() != 0)
                 throw new RuntimeException("Invalid fixture. Table has rows: " . $tableName->getName());
         }
@@ -121,240 +121,240 @@ class ExtensionProps_IPIQuery_Test1 extends PHPUnit_Extensions_Database_TestCase
 
 
     /**
-     * Use this test to print out how the GocDB query will parenthesise a WHERE 
-     * clause in a DQL query. To run, the name of the test needs to start with 'test'  
+     * Use this test to print out how the GocDB query will parenthesise a WHERE
+     * clause in a DQL query. To run, the name of the test needs to start with 'test'
      */
     public function xtestDemo_PrintQuery() {
         print __METHOD__ . "\n";
-        
+
         $query = new \org\gocdb\services\GetSite($this->em);
-        $params = array('scope' => '', 'scope_match' => 'all', 
-            'extensions' => '(VO=food)(s4p1=v1)OR(VO2=baz)AND(VO2=bling)'); 
+        $params = array('scope' => '', 'scope_match' => 'all',
+            'extensions' => '(VO=food)(s4p1=v1)OR(VO2=baz)AND(VO2=bling)');
             // becomes: (((VO=food)(s4p1=v1))OR(VO2=baz)) AND(VO2=bling)
         $query->validateParameters($params);
         /* @var $dqlQuery \Doctrine\ORM\Query */
         $dqlQuery = $query->createQuery();
-        //print_r($dqlQuery->getDql()); 
+        //print_r($dqlQuery->getDql());
         /*
         http://www.freeformatter.com/sql-formatter.html
-        SELECT s, sc, sp, i, cs, c, n, sgrid, ti 
-        FROM Site s 
-        LEFT JOIN s.siteProperties sp 
-        LEFT JOIN s.scopes sc 
-        LEFT JOIN s.ngi n 
-        LEFT JOIN s.country c 
-        LEFT JOIN s.certificationStatus cs 
-        LEFT JOIN s.infrastructure i 
-        LEFT JOIN s.subGrid sgrid 
-        LEFT JOIN s.tier ti 
+        SELECT s, sc, sp, i, cs, c, n, sgrid, ti
+        FROM Site s
+        LEFT JOIN s.siteProperties sp
+        LEFT JOIN s.scopes sc
+        LEFT JOIN s.ngi n
+        LEFT JOIN s.country c
+        LEFT JOIN s.certificationStatus cs
+        LEFT JOIN s.infrastructure i
+        LEFT JOIN s.subGrid sgrid
+        LEFT JOIN s.tier ti
         WHERE
            (
               (
                  (
-                    s IN( SELECT s0.id FROM Site s0 
-                       INNER JOIN s0.siteProperties sp0 
+                    s IN( SELECT s0.id FROM Site s0
+                       INNER JOIN s0.siteProperties sp0
                        WHERE sp0.keyName = ?0 AND sp0.keyValue = ?1)
-                 ) 
+                 )
                  AND (
-                    s IN( SELECT s1.id FROM Site s1 
-                       INNER JOIN s1.siteProperties sp1 
+                    s IN( SELECT s1.id FROM Site s1
+                       INNER JOIN s1.siteProperties sp1
                        WHERE sp1.keyName = ?2 AND sp1.keyValue = ?3)
                  )
-              ) 
+              )
               OR (
-                 s IN( SELECT s2.id FROM Site s2 
-                    INNER JOIN s2.siteProperties sp2 
+                 s IN( SELECT s2.id FROM Site s2
+                    INNER JOIN s2.siteProperties sp2
                     WHERE sp2.keyName = ?4 AND sp2.keyValue = ?5)
               )
-           ) 
-           AND ( s IN( SELECT s3.id FROM Site s3 
-                 INNER JOIN s3.siteProperties sp3 
-                 WHERE sp3.keyName = ?6 AND sp3.keyValue = ?7)
            )
-         */
-        
-        $query = new \org\gocdb\services\GetSite($this->em);
-        $params = array('scope' => '', 'scope_match' => 'all', 
-            'extensions' =>'(VO=food)(s4p1=v1)OR(VO2=bar)(VO2=baz)');
-           // becomes: ((VO=food)(s4p1=v1))OR(VO2=bar)OR(VO2=baz)  // notice ORs at same level 
-        $query->validateParameters($params);
-        /* @var $dqlQuery \Doctrine\ORM\Query */
-        $dqlQuery = $query->createQuery();
-        //print_r($dqlQuery->getDql()); 
-        /*
-        SELECT s, sc, sp, i, cs, c, n, sgrid, ti 
-        FROM Site s 
-        LEFT JOIN s.siteProperties sp 
-        LEFT JOIN s.scopes sc 
-        LEFT JOIN s.ngi n 
-        LEFT JOIN s.country c 
-        LEFT JOIN s.certificationStatus cs 
-        LEFT JOIN s.infrastructure i 
-        LEFT JOIN s.subGrid sgrid 
-        LEFT JOIN s.tier ti 
-        WHERE
-           (
-              (
-                 s IN( SELECT s0.id FROM Site s0 
-                    INNER JOIN s0.siteProperties sp0 
-                    WHERE sp0.keyName = ?0 AND sp0.keyValue = ?1)
-              ) 
-              AND (
-                 s IN( SELECT s1.id FROM Site s1 
-                    INNER JOIN s1.siteProperties sp1 
-                    WHERE sp1.keyName = ?2 AND sp1.keyValue = ?3)
-              )
-           ) 
-           OR ( s IN( SELECT s2.id FROM Site s2 
-                 INNER JOIN s2.siteProperties sp2 
-                 WHERE sp2.keyName = ?4 AND sp2.keyValue = ?5)
-           ) 
-           OR ( s IN(
-                 SELECT s3.id FROM Site s3 
-                 INNER JOIN s3.siteProperties sp3 
+           AND ( s IN( SELECT s3.id FROM Site s3
+                 INNER JOIN s3.siteProperties sp3
                  WHERE sp3.keyName = ?6 AND sp3.keyValue = ?7)
            )
          */
 
         $query = new \org\gocdb\services\GetSite($this->em);
-        $params = array('scope' => '', 'scope_match' => 'all', 
-            'extensions' =>'(VO=food)OR(s4p1=v1)OR(VO2=bar)'); // notice ORs at same level 
+        $params = array('scope' => '', 'scope_match' => 'all',
+            'extensions' =>'(VO=food)(s4p1=v1)OR(VO2=bar)(VO2=baz)');
+           // becomes: ((VO=food)(s4p1=v1))OR(VO2=bar)OR(VO2=baz)  // notice ORs at same level
+        $query->validateParameters($params);
+        /* @var $dqlQuery \Doctrine\ORM\Query */
+        $dqlQuery = $query->createQuery();
+        //print_r($dqlQuery->getDql());
+        /*
+        SELECT s, sc, sp, i, cs, c, n, sgrid, ti
+        FROM Site s
+        LEFT JOIN s.siteProperties sp
+        LEFT JOIN s.scopes sc
+        LEFT JOIN s.ngi n
+        LEFT JOIN s.country c
+        LEFT JOIN s.certificationStatus cs
+        LEFT JOIN s.infrastructure i
+        LEFT JOIN s.subGrid sgrid
+        LEFT JOIN s.tier ti
+        WHERE
+           (
+              (
+                 s IN( SELECT s0.id FROM Site s0
+                    INNER JOIN s0.siteProperties sp0
+                    WHERE sp0.keyName = ?0 AND sp0.keyValue = ?1)
+              )
+              AND (
+                 s IN( SELECT s1.id FROM Site s1
+                    INNER JOIN s1.siteProperties sp1
+                    WHERE sp1.keyName = ?2 AND sp1.keyValue = ?3)
+              )
+           )
+           OR ( s IN( SELECT s2.id FROM Site s2
+                 INNER JOIN s2.siteProperties sp2
+                 WHERE sp2.keyName = ?4 AND sp2.keyValue = ?5)
+           )
+           OR ( s IN(
+                 SELECT s3.id FROM Site s3
+                 INNER JOIN s3.siteProperties sp3
+                 WHERE sp3.keyName = ?6 AND sp3.keyValue = ?7)
+           )
+         */
+
+        $query = new \org\gocdb\services\GetSite($this->em);
+        $params = array('scope' => '', 'scope_match' => 'all',
+            'extensions' =>'(VO=food)OR(s4p1=v1)OR(VO2=bar)'); // notice ORs at same level
            // becomes:  (VO=food)OR(s4p1=v1)OR(VO2=bar)
         $query->validateParameters($params);
         /* @var $dqlQuery \Doctrine\ORM\Query */
         $dqlQuery = $query->createQuery();
-        //print_r($dqlQuery->getDql()); 
+        //print_r($dqlQuery->getDql());
         /*
-        SELECT s, sc, sp, i, cs, c, n, sgrid, ti 
-        FROM Site s 
-        LEFT JOIN s.siteProperties sp 
-        LEFT JOIN s.scopes sc 
-        LEFT JOIN s.ngi n 
-        LEFT JOIN s.country c 
-        LEFT JOIN s.certificationStatus cs 
-        LEFT JOIN s.infrastructure i 
-        LEFT JOIN s.subGrid sgrid 
-        LEFT JOIN s.tier ti 
+        SELECT s, sc, sp, i, cs, c, n, sgrid, ti
+        FROM Site s
+        LEFT JOIN s.siteProperties sp
+        LEFT JOIN s.scopes sc
+        LEFT JOIN s.ngi n
+        LEFT JOIN s.country c
+        LEFT JOIN s.certificationStatus cs
+        LEFT JOIN s.infrastructure i
+        LEFT JOIN s.subGrid sgrid
+        LEFT JOIN s.tier ti
         WHERE
            (
-              s IN( SELECT s0.id FROM Site s0 
-                 INNER JOIN s0.siteProperties sp0 
+              s IN( SELECT s0.id FROM Site s0
+                 INNER JOIN s0.siteProperties sp0
                  WHERE sp0.keyName = ?0 AND sp0.keyValue  = ?1)
-           ) 
-           OR ( s IN( SELECT s1.id FROM Site s1 
-                 INNER JOIN s1.siteProperties sp1 
+           )
+           OR ( s IN( SELECT s1.id FROM Site s1
+                 INNER JOIN s1.siteProperties sp1
                  WHERE sp1.keyName = ?2 AND sp1.keyValue = ?3)
-           )  
-           OR ( s IN( SELECT s2.id FROM Site s2 
-                 INNER JOIN s2.siteProperties sp2 
+           )
+           OR ( s IN( SELECT s2.id FROM Site s2
+                 INNER JOIN s2.siteProperties sp2
                  WHERE sp2.keyName = ?4 AND sp2.keyValue = ?5)
            )
          */
 
 
         $query = new \org\gocdb\services\GetSite($this->em);
-        $params = array('scope' => '', 'scope_match' => 'all', 
-            'extensions' =>'(VO=food)OR(s4p1=v1)AND(VO2=bar)');    
-           // becomes: ((VO=food)OR(s4p1=v1))AND(VO2=bar)  // notice brackets around OR'd 
+        $params = array('scope' => '', 'scope_match' => 'all',
+            'extensions' =>'(VO=food)OR(s4p1=v1)AND(VO2=bar)');
+           // becomes: ((VO=food)OR(s4p1=v1))AND(VO2=bar)  // notice brackets around OR'd
         $query->validateParameters($params);
         /* @var $dqlQuery \Doctrine\ORM\Query */
         $dqlQuery = $query->createQuery();
-        //print_r($dqlQuery->getDql()); 
+        //print_r($dqlQuery->getDql());
         /*
-        SELECT s, sc, sp, i, cs, c, n, sgrid, ti 
-        FROM Site s 
-        LEFT JOIN s.siteProperties  sp 
-        LEFT JOIN s.scopes sc 
-        LEFT JOIN s.ngi n 
-        LEFT JOIN s.country c 
-        LEFT JOIN s.certificationStatus cs 
-        LEFT JOIN s.infrastructure i 
-        LEFT JOIN s.subGrid sgrid 
-        LEFT  JOIN s.tier ti 
+        SELECT s, sc, sp, i, cs, c, n, sgrid, ti
+        FROM Site s
+        LEFT JOIN s.siteProperties  sp
+        LEFT JOIN s.scopes sc
+        LEFT JOIN s.ngi n
+        LEFT JOIN s.country c
+        LEFT JOIN s.certificationStatus cs
+        LEFT JOIN s.infrastructure i
+        LEFT JOIN s.subGrid sgrid
+        LEFT  JOIN s.tier ti
         WHERE
            (
               (
-                 s IN( SELECT s0.id FROM Site s0 
-                    INNER JOIN s0.siteProperties sp0 
+                 s IN( SELECT s0.id FROM Site s0
+                    INNER JOIN s0.siteProperties sp0
                     WHERE sp0.keyName = ?0 AND sp0.keyValue = ?1)
-              ) 
-              OR ( s IN( SELECT s1.id FROM Site s1 
-                    INNER JOIN s1.siteProperties sp1 
+              )
+              OR ( s IN( SELECT s1.id FROM Site s1
+                    INNER JOIN s1.siteProperties sp1
                     WHERE sp1.keyName = ?2 AND sp1.keyValue = ?3)
               )
-           ) 
+           )
            AND (
-              s IN( SELECT s2.id FROM Site s2 
-                 INNER JOIN s2.siteProperties sp2 
+              s IN( SELECT s2.id FROM Site s2
+                 INNER JOIN s2.siteProperties sp2
                  WHERE sp2.keyName = ?4 AND sp2.keyValue = ?5)
            )
          */
     }
-    
+
     /**
-     * Run queries against Sites with extension properties. 
+     * Run queries against Sites with extension properties.
      */
     public function testSiteExtensions() {
         print __METHOD__ . "\n";
         include __DIR__ . '/resources/sampleFixtureData3.php';
 
         $query = new \org\gocdb\services\GetSite($this->em);
-        $this->queryForIScopedEntity($query, array('scope' => '', 'scope_match' => 'all', 'extensions' => 'NOT(key=val)'), 5); 
-         
-        $sites = $this->queryForIScopedEntity($query, array('scope' => '', 'scope_match' => 'all', 'extensions' => '(s1p1=v1)'), 1); 
-        $this->assertEquals('Site1', $sites[0]->getShortName());  
-        $sites = $this->queryForIScopedEntity($query, array('scope' => '', 'scope_match' => 'all', 'extensions' => '(s1p1=)'), 1); 
-        $this->assertEquals('Site1', $sites[0]->getShortName());  
-        
-        $this->queryForIScopedEntity($query, array('scope' => '', 'scope_match' => 'all', 'extensions' => '(s2p1=)(s2p2=)'), 1); 
-        $sites = $this->queryForIScopedEntity($query, array('scope' => '', 'scope_match' => 'all', 'extensions' => '(s2p1=v1)(s2p2=v2)'), 1); 
-        $this->assertEquals('Site2', $sites[0]->getShortName());  
-        
-        $this->queryForIScopedEntity($query, array('scope' => '', 'scope_match' => 'all', 'extensions' => '(VO=)'), 2); 
-        $this->queryForIScopedEntity($query, array('scope' => '', 'scope_match' => 'all', 'extensions' => '(VO=foo)'), 2); 
-        $this->queryForIScopedEntity($query, array('scope' => '', 'scope_match' => 'all', 'extensions' => '(VO=)(VO2=)'), 2); 
-        $this->queryForIScopedEntity($query, array('scope' => '', 'scope_match' => 'all', 'extensions' => '(VO=foo)(VO2=)'), 2); 
-        $this->queryForIScopedEntity($query, array('scope' => '', 'scope_match' => 'all', 'extensions' => '(VO2=)NOT(VO=foo)'), 0); 
-        
-        $sites = $this->queryForIScopedEntity($query, array('scope' => '', 'scope_match' => 'all', 'extensions' => '(VO=)(VO2=)NOT(VO2=baz)'), 1); 
-        $this->assertEquals('Site3', $sites[0]->getShortName());  
-        
-        $this->queryForIScopedEntity($query, array('scope' => '', 'scope_match' => 'all', 'extensions' => '(VO=)(VO2=)NOT(VO2=)(VO=)'), 0); 
-        
-        
-        $this->queryForIScopedEntity($query, array('scope' => '', 'scope_match' => 'all', 'extensions' => 'OR(VO2=bar)(VO2=baz)'), 2); 
-        $this->queryForIScopedEntity($query, array('scope' => '', 'scope_match' => 'all', 'extensions' => '(VO=food)OR(VO2=bar)(VO2=baz)'), 2); 
-        $this->queryForIScopedEntity($query, array('scope' => '', 'scope_match' => 'all', 'extensions' => '(VO=food)OR(VO2=bar)OR(VO2=baz)'), 2); 
-        
-        $sites = $this->queryForIScopedEntity($query, array('scope' => '', 'scope_match' => 'all', 'extensions' => '(VO=food)OR(VO2=bar)OR(VO2=baz)AND(s4p1=v1)'), 1); 
-        $this->assertEquals('Site4', $sites[0]->getShortName());  
-        
-        $sites = $this->queryForIScopedEntity($query, array('scope' => '', 'scope_match' => 'all', 'extensions' => '(VO=food)(s4p1=v1)OR(VO2=bar)(VO2=baz)'), 2); 
-        $this->assertEquals('Site3', $sites[0]->getShortName()); 
-        $this->assertEquals('Site4', $sites[1]->getShortName()); 
-        
-        $this->queryForIScopedEntity($query, array('scope' => '', 'scope_match' => 'all', 'extensions' => '(VO=food)(s4p1=v1)OR(VO2=baz)AND(VO2=bling)'), 0); 
-        
-        $sites = $this->queryForIScopedEntity($query, array('scope' => '', 'scope_match' => 'all', 'extensions' => '(VO2=bing)AND(VO2=baz)AND(VO=bar)OR(s1p1=v1)'), 2); 
-        $this->assertEquals('Site1', $sites[0]->getShortName()); 
-        $this->assertEquals('Site4', $sites[1]->getShortName()); 
+        $this->queryForIScopedEntity($query, array('scope' => '', 'scope_match' => 'all', 'extensions' => 'NOT(key=val)'), 5);
+
+        $sites = $this->queryForIScopedEntity($query, array('scope' => '', 'scope_match' => 'all', 'extensions' => '(s1p1=v1)'), 1);
+        $this->assertEquals('Site1', $sites[0]->getShortName());
+        $sites = $this->queryForIScopedEntity($query, array('scope' => '', 'scope_match' => 'all', 'extensions' => '(s1p1=)'), 1);
+        $this->assertEquals('Site1', $sites[0]->getShortName());
+
+        $this->queryForIScopedEntity($query, array('scope' => '', 'scope_match' => 'all', 'extensions' => '(s2p1=)(s2p2=)'), 1);
+        $sites = $this->queryForIScopedEntity($query, array('scope' => '', 'scope_match' => 'all', 'extensions' => '(s2p1=v1)(s2p2=v2)'), 1);
+        $this->assertEquals('Site2', $sites[0]->getShortName());
+
+        $this->queryForIScopedEntity($query, array('scope' => '', 'scope_match' => 'all', 'extensions' => '(VO=)'), 2);
+        $this->queryForIScopedEntity($query, array('scope' => '', 'scope_match' => 'all', 'extensions' => '(VO=foo)'), 2);
+        $this->queryForIScopedEntity($query, array('scope' => '', 'scope_match' => 'all', 'extensions' => '(VO=)(VO2=)'), 2);
+        $this->queryForIScopedEntity($query, array('scope' => '', 'scope_match' => 'all', 'extensions' => '(VO=foo)(VO2=)'), 2);
+        $this->queryForIScopedEntity($query, array('scope' => '', 'scope_match' => 'all', 'extensions' => '(VO2=)NOT(VO=foo)'), 0);
+
+        $sites = $this->queryForIScopedEntity($query, array('scope' => '', 'scope_match' => 'all', 'extensions' => '(VO=)(VO2=)NOT(VO2=baz)'), 1);
+        $this->assertEquals('Site3', $sites[0]->getShortName());
+
+        $this->queryForIScopedEntity($query, array('scope' => '', 'scope_match' => 'all', 'extensions' => '(VO=)(VO2=)NOT(VO2=)(VO=)'), 0);
+
+
+        $this->queryForIScopedEntity($query, array('scope' => '', 'scope_match' => 'all', 'extensions' => 'OR(VO2=bar)(VO2=baz)'), 2);
+        $this->queryForIScopedEntity($query, array('scope' => '', 'scope_match' => 'all', 'extensions' => '(VO=food)OR(VO2=bar)(VO2=baz)'), 2);
+        $this->queryForIScopedEntity($query, array('scope' => '', 'scope_match' => 'all', 'extensions' => '(VO=food)OR(VO2=bar)OR(VO2=baz)'), 2);
+
+        $sites = $this->queryForIScopedEntity($query, array('scope' => '', 'scope_match' => 'all', 'extensions' => '(VO=food)OR(VO2=bar)OR(VO2=baz)AND(s4p1=v1)'), 1);
+        $this->assertEquals('Site4', $sites[0]->getShortName());
+
+        $sites = $this->queryForIScopedEntity($query, array('scope' => '', 'scope_match' => 'all', 'extensions' => '(VO=food)(s4p1=v1)OR(VO2=bar)(VO2=baz)'), 2);
+        $this->assertEquals('Site3', $sites[0]->getShortName());
+        $this->assertEquals('Site4', $sites[1]->getShortName());
+
+        $this->queryForIScopedEntity($query, array('scope' => '', 'scope_match' => 'all', 'extensions' => '(VO=food)(s4p1=v1)OR(VO2=baz)AND(VO2=bling)'), 0);
+
+        $sites = $this->queryForIScopedEntity($query, array('scope' => '', 'scope_match' => 'all', 'extensions' => '(VO2=bing)AND(VO2=baz)AND(VO=bar)OR(s1p1=v1)'), 2);
+        $this->assertEquals('Site1', $sites[0]->getShortName());
+        $this->assertEquals('Site4', $sites[1]->getShortName());
 
         /*$params = array('scope' => '', 'scope_match' => 'all', 'extensions' => '(VO2=bing)AND(VO2=baz)AND(VO=bar)OR(s1p1=v1)');
         $query->validateParameters($params);
         $dql = $query->createQuery();
-        print $dql->getDql(); 
+        print $dql->getDql();
         $results = $query->executeQuery();
         print count($results);
         $this->assertTrue(2 == count($results));
         foreach ( $results as $site ) {
-            print_r('site: ['.$site->getShortName().']'); 
+            print_r('site: ['.$site->getShortName().']');
         }
         */
-        
-        // these property values are only supported by ExtensionsParser2  
-        $sites = $this->queryForIScopedEntity($query, array('scope' => '', 'scope_match' => 'all', 'extensions' => '(VO2=\(bing\))AND(VO2=baz&)'), 0); 
-        //$this->assertEquals('Site1', $sites[0]->getShortName()); 
-        
+
+        // these property values are only supported by ExtensionsParser2
+        $sites = $this->queryForIScopedEntity($query, array('scope' => '', 'scope_match' => 'all', 'extensions' => '(VO2=\(bing\))AND(VO2=baz&)'), 0);
+        //$this->assertEquals('Site1', $sites[0]->getShortName());
+
     }
 
 
@@ -364,7 +364,7 @@ class ExtensionProps_IPIQuery_Test1 extends PHPUnit_Extensions_Database_TestCase
         $query->createQuery();
         $results = $query->executeQuery();
         $this->assertTrue($expectedCount == count($results));
-        return $results; 
+        return $results;
     }
 
 }

--- a/tests/doctrine/ExtensionsTest.php
+++ b/tests/doctrine/ExtensionsTest.php
@@ -13,8 +13,8 @@ require_once dirname(__FILE__) . '/bootstrap.php';
 
 /**
  * A template that includes all the setup and tear down functions for writting
- * a PHPUnit test to test doctrine.  
- * 
+ * a PHPUnit test to test doctrine.
+ *
  * @author James McCarthy
  */
 class ExtensionsTest extends PHPUnit_Extensions_Database_TestCase {
@@ -22,7 +22,7 @@ class ExtensionsTest extends PHPUnit_Extensions_Database_TestCase {
     private $em;
 
     /**
-     * Overridden. 
+     * Overridden.
      */
     public static function setUpBeforeClass() {
     parent::setUpBeforeClass();
@@ -40,8 +40,8 @@ class ExtensionsTest extends PHPUnit_Extensions_Database_TestCase {
     }
 
     /**
-     * Overridden. Returns the test dataset.  
-     * Defines how the initial state of the database should look before each test is executed. 
+     * Overridden. Returns the test dataset.
+     * Defines how the initial state of the database should look before each test is executed.
      * @return PHPUnit_Extensions_Database_DataSet_IDataSet
      */
     protected function getDataSet() {
@@ -49,7 +49,7 @@ class ExtensionsTest extends PHPUnit_Extensions_Database_TestCase {
     }
 
     /**
-     * Overridden. 
+     * Overridden.
      */
     protected function getSetUpOperation() {
     // CLEAN_INSERT is default
@@ -57,14 +57,14 @@ class ExtensionsTest extends PHPUnit_Extensions_Database_TestCase {
     //return PHPUnit_Extensions_Database_Operation_Factory::UPDATE();
     //return PHPUnit_Extensions_Database_Operation_Factory::NONE();
     //
-        // Issue a DELETE from <table> which is more portable than a 
-    // TRUNCATE table <table> (some DBs require high privileges for truncate statements 
+        // Issue a DELETE from <table> which is more portable than a
+    // TRUNCATE table <table> (some DBs require high privileges for truncate statements
     // and also do not allow truncates across tables with FK contstraints e.g. Oracle)
     return PHPUnit_Extensions_Database_Operation_Factory::DELETE_ALL();
     }
 
     /**
-     * Overridden. 
+     * Overridden.
      */
     protected function getTearDownOperation() {
     // NONE is default
@@ -81,7 +81,7 @@ class ExtensionsTest extends PHPUnit_Extensions_Database_TestCase {
     }
 
     /**
-     * @todo Still need to setup connection to different databases. 
+     * @todo Still need to setup connection to different databases.
      * @return EntityManager
      */
     private function createEntityManager() {
@@ -102,20 +102,20 @@ class ExtensionsTest extends PHPUnit_Extensions_Database_TestCase {
         //print $tableName->getName() . "\n";
         $sql = "SELECT * FROM " . $tableName->getName();
         $result = $con->createQueryTable('results_table', $sql);
-        //echo 'row count: '.$result->getRowCount() ; 
+        //echo 'row count: '.$result->getRowCount() ;
         if ($result->getRowCount() != 0)
         throw new RuntimeException("Invalid fixture. Table has rows: " . $tableName->getName());
     }
     }
 
     /**
-     * An example test showing the creation of a site and properties and that 
+     * An example test showing the creation of a site and properties and that
      * all data is removed on deletion of a site or property
      */
     public function testSitePropertyDeletions() {
     print __METHOD__ . "\n";
 
-    //Create a site    	
+    //Create a site
     $site = TestUtil::createSampleSite("TestSite");
     //Create site property
     $prop1 = TestUtil::createSampleSiteProperty("VO", "Atlas");
@@ -184,23 +184,23 @@ class ExtensionsTest extends PHPUnit_Extensions_Database_TestCase {
     $siteService->deleteSite($site, $adminUser, false);
     $this->em->flush();
 
-    //Check site is gone		
+    //Check site is gone
     $result = $con->createQueryTable('results', "SELECT * FROM Sites WHERE ID = '$siteId'");
     $this->assertEquals(0, $result->getRowCount());
 
-    //Check properties are gone		
+    //Check properties are gone
     $result = $con->createQueryTable('results', "SELECT * FROM site_properties WHERE PARENTSITE_ID = '$siteId'");
     $this->assertEquals(0, $result->getRowCount());
     }
 
     /**
-     * An example test showing the creation of a service and properties and that 
+     * An example test showing the creation of a service and properties and that
      * all data is removed on deletion of a service or property
      */
     public function testServicePropertyDeletions() {
     print __METHOD__ . "\n";
 
-    //Create a service    	
+    //Create a service
     $service = TestUtil::createSampleService("TestService");
 
     //Create a NGI
@@ -208,7 +208,7 @@ class ExtensionsTest extends PHPUnit_Extensions_Database_TestCase {
     //Create a site
     $site = TestUtil::createSampleSite("TestSite");
 
-    //Join service to site, and site to NGI. 		
+    //Join service to site, and site to NGI.
     $ngi->addSiteDoJoin($site);
 
     $site->addServiceDoJoin($service);
@@ -279,23 +279,23 @@ class ExtensionsTest extends PHPUnit_Extensions_Database_TestCase {
     $serviceService->deleteService($service, $adminUser, true);
     $this->em->flush();
 
-    //Check service is gone		
+    //Check service is gone
     $result = $con->createQueryTable('results', "SELECT * FROM Services WHERE ID = '$servId'");
     $this->assertEquals(0, $result->getRowCount());
 
-    //Check properties are gone		
+    //Check properties are gone
     $result = $con->createQueryTable('results', "SELECT * FROM service_properties WHERE PARENTSERVICE_ID = '$servId'");
     $this->assertEquals(0, $result->getRowCount());
     }
 
     /**
-     * An example test showing the creation of a service group and properties 
+     * An example test showing the creation of a service group and properties
      * and that all data is removed on deletion of a service group or property
      */
     public function testServiceGroupPropertyDeletions() {
     print __METHOD__ . "\n";
 
-    //Create a service    	
+    //Create a service
     $service = TestUtil::createSampleService("TestService");
 
     //Create a NGI
@@ -306,7 +306,7 @@ class ExtensionsTest extends PHPUnit_Extensions_Database_TestCase {
     //Create a service group
     $sg = TestUtil::createSampleServiceGroup("TestServiceGroup");
 
-    //Join service to site, and site to NGI. 		
+    //Join service to site, and site to NGI.
     $ngi->addSiteDoJoin($site);
     $site->addServiceDoJoin($service);
 
@@ -352,7 +352,7 @@ class ExtensionsTest extends PHPUnit_Extensions_Database_TestCase {
     $roleService = new org\gocdb\services\Role();
     $roleService->setEntityManager($this->em);
     $authService = new org\gocdb\services\RoleActionAuthorisationService($roleActionMappingService/* , $roleService */);
-    $authService->setEntityManager($this->em); 
+    $authService->setEntityManager($this->em);
     $sgService = new org\gocdb\services\ServiceGroup($authService);
     $sgService->setEntityManager($this->em);
     $sgService->setRoleActionAuthorisationService($authService);
@@ -384,17 +384,17 @@ class ExtensionsTest extends PHPUnit_Extensions_Database_TestCase {
     $sgService->deleteServiceGroup($sg, $adminUser, true);
     $this->em->flush();
 
-    //Check service group is gone		
+    //Check service group is gone
     $result = $con->createQueryTable('results', "SELECT * FROM ServiceGroups WHERE ID = '$sgId'");
     $this->assertEquals(0, $result->getRowCount());
 
-    //Check properties are gone		
+    //Check properties are gone
     $result = $con->createQueryTable('results', "SELECT * FROM servicegroup_properties WHERE PARENTSERVICEGROUP_ID = '$sgId'");
     $this->assertEquals(0, $result->getRowCount());
     }
 
     /**
-     * Show the creation of an endpoint and properties and that 
+     * Show the creation of an endpoint and properties and that
      * all data is removed on deletion of an endpoint or property
      */
     public function testEndpointPropertyDeletions() {
@@ -405,7 +405,7 @@ class ExtensionsTest extends PHPUnit_Extensions_Database_TestCase {
     $site = TestUtil::createSampleSite("TestSite");
     $endpoint = TestUtil::createSampleEndpointLocation();
 
-    //Join service to site, and site to NGI. 		
+    //Join service to site, and site to NGI.
     $ngi->addSiteDoJoin($site);
     $site->addServiceDoJoin($service);
     $service->addEndpointLocationDoJoin($endpoint);
@@ -475,16 +475,16 @@ class ExtensionsTest extends PHPUnit_Extensions_Database_TestCase {
     //Assert that only 2 service properties exist in the database for this service
     $this->assertEquals(2, $result->getRowCount());
 
-    //Now delete the endpont and check that it cascade deletes 
+    //Now delete the endpont and check that it cascade deletes
     //the endpoint's associated properties
     $serviceService->deleteEndpoint($endpoint, $adminUser);
     $this->em->flush();
 
-    //Check endpoint is gone		
+    //Check endpoint is gone
     $result = $con->createQueryTable('results', "SELECT * FROM EndpointLocations WHERE ID = '$endpointId'");
     $this->assertEquals(0, $result->getRowCount());
 
-    //Check properties are gone		
+    //Check properties are gone
     $result = $con->createQueryTable('results', "SELECT * FROM endpoint_properties WHERE PARENTENDPOINT_ID = '$endpointId'");
     $this->assertEquals(0, $result->getRowCount());
     }

--- a/tests/doctrine/NGIServiceTest.php
+++ b/tests/doctrine/NGIServiceTest.php
@@ -10,9 +10,9 @@ require_once dirname(__FILE__) . '/bootstrap.php';
 require_once dirname(__FILE__) . '/../../lib/Gocdb_Services/NGI.php';
 
 /**
- * Test the NGI service, in particular the cascade delete behaviour when  
- * deleting an ngi (i.e. cascading to Service, EndpointLocation, Downtime, Roles etc). 
- * 
+ * Test the NGI service, in particular the cascade delete behaviour when
+ * deleting an ngi (i.e. cascading to Service, EndpointLocation, Downtime, Roles etc).
+ *
  * @author David Meredith
  */
 class NGIServiceTest extends PHPUnit_Extensions_Database_TestCase {
@@ -24,7 +24,7 @@ class NGIServiceTest extends PHPUnit_Extensions_Database_TestCase {
     //private $eudatScope;
 
     /**
-     * Overridden. 
+     * Overridden.
      */
     public static function setUpBeforeClass() {
         parent::setUpBeforeClass();
@@ -42,8 +42,8 @@ class NGIServiceTest extends PHPUnit_Extensions_Database_TestCase {
     }
 
     /**
-     * Overridden. Returns the test dataset.  
-     * Defines how the initial state of the database should look before each test is executed. 
+     * Overridden. Returns the test dataset.
+     * Defines how the initial state of the database should look before each test is executed.
      * @return PHPUnit_Extensions_Database_DataSet_IDataSet
      */
     protected function getDataSet() {
@@ -53,7 +53,7 @@ class NGIServiceTest extends PHPUnit_Extensions_Database_TestCase {
     }
 
     /**
-     * Overridden. 
+     * Overridden.
      */
     protected function getSetUpOperation() {
         // CLEAN_INSERT is default
@@ -61,14 +61,14 @@ class NGIServiceTest extends PHPUnit_Extensions_Database_TestCase {
         //return PHPUnit_Extensions_Database_Operation_Factory::UPDATE();
         //return PHPUnit_Extensions_Database_Operation_Factory::NONE();
         //
-        // Issue a DELETE from <table> which is more portable than a 
-        // TRUNCATE table <table> (some DBs require high privileges for truncate statements 
+        // Issue a DELETE from <table> which is more portable than a
+        // TRUNCATE table <table> (some DBs require high privileges for truncate statements
         // and also do not allow truncates across tables with FK contstraints e.g. Oracle)
         return PHPUnit_Extensions_Database_Operation_Factory::DELETE_ALL();
     }
 
     /**
-     * Overridden. 
+     * Overridden.
      */
     protected function getTearDownOperation() {
         // NONE is default
@@ -85,7 +85,7 @@ class NGIServiceTest extends PHPUnit_Extensions_Database_TestCase {
     }
 
     /**
-     * @todo Still need to setup connection to different databases. 
+     * @todo Still need to setup connection to different databases.
      * @return EntityManager
      */
     private function createEntityManager() {
@@ -107,38 +107,38 @@ class NGIServiceTest extends PHPUnit_Extensions_Database_TestCase {
             //print $tableName->getName() . "\n";
             $sql = "SELECT * FROM " . $tableName->getName();
             $result = $con->createQueryTable('results_table', $sql);
-            //echo 'row count: '.$result->getRowCount() ; 
+            //echo 'row count: '.$result->getRowCount() ;
             if ($result->getRowCount() != 0)
                 throw new RuntimeException("Invalid fixture. Table has rows: " . $tableName->getName());
         }
     }
 
     /**
-     * Test the NGI service deleteNGI() method which recursively deletes child 
-     * sites and services, roles etc.  
+     * Test the NGI service deleteNGI() method which recursively deletes child
+     * sites and services, roles etc.
      */
     public function testNgiService_deleteNgi() {
         print __METHOD__ . "\n";
         include __DIR__ . '/resources/sampleFixtureData1.php';
 
-        // create an admin user (required to call the NGI service) 
+        // create an admin user (required to call the NGI service)
         $adminUser = TestUtil::createSampleUser('some', 'admin', '/some/admin');
         $adminUser->setAdmin(TRUE);
         $this->em->persist($adminUser);
 
-        // Now delete the ngi using the NGI service. 
+        // Now delete the ngi using the NGI service.
         $ngiService = new org\gocdb\services\NGI();
         $ngiService->setEntityManager($this->em);
         $ngiService->deleteNgi($ngi, $adminUser, FALSE);
 
 
-        // since we deleted the NGI, we expect an empty DB ! 
+        // since we deleted the NGI, we expect an empty DB !
         $result = $testConn->createQueryTable('results_table', "SELECT * FROM Roles");
         $this->assertTrue($result->getRowCount() == 0);
-        
+
         $result = $testConn->createQueryTable('results_table', "SELECT * FROM NGIs");
         $this->assertTrue($result->getRowCount() == 0);
-        
+
         $result = $testConn->createQueryTable('results_table', "SELECT * FROM Sites");
         $this->assertTrue($result->getRowCount() == 0);
 
@@ -150,7 +150,7 @@ class NGIServiceTest extends PHPUnit_Extensions_Database_TestCase {
 
         $result = $testConn->createQueryTable('results_table', "SELECT * FROM EndpointLocations");
         $this->assertTrue($result->getRowCount() == 0);
-        
+
         $result = $testConn->createQueryTable('results_table', "SELECT * FROM CertificationStatusLogs");
         $this->assertTrue($result->getRowCount() == 0);
     }

--- a/tests/doctrine/RoleActionRecordTests.php
+++ b/tests/doctrine/RoleActionRecordTests.php
@@ -29,9 +29,9 @@ use Doctrine\ORM\EntityManager;
 class RoleActionRecordTests extends PHPUnit_Extensions_Database_TestCase {
 
     private $em;
-    
+
     /**
-     * Overridden. 
+     * Overridden.
      */
     public static function setUpBeforeClass() {
         parent::setUpBeforeClass();
@@ -45,12 +45,12 @@ class RoleActionRecordTests extends PHPUnit_Extensions_Database_TestCase {
      */
     protected function getConnection() {
         require_once dirname(__FILE__) . '/bootstrap_pdo.php';
-        return getConnectionToTestDB(); 
+        return getConnectionToTestDB();
     }
-    
+
     /**
-     * Overridden. Returns the test dataset.  
-     * Defines how the initial state of the database should look before each test is executed. 
+     * Overridden. Returns the test dataset.
+     * Defines how the initial state of the database should look before each test is executed.
      * @return PHPUnit_Extensions_Database_DataSet_IDataSet
      */
     protected function getDataSet() {
@@ -58,7 +58,7 @@ class RoleActionRecordTests extends PHPUnit_Extensions_Database_TestCase {
     }
 
     /**
-     * Overridden. 
+     * Overridden.
      */
     protected function getSetUpOperation() {
         // CLEAN_INSERT is default
@@ -66,14 +66,14 @@ class RoleActionRecordTests extends PHPUnit_Extensions_Database_TestCase {
         //return PHPUnit_Extensions_Database_Operation_Factory::UPDATE();
         //return PHPUnit_Extensions_Database_Operation_Factory::NONE();
         //
-        // Issue a DELETE from <table> which is more portable than a 
-        // TRUNCATE table <table> (some DBs require high privileges for truncate statements 
+        // Issue a DELETE from <table> which is more portable than a
+        // TRUNCATE table <table> (some DBs require high privileges for truncate statements
         // and also do not allow truncates across tables with FK contstraints e.g. Oracle)
         return PHPUnit_Extensions_Database_Operation_Factory::DELETE_ALL();
     }
 
     /**
-     * Overridden. 
+     * Overridden.
      */
     protected function getTearDownOperation() {
         // NONE is default
@@ -90,7 +90,7 @@ class RoleActionRecordTests extends PHPUnit_Extensions_Database_TestCase {
     }
 
     /**
-     * @todo Still need to setup connection to different databases. 
+     * @todo Still need to setup connection to different databases.
      * @return EntityManager
      */
     private function createEntityManager() {
@@ -111,7 +111,7 @@ class RoleActionRecordTests extends PHPUnit_Extensions_Database_TestCase {
             //print $tableName->getName() . "\n";
             $sql = "SELECT * FROM " . $tableName->getName();
             $result = $con->createQueryTable('results_table', $sql);
-            //echo 'row count: '.$result->getRowCount() ; 
+            //echo 'row count: '.$result->getRowCount() ;
             if ($result->getRowCount() != 0){
                 throw new RuntimeException("Invalid fixture. Table has rows: " . $tableName->getName());
             }
@@ -121,11 +121,11 @@ class RoleActionRecordTests extends PHPUnit_Extensions_Database_TestCase {
 
     public function testRoleActionRecordCreateDelete() {
         print __METHOD__ . "\n";
-        for($i=0; $i<10; ++$i){ 
+        for($i=0; $i<10; ++$i){
             $rar = TestUtil::createRoleActionRecord();
-            $this->em->persist($rar); 
+            $this->em->persist($rar);
         }
-        
+
         //Commit the entites to the database
         $this->em->flush();
 
@@ -139,15 +139,15 @@ class RoleActionRecordTests extends PHPUnit_Extensions_Database_TestCase {
 
     public function testGetOwnedEntityDiscriminator() {
         print __METHOD__ . "\n";
-        $entity = TestUtil::createSampleNGI("NGI_1"); 
+        $entity = TestUtil::createSampleNGI("NGI_1");
 
-        // get the disriminator value 
+        // get the disriminator value
         $cmf = $this->em->getMetadataFactory();
         $meta = $cmf->getMetadataFor(get_class($entity));
-        $entityTypeName = $meta->discriminatorValue; 
-        $this->assertEquals('ngi', $entityTypeName); 
-        $this->assertEquals('ngi', $entity->getType()); 
+        $entityTypeName = $meta->discriminatorValue;
+        $this->assertEquals('ngi', $entityTypeName);
+        $this->assertEquals('ngi', $entity->getType());
     }
 
-    
+
 }

--- a/tests/doctrine/RoleCascadeDeletionsTest.php
+++ b/tests/doctrine/RoleCascadeDeletionsTest.php
@@ -12,16 +12,16 @@ use Doctrine\ORM\EntityManager;
 require_once dirname(__FILE__) . '/bootstrap.php';
 
 /**
- * Test the Role cascade delete functionality. The Role entity defines 
- * onDelete=CASCADE on its FK mappings to OwnedEntity and User. Therefore, 
- * when a User or OwnedEntity is deleted, the corresponding Roles are also 
- * cascade deleted. 
- *  
+ * Test the Role cascade delete functionality. The Role entity defines
+ * onDelete=CASCADE on its FK mappings to OwnedEntity and User. Therefore,
+ * when a User or OwnedEntity is deleted, the corresponding Roles are also
+ * cascade deleted.
+ *
  * This test case truncates the test database (a clean insert with no seed data)
- * and performs subsequent CRUD operations using Doctrine ORM. 
- * Usage: 
+ * and performs subsequent CRUD operations using Doctrine ORM.
+ * Usage:
  * Run the recreate.sh to create the sample database first (create tables etc), then run:
- * '$phpunit TestRoleCascadeDeletions.php' 
+ * '$phpunit TestRoleCascadeDeletions.php'
  *
  * @author David Meredith
  */
@@ -29,12 +29,12 @@ class RoleCascadeDeletionsTest extends PHPUnit_Extensions_Database_TestCase {
 
     private $em;
 
-    //private $egiScope; 
-    //private $localScope; 
-    //private $eudatScope; 
+    //private $egiScope;
+    //private $localScope;
+    //private $eudatScope;
 
     /**
-     * Overridden. 
+     * Overridden.
      */
     public static function setUpBeforeClass() {
         parent::setUpBeforeClass();
@@ -52,8 +52,8 @@ class RoleCascadeDeletionsTest extends PHPUnit_Extensions_Database_TestCase {
     }
 
     /**
-     * Overridden. Returns the test dataset.  
-     * Defines how the initial state of the database should look before each test is executed. 
+     * Overridden. Returns the test dataset.
+     * Defines how the initial state of the database should look before each test is executed.
      * @return PHPUnit_Extensions_Database_DataSet_IDataSet
      */
     protected function getDataSet() {
@@ -63,7 +63,7 @@ class RoleCascadeDeletionsTest extends PHPUnit_Extensions_Database_TestCase {
     }
 
     /**
-     * Overridden. 
+     * Overridden.
      */
     protected function getSetUpOperation() {
         // CLEAN_INSERT is default
@@ -71,14 +71,14 @@ class RoleCascadeDeletionsTest extends PHPUnit_Extensions_Database_TestCase {
         //return PHPUnit_Extensions_Database_Operation_Factory::UPDATE();
         //return PHPUnit_Extensions_Database_Operation_Factory::NONE();
         //
-        // Issue a DELETE from <table> which is more portable than a 
-        // TRUNCATE table <table> (some DBs require high privileges for truncate statements 
+        // Issue a DELETE from <table> which is more portable than a
+        // TRUNCATE table <table> (some DBs require high privileges for truncate statements
         // and also do not allow truncates across tables with FK contstraints e.g. Oracle)
         return PHPUnit_Extensions_Database_Operation_Factory::DELETE_ALL();
     }
 
     /**
-     * Overridden. 
+     * Overridden.
      */
     protected function getTearDownOperation() {
         // NONE is default
@@ -95,7 +95,7 @@ class RoleCascadeDeletionsTest extends PHPUnit_Extensions_Database_TestCase {
     }
 
     /**
-     * @todo Still need to setup connection to different databases. 
+     * @todo Still need to setup connection to different databases.
      * @return EntityManager
      */
     private function createEntityManager() {
@@ -117,27 +117,27 @@ class RoleCascadeDeletionsTest extends PHPUnit_Extensions_Database_TestCase {
             //print $tableName->getName() . "\n";
             $sql = "SELECT * FROM " . $tableName->getName();
             $result = $con->createQueryTable('results_table', $sql);
-            //echo 'row count: '.$result->getRowCount() ; 
+            //echo 'row count: '.$result->getRowCount() ;
             if ($result->getRowCount() != 0)
                 throw new RuntimeException("Invalid fixture. Table has rows: " . $tableName->getName());
         }
     }
 
     /**
-     * Create a linked OwnedEntity graph with user with Roles over those OwnedEntities.  
-     * Next, delete the User and assert that all the user's Roles were also deleted by the domain 
-     * model's automatic onDelete=CASCADE defined on the Role's FK mapping to User. 
+     * Create a linked OwnedEntity graph with user with Roles over those OwnedEntities.
+     * Next, delete the User and assert that all the user's Roles were also deleted by the domain
+     * model's automatic onDelete=CASCADE defined on the Role's FK mapping to User.
      */
     public function testRolesCascadeDelete_OnUserDeletion() {
         print __METHOD__ . "\n";
         include __DIR__ . '/resources/sampleFixtureData1.php';
 
         // Delete the user. The onDelete=CASCADE defined in Role's user FK mapping
-        // will remove all the user's roles. 
+        // will remove all the user's roles.
         $this->em->remove($userWithRoles);
         $this->em->flush();
 
-        // Need to clear the identity map (all objects become detached) so that 
+        // Need to clear the identity map (all objects become detached) so that
         // when we re-fetch the user, it will be looked from db not served by entity map
         $this->em->clear();
 
@@ -152,20 +152,20 @@ class RoleCascadeDeletionsTest extends PHPUnit_Extensions_Database_TestCase {
     }
 
     /**
-     * Create a linked OwnedEntity graph with user with Roles over those OwnedEntities.  
-     * Next, delete selected OwnedEntities and assert that all the Roles that 
-     * were linked to the deleted OwnedEntites were also deleted by the domain 
-     * model's automatic onDelete=CASCADE defined on the Role's FK mapping to OwnedEntity. 
-     * 
-     * Delete all the OwnedEntities 
+     * Create a linked OwnedEntity graph with user with Roles over those OwnedEntities.
+     * Next, delete selected OwnedEntities and assert that all the Roles that
+     * were linked to the deleted OwnedEntites were also deleted by the domain
+     * model's automatic onDelete=CASCADE defined on the Role's FK mapping to OwnedEntity.
+     *
+     * Delete all the OwnedEntities
      */
     public function testRolesCascadeDelete_OnOwnedEntityDeletion1() {
         print __METHOD__ . "\n";
         include __DIR__ . '/resources/sampleFixtureData1.php';
 
-        // Queue Deletion of ngi, site1 (and its services) and assert that the relevant 
-        // user roles were also deleted as expected by the onDelete=cascades configured in the entity model. 
-        // Note, we are not removing site2 as we want to keep this site and user's roles. 
+        // Queue Deletion of ngi, site1 (and its services) and assert that the relevant
+        // user roles were also deleted as expected by the onDelete=cascades configured in the entity model.
+        // Note, we are not removing site2 as we want to keep this site and user's roles.
         $siteDAO = new SiteDAO();
         $serviceDAO = new ServiceDAO();
         $ngiDAO = new NGIDAO();
@@ -173,7 +173,7 @@ class RoleCascadeDeletionsTest extends PHPUnit_Extensions_Database_TestCase {
         $serviceDAO->setEntityManager($this->em);
         $ngiDAO->setEntityManager($this->em);
 
-        // ordering of removal is NOT significant here !  
+        // ordering of removal is NOT significant here !
         $ngiDAO->removeNGI($ngi);
         $siteDAO->removeSite($site1);
         $siteDAO->removeSite($site2);
@@ -182,12 +182,12 @@ class RoleCascadeDeletionsTest extends PHPUnit_Extensions_Database_TestCase {
 
         $this->em->flush();
 
-        // Need to clear the identity map (all objects become detached) so that 
+        // Need to clear the identity map (all objects become detached) so that
         // when we re-fetch the user, it will be looked from db not served by entity map
         $this->em->clear();
 
-        // Need to re-fetch the user from the DB again, if don't, then user already 
-        // has his eargerly fetched roles present in UserProxy object  
+        // Need to re-fetch the user from the DB again, if don't, then user already
+        // has his eargerly fetched roles present in UserProxy object
         $userWithRoles = $this->em->find("User", $userId);
         $this->assertEquals(0, count($userWithRoles->getRoles()));
 
@@ -203,7 +203,7 @@ class RoleCascadeDeletionsTest extends PHPUnit_Extensions_Database_TestCase {
     }
 
     /**
-     * Delete both Services but not the ngi  
+     * Delete both Services but not the ngi
      * @see testRolesCascadeDelete_OnOwnedEntityDeletion1
      */
     public function testRolesCascadeDelete_OnOwnedEntityDeletion2() {
@@ -217,23 +217,23 @@ class RoleCascadeDeletionsTest extends PHPUnit_Extensions_Database_TestCase {
         $serviceDAO->setEntityManager($this->em);
         $ngiDAO->setEntityManager($this->em);
 
-        // ordering of removal is NOT significant here !  
+        // ordering of removal is NOT significant here !
         $serviceDAO->removeService($service1);
         $serviceDAO->removeService($service2);
         $siteDAO->removeSite($site1);
         $siteDAO->removeSite($site2);
-        //$ngiDAO->removeNGI($ngi); // don't remove NGI 
+        //$ngiDAO->removeNGI($ngi); // don't remove NGI
 
         $this->em->flush();
 
-        // Need to clear the identity map (all objects become detached) so that 
+        // Need to clear the identity map (all objects become detached) so that
         // when we re-fetch the user, it will be looked from db not served by entity map
         $this->em->clear();
 
-        // Need to re-fetch the user from the DB again, if don't, then user already 
-        // has his eargerly fetched roles present in UserProxy object  
+        // Need to re-fetch the user from the DB again, if don't, then user already
+        // has his eargerly fetched roles present in UserProxy object
         $userWithRoles = $this->em->find("User", $userId);
-        // user should have 2 remaining roles still from ngi 
+        // user should have 2 remaining roles still from ngi
         $this->assertEquals(2, count($userWithRoles->getRoles()));
 
         $testConn = $this->getConnection();
@@ -244,20 +244,20 @@ class RoleCascadeDeletionsTest extends PHPUnit_Extensions_Database_TestCase {
     }
 
     /**
-     * Delete the ngi but not the sites 
+     * Delete the ngi but not the sites
      * @see testRolesCascadeDelete_OnOwnedEntityDeletion1
      */
     public function testRolesCascadeDelete_OnOwnedEntityDeletion3() {
         print __METHOD__ . "\n";
         include __DIR__ . '/resources/sampleFixtureData1.php';
 
-        // Queue Deletion of ngi and assert that the relevant 
-        // ngi user roles were also deleted. 
+        // Queue Deletion of ngi and assert that the relevant
+        // ngi user roles were also deleted.
         $ngiDAO = new NGIDAO();
         $ngiDAO->setEntityManager($this->em);
 
         // need to delete the relationships between ngi and sites before deleting
-        // the ngi - remember to unlink from both sides of the relationship 
+        // the ngi - remember to unlink from both sides of the relationship
         $ngi->getSites()->removeElement($site1);
         $site1->setNgiDoJoin(null);
         $ngi->getSites()->removeElement($site2);
@@ -268,14 +268,14 @@ class RoleCascadeDeletionsTest extends PHPUnit_Extensions_Database_TestCase {
 
         $this->em->flush();
 
-        // Need to clear the identity map (all objects become detached) so that 
+        // Need to clear the identity map (all objects become detached) so that
         // when we re-fetch the user, it will be looked from db not served by entity map
         $this->em->clear();
 
-        // Need to re-fetch the user from the DB again, if don't, then user already 
-        // has his eargerly fetched roles present in UserProxy object  
+        // Need to re-fetch the user from the DB again, if don't, then user already
+        // has his eargerly fetched roles present in UserProxy object
         $userWithRoles = $this->em->find("User", $userId);
-        // user should have 4 remaining roles still from sites that exist in DB  
+        // user should have 4 remaining roles still from sites that exist in DB
         $this->assertEquals(4, count($userWithRoles->getRoles()));
 
         $testConn = $this->getConnection();

--- a/tests/doctrine/RoleServiceTest.php
+++ b/tests/doctrine/RoleServiceTest.php
@@ -1,64 +1,64 @@
 <?php
 //require_once 'PHPUnit/Extensions/Database/TestCase.php';
 //require_once 'PHPUnit/Extensions/Database/DataSet/DefaultDataSet.php';
-require_once dirname(__FILE__) . '/TestUtil.php'; 
+require_once dirname(__FILE__) . '/TestUtil.php';
 
-use Doctrine\ORM\EntityManager; 
+use Doctrine\ORM\EntityManager;
 require_once dirname(__FILE__) . '/bootstrap.php';
-require_once dirname(__FILE__). '/../../lib/Gocdb_Services/Role.php'; 
-require_once dirname(__FILE__). '/../../lib/Gocdb_Services/Site.php'; 
-require_once dirname(__FILE__). '/../../lib/Gocdb_Services/RoleActionMappingService.php'; 
-require_once dirname(__FILE__). '/../../lib/Gocdb_Services/RoleActionAuthorisationService.php'; 
+require_once dirname(__FILE__). '/../../lib/Gocdb_Services/Role.php';
+require_once dirname(__FILE__). '/../../lib/Gocdb_Services/Site.php';
+require_once dirname(__FILE__). '/../../lib/Gocdb_Services/RoleActionMappingService.php';
+require_once dirname(__FILE__). '/../../lib/Gocdb_Services/RoleActionAuthorisationService.php';
 
 /**
- * Test the role functionality. 
+ * Test the role functionality.
  * This test case truncates the test database (a clean insert with no seed data)
- * and performs subsequent CRUD operations using Doctrine ORM. 
- * Usage: 
+ * and performs subsequent CRUD operations using Doctrine ORM.
+ * Usage:
  * Run the recreate.sh to create the sample database first (create tables etc), then run:
- * '$phpunit TestRoles.php' 
+ * '$phpunit TestRoles.php'
  *
  * @author David Meredith
- * @author John Casson  
+ * @author John Casson
  */
 class RoleServiceTest extends PHPUnit_Extensions_Database_TestCase {
-   private $em; 
-   private $egiScope; 
-   private $localScope; 
-   private $eudatScope; 
+   private $em;
+   private $egiScope;
+   private $localScope;
+   private $eudatScope;
 
 
     /**
-     * Overridden. 
+     * Overridden.
      */
     public static function setUpBeforeClass() {
         parent::setUpBeforeClass();
         echo "\n\n-------------------------------------------------\n";
         echo "Executing RoleServiceTest. . .\n";
     }
-    
+
     /**
      * Overridden. Returns the test database connection.
      * @return PHPUnit_Extensions_Database_DB_IDatabaseConnection
      */
     protected function getConnection() {
         require_once dirname(__FILE__) . '/bootstrap_pdo.php';
-        return getConnectionToTestDB(); 
+        return getConnectionToTestDB();
     }
 
     /**
-     * Overridden. Returns the test dataset.  
-     * Defines how the initial state of the database should look before each test is executed. 
+     * Overridden. Returns the test dataset.
+     * Defines how the initial state of the database should look before each test is executed.
      * @return PHPUnit_Extensions_Database_DataSet_IDataSet
      */
-    protected function getDataSet() { 
+    protected function getDataSet() {
         return $this->createFlatXMLDataSet(dirname(__FILE__) . '/truncateDataTables.xml');
         // Use below to return an empty data set if we don't want to truncate and seed
         //return new PHPUnit_Extensions_Database_DataSet_DefaultDataSet();
     }
 
     /**
-     * Overridden. 
+     * Overridden.
      */
     protected function getSetUpOperation() {
         // CLEAN_INSERT is default
@@ -66,14 +66,14 @@ class RoleServiceTest extends PHPUnit_Extensions_Database_TestCase {
         //return PHPUnit_Extensions_Database_Operation_Factory::UPDATE();
         //return PHPUnit_Extensions_Database_Operation_Factory::NONE();
         //
-        // Issue a DELETE from <table> which is more portable than a 
-        // TRUNCATE table <table> (some DBs require high privileges for truncate statements 
+        // Issue a DELETE from <table> which is more portable than a
+        // TRUNCATE table <table> (some DBs require high privileges for truncate statements
         // and also do not allow truncates across tables with FK contstraints e.g. Oracle)
         return PHPUnit_Extensions_Database_Operation_Factory::DELETE_ALL();
     }
 
     /**
-     * Overridden. 
+     * Overridden.
      */
     protected function getTearDownOperation() {
         // NONE is default
@@ -85,18 +85,18 @@ class RoleServiceTest extends PHPUnit_Extensions_Database_TestCase {
      * This method is called before each test method is executed.
      */
     protected function setUp() {
-        parent::setUp();            
+        parent::setUp();
         $this->em = $this->createEntityManager();
     }
-    
+
     /**
-     * @todo Still need to setup connection to different databases. 
+     * @todo Still need to setup connection to different databases.
      * @return EntityManager
      */
     private function createEntityManager(){
         //require dirname(__FILE__).'/../lib/Doctrine/bootstrap.php';
         require dirname(__FILE__).'/bootstrap_doctrine.php';
-        return $entityManager; 
+        return $entityManager;
     }
 
     /**
@@ -112,99 +112,99 @@ class RoleServiceTest extends PHPUnit_Extensions_Database_TestCase {
             //print $tableName->getName() . "\n";
             $sql = "SELECT * FROM ".$tableName->getName();
             $result = $con->createQueryTable('results_table', $sql);
-            //echo 'row count: '.$result->getRowCount() ; 
-            if($result->getRowCount() != 0) 
+            //echo 'row count: '.$result->getRowCount() ;
+            if($result->getRowCount() != 0)
                 throw new RuntimeException("Invalid fixture. Table has rows: ".$tableName->getName());
         }
     }
 
 
     /*public function testPersistGetSupportedRoleTypeNameClassPairs(){
-       print __METHOD__ . "\n"; 
-       $roleTypes = TestUtil::getSupportedRoleTypes(); 
+       print __METHOD__ . "\n";
+       $roleTypes = TestUtil::getSupportedRoleTypes();
        if(count($roleTypes) == 0){
-           throw new LogicException('No roleTypes configured'); 
+           throw new LogicException('No roleTypes configured');
        }
-       // Assert that we can persist all the configured role types. 
-       // This is to test the unique constraint on the RoleType.name value 
-       // and any other DB col constraints. 
+       // Assert that we can persist all the configured role types.
+       // This is to test the unique constraint on the RoleType.name value
+       // and any other DB col constraints.
        foreach($roleTypes as $rt){
-          $this->em->persist($rt); 
+          $this->em->persist($rt);
        }
        $this->em->flush();
     }*/
 
 
-    
+
     public function test_getPendingRolesUserCanApprove(){
         print __METHOD__ . "\n";
         // Create fixture data
         // RoleTypes
         $siteAdminRT = TestUtil::createSampleRoleType(RoleTypeName::SITE_ADMIN/*, RoleTypeClass::SITE_USER*/);
-        $siteManRT = TestUtil::createSampleRoleType(RoleTypeName::SITE_OPS_MAN/*, RoleTypeClass::SITE_MANAGER*/); 
+        $siteManRT = TestUtil::createSampleRoleType(RoleTypeName::SITE_OPS_MAN/*, RoleTypeClass::SITE_MANAGER*/);
         $regFLSupportRT = TestUtil::createSampleRoleType(RoleTypeName::REG_FIRST_LINE_SUPPORT/*, RoleTypeClass::REGIONAL_USER*/);
-        
-        $this->em->persist($regFLSupportRT); 
+
+        $this->em->persist($regFLSupportRT);
         $this->em->persist($siteAdminRT);
         $this->em->persist($siteManRT);
-        
+
         // User
         $u = TestUtil::createSampleUser("Test", "Testing", "/c=test");
         $this->em->persist($u);
         // Site
         $site1 = TestUtil::createSampleSite("SITENAME");
         $this->em->persist($site1);
-        $n1 = TestUtil::createSampleNGI("NGI_UK"); 
-        $this->em->persist($n1); 
-        $p1 = new \Project("EGI");  
-        $this->em->persist($p1); 
+        $n1 = TestUtil::createSampleNGI("NGI_UK");
+        $this->em->persist($n1);
+        $p1 = new \Project("EGI");
+        $this->em->persist($p1);
 
-        $n1->addSiteDoJoin($site1); 
-        $p1->addNgi($n1); 
-        
-        // Create a SITE_OPS_MAN Role and link to the User, RoleType and site 
-        $roleSite = TestUtil::createSampleRole($u, $siteManRT, $site1, RoleStatus::GRANTED); 
+        $n1->addSiteDoJoin($site1);
+        $p1->addNgi($n1);
+
+        // Create a SITE_OPS_MAN Role and link to the User, RoleType and site
+        $roleSite = TestUtil::createSampleRole($u, $siteManRT, $site1, RoleStatus::GRANTED);
         $this->em->persist($roleSite);
 
-        // new user 
+        // new user
         $u2 = TestUtil::createSampleUser("Test2", "Testing2", "/c=test2");
         $this->em->persist($u2);
-        // Create a pending SITE_ADMIN Role request for new user  
-        $pendingSiteRole = TestUtil::createSampleRole($u2, $siteAdminRT, $site1, RoleStatus::PENDING); 
+        // Create a pending SITE_ADMIN Role request for new user
+        $pendingSiteRole = TestUtil::createSampleRole($u2, $siteAdminRT, $site1, RoleStatus::PENDING);
         $this->em->persist($pendingSiteRole);
         $this->em->flush();
 
         // ********NOTE******** Role Service uses a new connection for its transactional methods
-        $em2 = $this->createEntityManager(); 
-        $roleService = new org\gocdb\services\Role();  
-        $roleService->setEntityManager($em2);  
-        $roleActionMappingService = new org\gocdb\services\RoleActionMappingService(); 
-        $roleActionAuthorisationService = new org\gocdb\services\RoleActionAuthorisationService($roleActionMappingService); 
-        $roleActionAuthorisationService->setEntityManager($em2);  
-        $roleService->setRoleActionAuthorisationService($roleActionAuthorisationService); 
-        
-        $pendingGrantableRolesU1 = $roleService->getPendingRolesUserCanApprove($u); 
-       
-        // show that u1 has one pending role request 
-        $this->assertTrue(count($pendingGrantableRolesU1) == 1); 
-        $this->assertEquals($pendingSiteRole->getId(), $pendingGrantableRolesU1[0]->getId());  
-        $this->assertEquals(RoleStatus::PENDING, $pendingGrantableRolesU1[0]->getStatus()); 
-        $this->assertEquals(RoleTypeName::SITE_ADMIN, $pendingGrantableRolesU1[0]->getRoleType()->getName()); 
-        
-        // show that u2 has no pending role requests 
-        $pendingGrantableRolesU2 = $roleService->getPendingRolesUserCanApprove($u2);
-        $this->assertTrue(count($pendingGrantableRolesU2) == 0); 
-    }
-   
+        $em2 = $this->createEntityManager();
+        $roleService = new org\gocdb\services\Role();
+        $roleService->setEntityManager($em2);
+        $roleActionMappingService = new org\gocdb\services\RoleActionMappingService();
+        $roleActionAuthorisationService = new org\gocdb\services\RoleActionAuthorisationService($roleActionMappingService);
+        $roleActionAuthorisationService->setEntityManager($em2);
+        $roleService->setRoleActionAuthorisationService($roleActionAuthorisationService);
 
-    
+        $pendingGrantableRolesU1 = $roleService->getPendingRolesUserCanApprove($u);
+
+        // show that u1 has one pending role request
+        $this->assertTrue(count($pendingGrantableRolesU1) == 1);
+        $this->assertEquals($pendingSiteRole->getId(), $pendingGrantableRolesU1[0]->getId());
+        $this->assertEquals(RoleStatus::PENDING, $pendingGrantableRolesU1[0]->getStatus());
+        $this->assertEquals(RoleTypeName::SITE_ADMIN, $pendingGrantableRolesU1[0]->getRoleType()->getName());
+
+        // show that u2 has no pending role requests
+        $pendingGrantableRolesU2 = $roleService->getPendingRolesUserCanApprove($u2);
+        $this->assertTrue(count($pendingGrantableRolesU2) == 0);
+    }
+
+
+
     public function test_getUserRoleNamesOverEntity(){
         print __METHOD__ . "\n";
         // Create fixture data
         // RoleTypes
         $siteAdminRT = TestUtil::createSampleRoleType(RoleTypeName::SITE_ADMIN/*, RoleTypeClass::SITE_USER*/);
         $regFLSupportRT = TestUtil::createSampleRoleType(RoleTypeName::REG_FIRST_LINE_SUPPORT/*, RoleTypeClass::REGIONAL_USER*/);
-        $this->em->persist($regFLSupportRT); 
+        $this->em->persist($regFLSupportRT);
         $this->em->persist($siteAdminRT);
         // User
         $u = TestUtil::createSampleUser("Test", "Testing", "/c=test");
@@ -212,35 +212,35 @@ class RoleServiceTest extends PHPUnit_Extensions_Database_TestCase {
         // Site
         $site1 = TestUtil::createSampleSite("SITENAME"/*, "PK01"*/);
         $this->em->persist($site1);
-        // Create a Role and link to the User, ngiRoleType and site 
-        $roleSite = TestUtil::createSampleRole($u, $siteAdminRT, $site1, RoleStatus::GRANTED); 
+        // Create a Role and link to the User, ngiRoleType and site
+        $roleSite = TestUtil::createSampleRole($u, $siteAdminRT, $site1, RoleStatus::GRANTED);
         $this->em->persist($roleSite);
         $this->em->flush();
-       
+
         // ********NOTE******** Role Service uses a new connection for its transactional methods
-        $roleService = new org\gocdb\services\Role(); 
-        $roleService->setEntityManager($this->createEntityManager()); 
-        
-        // Now test that method returns expected results 
-        $roleNames = $roleService->getUserRoleNamesOverEntity($site1, $u, \RoleStatus::GRANTED); 
-        $this->assertEquals(1, count($roleNames)); 
-        $this->assertContains(RoleTypeName::SITE_ADMIN, $roleNames); 
+        $roleService = new org\gocdb\services\Role();
+        $roleService->setEntityManager($this->createEntityManager());
+
+        // Now test that method returns expected results
+        $roleNames = $roleService->getUserRoleNamesOverEntity($site1, $u, \RoleStatus::GRANTED);
+        $this->assertEquals(1, count($roleNames));
+        $this->assertContains(RoleTypeName::SITE_ADMIN, $roleNames);
 
         // Create new NGI
         $n = TestUtil::createSampleNGI("MYNGI");
         $this->em->persist($n);
-        
-        $roleNgi = TestUtil::createSampleRole($u, $regFLSupportRT, $n, RoleStatus::GRANTED); 
+
+        $roleNgi = TestUtil::createSampleRole($u, $regFLSupportRT, $n, RoleStatus::GRANTED);
         $this->em->persist($roleNgi);
         $this->em->flush();
 
-        // Now test that method returns expected results 
-        $roleNames = $roleService->getUserRoleNamesOverEntity($n, $u); 
-        $this->assertEquals(1, count($roleNames)); 
-        $this->assertContains(RoleTypeName::REG_FIRST_LINE_SUPPORT, $roleNames); 
+        // Now test that method returns expected results
+        $roleNames = $roleService->getUserRoleNamesOverEntity($n, $u);
+        $this->assertEquals(1, count($roleNames));
+        $this->assertContains(RoleTypeName::REG_FIRST_LINE_SUPPORT, $roleNames);
     }
 
-    
+
     public function testGetUserRoles(){
         print __METHOD__ . "\n";
         // Create two roletypes
@@ -248,17 +248,17 @@ class RoleServiceTest extends PHPUnit_Extensions_Database_TestCase {
         $siteRoleType = TestUtil::createSampleRoleType("RT2_NAME"/*, RoleTypeClass::REGIONAL_USER*/);
         $this->em->persist($ngiRoleType);
         $this->em->persist($siteRoleType);
-    
+
         // Create a user
         $u = TestUtil::createSampleUser("Test", "Testing", "/c=test");
         $this->em->persist($u);
-    
+
         // Create an NGI
         $ngi = TestUtil::createSampleNGI("MYNGI");
         $this->em->persist($ngi);
-    
-        // Create a Role and link to the User, ngiRoleType and ngi 
-        $roleNgi = TestUtil::createSampleRole($u, $ngiRoleType, $ngi, RoleStatus::GRANTED); 
+
+        // Create a Role and link to the User, ngiRoleType and ngi
+        $roleNgi = TestUtil::createSampleRole($u, $ngiRoleType, $ngi, RoleStatus::GRANTED);
         $this->em->persist($roleNgi);
 
         // Create a site
@@ -266,97 +266,97 @@ class RoleServiceTest extends PHPUnit_Extensions_Database_TestCase {
         $this->em->persist($site1);
 
         // Create another role and link to the User, siteRoleType and site
-        $roleSite = TestUtil::createSampleRole($u, $siteRoleType, $site1, RoleStatus::GRANTED) ; 
+        $roleSite = TestUtil::createSampleRole($u, $siteRoleType, $site1, RoleStatus::GRANTED) ;
         $this->em->persist($roleSite);
 
-        // Create a second and third sites and add to the NGI, but DO NOT add direct 
-        // roles over those sites for the user. The user will still have role 
-        // over the sites because they have a role over the NGI ! 
+        // Create a second and third sites and add to the NGI, but DO NOT add direct
+        // roles over those sites for the user. The user will still have role
+        // over the sites because they have a role over the NGI !
         $site2 = TestUtil::createSampleSite("SITENAME2"/*, "PK01"*/);
         $site3 = TestUtil::createSampleSite("SITENAME3"/*, "PK01"*/);
-        $this->em->persist($site2);        
-        $this->em->persist($site3);        
-        $ngi->addSiteDoJoin($site2);  
-        $ngi->addSiteDoJoin($site3);  
-        
+        $this->em->persist($site2);
+        $this->em->persist($site3);
+        $ngi->addSiteDoJoin($site2);
+        $ngi->addSiteDoJoin($site3);
+
         $this->em->flush();
 
-        // ********MUST******** start a new connection to test transactional 
-        // isolation of RoleService methods.  
+        // ********MUST******** start a new connection to test transactional
+        // isolation of RoleService methods.
         $em = $this->createEntityManager();
-        $roleService = new org\gocdb\services\Role();  
-        $roleService->setEntityManager($em); 
-        // assert that user has expected roles 
-        $roles = $roleService->getUserRoles($u, RoleStatus::GRANTED);  
-        $this->assertEquals(2, sizeof($roles)); 
+        $roleService = new org\gocdb\services\Role();
+        $roleService->setEntityManager($em);
+        // assert that user has expected roles
+        $roles = $roleService->getUserRoles($u, RoleStatus::GRANTED);
+        $this->assertEquals(2, sizeof($roles));
         $this->assertTrue(count($roleService->getUserRoleNamesOverEntity($ngi, $u)) == 1);
         $this->assertTrue(count($roleService->getUserRoleNamesOverEntity($site1, $u)) == 1);
         $this->assertTrue(count($roleService->getUserRoleNamesOverEntity($site2, $u)) == 0);
         $this->assertTrue(count($roleService->getUserRoleNamesOverEntity($site3, $u)) == 0);
-        
-        // assert that the user has an expected site count with roles over those sites  
-        $mySites = $roleService->getReachableSitesFromOwnedObjectRoles($u); 
-        $this->assertEquals(3, sizeof($mySites)); 
-        
+
+        // assert that the user has an expected site count with roles over those sites
+        $mySites = $roleService->getReachableSitesFromOwnedObjectRoles($u);
+        $this->assertEquals(3, sizeof($mySites));
+
         // assert user don't have these pending/revoked roles
-        $roles = $roleService->getUserRoles($u, RoleStatus::PENDING);  
-        $this->assertEmpty($roles); 
+        $roles = $roleService->getUserRoles($u, RoleStatus::PENDING);
+        $this->assertEmpty($roles);
     }
 
     /**
-     * @expectedException \LogicException 
+     * @expectedException \LogicException
      */
     public function testInvalidRoleStatus(){
         print __METHOD__ . "\n";
-       $roleService = new org\gocdb\services\Role();   
+       $roleService = new org\gocdb\services\Role();
        $this->assertFalse($roleService->isValidRoleStatus("some invalid role"));
        $u = TestUtil::createSampleUser("Test", "Testing", "/c=test");
-       $roleService->getUserRoles($u, "some invalid role"); 
+       $roleService->getUserRoles($u, "some invalid role");
     }
 
 
     public function test_getReachableProjectsFromOwnedEntity(){
         print __METHOD__ . "\n";
         include __DIR__ . '/resources/sampleFixtureData5.php';
-        $this->em->flush(); 
+        $this->em->flush();
 
 
-        // ********MUST******** start a new connection to test transactional 
-        // isolation of RoleService methods.  
+        // ********MUST******** start a new connection to test transactional
+        // isolation of RoleService methods.
         $em = $this->createEntityManager();
-        $roleService = new org\gocdb\services\Role();  
-        $roleService->setEntityManager($em); 
+        $roleService = new org\gocdb\services\Role();
+        $roleService->setEntityManager($em);
 
-        
-        $projects = $roleService->getReachableProjectsFromOwnedEntity($p1); 
-        $this->assertEquals($p1, $projects[0]); 
-        $this->assertTrue(count($projects) == 1); 
-        $projects = $roleService->getReachableProjectsFromOwnedEntity($n1); 
-        $this->assertEquals($p1, $projects[0]); 
-        $this->assertTrue(count($projects) == 1); 
-        $projects = $roleService->getReachableProjectsFromOwnedEntity($s1); 
-        $this->assertTrue(count($projects) == 1); 
-        $this->assertEquals($p1, $projects[0]); 
- 
 
-        $projects = $roleService->getReachableProjectsFromOwnedEntity($p2); 
-        $this->assertEquals($p2, $projects[0]); 
-        $projects = $roleService->getReachableProjectsFromOwnedEntity($n2); 
-        $this->assertTrue(count($projects) == 2); 
-        $this->assertTrue(in_array($p2, $projects)); 
-        $this->assertTrue(in_array($p3, $projects)); 
-        $projects = $roleService->getReachableProjectsFromOwnedEntity($s2); 
-        $this->assertTrue(count($projects) == 2); 
-        $this->assertTrue(in_array($p2, $projects)); 
-        $this->assertTrue(in_array($p3, $projects)); 
+        $projects = $roleService->getReachableProjectsFromOwnedEntity($p1);
+        $this->assertEquals($p1, $projects[0]);
+        $this->assertTrue(count($projects) == 1);
+        $projects = $roleService->getReachableProjectsFromOwnedEntity($n1);
+        $this->assertEquals($p1, $projects[0]);
+        $this->assertTrue(count($projects) == 1);
+        $projects = $roleService->getReachableProjectsFromOwnedEntity($s1);
+        $this->assertTrue(count($projects) == 1);
+        $this->assertEquals($p1, $projects[0]);
 
-        
-        $projects = $roleService->getReachableProjectsFromOwnedEntity($n3); 
-        $this->assertTrue(count($projects) == 1); 
-        $this->assertEquals($p3, $projects[0]); 
-        $projects = $roleService->getReachableProjectsFromOwnedEntity($s3); 
-        $this->assertTrue(count($projects) == 1); 
-        $this->assertEquals($p3, $projects[0]); 
+
+        $projects = $roleService->getReachableProjectsFromOwnedEntity($p2);
+        $this->assertEquals($p2, $projects[0]);
+        $projects = $roleService->getReachableProjectsFromOwnedEntity($n2);
+        $this->assertTrue(count($projects) == 2);
+        $this->assertTrue(in_array($p2, $projects));
+        $this->assertTrue(in_array($p3, $projects));
+        $projects = $roleService->getReachableProjectsFromOwnedEntity($s2);
+        $this->assertTrue(count($projects) == 2);
+        $this->assertTrue(in_array($p2, $projects));
+        $this->assertTrue(in_array($p3, $projects));
+
+
+        $projects = $roleService->getReachableProjectsFromOwnedEntity($n3);
+        $this->assertTrue(count($projects) == 1);
+        $this->assertEquals($p3, $projects[0]);
+        $projects = $roleService->getReachableProjectsFromOwnedEntity($s3);
+        $this->assertTrue(count($projects) == 1);
+        $this->assertEquals($p3, $projects[0]);
     }
 
 
@@ -364,11 +364,11 @@ class RoleServiceTest extends PHPUnit_Extensions_Database_TestCase {
         print __METHOD__ . "\n";
         include __DIR__ . '/resources/sampleFixtureData5.php';
 
-        // create a user 
-        $u = TestUtil::createSampleUser("dave", "meredith", "idSTring"); 
-        $this->em->persist($u); 
-        
-        // add some roles to domain model 
+        // create a user
+        $u = TestUtil::createSampleUser("dave", "meredith", "idSTring");
+        $this->em->persist($u);
+
+        // add some roles to domain model
         $ngiRoleType = TestUtil::createSampleRoleType("NGI_RT");
         $siteRoleType = TestUtil::createSampleRoleType("SITE_RT");
         $siteRoleType2 = TestUtil::createSampleRoleType("SITE_RT2");
@@ -377,315 +377,315 @@ class RoleServiceTest extends PHPUnit_Extensions_Database_TestCase {
         $this->em->persist($siteRoleType);
         $this->em->persist($siteRoleType2);
         $this->em->persist($projRoleType);
-        
-        $this->em->flush(); 
 
-        $roleService = new org\gocdb\services\Role();  
+        $this->em->flush();
 
-        // We could create/inject a new em connection into the roleService 
+        $roleService = new org\gocdb\services\Role();
+
+        // We could create/inject a new em connection into the roleService
         // to test the transactional isolation of its methods (rather than injecting
-        // $this->em instance), e.g.:  
+        // $this->em instance), e.g.:
         //   $em = $this->createEntityManager();
-        //   $roleService->setEntityManager($em); 
-        //   
-        // However, this is problematic for this test which 
-        // needs to use the in_array() method to assert that the tested methods return 
+        //   $roleService->setEntityManager($em);
+        //
+        // However, this is problematic for this test which
+        // needs to use the in_array() method to assert that the tested methods return
         // the expected roles - in_array() uses object-instance-equality to deterine
-        // if the role exists in the array, and using a different $em instance 
-        // means the returned roles will be considered different      
-        // instances. We could get round this by comparing the Ids, but this makes 
-        // checking more of hassle as we need to extract all the Ids from the roles  
-        // into another array to assert the ids are expected, as in:     
-        //   $roleIds = array(); 
+        // if the role exists in the array, and using a different $em instance
+        // means the returned roles will be considered different
+        // instances. We could get round this by comparing the Ids, but this makes
+        // checking more of hassle as we need to extract all the Ids from the roles
+        // into another array to assert the ids are expected, as in:
+        //   $roleIds = array();
         //   foreach($roles as $r){ $roleIds[] = $r->getId(); }
-        //   $this->assertTrue(in_array($r1->getId(), $roleIds)); 
+        //   $this->assertTrue(in_array($r1->getId(), $roleIds));
         //   $this->assertTrue(in_array($r2->getId(), $roleIds));
         //
-        // For this test, we will therefore re-use $this->em to ensure 
+        // For this test, we will therefore re-use $this->em to ensure
         // object-equality:
-        $roleService->setEntityManager($this->em); 
+        $roleService->setEntityManager($this->em);
 
-        // confirm that function runs with no user roles over entity 
-        $roles = $roleService->getUserRolesByProject($u, $p1); 
-        $this->assertEmpty($roles); 
+        // confirm that function runs with no user roles over entity
+        $roles = $roleService->getUserRolesByProject($u, $p1);
+        $this->assertEmpty($roles);
 
 
-        // Create a Role and link to the User, ngiRoleType and ngi 
+        // Create a Role and link to the User, ngiRoleType and ngi
         /*
          * p1     p2     p3
          * |      |     /|
          * n1     n2-r1  n3
-         * |      |      | 
-         * s1     s2     s3 
+         * |      |      |
+         * s1     s2     s3
          */
-        $r1 = TestUtil::createSampleRole($u, $ngiRoleType, $n2, RoleStatus::GRANTED); 
+        $r1 = TestUtil::createSampleRole($u, $ngiRoleType, $n2, RoleStatus::GRANTED);
         $this->em->persist($r1);
-        $this->em->flush(); 
+        $this->em->flush();
 
-        $rolesDirect = $u->getRoles(); 
+        $rolesDirect = $u->getRoles();
         $this->assertEquals(1, count($rolesDirect));
-       
-        $roles = $roleService->getUserRolesByProject($u, $p1); 
-        $this->assertEmpty($roles);
-        $roles = $roleService->getUserRolesByProject($u, $p2); 
-        $this->assertEquals(1, count($roles)); 
-        $this->assertEquals($r1->getId(), $roles[0]->getId()); 
-        $roles = $roleService->getUserRolesByProject($u, $p3); 
-        $this->assertEquals(1, count($roles)); 
-        $this->assertEquals($r1->getId(), $roles[0]->getId()); 
 
-        
+        $roles = $roleService->getUserRolesByProject($u, $p1);
+        $this->assertEmpty($roles);
+        $roles = $roleService->getUserRolesByProject($u, $p2);
+        $this->assertEquals(1, count($roles));
+        $this->assertEquals($r1->getId(), $roles[0]->getId());
+        $roles = $roleService->getUserRolesByProject($u, $p3);
+        $this->assertEquals(1, count($roles));
+        $this->assertEquals($r1->getId(), $roles[0]->getId());
+
+
         /*
          * p1     p2     p3
          * |      |     /|
          * n1     n2-r1  n3-r2
-         * |      |      | 
-         * s1     s2     s3 
+         * |      |      |
+         * s1     s2     s3
          */
-        $r2 = TestUtil::createSampleRole($u, $ngiRoleType, $n3, RoleStatus::GRANTED); 
+        $r2 = TestUtil::createSampleRole($u, $ngiRoleType, $n3, RoleStatus::GRANTED);
         $this->em->persist($r2);
-        $this->em->flush(); 
-       
-        $roles = $roleService->getUserRolesByProject($u, $p1); 
+        $this->em->flush();
+
+        $roles = $roleService->getUserRolesByProject($u, $p1);
         $this->assertEmpty($roles);
-        $roles = $roleService->getUserRolesByProject($u, $p2); 
-        $this->assertEquals(1, count($roles)); 
-        $this->assertEquals($r1->getId(), $roles[0]->getId()); 
-        
-        $roles = $roleService->getUserRolesByProject($u, $p3); 
-        $this->assertEquals(2, count($roles)); 
-        $roleIds = array(); 
+        $roles = $roleService->getUserRolesByProject($u, $p2);
+        $this->assertEquals(1, count($roles));
+        $this->assertEquals($r1->getId(), $roles[0]->getId());
+
+        $roles = $roleService->getUserRolesByProject($u, $p3);
+        $this->assertEquals(2, count($roles));
+        $roleIds = array();
         foreach($roles as $r){ $roleIds[] = $r->getId(); }
-        $this->assertTrue(in_array($r1->getId(), $roleIds)); 
-        $this->assertTrue(in_array($r2->getId(), $roleIds)); 
+        $this->assertTrue(in_array($r1->getId(), $roleIds));
+        $this->assertTrue(in_array($r2->getId(), $roleIds));
 
         /*
          * p1     p2     p3
          * |      |     /|
          * n1     n2-r1  n3-r2
-         * |      |      | 
-         * s1     s2     s3-r3 
+         * |      |      |
+         * s1     s2     s3-r3
          */
-        $r3 = TestUtil::createSampleRole($u, $siteRoleType, $s3, RoleStatus::GRANTED); 
+        $r3 = TestUtil::createSampleRole($u, $siteRoleType, $s3, RoleStatus::GRANTED);
         $this->em->persist($r3);
-        $this->em->flush(); 
+        $this->em->flush();
 
-        $roles = $roleService->getUserRolesByProject($u, $p1); 
+        $roles = $roleService->getUserRolesByProject($u, $p1);
         $this->assertEmpty($roles);
-        $roles = $roleService->getUserRolesByProject($u, $p2); 
-        $this->assertEquals(1, count($roles)); 
-        $this->assertEquals($r1->getId(), $roles[0]->getId()); 
-        
-        $roles = $roleService->getUserRolesByProject($u, $p3); 
-        $this->assertEquals(3, count($roles)); 
-        $this->assertTrue(in_array($r1, $roles)); 
-        $this->assertTrue(in_array($r2, $roles)); 
-        $this->assertTrue(in_array($r3, $roles)); 
+        $roles = $roleService->getUserRolesByProject($u, $p2);
+        $this->assertEquals(1, count($roles));
+        $this->assertEquals($r1->getId(), $roles[0]->getId());
+
+        $roles = $roleService->getUserRolesByProject($u, $p3);
+        $this->assertEquals(3, count($roles));
+        $this->assertTrue(in_array($r1, $roles));
+        $this->assertTrue(in_array($r2, $roles));
+        $this->assertTrue(in_array($r3, $roles));
 
         /*
          * p1     p2     p3-r4
          * |      |     /|
          * n1     n2-r1  n3-r2
-         * |      |      | 
-         * s1     s2     s3-r3 
+         * |      |      |
+         * s1     s2     s3-r3
          */
-        $r4 = TestUtil::createSampleRole($u, $projRoleType, $p3, RoleStatus::GRANTED); 
+        $r4 = TestUtil::createSampleRole($u, $projRoleType, $p3, RoleStatus::GRANTED);
         $this->em->persist($r4);
-        $this->em->flush(); 
+        $this->em->flush();
 
-        $rolesDirect = $u->getRoles(); 
+        $rolesDirect = $u->getRoles();
         $this->assertEquals(4, count($rolesDirect));
-        
-        $roles = $roleService->getUserRolesByProject($u, $p1); 
+
+        $roles = $roleService->getUserRolesByProject($u, $p1);
         $this->assertEmpty($roles);
-        $roles = $roleService->getUserRolesByProject($u, $p2); 
-        $this->assertEquals(1, count($roles)); 
-        $this->assertEquals($r1->getId(), $roles[0]->getId()); 
-        $roles = $roleService->getUserRolesByProject($u, $p3); 
-        $this->assertEquals(4, count($roles)); 
-        $this->assertTrue(in_array($r1, $roles)); 
-        $this->assertTrue(in_array($r2, $roles)); 
-        $this->assertTrue(in_array($r3, $roles)); 
-        $this->assertTrue(in_array($r4, $roles)); 
+        $roles = $roleService->getUserRolesByProject($u, $p2);
+        $this->assertEquals(1, count($roles));
+        $this->assertEquals($r1->getId(), $roles[0]->getId());
+        $roles = $roleService->getUserRolesByProject($u, $p3);
+        $this->assertEquals(4, count($roles));
+        $this->assertTrue(in_array($r1, $roles));
+        $this->assertTrue(in_array($r2, $roles));
+        $this->assertTrue(in_array($r3, $roles));
+        $this->assertTrue(in_array($r4, $roles));
 
         /*
          * p1     p2     p3-r4
          * |      |     /|
          * n1     n2-r1  n3-r2
-         * |      |      | 
-         * s1     s2-r5  s3-r3 
+         * |      |      |
+         * s1     s2-r5  s3-r3
          */
-        $r5 = TestUtil::createSampleRole($u, $siteRoleType, $s2, RoleStatus::GRANTED); 
+        $r5 = TestUtil::createSampleRole($u, $siteRoleType, $s2, RoleStatus::GRANTED);
         $this->em->persist($r5);
-        $this->em->flush(); 
+        $this->em->flush();
 
-        $rolesDirect = $u->getRoles(); 
+        $rolesDirect = $u->getRoles();
         $this->assertEquals(5, count($rolesDirect));
 
-        $roles = $roleService->getUserRolesByProject($u, $p1); 
+        $roles = $roleService->getUserRolesByProject($u, $p1);
         $this->assertEmpty($roles);
-        $roles = $roleService->getUserRolesByProject($u, $p2); 
-        $this->assertEquals(2, count($roles)); 
-        $this->assertTrue(in_array($r1, $roles)); 
-        $this->assertTrue(in_array($r5, $roles)); 
-        $roles = $roleService->getUserRolesByProject($u, $p3); 
-        $this->assertEquals(5, count($roles)); 
-        $this->assertTrue(in_array($r1, $roles)); 
-        $this->assertTrue(in_array($r2, $roles)); 
-        $this->assertTrue(in_array($r3, $roles)); 
-        $this->assertTrue(in_array($r4, $roles)); 
-        $this->assertTrue(in_array($r5, $roles)); 
+        $roles = $roleService->getUserRolesByProject($u, $p2);
+        $this->assertEquals(2, count($roles));
+        $this->assertTrue(in_array($r1, $roles));
+        $this->assertTrue(in_array($r5, $roles));
+        $roles = $roleService->getUserRolesByProject($u, $p3);
+        $this->assertEquals(5, count($roles));
+        $this->assertTrue(in_array($r1, $roles));
+        $this->assertTrue(in_array($r2, $roles));
+        $this->assertTrue(in_array($r3, $roles));
+        $this->assertTrue(in_array($r4, $roles));
+        $this->assertTrue(in_array($r5, $roles));
 
-       
+
         /*
          * p1     p2     p3-r4
          * |      |     /|
          * n1     n2-r1  n3-r2
-         * |      |      | 
-         * s1-r6  s2-r5  s3-r3 
+         * |      |      |
+         * s1-r6  s2-r5  s3-r3
          */
-        $r6 = TestUtil::createSampleRole($u, $siteRoleType, $s1, RoleStatus::GRANTED); 
+        $r6 = TestUtil::createSampleRole($u, $siteRoleType, $s1, RoleStatus::GRANTED);
         $this->em->persist($r6);
-        $this->em->flush(); 
+        $this->em->flush();
 
-        $rolesDirect = $u->getRoles(); 
+        $rolesDirect = $u->getRoles();
         $this->assertEquals(6, count($rolesDirect));
 
-        $roles = $roleService->getUserRolesByProject($u, $p1); 
-        $this->assertEquals(1, count($roles)); 
+        $roles = $roleService->getUserRolesByProject($u, $p1);
+        $this->assertEquals(1, count($roles));
         $this->assertTrue(in_array($r6, $roles));
-        $roles = $roleService->getUserRolesByProject($u, $p2); 
-        $this->assertEquals(2, count($roles)); 
-        $this->assertTrue(in_array($r1, $roles)); 
-        $this->assertTrue(in_array($r5, $roles)); 
-        $roles = $roleService->getUserRolesByProject($u, $p3); 
-        $this->assertEquals(5, count($roles)); 
-        $this->assertTrue(in_array($r1, $roles)); 
-        $this->assertTrue(in_array($r2, $roles)); 
-        $this->assertTrue(in_array($r3, $roles)); 
-        $this->assertTrue(in_array($r4, $roles)); 
-        $this->assertTrue(in_array($r5, $roles)); 
-       
+        $roles = $roleService->getUserRolesByProject($u, $p2);
+        $this->assertEquals(2, count($roles));
+        $this->assertTrue(in_array($r1, $roles));
+        $this->assertTrue(in_array($r5, $roles));
+        $roles = $roleService->getUserRolesByProject($u, $p3);
+        $this->assertEquals(5, count($roles));
+        $this->assertTrue(in_array($r1, $roles));
+        $this->assertTrue(in_array($r2, $roles));
+        $this->assertTrue(in_array($r3, $roles));
+        $this->assertTrue(in_array($r4, $roles));
+        $this->assertTrue(in_array($r5, $roles));
+
         /*
          * p1     p2     p3-r4
          * |      |     /|
          * n1     n2-r1  n3-r2
-         * |      |      | 
-         * s1-r6  s2-r5  s3-r3,r7 
+         * |      |      |
+         * s1-r6  s2-r5  s3-r3,r7
          */
-        $r7 = TestUtil::createSampleRole($u, $siteRoleType2, $s3, RoleStatus::GRANTED); 
+        $r7 = TestUtil::createSampleRole($u, $siteRoleType2, $s3, RoleStatus::GRANTED);
         $this->em->persist($r7);
-        $this->em->flush(); 
+        $this->em->flush();
 
-        $rolesDirect = $u->getRoles(); 
+        $rolesDirect = $u->getRoles();
         $this->assertEquals(7, count($rolesDirect));
 
-        $roles = $roleService->getUserRolesByProject($u, $p1); 
-        $this->assertEquals(1, count($roles)); 
+        $roles = $roleService->getUserRolesByProject($u, $p1);
+        $this->assertEquals(1, count($roles));
         $this->assertTrue(in_array($r6, $roles));
-        $roles = $roleService->getUserRolesByProject($u, $p2); 
-        $this->assertEquals(2, count($roles)); 
-        $this->assertTrue(in_array($r1, $roles)); 
-        $this->assertTrue(in_array($r5, $roles)); 
-        $roles = $roleService->getUserRolesByProject($u, $p3); 
-        $this->assertEquals(6, count($roles)); 
-        $this->assertTrue(in_array($r1, $roles)); 
-        $this->assertTrue(in_array($r2, $roles)); 
-        $this->assertTrue(in_array($r3, $roles)); 
-        $this->assertTrue(in_array($r4, $roles)); 
-        $this->assertTrue(in_array($r5, $roles));  
-        $this->assertTrue(in_array($r7, $roles));  
+        $roles = $roleService->getUserRolesByProject($u, $p2);
+        $this->assertEquals(2, count($roles));
+        $this->assertTrue(in_array($r1, $roles));
+        $this->assertTrue(in_array($r5, $roles));
+        $roles = $roleService->getUserRolesByProject($u, $p3);
+        $this->assertEquals(6, count($roles));
+        $this->assertTrue(in_array($r1, $roles));
+        $this->assertTrue(in_array($r2, $roles));
+        $this->assertTrue(in_array($r3, $roles));
+        $this->assertTrue(in_array($r4, $roles));
+        $this->assertTrue(in_array($r5, $roles));
+        $this->assertTrue(in_array($r7, $roles));
 
 
         /*
          * p1     p2-r8  p3-r4
          * |      |     /|
          * n1     n2-r1  n3-r2
-         * |      |      | 
-         * s1-r6  s2-r5  s3-r3,r7 
+         * |      |      |
+         * s1-r6  s2-r5  s3-r3,r7
          */
-        $r8 = TestUtil::createSampleRole($u, $projRoleType, $p2, RoleStatus::GRANTED); 
+        $r8 = TestUtil::createSampleRole($u, $projRoleType, $p2, RoleStatus::GRANTED);
         $this->em->persist($r8);
-        $this->em->flush(); 
-        
-        $rolesDirect = $u->getRoles(); 
+        $this->em->flush();
+
+        $rolesDirect = $u->getRoles();
         $this->assertEquals(8, count($rolesDirect));
-        
-        $roles = $roleService->getUserRolesByProject($u, $p1); 
-        $this->assertEquals(1, count($roles)); 
+
+        $roles = $roleService->getUserRolesByProject($u, $p1);
+        $this->assertEquals(1, count($roles));
         $this->assertTrue(in_array($r6, $roles));
-        $roles = $roleService->getUserRolesByProject($u, $p2); 
-        $this->assertEquals(3, count($roles)); 
-        $this->assertTrue(in_array($r1, $roles)); 
-        $this->assertTrue(in_array($r5, $roles)); 
-        $this->assertTrue(in_array($r8, $roles)); 
-        $roles = $roleService->getUserRolesByProject($u, $p3); 
-        $this->assertEquals(6, count($roles)); 
-        $this->assertTrue(in_array($r1, $roles)); 
-        $this->assertTrue(in_array($r2, $roles)); 
-        $this->assertTrue(in_array($r3, $roles)); 
-        $this->assertTrue(in_array($r4, $roles)); 
-        $this->assertTrue(in_array($r5, $roles));  
-        $this->assertTrue(in_array($r7, $roles)); 
+        $roles = $roleService->getUserRolesByProject($u, $p2);
+        $this->assertEquals(3, count($roles));
+        $this->assertTrue(in_array($r1, $roles));
+        $this->assertTrue(in_array($r5, $roles));
+        $this->assertTrue(in_array($r8, $roles));
+        $roles = $roleService->getUserRolesByProject($u, $p3);
+        $this->assertEquals(6, count($roles));
+        $this->assertTrue(in_array($r1, $roles));
+        $this->assertTrue(in_array($r2, $roles));
+        $this->assertTrue(in_array($r3, $roles));
+        $this->assertTrue(in_array($r4, $roles));
+        $this->assertTrue(in_array($r5, $roles));
+        $this->assertTrue(in_array($r7, $roles));
 
     }
 
 
 
-    
-    
+
+
 
     /*public function testRoleTypeValues(){
         print __METHOD__ . "\n";
-        $roleService = new org\gocdb\services\Role();  
-        
-        $roleType = new RoleType(RoleTypeName::SITE_ADMIN, RoleTypeClass::SITE_USER); 
-        $this->assertTrue($roleService->isValidRoleType($roleType)); 
-        $roleType = new RoleType(RoleTypeName::SITE_SECOFFICER, RoleTypeClass::SITE_MANAGER); 
-        $this->assertTrue($roleService->isValidRoleType($roleType)); 
-        $roleType = new RoleType(RoleTypeName::SITE_SECOFFICER, \RoleTypeClass::SITE_USER); 
-        $this->assertFalse($roleService->isValidRoleType($roleType)); 
+        $roleService = new org\gocdb\services\Role();
+
+        $roleType = new RoleType(RoleTypeName::SITE_ADMIN, RoleTypeClass::SITE_USER);
+        $this->assertTrue($roleService->isValidRoleType($roleType));
+        $roleType = new RoleType(RoleTypeName::SITE_SECOFFICER, RoleTypeClass::SITE_MANAGER);
+        $this->assertTrue($roleService->isValidRoleType($roleType));
+        $roleType = new RoleType(RoleTypeName::SITE_SECOFFICER, \RoleTypeClass::SITE_USER);
+        $this->assertFalse($roleService->isValidRoleType($roleType));
     }*/
 
     /*public function testGetRoleTypeClassificationsByRoleTypeName(){
         print __METHOD__ . "\n";
-        $roleService = new org\gocdb\services\Role(); 
-        
-        $roleNames = $roleService->getRoleTypeNamesByClassification(RoleTypeClass::PROJECT); 
-        $this->assertTrue(count($roleNames) == 4); 
+        $roleService = new org\gocdb\services\Role();
+
+        $roleNames = $roleService->getRoleTypeNamesByClassification(RoleTypeClass::PROJECT);
+        $this->assertTrue(count($roleNames) == 4);
         $this->assertTrue(in_array(RoleTypeName::COO, $roleNames));
         $this->assertTrue(in_array(RoleTypeName::COD_ADMIN, $roleNames));
         $this->assertTrue(in_array(RoleTypeName::COD_STAFF, $roleNames));
         $this->assertTrue(in_array(RoleTypeName::EGI_CSIRT_OFFICER, $roleNames));
-       
-        $roleNames = $roleService->getRoleTypeNamesByClassification(RoleTypeClass::REGIONAL_MANAGER); 
-        $this->assertTrue(count($roleNames) == 3); 
+
+        $roleNames = $roleService->getRoleTypeNamesByClassification(RoleTypeClass::REGIONAL_MANAGER);
+        $this->assertTrue(count($roleNames) == 3);
         $this->assertTrue(in_array(RoleTypeName::NGI_SEC_OFFICER, $roleNames));
         $this->assertTrue(in_array(RoleTypeName::NGI_OPS_DEP_MAN, $roleNames));
         $this->assertTrue(in_array(RoleTypeName::NGI_OPS_MAN, $roleNames));
-        
-        $roleNames = $roleService->getRoleTypeNamesByClassification(RoleTypeClass::REGIONAL_USER); 
-        $this->assertTrue(count($roleNames) == 2); 
+
+        $roleNames = $roleService->getRoleTypeNamesByClassification(RoleTypeClass::REGIONAL_USER);
+        $this->assertTrue(count($roleNames) == 2);
         $this->assertTrue(in_array(RoleTypeName::REG_STAFF_ROD, $roleNames));
         $this->assertTrue(in_array(RoleTypeName::REG_FIRST_LINE_SUPPORT, $roleNames));
-        
-        $roleNames = $roleService->getRoleTypeNamesByClassification(RoleTypeClass::SITE_MANAGER); 
-        $this->assertTrue(count($roleNames) == 3); 
+
+        $roleNames = $roleService->getRoleTypeNamesByClassification(RoleTypeClass::SITE_MANAGER);
+        $this->assertTrue(count($roleNames) == 3);
         $this->assertTrue(in_array(RoleTypeName::SITE_OPS_MAN, $roleNames));
         $this->assertTrue(in_array(RoleTypeName::SITE_OPS_DEP_MAN, $roleNames));
         $this->assertTrue(in_array(RoleTypeName::SITE_SECOFFICER, $roleNames));
-        
-        $roleNames = $roleService->getRoleTypeNamesByClassification(RoleTypeClass::SITE_USER); 
-        $this->assertTrue(count($roleNames) == 1); 
+
+        $roleNames = $roleService->getRoleTypeNamesByClassification(RoleTypeClass::SITE_USER);
+        $this->assertTrue(count($roleNames) == 1);
         $this->assertTrue(in_array(RoleTypeName::SITE_ADMIN, $roleNames));
-        
-        $roleNames = $roleService->getRoleTypeNamesByClassification(RoleTypeClass::SERVICEGROUP_ADMIN); 
-        $this->assertTrue(count($roleNames) == 1); 
+
+        $roleNames = $roleService->getRoleTypeNamesByClassification(RoleTypeClass::SERVICEGROUP_ADMIN);
+        $this->assertTrue(count($roleNames) == 1);
         $this->assertTrue(in_array(RoleTypeName::SERVICEGROUP_ADMIN, $roleNames));
     }*/
-        
 
-      
+
+
 }
 
 ?>

--- a/tests/doctrine/RolesTest.php
+++ b/tests/doctrine/RolesTest.php
@@ -1,63 +1,63 @@
 <?php
 //require_once 'PHPUnit/Extensions/Database/TestCase.php';
 //require_once 'PHPUnit/Extensions/Database/DataSet/DefaultDataSet.php';
-require_once dirname(__FILE__) . '/TestUtil.php'; 
+require_once dirname(__FILE__) . '/TestUtil.php';
 require_once dirname(__FILE__). '/../../lib/DAOs/ServiceDAO.php';
 require_once dirname(__FILE__). '/../../lib/DAOs/SiteDAO.php';
 require_once dirname(__FILE__). '/../../lib/DAOs/NGIDAO.php';
 
-use Doctrine\ORM\EntityManager; 
+use Doctrine\ORM\EntityManager;
 require_once dirname(__FILE__) . '/bootstrap.php';
 
 /**
- * Test the role functionality. 
+ * Test the role functionality.
  * This test case truncates the test database (a clean insert with no seed data)
- * and performs subsequent CRUD operations using Doctrine ORM. 
- * Usage: 
+ * and performs subsequent CRUD operations using Doctrine ORM.
+ * Usage:
  * Run the recreate.sh to create the sample database first (create tables etc), then run:
- * '$phpunit TestRoles.php' 
+ * '$phpunit TestRoles.php'
  *
  * @author David Meredith
- * @author John Casson  
+ * @author John Casson
  */
 class RolesTest extends PHPUnit_Extensions_Database_TestCase {
-   private $em; 
-   private $egiScope; 
-   private $localScope; 
-   private $eudatScope; 
+   private $em;
+   private $egiScope;
+   private $localScope;
+   private $eudatScope;
 
 
     /**
-     * Overridden. 
+     * Overridden.
      */
     public static function setUpBeforeClass() {
         parent::setUpBeforeClass();
         echo "\n\n-------------------------------------------------\n";
         echo "Executing RolesTest. . .\n";
     }
-    
+
     /**
      * Overridden. Returns the test database connection.
      * @return PHPUnit_Extensions_Database_DB_IDatabaseConnection
      */
     protected function getConnection() {
         require_once dirname(__FILE__) . '/bootstrap_pdo.php';
-        return getConnectionToTestDB(); 
+        return getConnectionToTestDB();
     }
 
     /**
-     * Overridden. Returns the test dataset.  
-     * Defines how the initial state of the database should look before each test is executed. 
+     * Overridden. Returns the test dataset.
+     * Defines how the initial state of the database should look before each test is executed.
      * @return PHPUnit_Extensions_Database_DataSet_IDataSet
      */
-    protected function getDataSet() { 
+    protected function getDataSet() {
         return $this->createFlatXMLDataSet(dirname(__FILE__) . '/truncateDataTables.xml');
         // Use below to return an empty data set if we don't want to truncate and seed
         //return new PHPUnit_Extensions_Database_DataSet_DefaultDataSet();
     }
 
     /**
-     * Overridden. 
+     * Overridden.
      */
     protected function getSetUpOperation() {
         // CLEAN_INSERT is default
@@ -65,14 +65,14 @@ class RolesTest extends PHPUnit_Extensions_Database_TestCase {
         //return PHPUnit_Extensions_Database_Operation_Factory::UPDATE();
         //return PHPUnit_Extensions_Database_Operation_Factory::NONE();
         //
-        // Issue a DELETE from <table> which is more portable than a 
-        // TRUNCATE table <table> (some DBs require high privileges for truncate statements 
+        // Issue a DELETE from <table> which is more portable than a
+        // TRUNCATE table <table> (some DBs require high privileges for truncate statements
         // and also do not allow truncates across tables with FK contstraints e.g. Oracle)
         return PHPUnit_Extensions_Database_Operation_Factory::DELETE_ALL();
     }
 
     /**
-     * Overridden. 
+     * Overridden.
      */
     protected function getTearDownOperation() {
         // NONE is default
@@ -84,18 +84,18 @@ class RolesTest extends PHPUnit_Extensions_Database_TestCase {
      * This method is called before each test method is executed.
      */
     protected function setUp() {
-        parent::setUp();            
+        parent::setUp();
         $this->em = $this->createEntityManager();
     }
-    
+
     /**
-     * @todo Still need to setup connection to different databases. 
+     * @todo Still need to setup connection to different databases.
      * @return EntityManager
      */
     private function createEntityManager(){
         //require dirname(__FILE__).'/../lib/Doctrine/bootstrap.php';
         require dirname(__FILE__).'/bootstrap_doctrine.php';
-        return $entityManager; 
+        return $entityManager;
     }
 
     /**
@@ -111,8 +111,8 @@ class RolesTest extends PHPUnit_Extensions_Database_TestCase {
             //print $tableName->getName() . "\n";
             $sql = "SELECT * FROM ".$tableName->getName();
             $result = $con->createQueryTable('results_table', $sql);
-            //echo 'row count: '.$result->getRowCount() ; 
-            if($result->getRowCount() != 0) 
+            //echo 'row count: '.$result->getRowCount() ;
+            if($result->getRowCount() != 0)
                 throw new RuntimeException("Invalid fixture. Table has rows: ".$tableName->getName());
         }
     }
@@ -128,30 +128,30 @@ class RolesTest extends PHPUnit_Extensions_Database_TestCase {
         // Create a roletype
         $rt = TestUtil::createSampleRoleType("ROLENAME");
         $this->em->persist($rt);
-        
+
         // Create a user
         $u = TestUtil::createSampleUser("Test", "Testing", "/c=test");
         $this->em->persist($u);
-        
+
         // Create a site
         $s = TestUtil::createSampleSite("SITENAME"/*, "PK01"*/);
         $this->em->persist($s);
-        
+
         // Create a role and link to the user, role type and site
-        $r = TestUtil::createSampleRole($u, $rt, $s, RoleStatus::GRANTED); 
+        $r = TestUtil::createSampleRole($u, $rt, $s, RoleStatus::GRANTED);
         $this->em->persist($r);
-        
+
         $this->em->flush();
-        
+
         // New reference to the freshly created role entity
         $dbRole = $this->em->find("Role", $r->getId());
         if(!$dbRole->getOwnedEntity() instanceof Site) {
             $this->fail();
         }
         // if we've reached this point without error the test
-        // has passed.    	 
+        // has passed.
     }
-      
+
    /**
     * Test Role's discriminator column
     * Add a role type, user, NGI and a role linking
@@ -163,22 +163,22 @@ class RolesTest extends PHPUnit_Extensions_Database_TestCase {
         // Create a roletype
         $rt = TestUtil::createSampleRoleType("Name");
         $this->em->persist($rt);
-         
+
         // Create a user
         $u = TestUtil::createSampleUser("Test", "Testing", "/c=test");
         $this->em->persist($u);
-         
+
         // Create an NGI
         $n = TestUtil::createSampleNGI("MYNGI");
         $this->em->persist($n);
-         
+
         // Create a role and link to the user, role type and site
         $r = TestUtil::createSampleRole($u, $rt, $n, RoleStatus::GRANTED);
-        
+
         $this->em->persist($r);
-         
+
         $this->em->flush();
-         
+
         // New reference to the freshly created role entity
         $dbRole = $this->em->find("Role", $r->getId());
         if(!$dbRole->getOwnedEntity() instanceof NGI) {
@@ -187,7 +187,7 @@ class RolesTest extends PHPUnit_Extensions_Database_TestCase {
         // if we've reached this point without error the test
         // has passed.
     }
-        
+
     /**
      * Test Role's discriminator column
      * Add a role type, user, NGI and a role linking
@@ -200,20 +200,20 @@ class RolesTest extends PHPUnit_Extensions_Database_TestCase {
         // Create a roletype
         $rt = TestUtil::createSampleRoleType("NAME");
         $this->em->persist($rt);
-    
+
         // Create a user
         $u = TestUtil::createSampleUser("Test", "Testing", "/c=test");
         $this->em->persist($u);
-    
+
         // Create an NGI
         $n = TestUtil::createSampleNGI("MYNGI");
         $this->em->persist($n);
-    
-        // Create a role and link to the user, role type and ngi 
-        $r = TestUtil::createSampleRole($u, $rt, $n, RoleStatus::GRANTED); 
+
+        // Create a role and link to the user, role type and ngi
+        $r = TestUtil::createSampleRole($u, $rt, $n, RoleStatus::GRANTED);
         $this->em->persist($r);
         $this->em->flush();
-        
+
         // try to delete the role type before deleting
         // the dependant role
         $this->em->remove($rt);
@@ -226,7 +226,7 @@ class RolesTest extends PHPUnit_Extensions_Database_TestCase {
      */
     public function testDuplicateRoleTypes() {
         print __METHOD__ . "\n";
-        // Should throw an expected exception because the role type Name value 
+        // Should throw an expected exception because the role type Name value
         // must be unique
         $rt1 = TestUtil::createSampleRoleType("RoleName"/*, RoleTypeClass::SITE_USER*/);
         $rt2 = TestUtil::createSampleRoleType("RoleName"/*, RoleTypeClass::REGIONAL_USER*/);
@@ -235,22 +235,22 @@ class RolesTest extends PHPUnit_Extensions_Database_TestCase {
         $this->em->flush();
     }
 
-    
+
 
 
     public function testRoleConstants(){
         print __METHOD__ . "\n";
-        
-        $roleNames = RoleTypeName::getAsArray(); 
-        $this->assertEquals(RoleTypeName::SITE_ADMIN, $roleNames['SITE_ADMIN'] ); 
-        $this->assertEquals(RoleTypeName::COD_ADMIN, $roleNames['COD_ADMIN'] ); 
-        
-        $roleStatusVals = RoleStatus::getAsArray(); 
-        $this->assertEquals(RoleStatus::GRANTED, $roleStatusVals['GRANTED']); 
-        $this->assertEquals(RoleStatus::PENDING, $roleStatusVals['PENDING']); 
+
+        $roleNames = RoleTypeName::getAsArray();
+        $this->assertEquals(RoleTypeName::SITE_ADMIN, $roleNames['SITE_ADMIN'] );
+        $this->assertEquals(RoleTypeName::COD_ADMIN, $roleNames['COD_ADMIN'] );
+
+        $roleStatusVals = RoleStatus::getAsArray();
+        $this->assertEquals(RoleStatus::GRANTED, $roleStatusVals['GRANTED']);
+        $this->assertEquals(RoleStatus::PENDING, $roleStatusVals['PENDING']);
     }
 
-      
+
 }
 
 ?>

--- a/tests/doctrine/Scoped_IPIQuery_Test1.php
+++ b/tests/doctrine/Scoped_IPIQuery_Test1.php
@@ -19,12 +19,12 @@ require_once dirname(__FILE__) . '/../../lib/Gocdb_Services/PI/QueryBuilders/Ext
 
 
 /**
- * Creates selected <code>IPIQuery</code> objects that perform scoped queries on 
- * <code>IScopedEntity</code> objects, and assert that the query objects return 
- * the expected number of scoped entities when querying against known fixture data. 
+ * Creates selected <code>IPIQuery</code> objects that perform scoped queries on
+ * <code>IScopedEntity</code> objects, and assert that the query objects return
+ * the expected number of scoped entities when querying against known fixture data.
  * <p>
  * Covers the following IPIQuery objects: GetNGI, GetSite, GetServiceEndpoint, GetServiceGroup
- * 
+ *
  * @author David Meredith
  */
 class Scoped_IPIQuery_Test1 extends PHPUnit_Extensions_Database_TestCase {
@@ -32,7 +32,7 @@ class Scoped_IPIQuery_Test1 extends PHPUnit_Extensions_Database_TestCase {
     private $em;
 
     /**
-     * Overridden. 
+     * Overridden.
      */
     public static function setUpBeforeClass() {
         parent::setUpBeforeClass();
@@ -50,8 +50,8 @@ class Scoped_IPIQuery_Test1 extends PHPUnit_Extensions_Database_TestCase {
     }
 
     /**
-     * Overridden. Returns the test dataset.  
-     * Defines how the initial state of the database should look before each test is executed. 
+     * Overridden. Returns the test dataset.
+     * Defines how the initial state of the database should look before each test is executed.
      * @return PHPUnit_Extensions_Database_DataSet_IDataSet
      */
     protected function getDataSet() {
@@ -61,7 +61,7 @@ class Scoped_IPIQuery_Test1 extends PHPUnit_Extensions_Database_TestCase {
     }
 
     /**
-     * Overridden. 
+     * Overridden.
      */
     protected function getSetUpOperation() {
         // CLEAN_INSERT is default
@@ -69,14 +69,14 @@ class Scoped_IPIQuery_Test1 extends PHPUnit_Extensions_Database_TestCase {
         //return PHPUnit_Extensions_Database_Operation_Factory::UPDATE();
         //return PHPUnit_Extensions_Database_Operation_Factory::NONE();
         //
-        // Issue a DELETE from <table> which is more portable than a 
-        // TRUNCATE table <table> (some DBs require high privileges for truncate statements 
+        // Issue a DELETE from <table> which is more portable than a
+        // TRUNCATE table <table> (some DBs require high privileges for truncate statements
         // and also do not allow truncates across tables with FK contstraints e.g. Oracle)
         return PHPUnit_Extensions_Database_Operation_Factory::DELETE_ALL();
     }
 
     /**
-     * Overridden. 
+     * Overridden.
      */
     protected function getTearDownOperation() {
         // NONE is default
@@ -113,14 +113,14 @@ class Scoped_IPIQuery_Test1 extends PHPUnit_Extensions_Database_TestCase {
             //print $tableName->getName() . "\n";
             $sql = "SELECT * FROM " . $tableName->getName();
             $result = $con->createQueryTable('results_table', $sql);
-            //echo 'row count: '.$result->getRowCount() ; 
+            //echo 'row count: '.$result->getRowCount() ;
             if ($result->getRowCount() != 0)
                 throw new RuntimeException("Invalid fixture. Table has rows: " . $tableName->getName());
         }
     }
 
    /**
-     * See class doc. 
+     * See class doc.
      */
     public function testGet_Scoped_IPIQuery() {
         print __METHOD__ . "\n";
@@ -145,48 +145,48 @@ class Scoped_IPIQuery_Test1 extends PHPUnit_Extensions_Database_TestCase {
 
     private function doScopedQueryCalls(\org\gocdb\services\IPIQuery $query) {
 
-        // empty scope string is a wildcard for 'any' value (i.e. scope can be any value) 
-        $this->queryForIScopedEntity($query, array('scope' => '', 'scope_match' => 'all'), 5); 
-        $this->queryForIScopedEntity($query, array('scope' => '', 'scope_match' => 'any'), 5); 
+        // empty scope string is a wildcard for 'any' value (i.e. scope can be any value)
+        $this->queryForIScopedEntity($query, array('scope' => '', 'scope_match' => 'all'), 5);
+        $this->queryForIScopedEntity($query, array('scope' => '', 'scope_match' => 'any'), 5);
         try {
-            $this->queryForIScopedEntity($query, null, 5);  
-            $this->fail("Expected and InvalidArgumentException"); 
+            $this->queryForIScopedEntity($query, null, 5);
+            $this->fail("Expected and InvalidArgumentException");
         } catch(InvalidArgumentException $ex){
-            // ok, we expected this so continue on below 
+            // ok, we expected this so continue on below
         }
-        // TODO - All Tests below involve missing/empty/null 'scope' and 'scope_match' 
-        // values. This causes the IPIQuery object to invoke the Factory::getConfigService() 
-        // to get the default 'scope' and 'scope_match' values. 
-        // If we were being strict OO practitioners, then the IPIQuery 
-        // objects shouldn't really depend on the Factory or ConfigService. 
-        // Instead, these defaults could be injected from calling/client code 
-        // (with an additional a hardwired fallback of 'scope_match = all' and 
-        // 'no' default scope defined within the IPIQuery).  
-        // 
-        // 5 queries below use the default scope and default scope_match values  
-        $this->queryForIScopedEntity($query, array('scope_match' => 'all'), 0); // no scope (uses default) 
+        // TODO - All Tests below involve missing/empty/null 'scope' and 'scope_match'
+        // values. This causes the IPIQuery object to invoke the Factory::getConfigService()
+        // to get the default 'scope' and 'scope_match' values.
+        // If we were being strict OO practitioners, then the IPIQuery
+        // objects shouldn't really depend on the Factory or ConfigService.
+        // Instead, these defaults could be injected from calling/client code
+        // (with an additional a hardwired fallback of 'scope_match = all' and
+        // 'no' default scope defined within the IPIQuery).
+        //
+        // 5 queries below use the default scope and default scope_match values
+        $this->queryForIScopedEntity($query, array('scope_match' => 'all'), 0); // no scope (uses default)
         $this->queryForIScopedEntity($query, array('scope_match' => ''), 0); // no scope and empty scope_match
-        $this->queryForIScopedEntity($query, array(), 0); // no scope, no scope_match (uses defaults)  
-        $this->queryForIScopedEntity($query, array('scope' => null, 'scope_match' => 'any'), 0); // no scope (uses default) 
-        $this->queryForIScopedEntity($query, array('scope' => null, 'scope_match' => 'all'), 0);// no scope (uses default)  
+        $this->queryForIScopedEntity($query, array(), 0); // no scope, no scope_match (uses defaults)
+        $this->queryForIScopedEntity($query, array('scope' => null, 'scope_match' => 'any'), 0); // no scope (uses default)
+        $this->queryForIScopedEntity($query, array('scope' => null, 'scope_match' => 'all'), 0);// no scope (uses default)
 
-        // Test with scope_match = all  
+        // Test with scope_match = all
         $this->queryForIScopedEntity($query, array('scope' => 'Scope0', 'scope_match' => 'all'), 4);
         $this->queryForIScopedEntity($query, array('scope' => 'Scope0,Scope1', 'scope_match' => 'all'), 3);
         $this->queryForIScopedEntity($query, array('scope' => 'Scope2', 'scope_match' => 'all'), 2);
         $this->queryForIScopedEntity($query, array('scope' => 'Scope3,Scope4,Scope5', 'scope_match' => 'all'), 1);
         $this->queryForIScopedEntity($query, array('scope' => 'Scope0,Scope1,ScopeX', 'scope_match' => 'all'), 0);
-        // Test with scope_match = any 
+        // Test with scope_match = any
         $this->queryForIScopedEntity($query, array('scope' => 'Scope0', 'scope_match' => 'any'), 4);
         $this->queryForIScopedEntity($query, array('scope' => 'Scope1', 'scope_match' => 'any'), 3);
         $this->queryForIScopedEntity($query, array('scope' => 'ScopeX0,ScopeX1,ScopeX1', 'scope_match' => 'any'), 0);
 
-//	$query->validateParameters(array('scope' => 'Scope0,Scope1,ScopeX', 'scope_match' => 'any')); 
+//	$query->validateParameters(array('scope' => 'Scope0,Scope1,ScopeX', 'scope_match' => 'any'));
 //	$query->createQuery();
 //      $results = $query->executeQuery();
-//	print_r(count($results)); 
+//	print_r(count($results));
 //      $this->assertTrue(4 == count($results));
-    
+
     $this->queryForIScopedEntity($query, array('scope' => 'Scope0,Scope1,ScopeX', 'scope_match' => 'any'), 4);
     $this->queryForIScopedEntity($query, array('scope' => 'Scope1,ScopeX,ScopeXX', 'scope_match' => 'any'), 3);
     $this->queryForIScopedEntity($query, array('scope' => 'Scope1,Scope2', 'scope_match' => 'any'), 3);
@@ -199,7 +199,7 @@ class Scoped_IPIQuery_Test1 extends PHPUnit_Extensions_Database_TestCase {
         $query->createQuery();
         $results = $query->executeQuery();
         $this->assertTrue($expectedCount == count($results));
-        return $results; 
+        return $results;
     }
 
 }

--- a/tests/doctrine/ServiceDAOTest.php
+++ b/tests/doctrine/ServiceDAOTest.php
@@ -13,9 +13,9 @@ require_once dirname(__FILE__) . '/../../lib/Gocdb_Services/ServiceService.php';
 require_once dirname(__FILE__) . '/../../lib/DAOs/ServiceDAO.php';
 
 /**
- * Test the ServiceDAO, in particular the cascade delete behaviour between 
- * Service, EndpointLocation and Downtime. 
- * 
+ * Test the ServiceDAO, in particular the cascade delete behaviour between
+ * Service, EndpointLocation and Downtime.
+ *
  * @author David Meredith
  */
 class ServiceDAOTest extends PHPUnit_Extensions_Database_TestCase {
@@ -26,7 +26,7 @@ class ServiceDAOTest extends PHPUnit_Extensions_Database_TestCase {
     //private $eudatScope;
 
     /**
-     * Overridden. 
+     * Overridden.
      */
     public static function setUpBeforeClass() {
         parent::setUpBeforeClass();
@@ -44,8 +44,8 @@ class ServiceDAOTest extends PHPUnit_Extensions_Database_TestCase {
     }
 
     /**
-     * Overridden. Returns the test dataset.  
-     * Defines how the initial state of the database should look before each test is executed. 
+     * Overridden. Returns the test dataset.
+     * Defines how the initial state of the database should look before each test is executed.
      * @return PHPUnit_Extensions_Database_DataSet_IDataSet
      */
     protected function getDataSet() {
@@ -55,7 +55,7 @@ class ServiceDAOTest extends PHPUnit_Extensions_Database_TestCase {
     }
 
     /**
-     * Overridden. 
+     * Overridden.
      */
     protected function getSetUpOperation() {
         // CLEAN_INSERT is default
@@ -63,14 +63,14 @@ class ServiceDAOTest extends PHPUnit_Extensions_Database_TestCase {
         //return PHPUnit_Extensions_Database_Operation_Factory::UPDATE();
         //return PHPUnit_Extensions_Database_Operation_Factory::NONE();
         //
-        // Issue a DELETE from <table> which is more portable than a 
-        // TRUNCATE table <table> (some DBs require high privileges for truncate statements 
+        // Issue a DELETE from <table> which is more portable than a
+        // TRUNCATE table <table> (some DBs require high privileges for truncate statements
         // and also do not allow truncates across tables with FK contstraints e.g. Oracle)
         return PHPUnit_Extensions_Database_Operation_Factory::DELETE_ALL();
     }
 
     /**
-     * Overridden. 
+     * Overridden.
      */
     protected function getTearDownOperation() {
         // NONE is default
@@ -83,11 +83,11 @@ class ServiceDAOTest extends PHPUnit_Extensions_Database_TestCase {
      */
     protected function setUp() {
         parent::setUp();
-        $this->em = $this->createEntityManager();		
+        $this->em = $this->createEntityManager();
     }
 
     /**
-     * @todo Still need to setup connection to different databases. 
+     * @todo Still need to setup connection to different databases.
      * @return EntityManager
      */
     private function createEntityManager() {
@@ -109,43 +109,43 @@ class ServiceDAOTest extends PHPUnit_Extensions_Database_TestCase {
             //print $tableName->getName() . "\n";
             $sql = "SELECT * FROM " . $tableName->getName();
             $result = $con->createQueryTable('results_table', $sql);
-            //echo 'row count: '.$result->getRowCount() ; 
+            //echo 'row count: '.$result->getRowCount() ;
             if ($result->getRowCount() != 0)
                 throw new RuntimeException("Invalid fixture. Table has rows: " . $tableName->getName());
         }
     }
 
     /**
-     * Test the ServiceDAO->removeService(); 
-     * Impt: A cascade=remove is configured between Service and EndpointLocation 
-     * so that when a Service is removed, its associated ELs are also removed. 
+     * Test the ServiceDAO->removeService();
+     * Impt: A cascade=remove is configured between Service and EndpointLocation
+     * so that when a Service is removed, its associated ELs are also removed.
      * <p>
-     * Note, no cascade remove behaviour is configured between EndpointLocation and 
-     * Downtime because we need to have fine-grained programmatic control over 
-     * which downtimes are deleted when a service EL is deleted (i.e. we only 
-     * want to delete those DTs that exclusively link to one EL only and which 
-     * would subsequently be orphaned). We do this managed deletion of DTs in ServiceDAO->removeService();  
+     * Note, no cascade remove behaviour is configured between EndpointLocation and
+     * Downtime because we need to have fine-grained programmatic control over
+     * which downtimes are deleted when a service EL is deleted (i.e. we only
+     * want to delete those DTs that exclusively link to one EL only and which
+     * would subsequently be orphaned). We do this managed deletion of DTs in ServiceDAO->removeService();
      */
     public function testServiceDAO_removeService() {
         print __METHOD__ . "\n";
         include __DIR__ . '/resources/sampleFixtureData1.php';
 
-        // Impt: When deleting a service, we can't rely solely on the 
-        // 'onDelete=cascade' defined on the 'EndpointLocation->service' 
-        // to correctly cascade-delete the EL. This is because downtimes can also be linked 
-        // to the EL.  Therefore, if we don't invoke an $em->remove() on the EL 
-        // (either via cascade="remove" or manually invoking em->remove() on each EL), 
-        // Doctrine will not have flagged the EL as removed and so will not automatically delete the 
-        // relevant row(s) in 'DOWNTIMES_ENDPOINTLOCATIONS' join table. 
-        // This would cause a FK integrity/violation constraint exception 
-        // on the 'DOWNTIMES_ENDPOINTLOCATIONS.ENDPOINTLOCATION_ID' FK column. 
+        // Impt: When deleting a service, we can't rely solely on the
+        // 'onDelete=cascade' defined on the 'EndpointLocation->service'
+        // to correctly cascade-delete the EL. This is because downtimes can also be linked
+        // to the EL.  Therefore, if we don't invoke an $em->remove() on the EL
+        // (either via cascade="remove" or manually invoking em->remove() on each EL),
+        // Doctrine will not have flagged the EL as removed and so will not automatically delete the
+        // relevant row(s) in 'DOWNTIMES_ENDPOINTLOCATIONS' join table.
+        // This would cause a FK integrity/violation constraint exception
+        // on the 'DOWNTIMES_ENDPOINTLOCATIONS.ENDPOINTLOCATION_ID' FK column.
         // This is why we need to do a managed delete using the ServiceDAO
         $serviceDao = new ServiceDAO();
         $serviceDao->setEntityManager($this->em);
         $serviceDao->removeService($service1);
         $this->em->flush();
 
-        // use DB connection to check data has been deleted  
+        // use DB connection to check data has been deleted
         $con = $this->getConnection();
         $result = $con->createQueryTable('results_table', "SELECT * FROM EndpointLocations");
         $this->assertTrue($result->getRowCount() == 0);
@@ -158,14 +158,14 @@ class ServiceDAOTest extends PHPUnit_Extensions_Database_TestCase {
         print __METHOD__ . "\n";
         include __DIR__ . '/resources/sampleFixtureData1.php';
 
-        $adminUser = TestUtil::createSampleUser('some', 'admin', '/some/admin'); 
-        $adminUser->setAdmin(TRUE); 
-        $this->em->persist($adminUser); 
-        
-        $ngiService = new org\gocdb\services\NGI(); 
-        $ngiService->setEntityManager($this->em); 
-        $ngiService->deleteNgi($ngi, $adminUser, FALSE); 
-        
+        $adminUser = TestUtil::createSampleUser('some', 'admin', '/some/admin');
+        $adminUser->setAdmin(TRUE);
+        $this->em->persist($adminUser);
+
+        $ngiService = new org\gocdb\services\NGI();
+        $ngiService->setEntityManager($this->em);
+        $ngiService->deleteNgi($ngi, $adminUser, FALSE);
+
      }
 
 }

--- a/tests/doctrine/ServiceMoveTest.php
+++ b/tests/doctrine/ServiceMoveTest.php
@@ -3,59 +3,59 @@
 //use org\gocdb\services\ServiceService;
 //require_once 'PHPUnit/Extensions/Database/TestCase.php';
 //require_once 'PHPUnit/Extensions/Database/DataSet/DefaultDataSet.php';
-require_once dirname(__FILE__) . '/TestUtil.php'; 
+require_once dirname(__FILE__) . '/TestUtil.php';
 
-use Doctrine\ORM\EntityManager; 
+use Doctrine\ORM\EntityManager;
 require_once dirname(__FILE__) . '/bootstrap.php';
-require_once dirname(__FILE__). '/../../lib/Gocdb_Services/Site.php'; 
+require_once dirname(__FILE__). '/../../lib/Gocdb_Services/Site.php';
 require_once dirname(__FILE__). '/../../lib/Gocdb_Services/ServiceService.php';
 
 /**
- * 
+ *
  *Test site ownership transfer between NGIs
  *
  * @author George Ryall
  * @author David Meredith
- * @author John Casson  
+ * @author John Casson
  */
 class ServiceMoveTest extends PHPUnit_Extensions_Database_TestCase {
-   private $em; 
-   private $egiScope; 
-   private $localScope; 
-   private $eudatScope; 
+   private $em;
+   private $egiScope;
+   private $localScope;
+   private $eudatScope;
 
 
     /**
-     * Overridden. 
+     * Overridden.
      */
     public static function setUpBeforeClass() {
         parent::setUpBeforeClass();
         echo "\n\n-------------------------------------------------\n";
         echo "Executing ServiceMoveTest. . .\n";
     }
-    
+
     /**
      * Overridden. Returns the test database connection.
      * @return PHPUnit_Extensions_Database_DB_IDatabaseConnection
      */
     protected function getConnection() {
         require_once dirname(__FILE__) . '/bootstrap_pdo.php';
-        return getConnectionToTestDB(); 
+        return getConnectionToTestDB();
     }
 
     /**
-     * Overridden. Returns the test dataset.  
-     * Defines how the initial state of the database should look before each test is executed. 
+     * Overridden. Returns the test dataset.
+     * Defines how the initial state of the database should look before each test is executed.
      * @return PHPUnit_Extensions_Database_DataSet_IDataSet
      */
-    protected function getDataSet() { 
+    protected function getDataSet() {
         return $this->createFlatXMLDataSet(dirname(__FILE__) . '/truncateDataTables.xml');
         // Use below to return an empty data set if we don't want to truncate and seed
         //return new PHPUnit_Extensions_Database_DataSet_DefaultDataSet();
     }
 
     /**
-     * Overridden. 
+     * Overridden.
      */
     protected function getSetUpOperation() {
         // CLEAN_INSERT is default
@@ -63,14 +63,14 @@ class ServiceMoveTest extends PHPUnit_Extensions_Database_TestCase {
         //return PHPUnit_Extensions_Database_Operation_Factory::UPDATE();
         //return PHPUnit_Extensions_Database_Operation_Factory::NONE();
         //
-        // Issue a DELETE from <table> which is more portable than a 
-        // TRUNCATE table <table> (some DBs require high privileges for truncate statements 
+        // Issue a DELETE from <table> which is more portable than a
+        // TRUNCATE table <table> (some DBs require high privileges for truncate statements
         // and also do not allow truncates across tables with FK contstraints e.g. Oracle)
         return PHPUnit_Extensions_Database_Operation_Factory::DELETE_ALL();
     }
 
     /**
-     * Overridden. 
+     * Overridden.
      */
     protected function getTearDownOperation() {
         // NONE is default
@@ -82,18 +82,18 @@ class ServiceMoveTest extends PHPUnit_Extensions_Database_TestCase {
      * This method is called before each test method is executed.
      */
     protected function setUp() {
-        parent::setUp();            
+        parent::setUp();
         $this->em = $this->createEntityManager();
     }
-    
+
     /**
-     * @todo Still need to setup connection to different databases. 
+     * @todo Still need to setup connection to different databases.
      * @return EntityManager
      */
     private function createEntityManager(){
         //require dirname(__FILE__).'/../lib/Doctrine/bootstrap.php';
         require dirname(__FILE__).'/bootstrap_doctrine.php';
-        return $entityManager; 
+        return $entityManager;
     }
 
     /**
@@ -109,8 +109,8 @@ class ServiceMoveTest extends PHPUnit_Extensions_Database_TestCase {
             //print $tableName->getName() . "\n";
             $sql = "SELECT * FROM ".$tableName->getName();
             $result = $con->createQueryTable('results_table', $sql);
-            //echo 'row count: '.$result->getRowCount() ; 
-            if($result->getRowCount() != 0) 
+            //echo 'row count: '.$result->getRowCount() ;
+            if($result->getRowCount() != 0)
                 throw new RuntimeException("Invalid fixture. Table has rows: ".$tableName->getName());
         }
     }
@@ -122,9 +122,9 @@ class ServiceMoveTest extends PHPUnit_Extensions_Database_TestCase {
      *  Checks the sites are under the right NGIs.
      */
     public function testServiceMoves() {
-        
-        print __METHOD__ . "\n";	
-        
+
+        print __METHOD__ . "\n";
+
         //Insert initial data
         $S1 = TestUtil::createSamplesite("Site1");
         $S2 = TestUtil::createSamplesite("Site2");
@@ -132,15 +132,15 @@ class ServiceMoveTest extends PHPUnit_Extensions_Database_TestCase {
         $SE2 = TestUtil::createSampleService("SEP2");
         $SE3 = TestUtil::createSampleService("SEP3");
         $dummy_user = TestUtil::createSampleUser('Test', 'User', '/Some/string');
-        
+
         //Make dummy user a GOCDB admin so it can perfirm site moves etc.
         $dummy_user->setAdmin(true);
-        
+
         // Assign the service end points to the sites
         $S1->addServiceDoJoin($SE1);
         $S2->addServiceDoJoin($SE2);
-        $S2->addServiceDoJoin($SE3);   	
-            
+        $S2->addServiceDoJoin($SE3);
+
         //Persist initial data
         $this->em->persist($S1);
         $this->em->persist($S2);
@@ -149,10 +149,10 @@ class ServiceMoveTest extends PHPUnit_Extensions_Database_TestCase {
         $this->em->persist($SE3);
         $this->em->persist($dummy_user);
         $this->em->flush();
-        
+
         //Use DB connection to check data
         $con = $this->getConnection();
-            
+
             /*
              * Check both that each Site is present and that the ID matches the doctrine one
              */
@@ -160,12 +160,12 @@ class ServiceMoveTest extends PHPUnit_Extensions_Database_TestCase {
             $sql = "SELECT 1 FROM sites WHERE shortname = 'Site1' AND ID = '$S1_ID'";
             $result = $con->createQueryTable('', $sql);
             $this->assertEquals(1, $result->getRowCount());
-            
+
             $S2_ID = $S2->getId();
             $sql = "SELECT 1 FROM sites WHERE shortname = 'Site2' AND ID = '$S2_ID'";
             $result = $con->createQueryTable('', $sql);
             $this->assertEquals(1, $result->getRowCount());
-            
+
             /*
              * Check each service endpoint is: present, has the right ID & parent Site
              */
@@ -173,89 +173,89 @@ class ServiceMoveTest extends PHPUnit_Extensions_Database_TestCase {
             $sql = "SELECT 1 FROM services WHERE hostname = 'SEP1' AND ID = '$SE1_id' AND PARENTSITE_ID = '$S1_ID'";
             $result = $con->createQueryTable('', $sql);
             $this->assertEquals(1, $result->getRowCount());
-            
+
             $SE2_id= $SE2->getId();
             $sql = "SELECT 1 FROM services WHERE hostname = 'SEP2' AND ID = '$SE2_id' AND PARENTSITE_ID = '$S2_ID'";
             $result = $con->createQueryTable('', $sql);
             $this->assertEquals(1, $result->getRowCount());
-            
+
             $SE3_id= $SE3->getId();
             $sql = "SELECT 1 FROM services WHERE hostname = 'SEP3' AND ID = '$SE3_id' AND PARENTSITE_ID = '$S2_ID'";
             $result = $con->createQueryTable('', $sql);
             $this->assertEquals(1, $result->getRowCount());
 
-        
+
         //Move service endpoints
         $serv = new org\gocdb\services\ServiceService;
         $serv->setEntityManager($this->em);
         $serv->moveService($SE1, $S2, $dummy_user);
         $serv->moveService($SE2, $S1, $dummy_user);
         $serv->moveService($SE3, $S2, $dummy_user); //No change
-        
-        
+
+
         //flush movement
         $this->em->flush();
-        
+
         //Use doctrine to check movement
             //Check correct Site for each service endpoint
             $this->assertEquals($S2, $SE1->getParentSite());
             $this->assertEquals($S1, $SE2->getParentSite());
             $this->assertEquals($S2, $SE3->getParentSite());
-            
-                
+
+
             //Check correct service endpoints for each Site
                 //Site1
                 $SiteSEPs = $S1->getServices();
                 foreach ($SiteSEPs as $SEP){
-                    $this->assertEquals($SE2, $SEP); 
+                    $this->assertEquals($SE2, $SEP);
                 }
                 //Site2
                 $SiteSEPs = $S2->getServices();
                 foreach ($SiteSEPs as $SEP){
                     $this->assertTrue(($SEP==$SE1) or ($SEP==$SE3));
                 }
-            
-    
+
+
         //Use database connection to check movememrnt
             $con = $this->getConnection();
-            
+
             //Check Sites are still present and their ID is unchanged
             $sql = "SELECT 1 FROM sites WHERE shortname = 'Site1' AND ID = '$S1_ID'";
             $result = $con->createQueryTable('', $sql);
             $this->assertEquals(1, $result->getRowCount());
-            
+
             $sql = "SELECT 1 FROM sites WHERE shortname = 'Site2' AND ID = '$S2_ID'";
             $result = $con->createQueryTable('', $sql);
             $this->assertEquals(1, $result->getRowCount());
-            
-            
+
+
             //Check each Site has the correct number of service endpoints
                 //Site 1
                 $sql = "SELECT 1 FROM services WHERE parentsite_id = '$S1_ID'";
                 $result = $con->createQueryTable('', $sql);
-                $this->assertEquals(1, $result->getRowCount());	    	
-                
+                $this->assertEquals(1, $result->getRowCount());
+
                 //Site 2
                 $sql = "SELECT 1 FROM services WHERE parentsite_id = '$S2_ID'";
                 $result = $con->createQueryTable('', $sql);
-                $this->assertEquals(2, $result->getRowCount());	 
-                
+                $this->assertEquals(2, $result->getRowCount());
+
             //check Site IDs are unchanged and they are assigned to the correct NGI
                 //Site 1
                 $sql = "SELECT 1 FROM services WHERE hostname = 'SEP1' AND id = '$SE1_id' AND parentsite_id = '$S2_ID'";
                 $result = $con->createQueryTable('', $sql);
                 $this->assertEquals(1, $result->getRowCount());
-                
+
                 //Site 2
                 $sql = "SELECT 1 FROM services WHERE hostname = 'SEP2' AND id = '$SE2_id' AND parentsite_id = '$S1_ID'";
                 $result = $con->createQueryTable('', $sql);
                 $this->assertEquals(1, $result->getRowCount());
-                
+
                 //Site 3
                 $sql = "SELECT 1 FROM services WHERE hostname = 'SEP3' AND id = '$SE3_id' AND parentsite_id = '$S2_ID'";
                 $result = $con->createQueryTable('', $sql);
-                $this->assertEquals(1, $result->getRowCount());				
-    
+                $this->assertEquals(1, $result->getRowCount());
+
     }//close function
 }//close class
 

--- a/tests/doctrine/SiteMoveTest.php
+++ b/tests/doctrine/SiteMoveTest.php
@@ -3,60 +3,60 @@
 //use org\gocdb\services\Site;
 //require_once 'PHPUnit/Extensions/Database/TestCase.php';
 //require_once 'PHPUnit/Extensions/Database/DataSet/DefaultDataSet.php';
-require_once dirname(__FILE__) . '/TestUtil.php'; 
+require_once dirname(__FILE__) . '/TestUtil.php';
 
-use Doctrine\ORM\EntityManager; 
+use Doctrine\ORM\EntityManager;
 require_once dirname(__FILE__) . '/bootstrap.php';
-require_once dirname(__FILE__) . '/../../lib/Gocdb_Services/Site.php'; 
+require_once dirname(__FILE__) . '/../../lib/Gocdb_Services/Site.php';
 require_once dirname(__FILE__) . '/../../lib/Gocdb_Services/NGI.php';
 require_once dirname(__FILE__) . '/../../lib/Gocdb_Services/ServiceService.php';
 
 /**
- * 
+ *
  *Test site ownership transfer between NGIs
  *
  * @author George Ryall
  * @author David Meredith
- * @author John Casson  
+ * @author John Casson
  */
 class SiteMoveTest extends PHPUnit_Extensions_Database_TestCase {
-   private $em; 
-   private $egiScope; 
-   private $localScope; 
-   private $eudatScope; 
+   private $em;
+   private $egiScope;
+   private $localScope;
+   private $eudatScope;
 
 
     /**
-     * Overridden. 
+     * Overridden.
      */
     public static function setUpBeforeClass() {
         parent::setUpBeforeClass();
         echo "\n\n-------------------------------------------------\n";
         echo "Executing SiteMoveTest. . .\n";
     }
-    
+
     /**
      * Overridden. Returns the test database connection.
      * @return PHPUnit_Extensions_Database_DB_IDatabaseConnection
      */
     protected function getConnection() {
         require_once dirname(__FILE__) . '/bootstrap_pdo.php';
-        return getConnectionToTestDB(); 
+        return getConnectionToTestDB();
     }
 
     /**
-     * Overridden. Returns the test dataset.  
-     * Defines how the initial state of the database should look before each test is executed. 
+     * Overridden. Returns the test dataset.
+     * Defines how the initial state of the database should look before each test is executed.
      * @return PHPUnit_Extensions_Database_DataSet_IDataSet
      */
-    protected function getDataSet() { 
+    protected function getDataSet() {
         return $this->createFlatXMLDataSet(dirname(__FILE__) . '/truncateDataTables.xml');
         // Use below to return an empty data set if we don't want to truncate and seed
         //return new PHPUnit_Extensions_Database_DataSet_DefaultDataSet();
     }
 
     /**
-     * Overridden. 
+     * Overridden.
      */
     protected function getSetUpOperation() {
         // CLEAN_INSERT is default
@@ -64,14 +64,14 @@ class SiteMoveTest extends PHPUnit_Extensions_Database_TestCase {
         //return PHPUnit_Extensions_Database_Operation_Factory::UPDATE();
         //return PHPUnit_Extensions_Database_Operation_Factory::NONE();
         //
-        // Issue a DELETE from <table> which is more portable than a 
-        // TRUNCATE table <table> (some DBs require high privileges for truncate statements 
+        // Issue a DELETE from <table> which is more portable than a
+        // TRUNCATE table <table> (some DBs require high privileges for truncate statements
         // and also do not allow truncates across tables with FK contstraints e.g. Oracle)
         return PHPUnit_Extensions_Database_Operation_Factory::DELETE_ALL();
     }
 
     /**
-     * Overridden. 
+     * Overridden.
      */
     protected function getTearDownOperation() {
         // NONE is default
@@ -83,18 +83,18 @@ class SiteMoveTest extends PHPUnit_Extensions_Database_TestCase {
      * This method is called before each test method is executed.
      */
     protected function setUp() {
-        parent::setUp();            
+        parent::setUp();
         $this->em = $this->createEntityManager();
     }
-    
+
     /**
-     * @todo Still need to setup connection to different databases. 
+     * @todo Still need to setup connection to different databases.
      * @return EntityManager
      */
     private function createEntityManager(){
         //require dirname(__FILE__).'/../lib/Doctrine/bootstrap.php';
         require dirname(__FILE__).'/bootstrap_doctrine.php';
-        return $entityManager; 
+        return $entityManager;
     }
 
     /**
@@ -110,8 +110,8 @@ class SiteMoveTest extends PHPUnit_Extensions_Database_TestCase {
             //print $tableName->getName() . "\n";
             $sql = "SELECT * FROM ".$tableName->getName();
             $result = $con->createQueryTable('results_table', $sql);
-            //echo 'row count: '.$result->getRowCount() ; 
-            if($result->getRowCount() != 0) 
+            //echo 'row count: '.$result->getRowCount() ;
+            if($result->getRowCount() != 0)
                 throw new RuntimeException("Invalid fixture. Table has rows: ".$tableName->getName());
         }
     }
@@ -123,9 +123,9 @@ class SiteMoveTest extends PHPUnit_Extensions_Database_TestCase {
      *  Checks the sites are under the right NGIs.
      */
     public function testSiteMoves() {
-        
-        print __METHOD__ . "\n";	
-        
+
+        print __METHOD__ . "\n";
+
         //Insert initial data
         $N1 = TestUtil::createSampleNGI("NGI1");
         $N2 = TestUtil::createSampleNGI("NGI2");
@@ -134,10 +134,10 @@ class SiteMoveTest extends PHPUnit_Extensions_Database_TestCase {
         $S3 = TestUtil::createSampleSite("Site3");
         $SE1= TestUtil::createSampleService("SEP1");
         $dummy_user = TestUtil::createSampleUser('Test', 'User', '/Some/string');
-        
+
         //Make dummy user a GOCDB admin so it can perfirm site moves etc.
         $dummy_user->setAdmin(true);
-        
+
         /*
          * Current code in TestUtil does not set sites up as being owned by an an NGI by default.
          *Add them to NGI
@@ -148,7 +148,7 @@ class SiteMoveTest extends PHPUnit_Extensions_Database_TestCase {
 
         //Add service end point to service 1
         $S1->addServiceDoJoin($SE1);
-            
+
         //Persist initial data
         $this->em->persist($N1);
         $this->em->persist($N2);
@@ -158,10 +158,10 @@ class SiteMoveTest extends PHPUnit_Extensions_Database_TestCase {
         $this->em->persist($SE1);
         $this->em->persist($dummy_user);
         $this->em->flush();
-        
+
         //Use DB connection to check data
         $con = $this->getConnection();
-            
+
             /*
              * Check both that each NGI is present and that the ID matches the doctrine one
              */
@@ -169,12 +169,12 @@ class SiteMoveTest extends PHPUnit_Extensions_Database_TestCase {
             $sql = "SELECT 1 FROM ngis WHERE name = 'NGI1' AND ID = '$N1_ID'";
             $result = $con->createQueryTable('', $sql);
             $this->assertEquals(1, $result->getRowCount());
-            
+
             $N2_ID = $N2->getId();
             $sql = "SELECT 1 FROM ngis WHERE name = 'NGI2' AND ID = '$N2_ID'";
             $result = $con->createQueryTable('', $sql);
             $this->assertEquals(1, $result->getRowCount());
-            
+
             /*
              * Check each site is: present, has the right ID & parent NGI
              */
@@ -182,95 +182,95 @@ class SiteMoveTest extends PHPUnit_Extensions_Database_TestCase {
             $sql = "SELECT 1 FROM sites WHERE shortname = 'Site1' AND ID = '$S1_id' AND NGI_ID = '$N1_ID'";
             $result = $con->createQueryTable('', $sql);
             $this->assertEquals(1, $result->getRowCount());
-            
+
             $S2_id= $S2->getId();
             $sql = "SELECT 1 FROM sites WHERE shortname = 'Site2' AND ID = '$S2_id' AND NGI_ID = '$N2_ID'";
             $result = $con->createQueryTable('', $sql);
             $this->assertEquals(1, $result->getRowCount());
-            
+
             $S3_id= $S3->getId();
             $sql = "SELECT 1 FROM sites WHERE shortname = 'Site3' AND ID = '$S3_id' AND NGI_ID = '$N2_ID'";
             $result = $con->createQueryTable('', $sql);
             $this->assertEquals(1, $result->getRowCount());
-            
-            //Check the SEP has correct id and Site 
+
+            //Check the SEP has correct id and Site
             $sql = "SELECT 1 FROM services WHERE hostname = 'SEP1' AND parentsite_id = '$S1_id'";
             $result = $con->createQueryTable('', $sql);
             $this->assertEquals(1, $result->getRowCount());
-        
+
         //Move sites
         $serv =  new org\gocdb\services\Site();
         $serv->setEntityManager($this->em);
         $serv->moveSite($S1,$N2, $dummy_user);
         $serv->moveSite($S2,$N1, $dummy_user);
         $serv->moveSite($S3,$N2, $dummy_user); //No change
-        
-        
+
+
         //flush movement
         $this->em->flush();
-        
+
         //Use doctrine to check movement
             //Check correct NGI for each site
             $this->assertEquals($N2, $S1->getNgi());
             $this->assertEquals($N1, $S2->getNgi());
             $this->assertEquals($N2, $S3->getNgi());
-            
+
             //Check correct sites for each NGI
                 //NGI1
                 $ngisites = $N1->getSites();
                 foreach ($ngisites as $site){
-                    $this->assertEquals($S2, $site); 
+                    $this->assertEquals($S2, $site);
                 }
                 //NGI2
                 $ngisites = $N2->getSites();
                 foreach ($ngisites as $site){
                     $this->assertTrue(($site==$S1) or ($site==$S3));
                 }
-            
+
             //check Service End Point
             $this->assertEquals($S1,$SE1->getParentSite());
-            
-    
+
+
         //Use database connection to check movememrnt
             $con = $this->getConnection();
-            
+
             //Check NGIs are still present and their ID is unchanged
             $sql = "SELECT 1 FROM ngis WHERE name = 'NGI1' AND ID = '$N1_ID'";
             $result = $con->createQueryTable('', $sql);
             $this->assertEquals(1, $result->getRowCount());
-            
+
             $sql = "SELECT 1 FROM ngis WHERE name = 'NGI2' AND ID = '$N2_ID'";
             $result = $con->createQueryTable('', $sql);
             $this->assertEquals(1, $result->getRowCount());
-            
-            
+
+
             //Check each NGI has the correct number of sites
                 //NGI1
                 $sql = "SELECT 1 FROM sites WHERE NGI_ID = '$N1_ID'";
                 $result = $con->createQueryTable('', $sql);
-                $this->assertEquals(1, $result->getRowCount());	    	
-                
+                $this->assertEquals(1, $result->getRowCount());
+
                 //NGI2
                 $sql = "SELECT 1 FROM sites WHERE NGI_ID = '$N2_ID'";
                 $result = $con->createQueryTable('', $sql);
-                $this->assertEquals(2, $result->getRowCount());	 
-                
+                $this->assertEquals(2, $result->getRowCount());
+
             //check Site IDs are unchanged and they are assigned to the correct NGI
                 //Site 1
                 $sql = "SELECT 1 FROM sites WHERE shortname = 'Site1' AND ID = '$S1_id' AND NGI_ID = '$N2_ID'";
                 $result = $con->createQueryTable('', $sql);
                 $this->assertEquals(1, $result->getRowCount());
-                
+
                 //Site 2
                 $sql = "SELECT 1 FROM sites WHERE shortname = 'Site2' AND ID = '$S2_id' AND NGI_ID = '$N1_ID'";
                 $result = $con->createQueryTable('', $sql);
                 $this->assertEquals(1, $result->getRowCount());
-                
+
                 //Site 3
                 $sql = "SELECT 1 FROM sites WHERE shortname = 'Site3' AND ID = '$S3_id' AND NGI_ID = '$N2_ID'";
                 $result = $con->createQueryTable('', $sql);
-                $this->assertEquals(1, $result->getRowCount());				
-    
+                $this->assertEquals(1, $result->getRowCount());
+
     }//close function
 }//close class
 

--- a/tests/doctrine/Site_CertStatusLogCascadeDeletionsTest.php
+++ b/tests/doctrine/Site_CertStatusLogCascadeDeletionsTest.php
@@ -12,13 +12,13 @@ use Doctrine\ORM\EntityManager;
 require_once dirname(__FILE__) . '/bootstrap.php';
 
 /**
- * Test the CertStatusLog cascade delete functionality.    
- * 
+ * Test the CertStatusLog cascade delete functionality.
+ *
  * This test case truncates the test database (a clean insert with no seed data)
- * and performs subsequent CRUD operations using Doctrine ORM. 
- * Usage: 
+ * and performs subsequent CRUD operations using Doctrine ORM.
+ * Usage:
  * Run the recreate.sh to create the sample database first (create tables etc), then run:
- * '$phpunit TestSite_CertStatusLogCascadeDeletions.php' 
+ * '$phpunit TestSite_CertStatusLogCascadeDeletions.php'
  *
  * @author David Meredith
  */
@@ -26,12 +26,12 @@ class Site_CertStatusLogCascadeDeletionsTest extends PHPUnit_Extensions_Database
 
     private $em;
 
-    //private $egiScope; 
-    //private $localScope; 
-    //private $eudatScope; 
+    //private $egiScope;
+    //private $localScope;
+    //private $eudatScope;
 
     /**
-     * Overridden. 
+     * Overridden.
      */
     public static function setUpBeforeClass() {
         parent::setUpBeforeClass();
@@ -49,8 +49,8 @@ class Site_CertStatusLogCascadeDeletionsTest extends PHPUnit_Extensions_Database
     }
 
     /**
-     * Overridden. Returns the test dataset.  
-     * Defines how the initial state of the database should look before each test is executed. 
+     * Overridden. Returns the test dataset.
+     * Defines how the initial state of the database should look before each test is executed.
      * @return PHPUnit_Extensions_Database_DataSet_IDataSet
      */
     protected function getDataSet() {
@@ -60,7 +60,7 @@ class Site_CertStatusLogCascadeDeletionsTest extends PHPUnit_Extensions_Database
     }
 
     /**
-     * Overridden. 
+     * Overridden.
      */
     protected function getSetUpOperation() {
         // CLEAN_INSERT is default
@@ -68,14 +68,14 @@ class Site_CertStatusLogCascadeDeletionsTest extends PHPUnit_Extensions_Database
         //return PHPUnit_Extensions_Database_Operation_Factory::UPDATE();
         //return PHPUnit_Extensions_Database_Operation_Factory::NONE();
         //
-        // Issue a DELETE from <table> which is more portable than a 
-        // TRUNCATE table <table> (some DBs require high privileges for truncate statements 
+        // Issue a DELETE from <table> which is more portable than a
+        // TRUNCATE table <table> (some DBs require high privileges for truncate statements
         // and also do not allow truncates across tables with FK contstraints e.g. Oracle)
         return PHPUnit_Extensions_Database_Operation_Factory::DELETE_ALL();
     }
 
     /**
-     * Overridden. 
+     * Overridden.
      */
     protected function getTearDownOperation() {
         // NONE is default
@@ -92,7 +92,7 @@ class Site_CertStatusLogCascadeDeletionsTest extends PHPUnit_Extensions_Database
     }
 
     /**
-     * @todo Still need to setup connection to different databases. 
+     * @todo Still need to setup connection to different databases.
      * @return EntityManager
      */
     private function createEntityManager() {
@@ -114,7 +114,7 @@ class Site_CertStatusLogCascadeDeletionsTest extends PHPUnit_Extensions_Database
             //print $tableName->getName() . "\n";
             $sql = "SELECT * FROM " . $tableName->getName();
             $result = $con->createQueryTable('results_table', $sql);
-            //echo 'row count: '.$result->getRowCount() ; 
+            //echo 'row count: '.$result->getRowCount() ;
             if ($result->getRowCount() != 0)
                 throw new RuntimeException("Invalid fixture. Table has rows: " . $tableName->getName());
         }
@@ -132,7 +132,7 @@ class Site_CertStatusLogCascadeDeletionsTest extends PHPUnit_Extensions_Database
 
         $this->em->flush();
 
-        // Need to clear the identity map (all objects become detached) so that 
+        // Need to clear the identity map (all objects become detached) so that
         // when we re-fetch the user, it will be looked from db not served by entity map
         $this->em->clear();
 
@@ -143,7 +143,7 @@ class Site_CertStatusLogCascadeDeletionsTest extends PHPUnit_Extensions_Database
 
     }
 
-    
+
 }
 
 ?>

--- a/tests/doctrine/TestUtil.php
+++ b/tests/doctrine/TestUtil.php
@@ -1,51 +1,51 @@
 <?php
 
 require_once dirname(__FILE__) . "/bootstrap.php";
-require_once dirname(__FILE__). '/../../lib/Gocdb_Services/Role.php'; 
+require_once dirname(__FILE__). '/../../lib/Gocdb_Services/Role.php';
 
 /**
- *  A collection of helper functions to create common GocDB objects. 
+ *  A collection of helper functions to create common GocDB objects.
  *
- * @author David Meredith 
+ * @author David Meredith
  * @author James McCarthy
  */
 class TestUtil {
 
     public static function createRoleActionRecord(){
-         /*$rar = new RoleActionRecord($updatedByUserId, $updatedByUserPrinciple, 
-                $roleId, $rolePreStatus, $roleNewStatus, $roleTypeId, 
-                $roleTypeName, $roleTargetOwnedEntityId, $roleTargetOwnedEntityType, 
+         /*$rar = new RoleActionRecord($updatedByUserId, $updatedByUserPrinciple,
+                $roleId, $rolePreStatus, $roleNewStatus, $roleTypeId,
+                $roleTypeName, $roleTargetOwnedEntityId, $roleTargetOwnedEntityType,
                 $roleUserId, $roleUserPrinciple); */
-        $rar = new RoleActionRecord(1, '/some/DN/updatedBy', 
-        2, 'STATUS_PENDING', 'STATUS_GRANTED', 3, 
-        'Site Administrator', 4, 'Site', 
-        5, '/some/DN/roleOwner'); 
-        return $rar; 
+        $rar = new RoleActionRecord(1, '/some/DN/updatedBy',
+        2, 'STATUS_PENDING', 'STATUS_GRANTED', 3,
+        'Site Administrator', 4, 'Site',
+        5, '/some/DN/roleOwner');
+        return $rar;
     }
-    
+
     public static function createSampleDowntime($severity = 'OUTAGE', $classification = 'SCHEDULED'){
-        $downtime = new Downtime(); 
-        $downtime->setDescription("A sample skeleton downtime"); 
-        $downtime->setSeverity($severity); 
-        $downtime->setClassification($classification); 
-        return $downtime; 
+        $downtime = new Downtime();
+        $downtime->setDescription("A sample skeleton downtime");
+        $downtime->setSeverity($severity);
+        $downtime->setClassification($classification);
+        return $downtime;
     }
-    
+
     public static function createSampleEndpointLocation(){
-        $el = new EndpointLocation(); 
-        $el->setUrl("https://google.co.uk"); 
-        return $el; 
+        $el = new EndpointLocation();
+        $el->setUrl("https://google.co.uk");
+        return $el;
     }
-    
+
    public static function createSampleService($label){
-        $se = new Service(); 
-        $se->setHostName(''.$label); 
-        $se->setBeta(false); 
-        $se->setProduction(true); 
+        $se = new Service();
+        $se->setHostName(''.$label);
+        $se->setBeta(false);
+        $se->setProduction(true);
         $se->setMonitored(true);
-        return $se; 
+        return $se;
     }
-    
+
     public static function createSampleRoleType($name) {
         $rt = new RoleType($name);
         return $rt;
@@ -56,7 +56,7 @@ class TestUtil {
         $u->setForename($forename);
         $u->setSurname($surname);
         $u->setCertificateDn($dn);
-        $u->setAdmin(FALSE); 
+        $u->setAdmin(FALSE);
         return $u;
     }
 
@@ -72,18 +72,18 @@ class TestUtil {
     }
 
     public static function createSampleRole(\User $user, \RoleType $roleType, \OwnedEntity $ownedEntity, $roleStatus) {
-        $r = new Role($roleType, $user, $ownedEntity, $roleStatus); 
+        $r = new Role($roleType, $user, $ownedEntity, $roleStatus);
         return $r;
     }
 
     public static function createSampleSite($label) {
         $site = new Site();
-        $v4PK = new PrimaryKey(); 
-        $site->setPrimaryKey($v4PK->getId());  
+        $v4PK = new PrimaryKey();
+        $site->setPrimaryKey($v4PK->getId());
         $site->setShortName($label);
         return $site;
     }
-    
+
     public static function createSampleServiceGroup($label){
         $sg = new ServiceGroup();
         $sg->setName($label);
@@ -91,7 +91,7 @@ class TestUtil {
         $sg->setEmail($label."@email.com");
         return $sg;
     }
-            
+
     public static function createSampleSiteProperty($key, $val){
         $prop = new SiteProperty();
         $prop->setKeyName($key);
@@ -112,25 +112,25 @@ class TestUtil {
         $prop->setKeyValue($key);
         return $prop;
     }
-    
+
     public static function createSampleServiceGroupProperty($name, $key){
         $prop = new ServiceGroupProperty();
         $prop->setKeyName($name);
         $prop->setKeyValue($key);
         return $prop;
-    }	
-    
+    }
+
     public static function createSampleCertStatusLog($addedBy = '/some/user'){
-        $certStatusLog = new CertificationStatusLog(); 
-        $certStatusLog->setAddedBy($addedBy); 
-        return $certStatusLog; 
+        $certStatusLog = new CertificationStatusLog();
+        $certStatusLog->setAddedBy($addedBy);
+        return $certStatusLog;
     }
 
     public static function createSampleScope($description, $name){
-        $scope = new Scope(); 
+        $scope = new Scope();
         $scope->setDescription($description);
-        $scope->setName($name);         
-        return $scope; 
+        $scope->setName($name);
+        return $scope;
     }
 
 }

--- a/tests/doctrine/bootstrap.php
+++ b/tests/doctrine/bootstrap.php
@@ -1,6 +1,6 @@
 <?php
 // bootstrap_test.php
-$entitiesPath = dirname(__FILE__)."/../../lib/Doctrine/entities"; 
+$entitiesPath = dirname(__FILE__)."/../../lib/Doctrine/entities";
 
 require_once $entitiesPath."/OwnedEntity.php";
 require_once $entitiesPath."/Site.php";
@@ -31,8 +31,8 @@ require_once $entitiesPath."/ArchivedNGI.php";
 require_once $entitiesPath."/ArchivedService.php";
 require_once $entitiesPath."/ArchivedServiceGroup.php";
 require_once $entitiesPath."/ArchivedSite.php";
-require_once $entitiesPath."/EndpointProperty.php"; 
-require_once $entitiesPath."/RoleActionRecord.php"; 
+require_once $entitiesPath."/EndpointProperty.php";
+require_once $entitiesPath."/RoleActionRecord.php";
 
 //if (!class_exists("Doctrine\Common\Version", false)) {
 //    require_once dirname(__FILE__)."/bootstrap_doctrine.php";

--- a/tests/doctrine/bootstrap_doctrine_TEMPLATE.php
+++ b/tests/doctrine/bootstrap_doctrine_TEMPLATE.php
@@ -41,7 +41,7 @@ $config = Setup::createAnnotationMetadataConfiguration(array(__DIR__."/../../lib
     // );
     /////////////////////////////////////////////////////////////////////////////////////////////
 
-     
+
     ///////////////////////ORACLE CONNECTION DETAILS////////////////////////////////////////////
     //	$conn = array(
     //		'driver' => 'oci8',
@@ -53,10 +53,10 @@ $config = Setup::createAnnotationMetadataConfiguration(array(__DIR__."/../../lib
     //	);
     //  // Need to explicitly set the Oracle session date format [1]
     //  $evm = new EventManager();
-    //  $evm->addEventSubscriber(new OracleSessionInit(array('NLS_TIME_FORMAT' => 'HH24:MI:SS')));	
+    //  $evm->addEventSubscriber(new OracleSessionInit(array('NLS_TIME_FORMAT' => 'HH24:MI:SS')));
     /////////////////////////////////////////////////////////////////////////////////////////////
 
-    
+
     ///////////////////////MYSQL CONNECTION DETAILS////////////////////////////////////////////
     //$conn = array(
     //	'driver' => 'pdo_mysql',
@@ -67,7 +67,7 @@ $config = Setup::createAnnotationMetadataConfiguration(array(__DIR__."/../../lib
     //  'charset' => 'AL32UTF8'
     //);
     /////////////////////////////////////////////////////////////////////////////////////////////
-    
+
 
 
 

--- a/tests/doctrine/bootstrap_pdo_TEMPLATE.php
+++ b/tests/doctrine/bootstrap_pdo_TEMPLATE.php
@@ -15,21 +15,21 @@
  * @return PHPUnit_Extensions_Database_DB_IDatabaseConnection
  */
 function getConnectionToTestDB() {
-     
+
      /*** Uncomment and fill in the connection details for your chosen database ***/
-     
-     
+
+
      ///////////////////////SQLITE CONNECTION DETAILS/////////////////////////////////////////////
      // $sqliteFile = __DIR__ . '/../db.sqlite';
      // $pdo = new PDO("sqlite:" . $sqliteFile);
      // return new PHPUnit_Extensions_Database_DB_DefaultDatabaseConnection($pdo, 'sqlite');
      /////////////////////////////////////////////////////////////////////////////////////////////
-         
+
      ///////////////////////ORACLE CONNECTION DETAILS/////////////////////////////////////////////
-     // $pdo = new PDO('oci:dbname=//localhost:1521/xe', '<USER>', '<PASSWORD>');      
+     // $pdo = new PDO('oci:dbname=//localhost:1521/xe', '<USER>', '<PASSWORD>');
      // return new PHPUnit_Extensions_Database_DB_DefaultDatabaseConnection($pdo, 'USERS');
      /////////////////////////////////////////////////////////////////////////////////////////////
-        
+
      ///////////////////////MYSQL CONNECTION DETAILS//////////////////////////////////////////////
      //  $pdo = new PDO('mysql:host=localhost;dbname=doctrine;charset=UTF8', 'doctrine', 'doc');
      //  return new PHPUnit_Extensions_Database_DB_DefaultDatabaseConnection($pdo);

--- a/tests/doctrine/cli-config.php
+++ b/tests/doctrine/cli-config.php
@@ -8,7 +8,7 @@ require_once dirname(__FILE__)."/bootstrap.php";
 return ConsoleRunner::createHelperSet($entityManager);
 
 
-// Doctrine 2.3 and below: 
+// Doctrine 2.3 and below:
 /*
 require_once dirname(__FILE__)."/bootstrap.php";
 
@@ -16,6 +16,6 @@ $helperSet = new \Symfony\Component\Console\Helper\HelperSet(array(
     'db' => new \Doctrine\DBAL\Tools\Console\Helper\ConnectionHelper($entityManager->getConnection()),
     'em' => new \Doctrine\ORM\Tools\Console\Helper\EntityManagerHelper($entityManager)
 ));
-return $helperSet; 
+return $helperSet;
 */
 

--- a/tests/doctrine/resources/sampleFixtureData1.php
+++ b/tests/doctrine/resources/sampleFixtureData1.php
@@ -1,16 +1,16 @@
 <?php
- 
+
 /*
- * Include this file in your tests in order to persist a set of known fixuture data 
+ * Include this file in your tests in order to persist a set of known fixuture data
  * for subsequent use in testing.
- *  
- * The Fixture data consists of NGI, Sites, Services, User and Roles etc. 
- * If you update this fixture data, make sure you update the tests that 
- * include this file as the tests assume a known fixture data structure. 
- * 
- * See the corresponding fixtureDataERD.svg file for an ERD of this fixture data 
- * 
- * @author David Meredith 
+ *
+ * The Fixture data consists of NGI, Sites, Services, User and Roles etc.
+ * If you update this fixture data, make sure you update the tests that
+ * include this file as the tests assume a known fixture data structure.
+ *
+ * See the corresponding fixtureDataERD.svg file for an ERD of this fixture data
+ *
+ * @author David Meredith
  */
 
         $roleType1 = TestUtil::createSampleRoleType("NAME");
@@ -21,48 +21,48 @@
         // Create a user
         $userWithRoles = TestUtil::createSampleUser("Test", "Testing", "/c=test");
         $this->em->persist($userWithRoles);
-        $userId = $userWithRoles->getId(); 
+        $userId = $userWithRoles->getId();
 
         // Create an NGI, site and services
         $ngi = TestUtil::createSampleNGI("MYNGI");
-        $site1 = TestUtil::createSampleSite('site1'); 
-        $site2 = TestUtil::createSampleSite('site2'); 
-        $service1 = TestUtil::createSampleService('site1_service1'); 
-        $service2 = TestUtil::createSampleService('site1_service2'); 
-        
-        $endpoint1 = TestUtil::createSampleEndpointLocation(); 
-        $downtime1 = TestUtil::createSampleDowntime(); 
-        $downtime2 = TestUtil::createSampleDowntime(); 
-        $service1->addEndpointLocationDoJoin($endpoint1); 
-        $downtime1->addEndpointLocation($endpoint1); 
-        $downtime2->addEndpointLocation($endpoint1); 
-        
-        $site1->addServiceDoJoin($service1); 
-        $site1->addServiceDoJoin($service2); 
-        
-        $ngi->addSiteDoJoin($site1); 
-        $ngi->addSiteDoJoin($site2); 
+        $site1 = TestUtil::createSampleSite('site1');
+        $site2 = TestUtil::createSampleSite('site2');
+        $service1 = TestUtil::createSampleService('site1_service1');
+        $service2 = TestUtil::createSampleService('site1_service2');
+
+        $endpoint1 = TestUtil::createSampleEndpointLocation();
+        $downtime1 = TestUtil::createSampleDowntime();
+        $downtime2 = TestUtil::createSampleDowntime();
+        $service1->addEndpointLocationDoJoin($endpoint1);
+        $downtime1->addEndpointLocation($endpoint1);
+        $downtime2->addEndpointLocation($endpoint1);
+
+        $site1->addServiceDoJoin($service1);
+        $site1->addServiceDoJoin($service2);
+
+        $ngi->addSiteDoJoin($site1);
+        $ngi->addSiteDoJoin($site2);
 
 
-        $certStatusLog1 = TestUtil::createSampleCertStatusLog(); 
-        $certStatusLog2 = TestUtil::createSampleCertStatusLog(); 
-        $site2->addCertificationStatusLog($certStatusLog1); 
-        $site2->addCertificationStatusLog($certStatusLog2); 
-        
+        $certStatusLog1 = TestUtil::createSampleCertStatusLog();
+        $certStatusLog2 = TestUtil::createSampleCertStatusLog();
+        $site2->addCertificationStatusLog($certStatusLog1);
+        $site2->addCertificationStatusLog($certStatusLog2);
+
 
         $this->em->persist($ngi);
         $this->em->persist($site1);
         $this->em->persist($site2);
         $this->em->persist($service1);
         $this->em->persist($service2);
-        $this->em->persist($certStatusLog1); 
-        $this->em->persist($certStatusLog2); 
-        $this->em->persist($endpoint1);  
-        $this->em->persist($downtime1);  
-        $this->em->persist($downtime2);  
+        $this->em->persist($certStatusLog1);
+        $this->em->persist($certStatusLog2);
+        $this->em->persist($endpoint1);
+        $this->em->persist($downtime1);
+        $this->em->persist($downtime2);
 
-        // Create some roles and link to the user, role type and ngi 
-        // roles on ngi 
+        // Create some roles and link to the user, role type and ngi
+        // roles on ngi
         $ngiRole1 = TestUtil::createSampleRole($userWithRoles, $roleType1, $ngi, RoleStatus::GRANTED);
         $ngiRole2 = TestUtil::createSampleRole($userWithRoles, $roleType2, $ngi, RoleStatus::GRANTED);
         // roles on site1
@@ -71,7 +71,7 @@
         // roles on site2
         $site2Role1= TestUtil::createSampleRole($userWithRoles, $roleType1, $site2, RoleStatus::GRANTED);
         $site2Role2= TestUtil::createSampleRole($userWithRoles, $roleType2, $site2, RoleStatus::GRANTED);
-        
+
         $this->em->persist($ngiRole1);
         $this->em->persist($ngiRole2);
         $this->em->persist($site1Role1);
@@ -82,18 +82,18 @@
 
 
 
-        // Assert fixture data is setup correctly in the DB.  
+        // Assert fixture data is setup correctly in the DB.
         $testConn = $this->getConnection();
 
         $result = $testConn->createQueryTable('results_table', "SELECT * FROM Users");
         $this->assertTrue($result->getRowCount() == 1);
-        
+
         $result = $testConn->createQueryTable('results_table', "SELECT * FROM Roles");
         $this->assertTrue($result->getRowCount() == 6);
-        
+
         $result = $testConn->createQueryTable('results_table', "SELECT * FROM NGIs");
         $this->assertTrue($result->getRowCount() == 1);
-        
+
         $result = $testConn->createQueryTable('results_table', "SELECT * FROM Sites");
         $this->assertTrue($result->getRowCount() == 2);
 
@@ -105,7 +105,7 @@
 
         $result = $testConn->createQueryTable('results_table', "SELECT * FROM EndpointLocations");
         $this->assertTrue($result->getRowCount() == 1);
-        
+
         $result = $testConn->createQueryTable('results_table', "SELECT * FROM CertificationStatusLogs");
         $this->assertTrue($result->getRowCount() == 2);
 ?>

--- a/tests/doctrine/resources/sampleFixtureData2.php
+++ b/tests/doctrine/resources/sampleFixtureData2.php
@@ -1,42 +1,42 @@
 <?php
 /*
- * Include this file in your tests in order to persist a set of known fixuture data 
+ * Include this file in your tests in order to persist a set of known fixuture data
  * for subsequent use in testing.
- *  
- * @author David Meredith 
+ *
+ * @author David Meredith
  */
 
 /*
- * Entity graph is as follows (<IScopedEntity> can be subsituted for NGI, Site, Service, ServiceGroup): 
- * 
- * <IScopedEntity0> 
+ * Entity graph is as follows (<IScopedEntity> can be subsituted for NGI, Site, Service, ServiceGroup):
+ *
+ * <IScopedEntity0>
  *  -
- *  
- * <IScopedEntity1>  
+ *
+ * <IScopedEntity1>
  *  - Scope0
- * 
- * <IScopedEntity2> 
- *  - Scope0
- *  - Scope1
- * 
- * <IScopedEntity3> 
+ *
+ * <IScopedEntity2>
  *  - Scope0
  *  - Scope1
- *  - Scope2 
- *  
- * <IScopedEntity4> 
+ *
+ * <IScopedEntity3>
  *  - Scope0
  *  - Scope1
- *  - Scope2 
- *  - Scope3 
- *  - Scope4 
- *  - Scope5 
+ *  - Scope2
+ *
+ * <IScopedEntity4>
+ *  - Scope0
+ *  - Scope1
+ *  - Scope2
+ *  - Scope3
+ *  - Scope4
+ *  - Scope5
  */
-        $scopeCount = 6; 
-        $scopes = array(); 
+        $scopeCount = 6;
+        $scopes = array();
         // create scopes and persist
         for($i=0; $i<$scopeCount; $i++){
-            $scopes[] = TestUtil::createSampleScope("Proj scope ".$i, "Scope".$i); 
+            $scopes[] = TestUtil::createSampleScope("Proj scope ".$i, "Scope".$i);
             $this->em->persist($scopes[$i]);
         }
 
@@ -52,100 +52,100 @@
         $this->em->persist($ngi2);
         $this->em->persist($ngi3);
         $this->em->persist($ngi4);
-        // Add different scopes to selected ngis:  
+        // Add different scopes to selected ngis:
         // ngi0 has no scope
         // ngi1 has one scope
-        $ngi1->addScope($scopes[0]); 
-        // ngi2 has 2 scopes 
-        $ngi2->addScope($scopes[0]); 
-        $ngi2->addScope($scopes[1]); 
-        // ngi3 has 3 scopes 
-        $ngi3->addScope($scopes[0]); 
-        $ngi3->addScope($scopes[1]); 
-        $ngi3->addScope($scopes[2]); 
+        $ngi1->addScope($scopes[0]);
+        // ngi2 has 2 scopes
+        $ngi2->addScope($scopes[0]);
+        $ngi2->addScope($scopes[1]);
+        // ngi3 has 3 scopes
+        $ngi3->addScope($scopes[0]);
+        $ngi3->addScope($scopes[1]);
+        $ngi3->addScope($scopes[2]);
         //  ngi4 has all scopes
         for($i=0; $i<$scopeCount; $i++){
-            $ngi4->addScope($scopes[$i]); 
+            $ngi4->addScope($scopes[$i]);
         }
         // NGIs ****************************
 
 
         // At least one certStatus is needed for the tests
-        $certStatus = new CertificationStatus(); 
-        $certStatus->setName('Certified');  
-        $this->em->persist($certStatus); 
-       
-        // Sites: all have same 'Certified' cert status 
+        $certStatus = new CertificationStatus();
+        $certStatus->setName('Certified');
+        $this->em->persist($certStatus);
+
+        // Sites: all have same 'Certified' cert status
         // ****************************
         $site0 = TestUtil::createSampleSite("Site0");
-        $site0->setCertificationStatus($certStatus); 
+        $site0->setCertificationStatus($certStatus);
         $site1 = TestUtil::createSampleSite("Site1");
-        $site1->setCertificationStatus($certStatus); 
+        $site1->setCertificationStatus($certStatus);
         $site2 = TestUtil::createSampleSite("Site2");
-        $site2->setCertificationStatus($certStatus); 
+        $site2->setCertificationStatus($certStatus);
         $site3 = TestUtil::createSampleSite("Site3");
-        $site3->setCertificationStatus($certStatus); 
+        $site3->setCertificationStatus($certStatus);
         $site4 = TestUtil::createSampleSite("Site4");
-        $site4->setCertificationStatus($certStatus); 
-        
-                
+        $site4->setCertificationStatus($certStatus);
+
+
         $this->em->persist($site0);
         $this->em->persist($site1);
         $this->em->persist($site2);
         $this->em->persist($site3);
         $this->em->persist($site4);
-        // Add different scopes to selected sites:  
+        // Add different scopes to selected sites:
         // site0 has no scope
-        // site1 has one scope 
-        $site1->addScope($scopes[0]); 
+        // site1 has one scope
+        $site1->addScope($scopes[0]);
         // site2 has two scopes
-        $site2->addScope($scopes[0]); 
-        $site2->addScope($scopes[1]); 
+        $site2->addScope($scopes[0]);
+        $site2->addScope($scopes[1]);
         // site3 has three scopes
-        $site3->addScope($scopes[0]); 
-        $site3->addScope($scopes[1]); 
-        $site3->addScope($scopes[2]); 
+        $site3->addScope($scopes[0]);
+        $site3->addScope($scopes[1]);
+        $site3->addScope($scopes[2]);
         //  site4 has all scopes
         for($i=0; $i<$scopeCount; $i++){
-            $site4->addScope($scopes[$i]); 
+            $site4->addScope($scopes[$i]);
         }
         // Sites ****************************
-       
 
-        // Services: all services are added to $site0 
+
+        // Services: all services are added to $site0
         // ****************************
         $service0 = TestUtil::createSampleService("Service0");
-        $site0->addServiceDoJoin($service0); 
+        $site0->addServiceDoJoin($service0);
         $service1 = TestUtil::createSampleService("Service1");
-        $site0->addServiceDoJoin($service1); 
+        $site0->addServiceDoJoin($service1);
         $service2 = TestUtil::createSampleService("Service2");
-        $site0->addServiceDoJoin($service2); 
+        $site0->addServiceDoJoin($service2);
         $service3 = TestUtil::createSampleService("Service3");
-        $site0->addServiceDoJoin($service3); 
+        $site0->addServiceDoJoin($service3);
         $service4 = TestUtil::createSampleService("Service4");
-        $site0->addServiceDoJoin($service4); 
+        $site0->addServiceDoJoin($service4);
         $this->em->persist($service0);
         $this->em->persist($service1);
         $this->em->persist($service2);
         $this->em->persist($service3);
         $this->em->persist($service4);
-        // Add different scopes to selected services:  
+        // Add different scopes to selected services:
         // service0 has no scope
-        // service1 has one scope 
-        $service0->addScope($scopes[0]); 
+        // service1 has one scope
+        $service0->addScope($scopes[0]);
         // service2 has two scopes
-        $service2->addScope($scopes[0]); 
-        $service2->addScope($scopes[1]); 
+        $service2->addScope($scopes[0]);
+        $service2->addScope($scopes[1]);
         // service3 has three scopes
-        $service3->addScope($scopes[0]); 
-        $service3->addScope($scopes[1]); 
-        $service3->addScope($scopes[2]); 
+        $service3->addScope($scopes[0]);
+        $service3->addScope($scopes[1]);
+        $service3->addScope($scopes[2]);
         //  service4 has all scopes
         for($i=0; $i<$scopeCount; $i++){
-            $service4->addScope($scopes[$i]); 
+            $service4->addScope($scopes[$i]);
         }
         // Services ****************************
-        
+
 
         // ServiceGroups ****************************
         $sg0 = TestUtil::createSampleServiceGroup("SG0");
@@ -158,38 +158,38 @@
         $this->em->persist($sg2);
         $this->em->persist($sg3);
         $this->em->persist($sg4);
-        // Add different scopes to selected sgs:  
+        // Add different scopes to selected sgs:
         // sg0 has no scope
-        // sg1 has one scope 
-        $sg1->addScope($scopes[0]); 
+        // sg1 has one scope
+        $sg1->addScope($scopes[0]);
         // sg2 has two scopes
-        $sg2->addScope($scopes[0]); 
-        $sg2->addScope($scopes[1]);  
+        $sg2->addScope($scopes[0]);
+        $sg2->addScope($scopes[1]);
         // sg3 has three scopes
-        $sg3->addScope($scopes[0]); 
-        $sg3->addScope($scopes[1]); 
+        $sg3->addScope($scopes[0]);
+        $sg3->addScope($scopes[1]);
         $sg3->addScope($scopes[2]);
         //  sg4 has all scopes
         for($i=0; $i<$scopeCount; $i++){
-            $sg4->addScope($scopes[$i]); 
+            $sg4->addScope($scopes[$i]);
         }
         // ServiceGroups ****************************
-        
-        // commit 
+
+        // commit
         $this->em->flush();
 
-        // Assert fixture data is setup correctly in the DB.  
+        // Assert fixture data is setup correctly in the DB.
         $testConn = $this->getConnection();
 
         $result = $testConn->createQueryTable('results_table', "SELECT * FROM Scopes");
         $this->assertTrue($result->getRowCount() == $scopeCount);
-        
+
         $result = $testConn->createQueryTable('results_table', "SELECT * FROM Ngis");
         $this->assertTrue($result->getRowCount() == 5);
 
         $result = $testConn->createQueryTable('results_table', "SELECT * FROM Sites");
         $this->assertTrue($result->getRowCount() == 5);
-        
+
         $result = $testConn->createQueryTable('results_table', "SELECT * FROM Services");
         $this->assertTrue($result->getRowCount() == 5);
 

--- a/tests/doctrine/resources/sampleFixtureData3.php
+++ b/tests/doctrine/resources/sampleFixtureData3.php
@@ -1,15 +1,15 @@
 <?php
 /*
- * Include this file in your tests in order to persist a set of known fixuture data 
+ * Include this file in your tests in order to persist a set of known fixuture data
  * for subsequent use in testing.
- *  
- * @author David Meredith 
+ *
+ * @author David Meredith
  */
 
 /*
 
  */
-    
+
 
         // Sites ****************************
         $site0 = TestUtil::createSampleSite("Site0");
@@ -24,12 +24,12 @@
         $this->em->persist($site4);
         // Sites ****************************
 
-       
-        
+
+
 
         // site1 has 1 prop
         $s1p1 = TestUtil::createSampleSiteProperty("s1p1", "v1");
-        $site1->addSitePropertyDoJoin($s1p1); 
+        $site1->addSitePropertyDoJoin($s1p1);
         $this->em->persist($s1p1);
 
         // site2 has 2 props
@@ -37,10 +37,10 @@
         $s2p2 = TestUtil::createSampleSiteProperty("s2p2", "v2");
         $this->em->persist($s2p1);
         $this->em->persist($s2p2);
-        $site2->addSitePropertyDoJoin($s2p1); 
-        $site2->addSitePropertyDoJoin($s2p2); 
+        $site2->addSitePropertyDoJoin($s2p1);
+        $site2->addSitePropertyDoJoin($s2p2);
 
-        // site3  
+        // site3
         $s3p1 = TestUtil::createSampleSiteProperty("s3p1", "v1");
         $s3p2 = TestUtil::createSampleSiteProperty("s3p2", "v2");
         $s3p3 = TestUtil::createSampleSiteProperty("VO", "foo");
@@ -49,12 +49,12 @@
         $this->em->persist($s3p2);
         $this->em->persist($s3p3);
         $this->em->persist($s3p4);
-        $site3->addSitePropertyDoJoin($s3p1); 
-        $site3->addSitePropertyDoJoin($s3p2); 
-        $site3->addSitePropertyDoJoin($s3p3); 
-        $site3->addSitePropertyDoJoin($s3p4); 
-       
-        // site4  
+        $site3->addSitePropertyDoJoin($s3p1);
+        $site3->addSitePropertyDoJoin($s3p2);
+        $site3->addSitePropertyDoJoin($s3p3);
+        $site3->addSitePropertyDoJoin($s3p4);
+
+        // site4
         $s4p1 = TestUtil::createSampleSiteProperty("s4p1", "v1");
         $s4p2 = TestUtil::createSampleSiteProperty("s4p2", "v2");
         $s4p3 = TestUtil::createSampleSiteProperty("VO", "foo");
@@ -67,18 +67,18 @@
         $this->em->persist($s4p4);
         $this->em->persist($s4p5);
         $this->em->persist($s4p6);
-        $site4->addSitePropertyDoJoin($s4p1); 
-        $site4->addSitePropertyDoJoin($s4p2); 
-        $site4->addSitePropertyDoJoin($s4p3); 
-        $site4->addSitePropertyDoJoin($s4p4); 
-        $site4->addSitePropertyDoJoin($s4p5); 
-        $site4->addSitePropertyDoJoin($s4p6); 
-        
-        
-        // commit 
+        $site4->addSitePropertyDoJoin($s4p1);
+        $site4->addSitePropertyDoJoin($s4p2);
+        $site4->addSitePropertyDoJoin($s4p3);
+        $site4->addSitePropertyDoJoin($s4p4);
+        $site4->addSitePropertyDoJoin($s4p5);
+        $site4->addSitePropertyDoJoin($s4p6);
+
+
+        // commit
         $this->em->flush();
 
-        // Assert fixture data is setup correctly in the DB.  
+        // Assert fixture data is setup correctly in the DB.
         $testConn = $this->getConnection();
 
 

--- a/tests/doctrine/resources/sampleFixtureData4.php
+++ b/tests/doctrine/resources/sampleFixtureData4.php
@@ -1,16 +1,16 @@
 <?php
- 
+
 /*
- * Include this file in your tests in order to persist a set of known fixuture data 
+ * Include this file in your tests in order to persist a set of known fixuture data
  * for subsequent use in testing.
- *  
- * The Fixture data consists of NGI, Sites, Services, User and Roles etc. 
- * If you update this fixture data, make sure you update the tests that 
- * include this file as the tests assume a known fixture data structure. 
- * 
- * See the corresponding fixtureData4ERD.svg file for an ERD of this fixture data 
- * 
- * @author David Meredith 
+ *
+ * The Fixture data consists of NGI, Sites, Services, User and Roles etc.
+ * If you update this fixture data, make sure you update the tests that
+ * include this file as the tests assume a known fixture data structure.
+ *
+ * See the corresponding fixtureData4ERD.svg file for an ERD of this fixture data
+ *
+ * @author David Meredith
  */
 
         $roleType1 = TestUtil::createSampleRoleType("NAME");
@@ -21,72 +21,72 @@
         // Create a user
         $userWithRoles = TestUtil::createSampleUser("Test", "Testing", "/c=test");
         $this->em->persist($userWithRoles);
-        $userId = $userWithRoles->getId(); 
+        $userId = $userWithRoles->getId();
 
         // Create an NGI, site and services
         $ngi = TestUtil::createSampleNGI("MYNGI");
-        $site1 = TestUtil::createSampleSite('site1'); 
-        $site2 = TestUtil::createSampleSite('site2'); 
+        $site1 = TestUtil::createSampleSite('site1');
+        $site2 = TestUtil::createSampleSite('site2');
 
-        $service1 = TestUtil::createSampleService('site1_service1'); 
-        $endpoint1 = TestUtil::createSampleEndpointLocation(); 
-        $endpoint2 = TestUtil::createSampleEndpointLocation(); 
-        $service1->addEndpointLocationDoJoin($endpoint1); 
-        $service1->addEndpointLocationDoJoin($endpoint2); 
+        $service1 = TestUtil::createSampleService('site1_service1');
+        $endpoint1 = TestUtil::createSampleEndpointLocation();
+        $endpoint2 = TestUtil::createSampleEndpointLocation();
+        $service1->addEndpointLocationDoJoin($endpoint1);
+        $service1->addEndpointLocationDoJoin($endpoint2);
 
 
-        $service2 = TestUtil::createSampleService('site1_service2'); 
-        $endpoint2_1 = TestUtil::createSampleEndpointLocation(); 
-        $endpoint2_2 = TestUtil::createSampleEndpointLocation(); 
-        $service2->addEndpointLocationDoJoin($endpoint2_1); 
-        $service2->addEndpointLocationDoJoin($endpoint2_2); 
-        
+        $service2 = TestUtil::createSampleService('site1_service2');
+        $endpoint2_1 = TestUtil::createSampleEndpointLocation();
+        $endpoint2_2 = TestUtil::createSampleEndpointLocation();
+        $service2->addEndpointLocationDoJoin($endpoint2_1);
+        $service2->addEndpointLocationDoJoin($endpoint2_2);
 
-        
-        // create downtimes  
-        $downtime1 = TestUtil::createSampleDowntime(); 
-        $downtime2 = TestUtil::createSampleDowntime(); 
-        $downtime3 = TestUtil::createSampleDowntime(); 
-        $downtime4 = TestUtil::createSampleDowntime(); 
-        $downtime5 = TestUtil::createSampleDowntime(); 
-        $downtime6 = TestUtil::createSampleDowntime(); 
-        $downtime7 = TestUtil::createSampleDowntime(); 
-        $downtimeOrphan = TestUtil::createSampleDowntime(); 
-        $downtimeOrphan->setDescription("orphan");  
-      
-        // link downtimes to services and service-endpoints 
-        $downtime1->addEndpointLocation($endpoint1); 
-        $downtime1->addService($service1); 
-        $downtime2->addEndpointLocation($endpoint1); 
-        $downtime2->addService($service1); 
-        $downtime3->addEndpointLocation($endpoint2); 
-        $downtime3->addService($service1); 
-        $downtime4->addEndpointLocation($endpoint2); 
+
+
+        // create downtimes
+        $downtime1 = TestUtil::createSampleDowntime();
+        $downtime2 = TestUtil::createSampleDowntime();
+        $downtime3 = TestUtil::createSampleDowntime();
+        $downtime4 = TestUtil::createSampleDowntime();
+        $downtime5 = TestUtil::createSampleDowntime();
+        $downtime6 = TestUtil::createSampleDowntime();
+        $downtime7 = TestUtil::createSampleDowntime();
+        $downtimeOrphan = TestUtil::createSampleDowntime();
+        $downtimeOrphan->setDescription("orphan");
+
+        // link downtimes to services and service-endpoints
+        $downtime1->addEndpointLocation($endpoint1);
+        $downtime1->addService($service1);
+        $downtime2->addEndpointLocation($endpoint1);
+        $downtime2->addService($service1);
+        $downtime3->addEndpointLocation($endpoint2);
+        $downtime3->addService($service1);
+        $downtime4->addEndpointLocation($endpoint2);
         //$downtime4->addService($service1); // downtime4 is not linked to service !!!
         //$downtime5->addEndpointLocation($endpoint2); // downtime5 is not linked to endpoint
-        $downtime5->addService($service1); 
-        $downtime6->addService($service1); 
-      
+        $downtime5->addService($service1);
+        $downtime6->addService($service1);
 
-        //$downtime4->addEndpointLocation($endpoint2_1); // downtiem4 is not linked to endpoint ! 
+
+        //$downtime4->addEndpointLocation($endpoint2_1); // downtiem4 is not linked to endpoint !
         $downtime4->addService($service2);// downtime4 is directly linked to service2
-        $downtime6->addEndpointLocation($endpoint2_1); //downtime6 is linked to service2 via its endpoint 
-        //$downtime6->addService($service2);  // downtime6 is not linked to endpoint !  
-        $downtime7->addService($service2); 
-        $downtime7->addEndpointLocation($endpoint2_2); 
-
-        
-        
-        $site1->addServiceDoJoin($service1); 
-        $site1->addServiceDoJoin($service2); 
-        $ngi->addSiteDoJoin($site1); 
-        $ngi->addSiteDoJoin($site2); 
+        $downtime6->addEndpointLocation($endpoint2_1); //downtime6 is linked to service2 via its endpoint
+        //$downtime6->addService($service2);  // downtime6 is not linked to endpoint !
+        $downtime7->addService($service2);
+        $downtime7->addEndpointLocation($endpoint2_2);
 
 
-        $certStatusLog1 = TestUtil::createSampleCertStatusLog(); 
-        $certStatusLog2 = TestUtil::createSampleCertStatusLog(); 
-        $site2->addCertificationStatusLog($certStatusLog1); 
-        $site2->addCertificationStatusLog($certStatusLog2); 
+
+        $site1->addServiceDoJoin($service1);
+        $site1->addServiceDoJoin($service2);
+        $ngi->addSiteDoJoin($site1);
+        $ngi->addSiteDoJoin($site2);
+
+
+        $certStatusLog1 = TestUtil::createSampleCertStatusLog();
+        $certStatusLog2 = TestUtil::createSampleCertStatusLog();
+        $site2->addCertificationStatusLog($certStatusLog1);
+        $site2->addCertificationStatusLog($certStatusLog2);
 
         // ngi, site, service
         $this->em->persist($ngi);
@@ -95,26 +95,26 @@
         $this->em->persist($service1);
         $this->em->persist($service2);
         // endpoints
-        $this->em->persist($endpoint1);  
-        $this->em->persist($endpoint2);  
-        $this->em->persist($endpoint2_1);  
-        $this->em->persist($endpoint2_2);  
-        // downtimes 
-        $this->em->persist($downtime1);  
-        $this->em->persist($downtime2);  
-        $this->em->persist($downtime3);  
-        $this->em->persist($downtime4);  
-        $this->em->persist($downtime5);  
-        $this->em->persist($downtime6);  
-        $this->em->persist($downtime7);  
-        $this->em->persist($downtimeOrphan);  
-        // cert status logs 
-        $this->em->persist($certStatusLog1); 
-        $this->em->persist($certStatusLog2); 
+        $this->em->persist($endpoint1);
+        $this->em->persist($endpoint2);
+        $this->em->persist($endpoint2_1);
+        $this->em->persist($endpoint2_2);
+        // downtimes
+        $this->em->persist($downtime1);
+        $this->em->persist($downtime2);
+        $this->em->persist($downtime3);
+        $this->em->persist($downtime4);
+        $this->em->persist($downtime5);
+        $this->em->persist($downtime6);
+        $this->em->persist($downtime7);
+        $this->em->persist($downtimeOrphan);
+        // cert status logs
+        $this->em->persist($certStatusLog1);
+        $this->em->persist($certStatusLog2);
 
-        
-        // Create some roles and link to the user, role type and ngi 
-        // roles on ngi 
+
+        // Create some roles and link to the user, role type and ngi
+        // roles on ngi
         $ngiRole1 = TestUtil::createSampleRole($userWithRoles, $roleType1, $ngi, RoleStatus::GRANTED);
         $ngiRole2 = TestUtil::createSampleRole($userWithRoles, $roleType2, $ngi, RoleStatus::GRANTED);
         // roles on site1
@@ -123,32 +123,32 @@
         // roles on site2
         $site2Role1= TestUtil::createSampleRole($userWithRoles, $roleType1, $site2, RoleStatus::GRANTED);
         $site2Role2= TestUtil::createSampleRole($userWithRoles, $roleType2, $site2, RoleStatus::GRANTED);
-        
+
         $this->em->persist($ngiRole1);
         $this->em->persist($ngiRole2);
         $this->em->persist($site1Role1);
         $this->em->persist($site1Role2);
         $this->em->persist($site2Role1);
         $this->em->persist($site2Role2);
-       
 
-        
+
+
         $this->em->flush();
 
 
 
-        // Assert fixture data is setup correctly in the DB.  
+        // Assert fixture data is setup correctly in the DB.
         $testConn = $this->getConnection();
 
         $result = $testConn->createQueryTable('results_table', "SELECT * FROM Users");
         $this->assertTrue($result->getRowCount() == 1);
-        
+
         $result = $testConn->createQueryTable('results_table', "SELECT * FROM Roles");
         $this->assertTrue($result->getRowCount() == 6);
-        
+
         $result = $testConn->createQueryTable('results_table', "SELECT * FROM NGIs");
         $this->assertTrue($result->getRowCount() == 1);
-        
+
         $result = $testConn->createQueryTable('results_table', "SELECT * FROM Sites");
         $this->assertTrue($result->getRowCount() == 2);
 
@@ -160,5 +160,5 @@
 
         $result = $testConn->createQueryTable('results_table', "SELECT * FROM EndpointLocations");
         $this->assertTrue($result->getRowCount() == 4);
-        
+
 ?>

--- a/tests/doctrine/resources/sampleFixtureData5.php
+++ b/tests/doctrine/resources/sampleFixtureData5.php
@@ -15,39 +15,39 @@
 
 
         /*
-         * Create test data with the following structure (note p3 has two ngis) 
-         * 
+         * Create test data with the following structure (note p3 has two ngis)
+         *
          * p1  p2  p3
          * |   |  /|
          * n1  n2  n3
-         * |   |   | 
-         * s1  s2  s3 
+         * |   |   |
+         * s1  s2  s3
          */
-        $p1 = new \Project("p1");  
+        $p1 = new \Project("p1");
         $n1 = TestUtil::createSampleNGI("n1");
-        $s1 = TestUtil::createSampleSite("s1"); 
+        $s1 = TestUtil::createSampleSite("s1");
         $this->em->persist($p1);
         $this->em->persist($n1);
         $this->em->persist($s1);
-        $n1->addSiteDoJoin($s1); 
-        $p1->addNgi($n1); 
+        $n1->addSiteDoJoin($s1);
+        $p1->addNgi($n1);
 
-        $p2 = new \Project("p2");  
+        $p2 = new \Project("p2");
         $n2 = TestUtil::createSampleNGI("n2");
-        $s2 = TestUtil::createSampleSite("s2"); 
+        $s2 = TestUtil::createSampleSite("s2");
         $this->em->persist($p2);
         $this->em->persist($n2);
         $this->em->persist($s2);
-        $n2->addSiteDoJoin($s2); 
-        $p2->addNgi($n2); 
+        $n2->addSiteDoJoin($s2);
+        $p2->addNgi($n2);
 
-        $p3 = new \Project("p3");  
+        $p3 = new \Project("p3");
         $n3 = TestUtil::createSampleNGI("n3");
-        $s3 = TestUtil::createSampleSite("s3"); 
+        $s3 = TestUtil::createSampleSite("s3");
         $this->em->persist($p3);
         $this->em->persist($n3);
         $this->em->persist($s3);
-        $n3->addSiteDoJoin($s3); 
-        $p3->addNgi($n3); 
+        $n3->addSiteDoJoin($s3);
+        $p3->addNgi($n3);
         $p3->addNgi($n2);     // note the p3 is parent to n2 + n3
 

--- a/tests/exampleTests/DoctrineTestExample.php
+++ b/tests/exampleTests/DoctrineTestExample.php
@@ -10,17 +10,17 @@ require_once dirname(__FILE__) . '/bootstrap.php';
 
 /**
  * A template that includes all the setup and tear down functions for writting
- * a PHPUnit test to test doctrine.  
- * 
+ * a PHPUnit test to test doctrine.
+ *
  * @author David Meredith
  * @author James McCarthy
  */
 class DoctrineTestExample extends PHPUnit_Extensions_Database_TestCase {
 
     private $em;
-    
+
      /**
-     * Overridden. 
+     * Overridden.
      */
     public static function setUpBeforeClass() {
         parent::setUpBeforeClass();
@@ -34,12 +34,12 @@ class DoctrineTestExample extends PHPUnit_Extensions_Database_TestCase {
      */
     protected function getConnection() {
         require_once dirname(__FILE__) . '/bootstrap_pdo.php';
-        return getConnectionToTestDB(); 
+        return getConnectionToTestDB();
     }
-    
+
     /**
-     * Overridden. Returns the test dataset.  
-     * Defines how the initial state of the database should look before each test is executed. 
+     * Overridden. Returns the test dataset.
+     * Defines how the initial state of the database should look before each test is executed.
      * @return PHPUnit_Extensions_Database_DataSet_IDataSet
      */
     protected function getDataSet() {
@@ -47,7 +47,7 @@ class DoctrineTestExample extends PHPUnit_Extensions_Database_TestCase {
     }
 
     /**
-     * Overridden. 
+     * Overridden.
      */
     protected function getSetUpOperation() {
         // CLEAN_INSERT is default
@@ -55,14 +55,14 @@ class DoctrineTestExample extends PHPUnit_Extensions_Database_TestCase {
         //return PHPUnit_Extensions_Database_Operation_Factory::UPDATE();
         //return PHPUnit_Extensions_Database_Operation_Factory::NONE();
         //
-        // Issue a DELETE from <table> which is more portable than a 
-        // TRUNCATE table <table> (some DBs require high privileges for truncate statements 
+        // Issue a DELETE from <table> which is more portable than a
+        // TRUNCATE table <table> (some DBs require high privileges for truncate statements
         // and also do not allow truncates across tables with FK contstraints e.g. Oracle)
         return PHPUnit_Extensions_Database_Operation_Factory::DELETE_ALL();
     }
 
     /**
-     * Overridden. 
+     * Overridden.
      */
     protected function getTearDownOperation() {
         // NONE is default
@@ -79,7 +79,7 @@ class DoctrineTestExample extends PHPUnit_Extensions_Database_TestCase {
     }
 
     /**
-     * @todo Still need to setup connection to different databases. 
+     * @todo Still need to setup connection to different databases.
      * @return EntityManager
      */
     private function createEntityManager() {
@@ -100,7 +100,7 @@ class DoctrineTestExample extends PHPUnit_Extensions_Database_TestCase {
             //print $tableName->getName() . "\n";
             $sql = "SELECT * FROM " . $tableName->getName();
             $result = $con->createQueryTable('results_table', $sql);
-            //echo 'row count: '.$result->getRowCount() ; 
+            //echo 'row count: '.$result->getRowCount() ;
             if ($result->getRowCount() != 0)
                 throw new RuntimeException("Invalid fixture. Table has rows: " . $tableName->getName());
         }
@@ -111,40 +111,40 @@ class DoctrineTestExample extends PHPUnit_Extensions_Database_TestCase {
     */
     public function testDoctrineExample() {
         print __METHOD__ . "\n";
-        
+
         //Create a site
         $ourSite = TestUtil::createSampleSite("Our Example Site");
-        
+
         //Set some details of the site
         $ourSite->setEmail("myTest@email.com");
         $ourSite->setTelephone("012345678910");
         $ourSite->setLocation("United Kingdom");
-        
+
         //Persist the site in memory
         $this->em->persist($ourSite);
-        
+
         //Get the site ID from the object
-        $siteId = $ourSite->getId();   
-        
-        //Get a PDO database connection	    	
+        $siteId = $ourSite->getId();
+
+        //Get a PDO database connection
         $con = $this->getConnection();
-        
+
         //Search the database for this site
         $sql = "SELECT 1 FROM sites WHERE ID = '$siteId'";
         $result = $con->createQueryTable('', $sql);
-        
+
         //We expect this query to return no rows as the site does not exist in the database yet
         $this->assertEquals(0, $result->getRowCount());
-        
+
         //Commit the site to the database
         $this->em->flush();
-                
+
         //Search the database for this site again
         $sql = "SELECT 1 FROM sites WHERE ID = '$siteId'";
         $result = $con->createQueryTable('', $sql);
-        
+
         //We expect this query to return 1 rows as the site now exists in the database
-        $this->assertEquals(1, $result->getRowCount());		
+        $this->assertEquals(1, $result->getRowCount());
     }
 
 }

--- a/tests/exampleTests/DoctrineTestTemplate.php
+++ b/tests/exampleTests/DoctrineTestTemplate.php
@@ -10,16 +10,16 @@ require_once dirname(__FILE__) . '/bootstrap.php';
 
 /**
  * A template that includes all the setup and tear down functions for writting
- * a PHPUnit test to test doctrine.  
- * 
+ * a PHPUnit test to test doctrine.
+ *
  * @author David Meredith
  */
 class DoctrineTestTemplate extends PHPUnit_Extensions_Database_TestCase {
 
     private $em;
-    
+
      /**
-     * Overridden. 
+     * Overridden.
      */
     public static function setUpBeforeClass() {
         parent::setUpBeforeClass();
@@ -37,8 +37,8 @@ class DoctrineTestTemplate extends PHPUnit_Extensions_Database_TestCase {
     }
 
     /**
-     * Overridden. Returns the test dataset.  
-     * Defines how the initial state of the database should look before each test is executed. 
+     * Overridden. Returns the test dataset.
+     * Defines how the initial state of the database should look before each test is executed.
      * @return PHPUnit_Extensions_Database_DataSet_IDataSet
      */
     protected function getDataSet() {
@@ -46,7 +46,7 @@ class DoctrineTestTemplate extends PHPUnit_Extensions_Database_TestCase {
     }
 
     /**
-     * Overridden. 
+     * Overridden.
      */
     protected function getSetUpOperation() {
         // CLEAN_INSERT is default
@@ -54,14 +54,14 @@ class DoctrineTestTemplate extends PHPUnit_Extensions_Database_TestCase {
         //return PHPUnit_Extensions_Database_Operation_Factory::UPDATE();
         //return PHPUnit_Extensions_Database_Operation_Factory::NONE();
         //
-        // Issue a DELETE from <table> which is more portable than a 
-        // TRUNCATE table <table> (some DBs require high privileges for truncate statements 
+        // Issue a DELETE from <table> which is more portable than a
+        // TRUNCATE table <table> (some DBs require high privileges for truncate statements
         // and also do not allow truncates across tables with FK contstraints e.g. Oracle)
         return PHPUnit_Extensions_Database_Operation_Factory::DELETE_ALL();
     }
 
     /**
-     * Overridden. 
+     * Overridden.
      */
     protected function getTearDownOperation() {
         // NONE is default
@@ -78,7 +78,7 @@ class DoctrineTestTemplate extends PHPUnit_Extensions_Database_TestCase {
     }
 
     /**
-     * @todo Still need to setup connection to different databases. 
+     * @todo Still need to setup connection to different databases.
      * @return EntityManager
      */
     private function createEntityManager() {
@@ -99,18 +99,18 @@ class DoctrineTestTemplate extends PHPUnit_Extensions_Database_TestCase {
             //print $tableName->getName() . "\n";
             $sql = "SELECT * FROM " . $tableName->getName();
             $result = $con->createQueryTable('results_table', $sql);
-            //echo 'row count: '.$result->getRowCount() ; 
+            //echo 'row count: '.$result->getRowCount() ;
             if ($result->getRowCount() != 0)
                 throw new RuntimeException("Invalid fixture. Table has rows: " . $tableName->getName());
         }
     }
 
     /**
-     * Any function with test at the start of the name will execute with PHPUnit  
+     * Any function with test at the start of the name will execute with PHPUnit
      */
     public function testYourTest() {
         print __METHOD__ . "\n";
-        
+
         // Your test here
 
     }

--- a/tests/exampleTests/FirstTest.php
+++ b/tests/exampleTests/FirstTest.php
@@ -27,9 +27,9 @@
 /**
  * Demo class to show different examples of unit testing.
  * Class modified from tutorial by Sylvain.
- * 
+ *
  * Usage: /<GOCDBHOME>/htdocs/web_portal$ phpunit UnitTest ../../tests/sampleTests/FirstTest.php
- * 
+ *
  * @link http://www.sylvainartois.fr.nf/PHP/Unit-testing-with-PHPUnit-part-one
  * @copyright 2010 STFC
  * @todo Has not been fully implemented yet.
@@ -107,68 +107,68 @@ class FirstTest extends PHPUnit_Framework_TestCase {
 
 
     public function testQuickTest(){
-       print __METHOD__ . "\n"; 
-       $res[1] = $this->returnArray(); // store returned associative array in 1st element of  
-       print_r($res[1]); 
+       print __METHOD__ . "\n";
+       $res[1] = $this->returnArray(); // store returned associative array in 1st element of
+       print_r($res[1]);
 
        $counts=array("ok" => 0, "warn" => 0, "error" => 0);
 
         foreach ($res as $r){
             $counts[$r["status"]]++;
         }
-        print_r($counts); 
+        print_r($counts);
 
-       echo "done"; 
+       echo "done";
     }
     private function returnArray(){
         //$retval["status"] = "ok";
         //$retval["message"] = "everything is well";
         $retval["status"] = "error";
         $retval["message"] = "everything is not well";
-        return $retval; 
+        return $retval;
     }
-    
+
     public function testExtactPKNumber(){
          print __METHOD__ . "\n";
          $v4pks = array('1GO', '20GO', '300GO');
-         $largestV4Pk = 0; 
+         $largestV4Pk = 0;
          foreach ($v4pks as $v4pkGO) {
-             $v4pk = (int)substr($v4pkGO, 0, strlen($v4pkGO)-2);  
+             $v4pk = (int)substr($v4pkGO, 0, strlen($v4pkGO)-2);
              if($v4pk > $largestV4Pk){
-                $largestV4Pk = $v4pk; 
+                $largestV4Pk = $v4pk;
              }
-             echo $v4pk; 
+             echo $v4pk;
          }
-         $this->assertEquals(300, $largestV4Pk);  
+         $this->assertEquals(300, $largestV4Pk);
     }
-    
-    
+
+
     public function testBitwiseAnd(){
         print __METHOD__ . "\n";
         if(3 & 1){
-            print '3 & 1 true'; 
+            print '3 & 1 true';
         }
         if(3 & 2){
-            print '3 & 2 true'; 
+            print '3 & 2 true';
         }
         if(3 & 4){
-            fail('3 & 4 should not be true'); 
+            fail('3 & 4 should not be true');
         }
         if(3 & 8){
-            fail('3 & 8 should not be true'); 
+            fail('3 & 8 should not be true');
         }
-        
+
         if(4 & 1){
-            fail('4 & 1 should not be true'); 
+            fail('4 & 1 should not be true');
         }
         if(4 & 2){
-            fail('4 & 2 should not be true'); 
+            fail('4 & 2 should not be true');
         }
         if(4 & 4){
-            print '4 & 4 true'; 
+            print '4 & 4 true';
         }
         if(4 & 8){
-            fail('4 & 8 should not be true'); 
+            fail('4 & 8 should not be true');
         }
     }
 
@@ -246,7 +246,7 @@ class FirstTest extends PHPUnit_Framework_TestCase {
     /**
      * This method is used as a provider for tests.
      * @see testDataProvider
-     * @return array Data used in tests. 
+     * @return array Data used in tests.
      */
     public function provider() {
         return array(
@@ -280,7 +280,7 @@ class FirstTest extends PHPUnit_Framework_TestCase {
         $this->assertStringEqualsFile(__DIR__.'/fixture.txt', 'Fake content');
 
         // didn't find this Test.xml file, so i return above (TODO).
-        if(true)return; 
+        if(true)return;
 
         // didn't find this Test.xml file, so i return above.
         $this->assertXmlStringEqualsXmlFile( 'Test.xml', $this->xXML );

--- a/tests/miscTests/DateTimeConvertTests.php
+++ b/tests/miscTests/DateTimeConvertTests.php
@@ -14,9 +14,9 @@
  */
 
 /**
- * Test/display PHP's current timezone conversions. You may need to update 
+ * Test/display PHP's current timezone conversions. You may need to update
  * the PHP timezonedb.so|dll file to be up to date with the current Olsen IANA
- * timezone daylight saving values. 
+ * timezone daylight saving values.
  *
  * @author David Meredith
  */
@@ -24,7 +24,7 @@ class DateTimeConvertTests extends PHPUnit_Framework_TestCase {
     //put your code here
 
     const FORMAT = 'd/m/Y H:i';
-     
+
     /**
      * Called once, before any of the tests are executed.
      */
@@ -72,74 +72,74 @@ class DateTimeConvertTests extends PHPUnit_Framework_TestCase {
     }
 
     /**
-     * Print what PHP thinks are the current times in the specified timezones. 
-     * You can run this test to check that you have configured the PHP timezone 
-     * settings correctly and have an up to date timezonedb.so|dll installed. 
+     * Print what PHP thinks are the current times in the specified timezones.
+     * You can run this test to check that you have configured the PHP timezone
+     * settings correctly and have an up to date timezonedb.so|dll installed.
      */
     public function testCurrentTimeInTimezones(){
         print __METHOD__ . "\n";
         print "To check your daylight timezone settings are correct and that "
         . "your php timezone.db is up to date, compare the output below with "
                 . "the current real times on the web. You may need to update your"
-                . "timezonedb.so|dll lib. \n"; 
+                . "timezonedb.so|dll lib. \n";
         // see: http://stackoverflow.com/questions/2532729/daylight-saving-time-and-time-zone-best-practices
 
         //date_default_timezone_set("UTC");
-        $utcTz = new \DateTimeZone("UTC"); 
-        $targetTz1 = new \DateTimeZone("Europe/Moscow"); 
-        $targetTz2 = new \DateTimeZone("Europe/Amsterdam"); 
-        $targetTz3 = new \DateTimeZone("America/New_York"); 
-        $targetTz4 = new \DateTimeZone("America/Denver"); 
-        $targetTz5 = new \DateTimeZone("Europe/London"); 
-       
-        // now in specified Tz 
-        $nowTz = new \DateTime(null, $targetTz1); 
-        print_r($nowTz);  
-        print_r("Offset from UTC in secs: ".$nowTz->getOffset()."\n\n"); //Returns the timezone offset in seconds from UTC on success or FALSE on failure. 
-        
-        $nowTz = new \DateTime(null, $targetTz2); 
-        print_r($nowTz);  
-        print_r("Offset from UTC in secs: ".$nowTz->getOffset()."\n\n");
-        
-        $nowTz = new \DateTime(null, $targetTz3); 
-        print_r($nowTz);  
-        print_r("Offset from UTC in secs: ".$nowTz->getOffset()."\n\n");
-        
-        $nowTz = new \DateTime(null, $targetTz4); 
-        print_r($nowTz);  
-        print_r("Offset from UTC in secs: ".$nowTz->getOffset()."\n\n"); 
-        
-        $nowTz = new \DateTime(null, $targetTz5); 
-        print_r($nowTz);  
-        print_r("Offset from UTC in secs: ".$nowTz->getOffset()."\n\n"); 
+        $utcTz = new \DateTimeZone("UTC");
+        $targetTz1 = new \DateTimeZone("Europe/Moscow");
+        $targetTz2 = new \DateTimeZone("Europe/Amsterdam");
+        $targetTz3 = new \DateTimeZone("America/New_York");
+        $targetTz4 = new \DateTimeZone("America/Denver");
+        $targetTz5 = new \DateTimeZone("Europe/London");
 
-        
-        // now in utc 
-        $nowUtc = new \DateTime(null, $utcTz); 
-        print_r($nowUtc); 
-        print_r("Offset from UTC in secs: ".$nowUtc->getOffset()."\n\n"); 
-        
+        // now in specified Tz
+        $nowTz = new \DateTime(null, $targetTz1);
+        print_r($nowTz);
+        print_r("Offset from UTC in secs: ".$nowTz->getOffset()."\n\n"); //Returns the timezone offset in seconds from UTC on success or FALSE on failure.
+
+        $nowTz = new \DateTime(null, $targetTz2);
+        print_r($nowTz);
+        print_r("Offset from UTC in secs: ".$nowTz->getOffset()."\n\n");
+
+        $nowTz = new \DateTime(null, $targetTz3);
+        print_r($nowTz);
+        print_r("Offset from UTC in secs: ".$nowTz->getOffset()."\n\n");
+
+        $nowTz = new \DateTime(null, $targetTz4);
+        print_r($nowTz);
+        print_r("Offset from UTC in secs: ".$nowTz->getOffset()."\n\n");
+
+        $nowTz = new \DateTime(null, $targetTz5);
+        print_r($nowTz);
+        print_r("Offset from UTC in secs: ".$nowTz->getOffset()."\n\n");
+
+
+        // now in utc
+        $nowUtc = new \DateTime(null, $utcTz);
+        print_r($nowUtc);
+        print_r("Offset from UTC in secs: ".$nowUtc->getOffset()."\n\n");
+
     }
 
     public function ntestDateConvert1(){
         print __METHOD__ . "\n";
 
-         // convert start and end into UTC 
+         // convert start and end into UTC
         $UTC = new \DateTimeZone("UTC");
         //$sourceTZ = new \DateTimeZone("Europe/Moscow");  // not ok
         //$sourceTZ = new \DateTimeZone("Europe/Amsterdam");
         $sourceTZ = new \DateTimeZone("America/New_York");
         //$sourceTZ = new \DateTimeZone("America/Denver");
         //$sourceTZ = new \DateTimeZone("Asia/Qatar");
-        
-        $start = \DateTime::createFromFormat($this::FORMAT, '14/05/2015 16:00', $sourceTZ);
-        
-        print_r($start); 
-        
-        // reset the TZ to UTC
-        $start->setTimezone($UTC); 
 
-        print_r($start); 
-        print_r('startEnd in UTC: '.$start->format($this::FORMAT)); 
+        $start = \DateTime::createFromFormat($this::FORMAT, '14/05/2015 16:00', $sourceTZ);
+
+        print_r($start);
+
+        // reset the TZ to UTC
+        $start->setTimezone($UTC);
+
+        print_r($start);
+        print_r('startEnd in UTC: '.$start->format($this::FORMAT));
     }
 }

--- a/tests/miscTests/IPv6FormatTests.php
+++ b/tests/miscTests/IPv6FormatTests.php
@@ -4,9 +4,9 @@ require_once __DIR__.'/../../lib/Gocdb_Services/validation/IPv6Validator.php';
 
 /**
  * Test the parsing and validation of IP addresses .
- * 
+ *
  * Usage: $phpunit UnitTest ../../tests/miscTests/IPv6FormatTests.php
- * 
+ *
  * @copyright 2013 STFC
  * @author David Meredith
  */
@@ -58,58 +58,58 @@ class IPv6FormatTests extends PHPUnit_Framework_TestCase {
         print __METHOD__ . "\n";
         throw $e;
     }
-    
+
 
     public function testIPv6Validator(){
         print __METHOD__ . "\n";
-        $validator = new IPv6Validator(); 
-        $errors = array(); 
+        $validator = new IPv6Validator();
+        $errors = array();
 
-        // Valid: 
-        $errors = $validator->validate('1:2::3:4/64', $errors ); 
-        $this->assertTrue(count($errors) == 0); 
+        // Valid:
+        $errors = $validator->validate('1:2::3:4/64', $errors );
+        $this->assertTrue(count($errors) == 0);
 
-        $errors = $validator->validate('2001:0db8:85a3:0000:0000:8a2e:0370:7334', $errors ); 
-        $this->assertTrue(count($errors) == 0); 
+        $errors = $validator->validate('2001:0db8:85a3:0000:0000:8a2e:0370:7334', $errors );
+        $this->assertTrue(count($errors) == 0);
 
-        $errors = $validator->validate('2001:0db8:85a3::8a2e:0370:7334', $errors ); 
-        $this->assertTrue(count($errors) == 0); 
+        $errors = $validator->validate('2001:0db8:85a3::8a2e:0370:7334', $errors );
+        $this->assertTrue(count($errors) == 0);
 
-        $errors = $validator->validate('fe80::2000:aff:fea7:f7c', $errors ); 
-        $this->assertTrue(count($errors) == 0); 
+        $errors = $validator->validate('fe80::2000:aff:fea7:f7c', $errors );
+        $this->assertTrue(count($errors) == 0);
 
-        $errors = $validator->validate('1:2::3:4/64', $errors ); 
-        $this->assertTrue(count($errors) == 0); 
-        
-        $errors = $validator->validate('2001:adb8:85a3:7334:0000:0000:0000:0000', $errors ); 
-        $this->assertTrue(count($errors) == 0); 
+        $errors = $validator->validate('1:2::3:4/64', $errors );
+        $this->assertTrue(count($errors) == 0);
 
-        $errors = $validator->validate('2001:adb8:85a3:7334:0000:0000:0000:0000/40', $errors ); 
-        $this->assertTrue(count($errors) == 0); 
-        
- 
+        $errors = $validator->validate('2001:adb8:85a3:7334:0000:0000:0000:0000', $errors );
+        $this->assertTrue(count($errors) == 0);
 
-        // Invalid:  
-        $errors = $validator->validate('123:', $errors ); 
+        $errors = $validator->validate('2001:adb8:85a3:7334:0000:0000:0000:0000/40', $errors );
+        $this->assertTrue(count($errors) == 0);
+
+
+
+        // Invalid:
+        $errors = $validator->validate('123:', $errors );
         $this->assertTrue(count($errors) == 1);
-        
-        $errors = $validator->validate('fe80::2000:aff:fea7:f7c/0', $errors ); 
-        $this->assertTrue(count($errors) == 2); 
-        
-        $errors = $validator->validate('fe80::2000:aff:fea7:f7c/illegal', $errors ); 
-        $this->assertTrue(count($errors) == 3); 
-        
-        $errors = $validator->validate('invalid', $errors ); 
-        $this->assertTrue(count($errors) == 4); 
 
-        $errors = $validator->validate('', $errors ); 
-        $this->assertTrue(count($errors) == 5); 
-        
-        $errors = $validator->validate(' ', $errors ); 
-        $this->assertTrue(count($errors) == 6); 
+        $errors = $validator->validate('fe80::2000:aff:fea7:f7c/0', $errors );
+        $this->assertTrue(count($errors) == 2);
+
+        $errors = $validator->validate('fe80::2000:aff:fea7:f7c/illegal', $errors );
+        $this->assertTrue(count($errors) == 3);
+
+        $errors = $validator->validate('invalid', $errors );
+        $this->assertTrue(count($errors) == 4);
+
+        $errors = $validator->validate('', $errors );
+        $this->assertTrue(count($errors) == 5);
+
+        $errors = $validator->validate(' ', $errors );
+        $this->assertTrue(count($errors) == 6);
     }
 
-   
+
 }
 
 

--- a/tests/miscTests/PI_Extensions_Param_ParsingTest.php
+++ b/tests/miscTests/PI_Extensions_Param_ParsingTest.php
@@ -1,19 +1,19 @@
 <?php
- require_once __DIR__. '/../../lib/Gocdb_Services/PI/QueryBuilders/ExtensionsQueryNormaliser.php';    
+ require_once __DIR__. '/../../lib/Gocdb_Services/PI/QueryBuilders/ExtensionsQueryNormaliser.php';
  require_once __DIR__.'/../../lib/Gocdb_Services/PI/QueryBuilders/KeyValueValidator.php';
  require_once __DIR__. '/../../lib/Gocdb_Services/PI/QueryBuilders/ExtensionsParser2.php';
 
 /**
  * Demo tests of candiate regex statements for parsing the 'expression' PI parameter.
- * These tests demonstrate the business logic used to implement: 
- * {@see \org\gocdb\services\ExensionsQueryNormaliser::convert($query)}  
+ * These tests demonstrate the business logic used to implement:
+ * {@see \org\gocdb\services\ExensionsQueryNormaliser::convert($query)}
  * {@see \org\gocdb\services\KeyValueValidator}
  * {@see \org\gocdb\services\ExtensionsParser2}
  * <p>
- * The tests do not require a test DB. 
- *  
+ * The tests do not require a test DB.
+ *
  * Usage: $phpunit UnitTest PI_Extensions_Param_ParsingTest.php
- * 
+ *
  * @link http://www.sylvainartois.fr.nf/PHP/Unit-testing-with-PHPUnit-part-one
  * @copyright 2013 STFC
  * @author David Meredith
@@ -68,58 +68,58 @@ class PI_Extensions_Param_ParsingTest extends PHPUnit_Framework_TestCase {
     }
 
 
-    // useful links for lexial/regex parsing for tokenizing 
+    // useful links for lexial/regex parsing for tokenizing
     // http://stackoverflow.com/questions/10208694/regex-to-parse-string-with-escaped-characters
-    // http://blog.angeloff.name/post/2012/08/05/php-recursive-patterns/ 
+    // http://blog.angeloff.name/post/2012/08/05/php-recursive-patterns/
     // https://github.com/nikic/Phlexy
-    // http://stackoverflow.com/questions/16387277/language-parser-library-written-in-php 
+    // http://stackoverflow.com/questions/16387277/language-parser-library-written-in-php
     // http://nikic.github.io/2011/10/23/Improving-lexing-performance-in-PHP.html
     // http://stackoverflow.com/questions/546433/regular-expression-to-match-outer-brackets
 
-    private $myVals = array(); 
-    
+    private $myVals = array();
+
     public function testDave(){
        $this->myVals[] = array(0, 'dave');
-       print_r($this->myVals); 
-       $this->assertNotEmpty($this->myVals); 
+       print_r($this->myVals);
+       $this->assertNotEmpty($this->myVals);
        is_array($this->myVals);
        is_array($this->myVals[0]);
     }
 
 
     /**
-     * Capture outer curly bracket groups using a repeating pattern that can contain: 
-     * - nested balanced curly brackets (no nested unbalanced escaped curly brackets are allowed) 
-     * - any other char that is not a curly bracket 
-     * Groups can be prefixed with an optional prefix that starts with @media. 
+     * Capture outer curly bracket groups using a repeating pattern that can contain:
+     * - nested balanced curly brackets (no nested unbalanced escaped curly brackets are allowed)
+     * - any other char that is not a curly bracket
+     * Groups can be prefixed with an optional prefix that starts with @media.
      */
     public function testDemoRecursiveRegex(){
-        print __METHOD__ . "\n"; 
+        print __METHOD__ . "\n";
         $string = <<<CSS
         body { color: #888; }
         @media print { body { color: #333; } }
         code { color: blue; }
 CSS;
-        //see: http://blog.angeloff.name/post/2012/08/05/php-recursive-patterns/ 
+        //see: http://blog.angeloff.name/post/2012/08/05/php-recursive-patterns/
         //$pattern = '/{(?:[^{}]+|(?R))*}/';
         $pattern = '/(?:@media[^{]+)?'     # @media is optional, e.g., when we have descended into it.
          . '{(?:[^{}]+|(?R))*}/s';
         preg_match_all($pattern, $string, $groups);
-        //print_r($groups); 
-       
-        $this->assertEquals('{ color: #888; }', $groups[0][0]); 
-        $this->assertEquals('@media print { body { color: #333; } }', $groups[0][1]); 
-        $this->assertEquals('{ color: blue; }', $groups[0][2]); 
+        //print_r($groups);
+
+        $this->assertEquals('{ color: #888; }', $groups[0][0]);
+        $this->assertEquals('@media print { body { color: #333; } }', $groups[0][1]);
+        $this->assertEquals('{ color: blue; }', $groups[0][2]);
 
     }
 
     /**
-     * Capture outer parenthesis groups using a repeating pattern that can contain: 
-     * - nested balanced parenthesis (no nested unbalanced escaped parenthesis are allowed) 
-     * - any other char that is not a parenthesis  
+     * Capture outer parenthesis groups using a repeating pattern that can contain:
+     * - nested balanced parenthesis (no nested unbalanced escaped parenthesis are allowed)
+     * - any other char that is not a parenthesis
      */
     public function testDemoRecursiveRegex2(){
-        print __METHOD__ . "\n"; 
+        print __METHOD__ . "\n";
         $string = <<<AAA
         body ( color: #888; )
         @media print ( body ( color: #333; ) )
@@ -127,281 +127,281 @@ CSS;
 AAA;
         $pattern = '/\((?:[^()]+|(?R))*\)/s';
         preg_match_all($pattern, $string, $groups);
-        //print_r($groups); 
-        $this->assertEquals('( color: #888; )', $groups[0][0]); 
-        $this->assertEquals('( body ( color: #333; ) )', $groups[0][1]); 
-        $this->assertEquals('( color: blue; )', $groups[0][2]); 
+        //print_r($groups);
+        $this->assertEquals('( color: #888; )', $groups[0][0]);
+        $this->assertEquals('( body ( color: #333; ) )', $groups[0][1]);
+        $this->assertEquals('( color: blue; )', $groups[0][2]);
     }
 
 
     /**
-     * Capture outer parenthesis groups using a repeating pattern that can contain: 
-     * - nested balanced parenthesis (no nested unbalanced escaped parenthesis are allowed) 
-     * - any other char that is not a parenthesis 
-     * Groups can be prefixed with an optional AND prefix. 
+     * Capture outer parenthesis groups using a repeating pattern that can contain:
+     * - nested balanced parenthesis (no nested unbalanced escaped parenthesis are allowed)
+     * - any other char that is not a parenthesis
+     * Groups can be prefixed with an optional AND prefix.
      */
     public function testDemoRecursiveRegex3(){
-        print __METHOD__ . "\n"; 
-        $string = 
+        print __METHOD__ . "\n";
+        $string =
         "AND ( color: #888; )
-        AND( body ( color: #333; ) ) 
-        don't capture me ( color: blue; )"; 
+        AND( body ( color: #333; ) )
+        don't capture me ( color: blue; )";
         //$pattern = '/\((?:[^()]+|(?R))*\)/s';
         $pattern = '/(?:AND[\s]*)?' . '\((?:[^()]+|(?R))*\)/s';
         # AND followed by space is optional, e.g., when we have descended into it.
         preg_match_all($pattern, $string, $groups);
-        //print_r($groups); 
-        $this->assertEquals('AND ( color: #888; )', $groups[0][0]); 
-        $this->assertEquals('AND( body ( color: #333; ) )', $groups[0][1]); 
-        $this->assertEquals('( color: blue; )', $groups[0][2]); 
+        //print_r($groups);
+        $this->assertEquals('AND ( color: #888; )', $groups[0][0]);
+        $this->assertEquals('AND( body ( color: #333; ) )', $groups[0][1]);
+        $this->assertEquals('( color: blue; )', $groups[0][2]);
     }
 
     /**
-     * Demo test to show regex capture of a repeating pattern that starts with an 
-     * optional AND|OR|NOT and is followed by optional whitespace with an 
-     * opening '(' containing any char inc escaped parenthesis and unescaped and 
+     * Demo test to show regex capture of a repeating pattern that starts with an
+     * optional AND|OR|NOT and is followed by optional whitespace with an
+     * opening '(' containing any char inc escaped parenthesis and unescaped and
      * balanced parethesis with a terminating ')'
-     * 
+     *
      * Importantly, the regex uses repeating-group syntax (?R) that allows nested balanced parenthesis
-     * to be captured within the outermost parenthesis, e.g. (((...))) 
-     * The outer parenthesis group can contain: 
-     * - nested balanced parenthesis (starts a new repeating group) 
-     * - escaped (un)balanced parenthesis 
-     * - any other char except parenthesis  
+     * to be captured within the outermost parenthesis, e.g. (((...)))
+     * The outer parenthesis group can contain:
+     * - nested balanced parenthesis (starts a new repeating group)
+     * - escaped (un)balanced parenthesis
+     * - any other char except parenthesis
      * Groups can be prefixed with an optional AND|OR|NOT prefix.
-     */ 
+     */
     public function testDemoRecursiveRegex4(){
-        print __METHOD__ . "\n"; 
-        $string =  
+        print __METHOD__ . "\n";
+        $string =
         "AND ( color: \) #888; )
-        OR ( body ( color: \( #333; ) ) 
-        NOT ( body \( color: \( #333; \) ) 
-        ( help me (forest) help me ) 
-        don't capture me ( color: blue;\(\) )"; 
- 
+        OR ( body ( color: \( #333; ) )
+        NOT ( body \( color: \( #333; \) )
+        ( help me (forest) help me )
+        don't capture me ( color: blue;\(\) )";
+
         //$pattern = '/\((?:[^()]+|(?R))*\)/s';
         #$pattern = '/(?:AND[\s]*)?' . '\((?:[^()]+|(?R))*\)/s';
         # AND followed by space is optional, e.g., when we have descended into it.
-        
-        $pattern = '/(?:(?:AND|OR|NOT)[\s]*)?' . 
+
+        $pattern = '/(?:(?:AND|OR|NOT)[\s]*)?' .
                 '\((?:(?:\\\\[()]|[^()])+|(?R))*\)/s';
-        
-         /* 1st list line: 
+
+         /* 1st list line:
          * /                   # start regex
          *   (?:               #    |start a new group but don't catpure group
          *      (?:            #         |start a new group but don't capture group
-         *         AND|OR|NOT  #         |  allow AND or OR or NOT 
+         *         AND|OR|NOT  #         |  allow AND or OR or NOT
          *      )              #         |close group
-         *      [\s]*          #         allow multiple whitespace 
-         *   )?                #    |close group, can occur zero or once (an optional group) 
+         *      [\s]*          #         allow multiple whitespace
+         *   )?                #    |close group, can occur zero or once (an optional group)
          */
-        // 2nd line: 
+        // 2nd line:
         /*
-         * \(                      # find first opening of '(' 
+         * \(                      # find first opening of '('
          *   (?:                   # | start a new group but don't capture group
-         *      (?:                # |      |start a new group but don't capture group 
-         *          \\\\[()]       # |      |  allow escaped parenthesis in group e.g. '\(' or '\)' 
-         *            |            # |      |     or 
+         *      (?:                # |      |start a new group but don't capture group
+         *          \\\\[()]       # |      |  allow escaped parenthesis in group e.g. '\(' or '\)'
+         *            |            # |      |     or
          *          [^()]          # |      |  allow any char except parenthesis in group
-         *      )+                 # |      |close group, must occur once or more 
+         *      )+                 # |      |close group, must occur once or more
          *      |                  # |  or
          *      (?R)               # |  we may be at the start of a new group, repeat whole pattern.
-         *   )*                    # close group, occurs zero or many 
+         *   )*                    # close group, occurs zero or many
          * \)                      # expect balanced closing ')'
-         * /s                  # end regex 
+         * /s                  # end regex
          */
         preg_match_all($pattern, $string, $groups);
-        //print_r($groups); 
-        $this->assertEquals('AND ( color: \) #888; )', $groups[0][0]); 
-        $this->assertEquals('OR ( body ( color: \( #333; ) )', $groups[0][1]); 
-        $this->assertEquals('NOT ( body \( color: \( #333; \) )', $groups[0][2]); 
-        $this->assertEquals('( help me (forest) help me )', $groups[0][3]); 
-        $this->assertEquals('( color: blue;\(\) )', $groups[0][4]); 
+        //print_r($groups);
+        $this->assertEquals('AND ( color: \) #888; )', $groups[0][0]);
+        $this->assertEquals('OR ( body ( color: \( #333; ) )', $groups[0][1]);
+        $this->assertEquals('NOT ( body \( color: \( #333; \) )', $groups[0][2]);
+        $this->assertEquals('( help me (forest) help me )', $groups[0][3]);
+        $this->assertEquals('( color: blue;\(\) )', $groups[0][4]);
     }
-    
+
 
 
 
     /**
-     * Demo test to show regex capture of repeating pattern that starts with an 
-     * optional AND|OR|NOT and is followed by optional whitespace with an 
+     * Demo test to show regex capture of repeating pattern that starts with an
+     * optional AND|OR|NOT and is followed by optional whitespace with an
      * opening '(' containing any char inc escaped parenthesis with a terminating ')'
-     * The parenthesis group can contain: 
-     * - escaped parenthesis, both balenced and un-balenced 
-     * - any other char except parenthesis 
+     * The parenthesis group can contain:
+     * - escaped parenthesis, both balenced and un-balenced
+     * - any other char except parenthesis
      * - Note, nested balanced parenthesis that are NOT escaped are NOT allowed
      * Groups can be prefixed with an optional AND|OR|NOT prefix.
-     * 
-     * Note, this method is functionally equal to {@link testDemoEscapedParenthesis2()} 
-     * but has a slightly different regex.  
+     *
+     * Note, this method is functionally equal to {@link testDemoEscapedParenthesis2()}
+     * but has a slightly different regex.
      */
     public function testDemoEscapedParenthesis1(){
-        print __METHOD__ . "\n"; 
-        $string = 
+        print __METHOD__ . "\n";
+        $string =
         "AND ( color: \) #888; )
-        OR ( body \( color: \( #333; \) ) 
-        NOT ( body \( color=\= \( #333; \) ) 
-        ( help\\ me \(forest\) help me ) 
+        OR ( body \( color: \( #333; \) )
+        NOT ( body \( color=\= \( #333; \) )
+        ( help\\ me \(forest\) help me )
         don't capture me ( color: blue;\(\) \n\n\n )
-        ( color: blue;\(\) \ ); 
+        ( color: blue;\(\) \ );
         ( \ )
         ( \\ )
-        ( tab\ttab )"; 
-                
+        ( tab\ttab )";
+
         // http://php.net/manual/en/regexp.reference.escape.php
         $pattern = '/(?:(?:AND|OR|NOT)[\s]*)?' .
                 "\((?:\\\\[()]|[^()])+\)/s";
-            
-        /* 1st list line: 
+
+        /* 1st list line:
          * /                   # start regex
          *   (?:               #    |start a new group but don't catpure group
          *      (?:            #         |start a new group but don't capture group
-         *         AND|OR|NOT  #         |  allow AND or OR or NOT 
+         *         AND|OR|NOT  #         |  allow AND or OR or NOT
          *      )              #         |close group
-         *      [\s]*          #         allow multiple whitespace 
-         *   )?                #    |close group, can occur zero or once (an optional group) 
+         *      [\s]*          #         allow multiple whitespace
+         *   )?                #    |close group, can occur zero or once (an optional group)
          */
-        // 2nd line in pattern: 
+        // 2nd line in pattern:
         /*
-         * \(                      # find first opening of '(' 
-         *      (?:                # |      |start a new group but don't capture group 
-         *          \\\\[()]       # |      |  allow escaped parenthesis in group e.g. '\(' or '\)' note, need 4 backslashes for this http://php.net/manual/en/regexp.reference.escape.php 
-         *            |            # |      |     or 
+         * \(                      # find first opening of '('
+         *      (?:                # |      |start a new group but don't capture group
+         *          \\\\[()]       # |      |  allow escaped parenthesis in group e.g. '\(' or '\)' note, need 4 backslashes for this http://php.net/manual/en/regexp.reference.escape.php
+         *            |            # |      |     or
          *          [^()]          # |      |  allow any char except parenthesis in group
-         *      )+                 # |      |close group, must occur once or more 
+         *      )+                 # |      |close group, must occur once or more
          * \)                      # expect balanced closing ')'
-         * /s                  # end regex 
+         * /s                  # end regex
          */
         preg_match_all($pattern, $string, $groups);
-        //print_r($groups); 
-        
-        $this->assertEquals("AND ( color: \) #888; )", $groups[0][0]); 
-        $this->assertEquals("OR ( body \( color: \( #333; \) )", $groups[0][1]); 
-        $this->assertEquals("NOT ( body \( color=\= \( #333; \) )", $groups[0][2]); 
-        $this->assertEquals("( help\\ me \(forest\) help me )", $groups[0][3]); 
-        $this->assertEquals("( color: blue;\(\) \n\n\n )", $groups[0][4]);  // note newlines are shown when printing to screen, which is correct !  
-        $this->assertEquals("( color: blue;\(\) \ )", $groups[0][5]); 
-        $this->assertEquals("( \ )", $groups[0][6]); 
-        $this->assertEquals("( \\ )", $groups[0][7]);   // note, output shows only a single backslash when printing to screen, which is correct !  
-        $this->assertEquals("( tab\ttab )", $groups[0][8]);   // note, output shows 'tab    tab' when printed to screen, which is correct !   
+        //print_r($groups);
+
+        $this->assertEquals("AND ( color: \) #888; )", $groups[0][0]);
+        $this->assertEquals("OR ( body \( color: \( #333; \) )", $groups[0][1]);
+        $this->assertEquals("NOT ( body \( color=\= \( #333; \) )", $groups[0][2]);
+        $this->assertEquals("( help\\ me \(forest\) help me )", $groups[0][3]);
+        $this->assertEquals("( color: blue;\(\) \n\n\n )", $groups[0][4]);  // note newlines are shown when printing to screen, which is correct !
+        $this->assertEquals("( color: blue;\(\) \ )", $groups[0][5]);
+        $this->assertEquals("( \ )", $groups[0][6]);
+        $this->assertEquals("( \\ )", $groups[0][7]);   // note, output shows only a single backslash when printing to screen, which is correct !
+        $this->assertEquals("( tab\ttab )", $groups[0][8]);   // note, output shows 'tab    tab' when printed to screen, which is correct !
     }
 
 
-    
+
     /**
-     * Demo test to show regex capture of repeating pattern that starts with an 
-     * optional AND|OR|NOT and is followed by optional whitespace with an 
-     * opening '(' containing any char inc escaped parenthesis with a terminating ')'  
-     * The parenthesis group can contain: 
-     * - escaped parenthesis, both balanced and un-balanced 
-     * - any other char except parenthesis 
-     * - Note, nested balanced parenthesis that are NOT escaped are NOT catered for, 
-     *   which is probably preferable compared to allowing nested balanced parenthesis 
-     *   in the 'extensions' URL parameter value. 
+     * Demo test to show regex capture of repeating pattern that starts with an
+     * optional AND|OR|NOT and is followed by optional whitespace with an
+     * opening '(' containing any char inc escaped parenthesis with a terminating ')'
+     * The parenthesis group can contain:
+     * - escaped parenthesis, both balanced and un-balanced
+     * - any other char except parenthesis
+     * - Note, nested balanced parenthesis that are NOT escaped are NOT catered for,
+     *   which is probably preferable compared to allowing nested balanced parenthesis
+     *   in the 'extensions' URL parameter value.
      * Groups can be prefixed with an optional AND|OR|NOT prefix.
-     * 
-     * Note, this method is functionally equal to {@link testDemoEscapedParenthesis1()} 
-     * but has a slightly different regex that may be more efficient.  
+     *
+     * Note, this method is functionally equal to {@link testDemoEscapedParenthesis1()}
+     * but has a slightly different regex that may be more efficient.
      */
     public function testDemoEscapedParenthesis2(){
-        print __METHOD__ . "\n"; 
+        print __METHOD__ . "\n";
 
-        $string = 
+        $string =
         "   AND ( color: \) #888; )  ".   // note leading/trailing whitespace is not captured
-        "  OR ( body \( color: \( #333; \) ) 
-        NOT ( body \( color=\= \( #333; \) ) 
-        ( help\\ me \(forest\) help me ) 
+        "  OR ( body \( color: \( #333; \) )
+        NOT ( body \( color=\= \( #333; \) )
+        ( help\\ me \(forest\) help me )
         don't capture me ( color: blue;\(\) \n\n\n )
-        ( color: blue;\(\) \ ); 
+        ( color: blue;\(\) \ );
         ( \ )
         ( \\ )
         ( tab\ttab )
         (\\\)
         (\\\\)
         NOT(\\\\////)
-        this line with unrecognised predicate and empty parentheis is not captured ()";     
-        $expectedCaptureCount = 12; // last line is not captured hence 12 not 13   
-        
-        // Regarding $optionalPredicateAndWhitespace :  
+        this line with unrecognised predicate and empty parentheis is not captured ()";
+        $expectedCaptureCount = 12; // last line is not captured hence 12 not 13
+
+        // Regarding $optionalPredicateAndWhitespace :
         // Its really important to capture the optional predicate and trailing whitespace
-        // in one group because this affects how the pattern is repeatedly 
+        // in one group because this affects how the pattern is repeatedly
         // matched - the pattern does NOT include leading whitespace!
-        // Therefore, a match will only start with EITHER a leading '(' or the 
+        // Therefore, a match will only start with EITHER a leading '(' or the
         // first char from one of the OR'd predicates: 'A' 'O' 'N'
-        $optionalPredicateAndWhitespace = '(?:(?:AND|OR|NOT)[\s]*)?' ; 
-        $parethesisGroup = '\((?:\\\\.|[^()\\\\])+\)'; 
-       
-        $patternMatchRepeat = '/' . $optionalPredicateAndWhitespace . $parethesisGroup . '/s'; 
-        
+        $optionalPredicateAndWhitespace = '(?:(?:AND|OR|NOT)[\s]*)?' ;
+        $parethesisGroup = '\((?:\\\\.|[^()\\\\])+\)';
+
+        $patternMatchRepeat = '/' . $optionalPredicateAndWhitespace . $parethesisGroup . '/s';
+
         // http://stackoverflow.com/questions/10208694/regex-to-parse-string-with-escaped-characters
-        
+
         /* $optionalPredicateAndWhitespace
          * /                   # start regex
          *   (?:               #    |start a new group but don't catpure group
          *      (?:            #         |start a new group but don't capture group
-         *         AND|OR|NOT  #         |  allow AND or OR or NOT 
+         *         AND|OR|NOT  #         |  allow AND or OR or NOT
          *      )              #         |close group
-         *      [\s]*          #         allow multiple whitespace 
-         *   )?                #    |close group, can occur zero or once (an optional group) 
+         *      [\s]*          #         allow multiple whitespace
+         *   )?                #    |close group, can occur zero or once (an optional group)
          */
         /* $parethesisGroup
-         * \(                  #     find first opening of '(' 
-         *      (?:            #     |      |start a new group but don't capture group 
+         * \(                  #     find first opening of '('
+         *      (?:            #     |      |start a new group but don't capture group
          *          \\\\.      #     |      |  allow any escaped char inc escaped parethesis \(  and escaped backslash \\
-         *            |        #     |      |     or 
+         *            |        #     |      |     or
          *          [^()\\\\]  #     |      |  allow any char except parenthesis or backslash in group
-         *      )+             #     |      |close group, must be one or more chars in group  
+         *      )+             #     |      |close group, must be one or more chars in group
          * \)                  #     find balanced closing ')'
-         * /s                  # end regex, /s is dotall mode - a dot metacharacter 
-         *                     # in the pattern matches all characters, including newlines. 
+         * /s                  # end regex, /s is dotall mode - a dot metacharacter
+         *                     # in the pattern matches all characters, including newlines.
          *                     # Without it, newlines are excluded
          */
-        // Note we don't capture any groups, therefore the regex captures the 
-        // whole (repeating) pattern that starts with an optional AND|OR|NOT and ends with a closing )  
+        // Note we don't capture any groups, therefore the regex captures the
+        // whole (repeating) pattern that starts with an optional AND|OR|NOT and ends with a closing )
         // Note, to escape a char we need to use 4 backslahses: http://php.net/manual/en/regexp.reference.escape.php
-     
+
         // preg_match_all
         // - Returns the number of full pattern matches (which might be zero),
-        // or FALSE if an error occurred. 
-        // - Default PREG_PATTERN_ORDER orders results so that $groups[0] is an 
-        // array of full pattern matches, $groups[1] is an array of strings 
-        // matched by the first parenthesized subgroup, and so on. Since we 
-        // are not capturing any sub-groups, only $groups[0] has matched values. 
+        // or FALSE if an error occurred.
+        // - Default PREG_PATTERN_ORDER orders results so that $groups[0] is an
+        // array of full pattern matches, $groups[1] is an array of strings
+        // matched by the first parenthesized subgroup, and so on. Since we
+        // are not capturing any sub-groups, only $groups[0] has matched values.
         $patternMatchCount = preg_match_all($patternMatchRepeat, $string, $groups);
-        //print_r($groups); 
-        $this->assertEquals($patternMatchCount, $expectedCaptureCount); 
+        //print_r($groups);
+        $this->assertEquals($patternMatchCount, $expectedCaptureCount);
 
-        $this->assertEquals("AND ( color: \) #888; )", $groups[0][0]); 
-        $this->assertEquals("OR ( body \( color: \( #333; \) )", $groups[0][1]); 
-        $this->assertEquals("NOT ( body \( color=\= \( #333; \) )", $groups[0][2]); 
-        $this->assertEquals("( help\\ me \(forest\) help me )", $groups[0][3]); 
-        $this->assertEquals("( color: blue;\(\) \n\n\n )", $groups[0][4]);  // note newlines are shown when printing to screen, which is correct !  
-        $this->assertEquals("( color: blue;\(\) \ )", $groups[0][5]); 
-        $this->assertEquals("( \ )", $groups[0][6]); 
-        $this->assertEquals("( \\ )", $groups[0][7]);   // note, output shows only a single backslash when printing to screen, which is correct !  
-        $this->assertEquals("( tab\ttab )", $groups[0][8]);   // note, output shows 'tab    tab' when printed to screen, which is correct ! 
+        $this->assertEquals("AND ( color: \) #888; )", $groups[0][0]);
+        $this->assertEquals("OR ( body \( color: \( #333; \) )", $groups[0][1]);
+        $this->assertEquals("NOT ( body \( color=\= \( #333; \) )", $groups[0][2]);
+        $this->assertEquals("( help\\ me \(forest\) help me )", $groups[0][3]);
+        $this->assertEquals("( color: blue;\(\) \n\n\n )", $groups[0][4]);  // note newlines are shown when printing to screen, which is correct !
+        $this->assertEquals("( color: blue;\(\) \ )", $groups[0][5]);
+        $this->assertEquals("( \ )", $groups[0][6]);
+        $this->assertEquals("( \\ )", $groups[0][7]);   // note, output shows only a single backslash when printing to screen, which is correct !
+        $this->assertEquals("( tab\ttab )", $groups[0][8]);   // note, output shows 'tab    tab' when printed to screen, which is correct !
         $this->assertEquals("(\\\)", $groups[0][9]);
         $this->assertEquals("(\\\\)", $groups[0][10]);
         $this->assertEquals("NOT(\\\\////)", $groups[0][11]);
-        // next step to implement new ExtensionParser: 
+        // next step to implement new ExtensionParser:
         // iterate the groups,
-        // record optional leading prefix (AND|OR|NOT) (throw if unexpected prefix), 
-        // trim and remove leading/trailing parenthesis (throw if no leading/trailing parenthesis) 
-        // spit on first equals '=' char to separate key and value (throw if no equals char present) 
-        // check for allowed/illegal chars in key and value e.g. something like below (throw if illegal chars present  
-       
+        // record optional leading prefix (AND|OR|NOT) (throw if unexpected prefix),
+        // trim and remove leading/trailing parenthesis (throw if no leading/trailing parenthesis)
+        // spit on first equals '=' char to separate key and value (throw if no equals char present)
+        // check for allowed/illegal chars in key and value e.g. something like below (throw if illegal chars present
+
         $matches = array_values($groups[0]); //returns all the values from the array and indexes the array numerically
         //foreach($matches as $match){ echo($match."\n"); }
-        // foreach prints the following on the command line, notice how the 
-        // \t \n escaped slashes are interpreted when printed to screen, which is correct. 
+        // foreach prints the following on the command line, notice how the
+        // \t \n escaped slashes are interpreted when printed to screen, which is correct.
         /*
          AND ( color: \) #888; )
          OR ( body \( color: \( #333; \) )
          NOT ( body \( color=\= \( #333; \) )
          ( help\ me \(forest\) help me )
          ( color: blue;\(\)
- 
- 
+
+
           )
          ( color: blue;\(\) \ )
          ( \ )
@@ -411,8 +411,8 @@ AAA;
          (\\)
          NOT(\\////)
          */
-        
-        // iterate the matches and create expected return format, e.g.  
+
+        // iterate the matches and create expected return format, e.g.
         /* the query 'AND(VO=Alice)(VO=Atlas)NOT(VO=LHCB)' requires this format:
         Array
         (
@@ -421,13 +421,13 @@ AAA;
                     [0] => AND
                     [1] => VO=Alice
                 )
-        
+
             [1] => Array
                 (
                     [0] => AND
                     [1] => VO=Atlas
                 )
-        
+
             [2] => Array
                 (
                     [0] => NOT
@@ -435,194 +435,194 @@ AAA;
                 )
         ) */
 
-        
-        
-        
+
+
+
         $lastEncounteredPredicate = 'AND';  //default if not specified
-        $normalizedKV = array(); 
+        $normalizedKV = array();
         foreach($matches as $match){
-            $firstChar = substr($match, 0, 1); 
+            $firstChar = substr($match, 0, 1);
             //echo $firstChar; // one of the following: ( A O N
             if($firstChar == '('){
-                $predicate = $lastEncounteredPredicate; 
+                $predicate = $lastEncounteredPredicate;
             } else if(strtolower($firstChar) == 'a'){
-                $predicate = 'AND'; 
+                $predicate = 'AND';
             } else if(strtolower($firstChar) == 'o'){
-                $predicate = 'OR';         
+                $predicate = 'OR';
             } else if(strtolower($firstChar) == 'n'){
-                $predicate = 'NOT';         
+                $predicate = 'NOT';
             } else {
-                throw new \InvalidArgumentException('Invalid expression, could not extract predicate'); 
+                throw new \InvalidArgumentException('Invalid expression, could not extract predicate');
             }
-            $lastEncounteredPredicate = $predicate; 
-            //echo " ".$predicate."\n"; 
-            
-            // Find the position of the first occurrence of '(' (zero offset) 
-            $openingParenthesisPos = strpos($match, '('); 
-            if($openingParenthesisPos === FALSE){
-                throw new \InvalidArgumentException('Invalid expression, could not extract starting parenthesis'); 
-            }
-            // extract just the (xxxxxx) part of the expression 
-            $keyValPair = substr($match, $openingParenthesisPos, strlen($match) ); 
-            // trim the leading and trailing parenthesis 
-            $keyValPairNoParenthesis = substr($keyValPair, 1, strlen($keyValPair)-2); 
-            //echo $predicate.' '.$keyValPairNoParenthesis."\n"; 
-            
-            // build expected/normalized array 
-            $pred_kv = array(); 
-            $pred_kv[] = $predicate; 
-            $pred_kv[] = $keyValPairNoParenthesis; 
-            $normalizedKV[] = $pred_kv; 
-        }
-        //print_r($normalizedKV); 
+            $lastEncounteredPredicate = $predicate;
+            //echo " ".$predicate."\n";
 
-        // Test testDemoEscapedParenthesis2_GreedyMatchWholeExpression() also uses a v.similar pattern but instead 
-        // uses a greedy match to test that the whole regex is valid and has 
-        // no invalid content such as un-supported predicates and interleaving text. 
-        // See next test below. 
+            // Find the position of the first occurrence of '(' (zero offset)
+            $openingParenthesisPos = strpos($match, '(');
+            if($openingParenthesisPos === FALSE){
+                throw new \InvalidArgumentException('Invalid expression, could not extract starting parenthesis');
+            }
+            // extract just the (xxxxxx) part of the expression
+            $keyValPair = substr($match, $openingParenthesisPos, strlen($match) );
+            // trim the leading and trailing parenthesis
+            $keyValPairNoParenthesis = substr($keyValPair, 1, strlen($keyValPair)-2);
+            //echo $predicate.' '.$keyValPairNoParenthesis."\n";
+
+            // build expected/normalized array
+            $pred_kv = array();
+            $pred_kv[] = $predicate;
+            $pred_kv[] = $keyValPairNoParenthesis;
+            $normalizedKV[] = $pred_kv;
+        }
+        //print_r($normalizedKV);
+
+        // Test testDemoEscapedParenthesis2_GreedyMatchWholeExpression() also uses a v.similar pattern but instead
+        // uses a greedy match to test that the whole regex is valid and has
+        // no invalid content such as un-supported predicates and interleaving text.
+        // See next test below.
     }
-  
+
     /**
-     * Demo test that shows how to greedy match a whole extensions expression 
-     * (rather than individual predicates and parenthesis groups). 
+     * Demo test that shows how to greedy match a whole extensions expression
+     * (rather than individual predicates and parenthesis groups).
      * @throws \LogicException
      */
     public function testDemoEscapedParenthesis2_GreedyMatchWholeExpression(){
-        print __METHOD__ . "\n"; 
-        
+        print __METHOD__ . "\n";
+
         // http://stackoverflow.com/questions/10208694/regex-to-parse-string-with-escaped-characters
-        $optionalPredicateAndWhitespaceGroup = '(?:(?:AND|OR|NOT)[\s]*)?' ; // occurs 0 or 1 
+        $optionalPredicateAndWhitespaceGroup = '(?:(?:AND|OR|NOT)[\s]*)?' ; // occurs 0 or 1
         $parethesisGroup = '\((?:\\\\.|[^()\\\\])+\)';  // occurs 1
-            
-        $patternGreedyMatchAllLine = 
+
+        $patternGreedyMatchAllLine =
                 '/^'.    // anchor left
                   '(?:'.   // start main group but don't capture group
                       '[\s]*'.  // optional whitespace
                       $optionalPredicateAndWhitespaceGroup. // occurs 0 or 1
                       $parethesisGroup.  // occurs 1
                       '[\s]*'.  // optional whitespace
-                  ')+'.    // close main group, at least one required 
-                '$/s';   // anchor right, keep newlines        
+                  ')+'.    // close main group, at least one required
+                '$/s';   // anchor right, keep newlines
 
         // This string is valid, there are no invalid predicates or rogue strings
-        // interleaved inbetween parenthesis groups 
-        $string = 
-        "  AND ( color: \) #888; )  ".   // note leading/trailing whitespace is allowed 
-        "OR ( body \( color: \( #333; \) ) 
-        NOT ( body \( color=\= \( #333; \) ) 
-        ( help\\ me \(forest\) help me ) 
+        // interleaved inbetween parenthesis groups
+        $string =
+        "  AND ( color: \) #888; )  ".   // note leading/trailing whitespace is allowed
+        "OR ( body \( color: \( #333; \) )
+        NOT ( body \( color=\= \( #333; \) )
+        ( help\\ me \(forest\) help me )
         NOT ( color: blue;\(\) \n\n\n )
-        ( color: blue;\(\) \ ) 
-        ( \ ) 
+        ( color: blue;\(\) \ )
+        ( \ )
         ( \\ )
         OR ( tab\ttab )
         (\\\)
         (\\\\)
-        NOT(\\\\////)  "; 
-        
-        // returns 1 if match, 0 if not match, FALSE if error 
-        $matchAllString = preg_match($patternGreedyMatchAllLine, $string); 
-        if($matchAllString === FALSE){
-            throw new \LogicException("An error occurred parsing query"); 
-        }
-        $this->assertEquals($matchAllString, 1); 
+        NOT(\\\\////)  ";
 
-        // This string is invalid, notice the rogue string sitting outside the parethesis 
-        $string = " AND ( color: \) #888; )  thisfailmatch ".   // note leading/trailing whitespace is allowed 
-        "OR ( body \( color: \( #333; \) ) "; 
-        
-        $matchAllString = preg_match($patternGreedyMatchAllLine, $string); 
+        // returns 1 if match, 0 if not match, FALSE if error
+        $matchAllString = preg_match($patternGreedyMatchAllLine, $string);
         if($matchAllString === FALSE){
-            throw new \LogicException("An error occurred parsing query"); 
+            throw new \LogicException("An error occurred parsing query");
         }
-        $this->assertEquals($matchAllString, 0); 
+        $this->assertEquals($matchAllString, 1);
+
+        // This string is invalid, notice the rogue string sitting outside the parethesis
+        $string = " AND ( color: \) #888; )  thisfailmatch ".   // note leading/trailing whitespace is allowed
+        "OR ( body \( color: \( #333; \) ) ";
+
+        $matchAllString = preg_match($patternGreedyMatchAllLine, $string);
+        if($matchAllString === FALSE){
+            throw new \LogicException("An error occurred parsing query");
+        }
+        $this->assertEquals($matchAllString, 0);
     }
 
-    
+
     public function test_DemoStripSlashes(){
-        print __METHOD__ . "\n"; 
+        print __METHOD__ . "\n";
         $query = 'NOT  (color: blue;\(\) \n\n\n) ';
-        $query = stripslashes($query); 
-        // Returns a string with backslashes stripped off. (\' becomes ' and so on.) 
-        // Double backslashes (\\) are made into a single backslash (\). 
-        $this->assertEquals('NOT  (color: blue;() nnn) ', $query); 
+        $query = stripslashes($query);
+        // Returns a string with backslashes stripped off. (\' becomes ' and so on.)
+        // Double backslashes (\\) are made into a single backslash (\).
+        $this->assertEquals('NOT  (color: blue;() nnn) ', $query);
 
-        $query = 'NOT(\\\\////) '; 
-        $query = stripslashes($query); 
-        $this->assertEquals('NOT(\////) ', $query); 
+        $query = 'NOT(\\\\////) ';
+        $query = stripslashes($query);
+        $this->assertEquals('NOT(\////) ', $query);
 
-        $query = '( help\\ me \(forest\) help me )'; 
-        $query = stripslashes($query); 
-        $this->assertEquals('( help me (forest) help me )', $query); 
-        
-        $query = '\\\\'; 
-        $query = stripslashes($query); 
-        $this->assertEquals('\\', $query);  // a single slash (which itself needs to be escaped in the expected value !) 
-       
-        $query = '\\\\\\\\'; 
-        $query = stripslashes($query); 
-        $this->assertEquals('\\\\', $query);  // a double slash '\\' (which itself needs to be escaped in the expected value !) 
-        
-        $query = '( tab\ttab )'; 
-        $query = stripslashes($query); 
-        $this->assertEquals('( tabttab )', $query); 
+        $query = '( help\\ me \(forest\) help me )';
+        $query = stripslashes($query);
+        $this->assertEquals('( help me (forest) help me )', $query);
+
+        $query = '\\\\';
+        $query = stripslashes($query);
+        $this->assertEquals('\\', $query);  // a single slash (which itself needs to be escaped in the expected value !)
+
+        $query = '\\\\\\\\';
+        $query = stripslashes($query);
+        $this->assertEquals('\\\\', $query);  // a double slash '\\' (which itself needs to be escaped in the expected value !)
+
+        $query = '( tab\ttab )';
+        $query = stripslashes($query);
+        $this->assertEquals('( tabttab )', $query);
     }
 
     public function test_ExensionsQueryNormaliser(){
-        print __METHOD__ . "\n"; 
-        $extNorm = new \org\gocdb\services\ExtensionsQueryNormaliser(); 
-        
-        $query = 'AND(VO=Alice)(VO=Atlas)NOT(VO=LHCB)';  
-        $normalisedQuery = $extNorm->convert($query); 
-        //print_r($normalisedQuery); 
-        $this->assertEquals('AND', $normalisedQuery[0][0]); 
-        $this->assertEquals('VO=Alice', $normalisedQuery[0][1]); 
-        $this->assertEquals('AND', $normalisedQuery[1][0]); 
-        $this->assertEquals('VO=Atlas', $normalisedQuery[1][1]); 
-        $this->assertEquals('NOT', $normalisedQuery[2][0]); 
-        $this->assertEquals('VO=LHCB', $normalisedQuery[2][1]); 
-        
-        $query= 
-        "  AND ( color: \) #888; )  ".   // note leading/trailing whitespace is allowed 
-        "OR ( body \( color: \( #333; \) ) 
-        NOT ( body \( color=\= \( #333; \) ) 
-        ( help\\ me \(forest\) help me ) 
+        print __METHOD__ . "\n";
+        $extNorm = new \org\gocdb\services\ExtensionsQueryNormaliser();
+
+        $query = 'AND(VO=Alice)(VO=Atlas)NOT(VO=LHCB)';
+        $normalisedQuery = $extNorm->convert($query);
+        //print_r($normalisedQuery);
+        $this->assertEquals('AND', $normalisedQuery[0][0]);
+        $this->assertEquals('VO=Alice', $normalisedQuery[0][1]);
+        $this->assertEquals('AND', $normalisedQuery[1][0]);
+        $this->assertEquals('VO=Atlas', $normalisedQuery[1][1]);
+        $this->assertEquals('NOT', $normalisedQuery[2][0]);
+        $this->assertEquals('VO=LHCB', $normalisedQuery[2][1]);
+
+        $query=
+        "  AND ( color: \) #888; )  ".   // note leading/trailing whitespace is allowed
+        "OR ( body \( color: \( #333; \) )
+        NOT ( body \( color=\= \( #333; \) )
+        ( help\\ me \(forest\) help me )
         NOT ( color: blue;\(\) \n\n\n )
-        ( color: blue;\(\) \ ) 
-        ( \ ) 
+        ( color: blue;\(\) \ )
+        ( \ )
         ( \\ )
         OR ( tab\ttab )
         (\\\)
         (\\\\)
-        NOT(\\\\////)  "; 
-        $normalisedQuery = $extNorm->convert($query); 
-        //print_r($normalisedQuery);  
-        $this->assertEquals('AND', $normalisedQuery[0][0]);   
-        $this->assertEquals(' color: \) #888; ', $normalisedQuery[0][1]); // note whitespace WITHIN value is preserved, inc leading/trailing  
-        $this->assertEquals('OR', $normalisedQuery[1][0]);   
-        $this->assertEquals(' body \( color: \( #333; \) ', $normalisedQuery[1][1]); // note whitespace WITHIN value is preserved, inc leading/trailing  
-        $this->assertEquals('NOT', $normalisedQuery[2][0]);   
-        $this->assertEquals(' body \( color=\= \( #333; \) ', $normalisedQuery[2][1]); 
-        $this->assertEquals('NOT', $normalisedQuery[3][0]);   
-        $this->assertEquals(' help\\ me \(forest\) help me ', $normalisedQuery[3][1]); 
-        $this->assertEquals('NOT', $normalisedQuery[4][0]);   
-        $this->assertEquals(" color: blue;\(\) \n\n\n ", $normalisedQuery[4][1]); //note " needed to evaluate newline 
-        $this->assertEquals('NOT', $normalisedQuery[5][0]);   
-        $this->assertEquals(" color: blue;\(\) \ ", $normalisedQuery[5][1]);  
- 
-        $this->assertEquals('OR', $normalisedQuery[8][0]);   
-        $this->assertEquals(" tab\ttab ", $normalisedQuery[8][1]);   // note " to evaluate tab 
-        
-        $this->assertEquals('OR', $normalisedQuery[10][0]);   
-        $this->assertEquals('\\\\', $normalisedQuery[10][1]);  
-        $this->assertEquals('NOT', $normalisedQuery[11][0]);   
-        $this->assertEquals('\\\\////', $normalisedQuery[11][1]);  
+        NOT(\\\\////)  ";
+        $normalisedQuery = $extNorm->convert($query);
+        //print_r($normalisedQuery);
+        $this->assertEquals('AND', $normalisedQuery[0][0]);
+        $this->assertEquals(' color: \) #888; ', $normalisedQuery[0][1]); // note whitespace WITHIN value is preserved, inc leading/trailing
+        $this->assertEquals('OR', $normalisedQuery[1][0]);
+        $this->assertEquals(' body \( color: \( #333; \) ', $normalisedQuery[1][1]); // note whitespace WITHIN value is preserved, inc leading/trailing
+        $this->assertEquals('NOT', $normalisedQuery[2][0]);
+        $this->assertEquals(' body \( color=\= \( #333; \) ', $normalisedQuery[2][1]);
+        $this->assertEquals('NOT', $normalisedQuery[3][0]);
+        $this->assertEquals(' help\\ me \(forest\) help me ', $normalisedQuery[3][1]);
+        $this->assertEquals('NOT', $normalisedQuery[4][0]);
+        $this->assertEquals(" color: blue;\(\) \n\n\n ", $normalisedQuery[4][1]); //note " needed to evaluate newline
+        $this->assertEquals('NOT', $normalisedQuery[5][0]);
+        $this->assertEquals(" color: blue;\(\) \ ", $normalisedQuery[5][1]);
 
-        // print 
+        $this->assertEquals('OR', $normalisedQuery[8][0]);
+        $this->assertEquals(" tab\ttab ", $normalisedQuery[8][1]);   // note " to evaluate tab
+
+        $this->assertEquals('OR', $normalisedQuery[10][0]);
+        $this->assertEquals('\\\\', $normalisedQuery[10][1]);
+        $this->assertEquals('NOT', $normalisedQuery[11][0]);
+        $this->assertEquals('\\\\////', $normalisedQuery[11][1]);
+
+        // print
 //        foreach($normalisedQuery as $singleOperatorAndExpression){
-//           $operator = $singleOperatorAndExpression[0]; 
-//           $expression= $singleOperatorAndExpression[1]; 
-//           print_r($operator.'  ['.$expression."]\n");  
+//           $operator = $singleOperatorAndExpression[0];
+//           $expression= $singleOperatorAndExpression[1];
+//           print_r($operator.'  ['.$expression."]\n");
 //        }
     }
 
@@ -632,7 +632,7 @@ AAA;
 
         $errors = array();
         $errors = $keyValValidator->validate(' VOa= testa ', $errors);
-        //print_r($errors); 
+        //print_r($errors);
         $this->assertEmpty($errors);
 
         $errors = array();
@@ -640,18 +640,18 @@ AAA;
         $this->assertEquals(1, count($errors));
 
         $errors = array();
-        $errors = $keyValValidator->validate('VOc=testc;', $errors); 
+        $errors = $keyValValidator->validate('VOc=testc;', $errors);
         $this->assertEquals(0, count($errors));
-        
+
         $errors = array();
-        // no equals char and empty string 
-        $multipleInvalidKVpairs = array('no equals char', 'key=(charIn value);', ''); 
+        // no equals char and empty string
+        $multipleInvalidKVpairs = array('no equals char', 'key=(charIn value);', '');
         foreach($multipleInvalidKVpairs as $keyValPair){
             $errors = $keyValValidator->validate($keyValPair, $errors);
         }
         $this->assertEquals(2, count($errors));
-        //print_r($errors); 
-        
+        //print_r($errors);
+
     }
 
     public function test_ExensionsParser2() {
@@ -659,139 +659,139 @@ AAA;
         $extP = new \org\gocdb\services\ExtensionsParser2();
 
         $query = "(VO2=bing)AND(VO2=baz) OR(VO=bar) NOT(s1p1=v1)";
-        $normalisedStripped = $extP->parseQuery($query); 
-        $this->assertEquals('AND', $normalisedStripped[0][0]); 
-        $this->assertEquals('VO2=bing', $normalisedStripped[0][1]); 
-        $this->assertEquals('AND', $normalisedStripped[1][0]); 
-        $this->assertEquals('VO2=baz', $normalisedStripped[1][1]); 
-        $this->assertEquals('OR', $normalisedStripped[2][0]); 
-        $this->assertEquals('VO=bar', $normalisedStripped[2][1]); 
-        $this->assertEquals('NOT', $normalisedStripped[3][0]); 
-        $this->assertEquals('s1p1=v1', $normalisedStripped[3][1]); 
+        $normalisedStripped = $extP->parseQuery($query);
+        $this->assertEquals('AND', $normalisedStripped[0][0]);
+        $this->assertEquals('VO2=bing', $normalisedStripped[0][1]);
+        $this->assertEquals('AND', $normalisedStripped[1][0]);
+        $this->assertEquals('VO2=baz', $normalisedStripped[1][1]);
+        $this->assertEquals('OR', $normalisedStripped[2][0]);
+        $this->assertEquals('VO=bar', $normalisedStripped[2][1]);
+        $this->assertEquals('NOT', $normalisedStripped[3][0]);
+        $this->assertEquals('s1p1=v1', $normalisedStripped[3][1]);
 
 
-        $query = "  AND (key= color: \) #888; )  " . // note leading/trailing whitespace is allowed 
-                "OR (key= body \( color: \( #333; \) ) 
-        NOT (key= body \( color=\= \( #333; \) ) 
-        (key=help\\ me \(forest\) help me ) 
+        $query = "  AND (key= color: \) #888; )  " . // note leading/trailing whitespace is allowed
+                "OR (key= body \( color: \( #333; \) )
+        NOT (key= body \( color=\= \( #333; \) )
+        (key=help\\ me \(forest\) help me )
         NOT (key=color: blue;\(\) \n\n\n )
-        (key=color: blue;\(\) \ ) 
-        (key= \ ) 
+        (key=color: blue;\(\) \ )
+        (key= \ )
         (key= \\ )
         OR (key= tab\ttab )
         (key=\\\)
         (key=\\\\)
         NOT(key=\\\\////)  AND(A=b)";
-       
-        $normalisedStripped = $extP->parseQuery($query); 
-        $this->assertEquals('AND', $normalisedStripped[0][0]); 
-        $this->assertEquals('key= color: ) #888; ', $normalisedStripped[0][1]); 
-        
-        $this->assertEquals('OR', $normalisedStripped[1][0]); 
-        $this->assertEquals('key= body ( color: ( #333; ) ', $normalisedStripped[1][1]); 
-        
-        $this->assertEquals('NOT', $normalisedStripped[2][0]); 
-        $this->assertEquals('key= body ( color== ( #333; ) ', $normalisedStripped[2][1]); 
 
-        $this->assertEquals('NOT', $normalisedStripped[3][0]); 
-        $this->assertEquals('key=help me (forest) help me ', $normalisedStripped[3][1]); 
+        $normalisedStripped = $extP->parseQuery($query);
+        $this->assertEquals('AND', $normalisedStripped[0][0]);
+        $this->assertEquals('key= color: ) #888; ', $normalisedStripped[0][1]);
 
-        $this->assertEquals('NOT', $normalisedStripped[4][0]); 
-        $this->assertEquals("key=color: blue;() \n\n\n ", $normalisedStripped[4][1]); // note we need double quote to evaluate the newline 
+        $this->assertEquals('OR', $normalisedStripped[1][0]);
+        $this->assertEquals('key= body ( color: ( #333; ) ', $normalisedStripped[1][1]);
 
-        $this->assertEquals('NOT', $normalisedStripped[6][0]); 
-        $this->assertEquals('key=  ', $normalisedStripped[6][1]);  // two spaces 
+        $this->assertEquals('NOT', $normalisedStripped[2][0]);
+        $this->assertEquals('key= body ( color== ( #333; ) ', $normalisedStripped[2][1]);
 
-        $this->assertEquals('NOT', $normalisedStripped[7][0]); 
-        $this->assertEquals('key=  ', $normalisedStripped[7][1]);  // two spaces 
+        $this->assertEquals('NOT', $normalisedStripped[3][0]);
+        $this->assertEquals('key=help me (forest) help me ', $normalisedStripped[3][1]);
 
-        $this->assertEquals('OR', $normalisedStripped[8][0]); 
-        $this->assertEquals("key= tab\ttab ", $normalisedStripped[8][1]); // note we need double quote to evaluate the tab 
-                
-        $this->assertEquals('OR', $normalisedStripped[9][0]); 
-        $this->assertEquals('key=\\', $normalisedStripped[9][1]);  // slingle slash (extra slash is to escape closing quote ' 
-        
-        $this->assertEquals('OR', $normalisedStripped[10][0]); 
-        $this->assertEquals('key=\\', $normalisedStripped[10][1]);  // single slash (extra slash is to escape closing quote ' 
+        $this->assertEquals('NOT', $normalisedStripped[4][0]);
+        $this->assertEquals("key=color: blue;() \n\n\n ", $normalisedStripped[4][1]); // note we need double quote to evaluate the newline
 
-        $this->assertEquals('NOT', $normalisedStripped[11][0]); 
-        $this->assertEquals('key=\////', $normalisedStripped[11][1]); // single slash followed by 4 forward slash  
-        
-        $this->assertEquals('AND', $normalisedStripped[12][0]); 
-        $this->assertEquals('A=b', $normalisedStripped[12][1]); 
-        
-        //print_r($normalisedStripped); 
+        $this->assertEquals('NOT', $normalisedStripped[6][0]);
+        $this->assertEquals('key=  ', $normalisedStripped[6][1]);  // two spaces
+
+        $this->assertEquals('NOT', $normalisedStripped[7][0]);
+        $this->assertEquals('key=  ', $normalisedStripped[7][1]);  // two spaces
+
+        $this->assertEquals('OR', $normalisedStripped[8][0]);
+        $this->assertEquals("key= tab\ttab ", $normalisedStripped[8][1]); // note we need double quote to evaluate the tab
+
+        $this->assertEquals('OR', $normalisedStripped[9][0]);
+        $this->assertEquals('key=\\', $normalisedStripped[9][1]);  // slingle slash (extra slash is to escape closing quote '
+
+        $this->assertEquals('OR', $normalisedStripped[10][0]);
+        $this->assertEquals('key=\\', $normalisedStripped[10][1]);  // single slash (extra slash is to escape closing quote '
+
+        $this->assertEquals('NOT', $normalisedStripped[11][0]);
+        $this->assertEquals('key=\////', $normalisedStripped[11][1]); // single slash followed by 4 forward slash
+
+        $this->assertEquals('AND', $normalisedStripped[12][0]);
+        $this->assertEquals('A=b', $normalisedStripped[12][1]);
+
+        //print_r($normalisedStripped);
     }
-    
+
     /*public function not_testDemoValidateFullExpressionAndExtractCaptures(){
          print __METHOD__ . "\n";
-       
-         $anchLeftToCapture='/';  
-         $anchRightToCapture='/i';  
-         $anchLeftFull='/';  
-         $anchRightFull='$/'; 
+
+         $anchLeftToCapture='/';
+         $anchRightToCapture='/i';
+         $anchLeftFull='/';
+         $anchRightFull='$/';
          // key is quite restrictive, only alpha-numerics and some chars considered useful for keys
-         $keyregex="[a-zA-Z0-9\s@_\-\[\]\+\.]{1,255}"; 
+         $keyregex="[a-zA-Z0-9\s@_\-\[\]\+\.]{1,255}";
          // val is any char except parenthesis () and the following to protect against sql injection  "';`
          $valregex="[^'\";\(\)`]{1,255}";
          // A single key=value pair
-         $keyVal = "\(".$keyregex."=".$valregex."\)"; 
+         $keyVal = "\(".$keyregex."=".$valregex."\)";
          // must specify at least 1 kv pair
-         $regexKeyVal = "(".$keyVal.")+"; 
+         $regexKeyVal = "(".$keyVal.")+";
          $regexOperator = "(AND|OR|NOT)?";
-         
-         // This regex can be used to extract the captures 
-         $regexCapture = $anchLeftToCapture."(".$regexOperator.$regexKeyVal.")".$anchRightToCapture; 
-         // This regex can be used to test that the whole string in full passes (using full left and right anchors) 
+
+         // This regex can be used to extract the captures
+         $regexCapture = $anchLeftToCapture."(".$regexOperator.$regexKeyVal.")".$anchRightToCapture;
+         // This regex can be used to test that the whole string in full passes (using full left and right anchors)
          $regexFull = $anchLeftFull."(".$regexOperator.$regexKeyVal.")".$anchRightFull;
-         //print $regexFull . "\n"; 
-        
-         $pattern ="(1VO=test1,test2,test3,test4)";  
-         $this->assertEquals(1, preg_match($regexFull, $pattern)); 
-         $this->assertEquals(1, preg_match_all($regexCapture, $pattern, $matches));
-         $this->assertEquals($matches[0][0],$pattern); 
-         print_r($matches);  
+         //print $regexFull . "\n";
 
-         
-         $pattern="(dave=1)(dave=2)(dave=3)";  
-         $this->assertEquals(1, preg_match($regexFull, $pattern)); 
+         $pattern ="(1VO=test1,test2,test3,test4)";
+         $this->assertEquals(1, preg_match($regexFull, $pattern));
          $this->assertEquals(1, preg_match_all($regexCapture, $pattern, $matches));
-         $this->assertEquals($matches[0][0],$pattern); 
-         print_r($matches);  
+         $this->assertEquals($matches[0][0],$pattern);
+         print_r($matches);
 
-         
-         $pattern="OR(VO=test1)(VO=test2)(VO=test3)"; 
-         $this->assertEquals(1, preg_match($regexFull, $pattern)); 
+
+         $pattern="(dave=1)(dave=2)(dave=3)";
+         $this->assertEquals(1, preg_match($regexFull, $pattern));
          $this->assertEquals(1, preg_match_all($regexCapture, $pattern, $matches));
-         $this->assertEquals($matches[0][0],$pattern); 
-         print_r($matches);  
+         $this->assertEquals($matches[0][0],$pattern);
+         print_r($matches);
 
-         
-         $p1="OR(VO=test)(VO=test)(VO=test)"; 
-         $p2="OR(VO=test)(VO=test)(VO=test)"; 
+
+         $pattern="OR(VO=test1)(VO=test2)(VO=test3)";
+         $this->assertEquals(1, preg_match($regexFull, $pattern));
+         $this->assertEquals(1, preg_match_all($regexCapture, $pattern, $matches));
+         $this->assertEquals($matches[0][0],$pattern);
+         print_r($matches);
+
+
+         $p1="OR(VO=test)(VO=test)(VO=test)";
+         $p2="OR(VO=test)(VO=test)(VO=test)";
          $p3="AND(VO=test)(VO=test)(VO=test)";
-         $pattern = $p1.$p2.$p3; 
-         $this->assertEquals(1, preg_match($regexFull, $pattern)); 
+         $pattern = $p1.$p2.$p3;
+         $this->assertEquals(1, preg_match($regexFull, $pattern));
          $this->assertEquals(3, preg_match_all($regexCapture, $pattern, $matches));
-         $this->assertEquals($matches[0][0],$p1); 
-         $this->assertEquals($matches[0][1],$p2); 
-         $this->assertEquals($matches[0][2],$p3); 
-         print_r($matches);  
+         $this->assertEquals($matches[0][0],$p1);
+         $this->assertEquals($matches[0][1],$p2);
+         $this->assertEquals($matches[0][2],$p3);
+         print_r($matches);
 
-         
+
          $p1="(VO=test)(VO=test)(VO=test)";
-         $p2="OR(VO=test)(VO=test)(VO=test)"; 
-         $p3="AND(VO=test)(VO=test)(VO=test)"; 
-         $pattern = $p1.$p2.$p3; 
-         $this->assertEquals(1, preg_match($regexFull, $pattern)); 
+         $p2="OR(VO=test)(VO=test)(VO=test)";
+         $p3="AND(VO=test)(VO=test)(VO=test)";
+         $pattern = $p1.$p2.$p3;
+         $this->assertEquals(1, preg_match($regexFull, $pattern));
          $this->assertEquals(3, preg_match_all($regexCapture, $pattern, $matches));
-         $this->assertEquals($matches[0][0],$p1); 
-         $this->assertEquals($matches[0][1],$p2); 
-         $this->assertEquals($matches[0][2],$p3); 
-         print_r($matches);  
+         $this->assertEquals($matches[0][0],$p1);
+         $this->assertEquals($matches[0][1],$p2);
+         $this->assertEquals($matches[0][2],$p3);
+         print_r($matches);
      }*/
 
-    
+
 }
 
 

--- a/tests/resources/QueryPI_GetXmlOutput.php
+++ b/tests/resources/QueryPI_GetXmlOutput.php
@@ -1,87 +1,87 @@
 <?php
-set_time_limit(0); 
+set_time_limit(0);
 /**
- * Calls the gocdb PI methods in the 'methods' array foreach of the 
- * given baseurls. The XML PI output is saved to a sub dir named after the 
- * key in the baseurls associatative array (sub-dir created in same dir as script). 
- * The script can be used to compare the output from multiple instances of gocdb, 
- * e.g. when testing the output between versions. 
- *    
- * You will need to modify the CURL connection settings as required, e.g. 
- * set the proxy, usercert/key, private key password and so on.   
- * 
- * @author David Meredith 
+ * Calls the gocdb PI methods in the 'methods' array foreach of the
+ * given baseurls. The XML PI output is saved to a sub dir named after the
+ * key in the baseurls associatative array (sub-dir created in same dir as script).
+ * The script can be used to compare the output from multiple instances of gocdb,
+ * e.g. when testing the output between versions.
+ *
+ * You will need to modify the CURL connection settings as required, e.g.
+ * set the proxy, usercert/key, private key password and so on.
+ *
+ * @author David Meredith
  */
-$methods = array(   /*	
+$methods = array(   /*
                     'get_site_count_per_country',
                     'get_site_count_per_country&certification_status=Certified',
-  
-                    'get_site', 
-                    'get_site&roc=NGI_DE', 
-                    'get_site&certification_status=Certified', 
+
+                    'get_site',
+                    'get_site&roc=NGI_DE',
+                    'get_site&certification_status=Certified',
                     'get_site&extensions=(P4U_Pilot_VAT=20)(P4U_Pilot_Grid_CPU=)',
                     'get_site&scope=Local',
                     'get_site&scope=Local,EGI&scope_match=all',
- 
-                    'get_site_list', 
-                    'get_site_list&country=UK', 
-                    'get_site_list&scope=EGI', 					
-  
-                    'get_site_contacts', 
-                    'get_site_contacts&roletype=Site Security Officer', 
-                    'get_site_contacts&sitename=RAL-LCG2', 
-  
+
+                    'get_site_list',
+                    'get_site_list&country=UK',
+                    'get_site_list&scope=EGI',
+
+                    'get_site_contacts',
+                    'get_site_contacts&roletype=Site Security Officer',
+                    'get_site_contacts&sitename=RAL-LCG2',
+
                     'get_site_security_info',
                     'get_site_security_info&production_status=PPS',
                     'get_site_security_info&roc=NGI_DE',
-  
-                    'get_roc_list', 
-                    'get_roc_list&roc=NGI_UK', 
-  
-                    'get_roc_contacts', 
-    
-                    'get_subgrid_list', 
-                    'get_service_types', 
-    
-                    'get_user', 
-                    'get_user&roletype=Chief Operations Officer', 
-    
-                    'get_cert_status_changes', 
-                    'get_cert_status_changes&site=RAL-LCG2', 
-    
-                    'get_cert_status_date', 					
-    
-                    'get_ngi', 
+
+                    'get_roc_list',
+                    'get_roc_list&roc=NGI_UK',
+
+                    'get_roc_contacts',
+
+                    'get_subgrid_list',
+                    'get_service_types',
+
+                    'get_user',
+                    'get_user&roletype=Chief Operations Officer',
+
+                    'get_cert_status_changes',
+                    'get_cert_status_changes&site=RAL-LCG2',
+
+                    'get_cert_status_date',
+
+                    'get_ngi',
                     'get_ngi&roc=NGI_UK',
-                    'get_ngi&scope=Local,EGI&scope_match=any', 
-                    'get_ngi&scope=Local,EGI&scope_match=all', 
-    
-                    'get_project_contacts', 
-  
+                    'get_ngi&scope=Local,EGI&scope_match=any',
+                    'get_ngi&scope=Local,EGI&scope_match=all',
+
+                    'get_project_contacts',
+
                     // expected diff <ENDPOINTS/>
-                    'get_service_endpoint',  
-                    'get_service_endpoint&sitename=100IT', 
+                    'get_service_endpoint',
+                    'get_service_endpoint&sitename=100IT',
                     'get_service_endpoint&scope=',
-                    'get_service_endpoint&extensions=(P4U_Pilot_VAT=)', 
-   
-                    // expected diff: <AFFECTED_ENDPOINTS/> 
-                    'get_service_group',  
-                    'get_service_group&service_group_name=OPSTOOLS',  
-                    
-                    'get_service_group_role', 
-                    'get_service_group_role&scope=Local', 
+                    'get_service_endpoint&extensions=(P4U_Pilot_VAT=)',
+
+                    // expected diff: <AFFECTED_ENDPOINTS/>
+                    'get_service_group',
+                    'get_service_group&service_group_name=OPSTOOLS',
+
+                    'get_service_group_role',
+                    'get_service_group_role&scope=Local',
                     'get_service_group_role&service_group_name=OPSTOOLS'
-    
-                    'get_site_security_info&certification_status=Certified', 
+
+                    'get_site_security_info&certification_status=Certified',
 
                     // expected diffs: <AFFECTED_ENDPOINTS/> and ordering of services affected by downtime
-                    'get_downtime_to_broadcast',  
-                    'get_downtime_to_broadcast&interval=5', 
-                    'get_downtime_to_broadcast&interval=1', 
-    
+                    'get_downtime_to_broadcast',
+                    'get_downtime_to_broadcast&interval=5',
+                    'get_downtime_to_broadcast&interval=1',
+
                     // expected diff: <AFFECTED_ENDPOINTS/>
                     'get_downtime&topentity=RAL-LCG2',
-                    'get_downtime&scope=Local', 
+                    'get_downtime&scope=Local',
                     'get_downtime&page=1',
                     'get_downtime&all_lastmonth',
                     'get_downtime&startdate=2013-01-01&enddate=2013-02-01',
@@ -90,9 +90,9 @@ $methods = array(   /*
                     'get_downtime&site_extensions=(P4U_Pilot_VAT=20)&scope=EGI',
                     'get_downtime&windowstart=2014-10-01&windowend=2014-11-01',
                     'get_downtime&startdate=2014-10-01&enddate=2014-11-01',
-                   
+
                     // expected diff: <AFFECTED_ENDPOINTS/>
-                    'get_downtime_nested_services&page=1', 
+                    'get_downtime_nested_services&page=1',
                     'get_downtime_nested_services&topentity=RAL-LCG2',
                     'get_downtime_nested_services&all_lastmonth',
                     'get_downtime_nested_services&startdate=2013-01-01&enddate=2013-02-01',
@@ -101,50 +101,50 @@ $methods = array(   /*
                     'get_downtime_nested_services&ongoing_only=yes',
                     'get_downtime_nested_services&site_extensions=(P4U_Pilot_VAT=20)&scope=EGI',*/
 
-                    );				 
-                
-if(!isset($argv[1])){ 
-    die("Error missing arg. Usage:  php ".basename(__FILE__)." query|diff \n"); 
+                    );
+
+if(!isset($argv[1])){
+    die("Error missing arg. Usage:  php ".basename(__FILE__)." query|diff \n");
 }
-$v = $argv[1]; 
+$v = $argv[1];
 if(strcmp($v,  'query') && strcmp($v,  'diff')){
-    die("Error invalid arg. Usage:  php ".basename(__FILE__)." query|diff \n"); 
+    die("Error invalid arg. Usage:  php ".basename(__FILE__)." query|diff \n");
 }
 
-// associative array, key is used as result directory, value is used as baseurl 
+// associative array, key is used as result directory, value is used as baseurl
 $baseurls = array(
     '5_3' => 'https://localhost/gocdbpi5_3',
     '5_2' => 'https://localhost/gocdbpi5_2'
-    ); 
+    );
 
 if("query" == $v){
-    echo "Querying for output files\n"; 
+    echo "Querying for output files\n";
     // foreach method call using the different baseurl
     foreach($methods as $method){
           foreach($baseurls as $key => $baseurl){
-                $resultDir = $key; 
+                $resultDir = $key;
                 if(!file_exists($resultDir)){
-                    mkdir($resultDir); 
+                    mkdir($resultDir);
                 }
                 $fp = fopen($resultDir."/".$method.".xml", 'w');
-                $piquery = $baseurl."/public/?method=".$method; 
+                $piquery = $baseurl."/public/?method=".$method;
                 echo "Call: ".$piquery."\n";
                 //open connection
                 $ch = curl_init($piquery);
-                
+
                 curl_setopt_array($ch, array(
                     CURLOPT_SSL_VERIFYPEER => false,  //only false during testing on local machine
                     CURLOPT_SSL_VERIFYHOST => 2,
-                    CURLOPT_VERBOSE => false,    
+                    CURLOPT_VERBOSE => false,
                     CURLOPT_SSLCERT => 'usercert.pem', // client certificate, in same dir as script
                     CURLOPT_SSLKEY => 'userkey.pem',   // client private key, in same dir as script
-                    CURLOPT_SSLCERTPASSWD => 'somepassword', 
+                    CURLOPT_SSLCERTPASSWD => 'somepassword',
                     CURLOPT_SSLCERTTYPE => 'PEM',
                     CURLOPT_FILE => $fp,
-                    //CURLOPT_SSLVERSION => 3, 
-                    CURLOPT_PROXY => null  // set to null if querying PI on localhost 
+                    //CURLOPT_SSLVERSION => 3,
+                    CURLOPT_PROXY => null  // set to null if querying PI on localhost
                 ));
-                //curl_setopt($ch, CURLOPT_SSLVERSION,3); 
+                //curl_setopt($ch, CURLOPT_SSLVERSION,3);
 
                 $data = curl_exec($ch);
                 //close connection
@@ -157,28 +157,28 @@ if("query" == $v){
 else if ("diff" == $v) {
     echo "Diffing output files\n";
     foreach ($methods as $method) {
-        $diff_files = array(); 
+        $diff_files = array();
         foreach ($baseurls as $key => $baseurl) {
             $resultDir = $key;
-            $diff_files[] = $resultDir."/".$method.".xml";    
+            $diff_files[] = $resultDir."/".$method.".xml";
         }
-        $diffstr = ""; 
+        $diffstr = "";
         foreach($diff_files as $diff_file){
-           $diffstr .= escapeshellarg($diff_file). " ";  
+           $diffstr .= escapeshellarg($diff_file). " ";
         }
-        $diffstr = trim($diffstr); 
-        $cmd = "diff ". $diffstr; 
-        echo $cmd; 
-        echo "\n"; 
-        system($cmd); 
+        $diffstr = trim($diffstr);
+        $cmd = "diff ". $diffstr;
+        echo $cmd;
+        echo "\n";
+        system($cmd);
     }
-} 
-
-else {
-    echo "Error no valid arg given\n"; 
 }
 
- 
+else {
+    echo "Error no valid arg given\n";
+}
+
+
 
 
 

--- a/tests/unit/lib/Gocdb_Services/RoleActionAuthorisationServiceTest.php
+++ b/tests/unit/lib/Gocdb_Services/RoleActionAuthorisationServiceTest.php
@@ -12,12 +12,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-require_once __DIR__ . '/../../../doctrine/TestUtil.php'; 
-require_once __DIR__ . '/../../../../lib/Gocdb_Services/Role.php'; 
-require_once __DIR__ . '/../../../../lib/Gocdb_Services/RoleActionMappingService.php'; 
-require_once __DIR__ . '/../../../../lib/Gocdb_Services/RoleActionAuthorisationService.php'; 
+require_once __DIR__ . '/../../../doctrine/TestUtil.php';
+require_once __DIR__ . '/../../../../lib/Gocdb_Services/Role.php';
+require_once __DIR__ . '/../../../../lib/Gocdb_Services/RoleActionMappingService.php';
+require_once __DIR__ . '/../../../../lib/Gocdb_Services/RoleActionAuthorisationService.php';
 
-use Doctrine\ORM\EntityManager; 
+use Doctrine\ORM\EntityManager;
 require_once __DIR__ . '/../../../doctrine/bootstrap.php';
 
 
@@ -27,41 +27,41 @@ require_once __DIR__ . '/../../../doctrine/bootstrap.php';
  * @author djm76
  */
 class RoleActionAuthorisationServiceTest  extends PHPUnit_Extensions_Database_TestCase{
-    private $em; 
+    private $em;
 
 
 
     /**
-     * Overridden. 
+     * Overridden.
      */
     public static function setUpBeforeClass() {
         parent::setUpBeforeClass();
         echo "\n\n-------------------------------------------------\n";
         echo "Executing RoleServiceTest. . .\n";
     }
-    
+
     /**
      * Overridden. Returns the test database connection.
      * @return PHPUnit_Extensions_Database_DB_IDatabaseConnection
      */
     protected function getConnection() {
         require_once __DIR__ . '/../../../doctrine/bootstrap_pdo.php';
-        return getConnectionToTestDB(); 
+        return getConnectionToTestDB();
     }
 
     /**
-     * Overridden. Returns the test dataset.  
-     * Defines how the initial state of the database should look before each test is executed. 
+     * Overridden. Returns the test dataset.
+     * Defines how the initial state of the database should look before each test is executed.
      * @return PHPUnit_Extensions_Database_DataSet_IDataSet
      */
-    protected function getDataSet() { 
+    protected function getDataSet() {
         return $this->createFlatXMLDataSet(__DIR__ . '/../../../doctrine/truncateDataTables.xml');
         // Use below to return an empty data set if we don't want to truncate and seed
         //return new PHPUnit_Extensions_Database_DataSet_DefaultDataSet();
     }
 
     /**
-     * Overridden. 
+     * Overridden.
      */
     protected function getSetUpOperation() {
         // CLEAN_INSERT is default
@@ -69,14 +69,14 @@ class RoleActionAuthorisationServiceTest  extends PHPUnit_Extensions_Database_Te
         //return PHPUnit_Extensions_Database_Operation_Factory::UPDATE();
         //return PHPUnit_Extensions_Database_Operation_Factory::NONE();
         //
-        // Issue a DELETE from <table> which is more portable than a 
-        // TRUNCATE table <table> (some DBs require high privileges for truncate statements 
+        // Issue a DELETE from <table> which is more portable than a
+        // TRUNCATE table <table> (some DBs require high privileges for truncate statements
         // and also do not allow truncates across tables with FK contstraints e.g. Oracle)
         return PHPUnit_Extensions_Database_Operation_Factory::DELETE_ALL();
     }
 
     /**
-     * Overridden. 
+     * Overridden.
      */
     protected function getTearDownOperation() {
         // NONE is default
@@ -88,17 +88,17 @@ class RoleActionAuthorisationServiceTest  extends PHPUnit_Extensions_Database_Te
      * This method is called before each test method is executed.
      */
     protected function setUp() {
-        parent::setUp();            
+        parent::setUp();
         $this->em = $this->createEntityManager();
     }
-    
+
     /**
-     * @todo Still need to setup connection to different databases. 
+     * @todo Still need to setup connection to different databases.
      * @return EntityManager
      */
     private function createEntityManager(){
         require __DIR__ . '/../../../doctrine/bootstrap_doctrine.php';
-        return $entityManager; 
+        return $entityManager;
     }
 
     /**
@@ -114,8 +114,8 @@ class RoleActionAuthorisationServiceTest  extends PHPUnit_Extensions_Database_Te
             //print $tableName->getName() . "\n";
             $sql = "SELECT * FROM ".$tableName->getName();
             $result = $con->createQueryTable('results_table', $sql);
-            //echo 'row count: '.$result->getRowCount() ; 
-            if($result->getRowCount() != 0){ 
+            //echo 'row count: '.$result->getRowCount() ;
+            if($result->getRowCount() != 0){
                 throw new RuntimeException("Invalid fixture. Table has rows: ".$tableName->getName());
             }
         }
@@ -123,60 +123,60 @@ class RoleActionAuthorisationServiceTest  extends PHPUnit_Extensions_Database_Te
 
 
     public function NOT_RUN_test_authoriseActionBug(){
-        print __METHOD__ . "\n";	
+        print __METHOD__ . "\n";
     $codRT = TestUtil::createSampleRoleType(TestRoleTypeName::COD_ADMIN);
-    $this->em->persist($codRT);  // edit all sites cert status only  
+    $this->em->persist($codRT);  // edit all sites cert status only
 
     // Create a user
         $u = TestUtil::createSampleUser("Test", "Testing", "/c=test");
         $this->em->persist($u);
 
     /*
-         * Create test data with the following structure 
-         * 
+         * Create test data with the following structure
+         *
          *   p1  EGI
          *    \  /
-         *     n1  
+         *     n1
          */
-        $p1 = new \Project("p1");  
-    $p2 = new \Project("EGI");  
+        $p1 = new \Project("p1");
+    $p2 = new \Project("EGI");
         $n1 = TestUtil::createSampleNGI("n1");
     $this->em->persist($p1);
     $this->em->persist($p2);
     $this->em->persist($n1);
-    $p1->addNgi($n1); 
-    $p2->addNgi($n1); 
+    $p1->addNgi($n1);
+    $p2->addNgi($n1);
 
-    // Build dependencies and inject business objects: 
-        // start a new connection to test transactional isolation of RoleService methods.  
+    // Build dependencies and inject business objects:
+        // start a new connection to test transactional isolation of RoleService methods.
         //$em2 = $this->createEntityManager();
         $em2 = $this->em;
 
         // Create RoleActionMappingService with non-default roleActionMappings file
-        $roleActionMappingService = new org\gocdb\services\RoleActionMappingService(); 
+        $roleActionMappingService = new org\gocdb\services\RoleActionMappingService();
         $roleActionMappingService->setRoleActionMappingsXmlPath(
-                __DIR__."/../../resources/roleActionMappingSamples/TestRoleActionMappings7.xml"); 
+                __DIR__."/../../resources/roleActionMappingSamples/TestRoleActionMappings7.xml");
 
-    // Create RoleActionAuthorisationService with dependencies 
+    // Create RoleActionAuthorisationService with dependencies
         $roleAuthServ = new org\gocdb\services\RoleActionAuthorisationService
-                ($roleActionMappingService/*, $roleService*/);  
-        $roleAuthServ->setEntityManager($em2); 
+                ($roleActionMappingService/*, $roleService*/);
+        $roleAuthServ->setEntityManager($em2);
 
-        // Create role and link user and owned entities (user link not shown) 
+        // Create role and link user and owned entities (user link not shown)
     /*
          * r1->p1  EGI
          *      \  /
-         *       n1  
+         *       n1
          */
-    $r1 = TestUtil::createSampleRole($u, $codRT, $p1, RoleStatus::GRANTED); 
+    $r1 = TestUtil::createSampleRole($u, $codRT, $p1, RoleStatus::GRANTED);
         $this->em->persist($r1);
         $this->em->flush();
 
-    // Assert user has no authorising roles over n1 BECAUSE p1 is not 
+    // Assert user has no authorising roles over n1 BECAUSE p1 is not
     // mapped in XML file and there is no default mapping!
-        $enablingRoles = $roleAuthServ->authoriseAction(\Action::REVOKE_ROLE, $n1, $u)->getGrantingRoles(); 
-    //print_r("dave: ".$enablingRoles[0]->getRoleType()->getName()); 
-        $this->assertEquals(0, count($enablingRoles)); 
+        $enablingRoles = $roleAuthServ->authoriseAction(\Action::REVOKE_ROLE, $n1, $u)->getGrantingRoles();
+    //print_r("dave: ".$enablingRoles[0]->getRoleType()->getName());
+        $this->assertEquals(0, count($enablingRoles));
     }
 
     public function test_authoriseAction(){
@@ -188,217 +188,217 @@ class RoleActionAuthorisationServiceTest  extends PHPUnit_Extensions_Database_Te
         $rodRT = TestUtil::createSampleRoleType(TestRoleTypeName::REG_STAFF_ROD);
         $codRT = TestUtil::createSampleRoleType(TestRoleTypeName::COD_ADMIN);
         $cooRT = TestUtil::createSampleRoleType(TestRoleTypeName::COO);
-        $this->em->persist($siteAdminRT); // edit site1 (but not cert status) 
+        $this->em->persist($siteAdminRT); // edit site1 (but not cert status)
         $this->em->persist($ngiManRT); // edit owned site1/site2 and cert status
         $this->em->persist($rodRT);  // edit owned sites 1and2 (but not cert status)
-        $this->em->persist($codRT);  // edit all sites cert status only  
-        $this->em->persist($cooRT);  // edit all sites cert status only  
-        $this->em->persist($siteDepManAdminRT);  // edit all sites cert status only  
-   
+        $this->em->persist($codRT);  // edit all sites cert status only
+        $this->em->persist($cooRT);  // edit all sites cert status only
+        $this->em->persist($siteDepManAdminRT);  // edit all sites cert status only
+
 
         // Create a user
         $u = TestUtil::createSampleUser("Test", "Testing", "/c=test");
         $this->em->persist($u);
 
         /*
-         * Create test data with the following structure (note p3 has two ngis) 
-         * 
+         * Create test data with the following structure (note p3 has two ngis)
+         *
          * p1  p2  p3
          * |   |  /|
          * n1  n2  n3
-         * |   |   | 
-         * s1  s2  s3 
+         * |   |   |
+         * s1  s2  s3
          */
         include __DIR__ . '/../../resources/sampleFixtureData6.php';
 
-        // Build dependencies and inject business objects: 
-        // start a new connection to test transactional isolation of RoleService methods.  
+        // Build dependencies and inject business objects:
+        // start a new connection to test transactional isolation of RoleService methods.
         //$em2 = $this->createEntityManager();
         $em2 = $this->em;
 
         // Create RoleActionMappingService with non-default roleActionMappings file
-        $roleActionMappingService = new org\gocdb\services\RoleActionMappingService(); 
+        $roleActionMappingService = new org\gocdb\services\RoleActionMappingService();
         $roleActionMappingService->setRoleActionMappingsXmlPath(
-                __DIR__."/../../resources/roleActionMappingSamples/TestRoleActionMappings6.xml"); 
+                __DIR__."/../../resources/roleActionMappingSamples/TestRoleActionMappings6.xml");
 
-        //Create Role Service 
-        //$roleService = new org\gocdb\services\Role(); 
-        //$roleService->setEntityManager($em2); 
-        
-        // Create RoleActionAuthorisationService with dependencies 
+        //Create Role Service
+        //$roleService = new org\gocdb\services\Role();
+        //$roleService->setEntityManager($em2);
+
+        // Create RoleActionAuthorisationService with dependencies
         $roleAuthServ = new org\gocdb\services\RoleActionAuthorisationService
-                ($roleActionMappingService/*, $roleService*/);  
-        $roleAuthServ->setEntityManager($em2); 
+                ($roleActionMappingService/*, $roleService*/);
+        $roleAuthServ->setEntityManager($em2);
 
 
-        // Create role and link user and owned entities (user link not shown) 
+        // Create role and link user and owned entities (user link not shown)
         /*
          *    p1  p2  p3
          *    |    |  /|
          * r1-n1  n2  n3
-         *    |   |   | 
-         *    s1  s2  s3 
+         *    |   |   |
+         *    s1  s2  s3
          */
-        $r1 = TestUtil::createSampleRole($u, $ngiManRT, $n1, RoleStatus::GRANTED); 
+        $r1 = TestUtil::createSampleRole($u, $ngiManRT, $n1, RoleStatus::GRANTED);
         $this->em->persist($r1);
         $this->em->flush();
-        
-        // Assert user can edit s1 using r1 
-        $enablingRoles = $roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $s1, $u)->getGrantingRoles(); 
-        $this->assertEquals(1, count($enablingRoles)); 
-        $this->assertTrue(in_array($r1, $enablingRoles)); 
-        $this->assertEquals(TestRoleTypeName::NGI_OPS_MAN, $enablingRoles[0]->getRoleType()->getName()); 
-        
+
+        // Assert user can edit s1 using r1
+        $enablingRoles = $roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $s1, $u)->getGrantingRoles();
+        $this->assertEquals(1, count($enablingRoles));
+        $this->assertTrue(in_array($r1, $enablingRoles));
+        $this->assertEquals(TestRoleTypeName::NGI_OPS_MAN, $enablingRoles[0]->getRoleType()->getName());
+
         // Assert user can edit n1 using r1
-        $enablingRoles = $roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $n1, $u)->getGrantingRoles(); 
-        $this->assertEquals(1, count($enablingRoles)); 
-        $this->assertTrue(in_array($r1, $enablingRoles)); 
-        $this->assertEquals(TestRoleTypeName::NGI_OPS_MAN, $enablingRoles[0]->getRoleType()->getName()); 
+        $enablingRoles = $roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $n1, $u)->getGrantingRoles();
+        $this->assertEquals(1, count($enablingRoles));
+        $this->assertTrue(in_array($r1, $enablingRoles));
+        $this->assertEquals(TestRoleTypeName::NGI_OPS_MAN, $enablingRoles[0]->getRoleType()->getName());
 
         // Assert user can change s1 cert status with r1
-        $this->assertTrue(in_array($r1, $roleAuthServ->authoriseAction(\Action::SITE_EDIT_CERT_STATUS, $s1, $u)->getGrantingRoles()) ); 
-        
-        // Assert user can't edit other sites/ngis/projects 
-        $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $s2, $u)->getGrantingRoles())); 
-        $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $s3, $u)->getGrantingRoles())); 
-        $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $n2, $u)->getGrantingRoles())); 
-        $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $n3, $u)->getGrantingRoles())); 
-        $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $p1, $u)->getGrantingRoles())); 
-        $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $p2, $u)->getGrantingRoles())); 
-        $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $p3, $u)->getGrantingRoles())); 
-       
+        $this->assertTrue(in_array($r1, $roleAuthServ->authoriseAction(\Action::SITE_EDIT_CERT_STATUS, $s1, $u)->getGrantingRoles()) );
+
+        // Assert user can't edit other sites/ngis/projects
+        $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $s2, $u)->getGrantingRoles()));
+        $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $s3, $u)->getGrantingRoles()));
+        $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $n2, $u)->getGrantingRoles()));
+        $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $n3, $u)->getGrantingRoles()));
+        $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $p1, $u)->getGrantingRoles()));
+        $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $p2, $u)->getGrantingRoles()));
+        $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $p3, $u)->getGrantingRoles()));
+
          /*
          *    p1  p2  p3
          *    |    |  /|
          * r1-n1  n2  n3
-         *    |   |   | 
-         * r2-s1  s2  s3 
+         *    |   |   |
+         * r2-s1  s2  s3
          */
-        $r2 = TestUtil::createSampleRole($u, $siteAdminRT, $s1, RoleStatus::GRANTED) ; 
+        $r2 = TestUtil::createSampleRole($u, $siteAdminRT, $s1, RoleStatus::GRANTED) ;
         $this->em->persist($r2);
-        $this->em->flush(); 
+        $this->em->flush();
 
-        // Assert user can edit s1 using r1 + r2 
-        $enablingRoles = $roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $s1, $u)->getGrantingRoles(); 
-        $this->assertEquals(2, count($enablingRoles)); 
-        $this->assertTrue(in_array($r1, $enablingRoles));  
-        $this->assertTrue(in_array($r2, $enablingRoles));  
-        //$enablingRoleNames = $this->getRoleTypeNames($enablingRoles); 
-        //$this->assertTrue(in_array(TestRoleTypeName::NGI_OPS_MAN, $enablingRoleNames)); 
-        //$this->assertTrue(in_array(TestRoleTypeName::SITE_ADMIN, $enablingRoleNames)); 
-        
-        // Assert user can change site cert status with r1 
-        $enablingRoles = $roleAuthServ->authoriseAction(\Action::SITE_EDIT_CERT_STATUS, $s1, $u)->getGrantingRoles(); 
-        $this->assertEquals(1, count($enablingRoles)); 
-        $this->assertTrue(in_array($r1, $enablingRoles));  
+        // Assert user can edit s1 using r1 + r2
+        $enablingRoles = $roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $s1, $u)->getGrantingRoles();
+        $this->assertEquals(2, count($enablingRoles));
+        $this->assertTrue(in_array($r1, $enablingRoles));
+        $this->assertTrue(in_array($r2, $enablingRoles));
+        //$enablingRoleNames = $this->getRoleTypeNames($enablingRoles);
+        //$this->assertTrue(in_array(TestRoleTypeName::NGI_OPS_MAN, $enablingRoleNames));
+        //$this->assertTrue(in_array(TestRoleTypeName::SITE_ADMIN, $enablingRoleNames));
 
-        // Assert user can't edit other sites/ngis/projects 
-        $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $s2, $u)->getGrantingRoles())); 
-        $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $s3, $u)->getGrantingRoles())); 
-        $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $n2, $u)->getGrantingRoles())); 
-        $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $n3, $u)->getGrantingRoles())); 
-        $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $p1, $u)->getGrantingRoles())); 
-        $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $p2, $u)->getGrantingRoles())); 
-        $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $p3, $u)->getGrantingRoles())); 
+        // Assert user can change site cert status with r1
+        $enablingRoles = $roleAuthServ->authoriseAction(\Action::SITE_EDIT_CERT_STATUS, $s1, $u)->getGrantingRoles();
+        $this->assertEquals(1, count($enablingRoles));
+        $this->assertTrue(in_array($r1, $enablingRoles));
+
+        // Assert user can't edit other sites/ngis/projects
+        $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $s2, $u)->getGrantingRoles()));
+        $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $s3, $u)->getGrantingRoles()));
+        $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $n2, $u)->getGrantingRoles()));
+        $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $n3, $u)->getGrantingRoles()));
+        $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $p1, $u)->getGrantingRoles()));
+        $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $p2, $u)->getGrantingRoles()));
+        $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $p3, $u)->getGrantingRoles()));
 
         /*
          *    p1     p2  p3
          *    |      |  /|
          * r1-n1     n2  n3
-         *    |      |   | 
-         * r2-s1  r3-s2  s3  
+         *    |      |   |
+         * r2-s1  r3-s2  s3
          */
-        $r3 = TestUtil::createSampleRole($u, $siteAdminRT, $s2, RoleStatus::GRANTED) ; 
+        $r3 = TestUtil::createSampleRole($u, $siteAdminRT, $s2, RoleStatus::GRANTED) ;
         $this->em->persist($r3);
-        $this->em->flush(); 
+        $this->em->flush();
 
-        // Assert user can edit s1 via r1 + r2 
-        $enablingRoles = $roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $s1, $u)->getGrantingRoles(); 
-        $this->assertEquals(2, count($enablingRoles)); 
-        $this->assertTrue(in_array($r1, $enablingRoles));  
-        $this->assertTrue(in_array($r2, $enablingRoles));  
+        // Assert user can edit s1 via r1 + r2
+        $enablingRoles = $roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $s1, $u)->getGrantingRoles();
+        $this->assertEquals(2, count($enablingRoles));
+        $this->assertTrue(in_array($r1, $enablingRoles));
+        $this->assertTrue(in_array($r2, $enablingRoles));
 
-        // Assert user can edit s2 via r3 
-        $enablingRoles = $roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $s2, $u)->getGrantingRoles(); 
-        $this->assertEquals(1, count($enablingRoles)); 
-        $this->assertTrue(in_array($r3, $enablingRoles));  
-        
+        // Assert user can edit s2 via r3
+        $enablingRoles = $roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $s2, $u)->getGrantingRoles();
+        $this->assertEquals(1, count($enablingRoles));
+        $this->assertTrue(in_array($r3, $enablingRoles));
+
         // Assert user can change s1 cert status via r1
-        $enablingRoles = $roleAuthServ->authoriseAction(\Action::SITE_EDIT_CERT_STATUS, $s1, $u)->getGrantingRoles(); 
-        $this->assertEquals(1, count($enablingRoles)); 
-        $this->assertTrue(in_array($r1, $enablingRoles));  
-       
-        // Assert user cant change s2 cert status 
-        $enablingRoles = $roleAuthServ->authoriseAction(\Action::SITE_EDIT_CERT_STATUS, $s2, $u)->getGrantingRoles(); 
-        $this->assertEquals(0, count($enablingRoles)); 
+        $enablingRoles = $roleAuthServ->authoriseAction(\Action::SITE_EDIT_CERT_STATUS, $s1, $u)->getGrantingRoles();
+        $this->assertEquals(1, count($enablingRoles));
+        $this->assertTrue(in_array($r1, $enablingRoles));
 
-        // Assert user can't edit other sites/ngis/projects 
-        $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $s3, $u)->getGrantingRoles())); 
-        $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $n2, $u)->getGrantingRoles())); 
-        $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $n3, $u)->getGrantingRoles())); 
-        $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $p1, $u)->getGrantingRoles())); 
-        $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $p2, $u)->getGrantingRoles())); 
-        $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $p3, $u)->getGrantingRoles())); 
+        // Assert user cant change s2 cert status
+        $enablingRoles = $roleAuthServ->authoriseAction(\Action::SITE_EDIT_CERT_STATUS, $s2, $u)->getGrantingRoles();
+        $this->assertEquals(0, count($enablingRoles));
+
+        // Assert user can't edit other sites/ngis/projects
+        $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $s3, $u)->getGrantingRoles()));
+        $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $n2, $u)->getGrantingRoles()));
+        $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $n3, $u)->getGrantingRoles()));
+        $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $p1, $u)->getGrantingRoles()));
+        $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $p2, $u)->getGrantingRoles()));
+        $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $p3, $u)->getGrantingRoles()));
 
 
         /*
          *    p1  r4-p2  p3
          *    |      |  /|
          * r1-n1     n2  n3
-         *    |      |   | 
-         * r2-s1  r3-s2  s3  
+         *    |      |   |
+         * r2-s1  r3-s2  s3
          */
-        $r4 = TestUtil::createSampleRole($u, $cooRT, $p2, RoleStatus::GRANTED); 
+        $r4 = TestUtil::createSampleRole($u, $cooRT, $p2, RoleStatus::GRANTED);
         $this->em->persist($r4);
-        $this->em->flush(); 
+        $this->em->flush();
 
         // Assert user can edit p2 via r4
         $enablingRoles = $roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $p2, $u)->getGrantingRoles();
-        $this->assertEquals(1, count($enablingRoles)); 
-        $this->assertTrue(in_array($r4, $enablingRoles));  
+        $this->assertEquals(1, count($enablingRoles));
+        $this->assertTrue(in_array($r4, $enablingRoles));
 
         // Assert user can grantRole on p2 via r4
         $enablingRoles = $roleAuthServ->authoriseAction(\Action::GRANT_ROLE, $p2, $u)->getGrantingRoles();
-        $this->assertEquals(1, count($enablingRoles)); 
-        $this->assertTrue(in_array($r4, $enablingRoles));
-        
-        // Assert user can grantRole on n2 via r4
-        $enablingRoles = $roleAuthServ->authoriseAction(\Action::GRANT_ROLE, $n2, $u)->getGrantingRoles();
-        $this->assertEquals(1, count($enablingRoles)); 
+        $this->assertEquals(1, count($enablingRoles));
         $this->assertTrue(in_array($r4, $enablingRoles));
 
-        // Assert user can't edit other sites/ngis/projects 
-        $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $n2, $u)->getGrantingRoles())); 
-        $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $s3, $u)->getGrantingRoles())); 
-        $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $n3, $u)->getGrantingRoles())); 
-        $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $p3, $u)->getGrantingRoles())); 
-       
+        // Assert user can grantRole on n2 via r4
+        $enablingRoles = $roleAuthServ->authoriseAction(\Action::GRANT_ROLE, $n2, $u)->getGrantingRoles();
+        $this->assertEquals(1, count($enablingRoles));
+        $this->assertTrue(in_array($r4, $enablingRoles));
+
+        // Assert user can't edit other sites/ngis/projects
+        $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $n2, $u)->getGrantingRoles()));
+        $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $s3, $u)->getGrantingRoles()));
+        $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $n3, $u)->getGrantingRoles()));
+        $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $p3, $u)->getGrantingRoles()));
+
         /*
          *    p1  r4-p2  p3-r5
          *    |      |  /|
          * r1-n1     n2  n3
-         *    |      |   | 
-         * r2-s1  r3-s2  s3  
+         *    |      |   |
+         * r2-s1  r3-s2  s3
          */
-        $r5 = TestUtil::createSampleRole($u, $codRT, $p3, RoleStatus::GRANTED); 
+        $r5 = TestUtil::createSampleRole($u, $codRT, $p3, RoleStatus::GRANTED);
         $this->em->persist($r5);
-        $this->em->flush(); 
+        $this->em->flush();
 
-        // Assert user can edit p3 with r5 
+        // Assert user can edit p3 with r5
         $enablingRoles = $roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $p3, $u)->getGrantingRoles();
-        $this->assertEquals(1, count($enablingRoles)); 
+        $this->assertEquals(1, count($enablingRoles));
         $this->assertTrue(in_array($r5, $enablingRoles));
-        
+
         // Assert user can grant role on n2 + n3 via r5
         $enablingRoles = $roleAuthServ->authoriseAction(\Action::GRANT_ROLE, $n2, $u)->getGrantingRoles();
-        $this->assertEquals(2, count($enablingRoles)); 
+        $this->assertEquals(2, count($enablingRoles));
         $this->assertTrue(in_array($r5, $enablingRoles));
         $this->assertTrue(in_array($r4, $enablingRoles));
 
-        // Assert user can't edit other sites/ngis/projects 
-        $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $n2, $u)->getGrantingRoles())); 
-        $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $s3, $u)->getGrantingRoles())); 
-        $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $n3, $u)->getGrantingRoles())); 
+        // Assert user can't edit other sites/ngis/projects
+        $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $n2, $u)->getGrantingRoles()));
+        $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $s3, $u)->getGrantingRoles()));
+        $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $n3, $u)->getGrantingRoles()));
 
 
 
@@ -406,27 +406,27 @@ class RoleActionAuthorisationServiceTest  extends PHPUnit_Extensions_Database_Te
          *    p1  r4-p2  p3-r5
          *    |      |  /|
          * r1-n1     n2  n3-r6
-         *    |      |   | 
-         * r2-s1  r3-s2  s3  
+         *    |      |   |
+         * r2-s1  r3-s2  s3
          */
-        $r6 = TestUtil::createSampleRole($u, $ngiManRT, $n3, RoleStatus::GRANTED); 
+        $r6 = TestUtil::createSampleRole($u, $ngiManRT, $n3, RoleStatus::GRANTED);
         $this->em->persist($r6);
-        $this->em->flush(); 
+        $this->em->flush();
 
         /*
          *    p1  r4-p2  p3-r5
          *    |      |  /|
          * r1-n1     n2  n3-r6
-         *    |      |   | 
-         * r2-s1  r3-s2  s3-r7  
+         *    |      |   |
+         * r2-s1  r3-s2  s3-r7
          */
-        $r7 = TestUtil::createSampleRole($u, $siteAdminRT, $s3, RoleStatus::GRANTED); 
+        $r7 = TestUtil::createSampleRole($u, $siteAdminRT, $s3, RoleStatus::GRANTED);
         $this->em->persist($r7);
-        $this->em->flush(); 
+        $this->em->flush();
 
         // Assert user can edit s3 with r6 + r7
         $enablingRoles = $roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $s3, $u)->getGrantingRoles();
-        $this->assertEquals(2, count($enablingRoles)); 
+        $this->assertEquals(2, count($enablingRoles));
         $this->assertTrue(in_array($r7, $enablingRoles));
         $this->assertTrue(in_array($r6, $enablingRoles));
 
@@ -435,86 +435,86 @@ class RoleActionAuthorisationServiceTest  extends PHPUnit_Extensions_Database_Te
          *    p1  r4-p2  p3-r5
          *    |      |  /|
          * r1-n1  r8-n2  n3-r6
-         *    |      |   | 
-         * r2-s1  r3-s2  s3-r7  
+         *    |      |   |
+         * r2-s1  r3-s2  s3-r7
          */
-        $r8 = TestUtil::createSampleRole($u, $ngiManRT, $n2, RoleStatus::GRANTED); 
+        $r8 = TestUtil::createSampleRole($u, $ngiManRT, $n2, RoleStatus::GRANTED);
         $this->em->persist($r8);
-        $this->em->flush(); 
-        
+        $this->em->flush();
+
         $enablingRoles = $roleAuthServ->authoriseAction(\Action::SITE_EDIT_CERT_STATUS, $s2, $u)->getGrantingRoles();
-        $this->assertEquals(3, count($enablingRoles)); 
+        $this->assertEquals(3, count($enablingRoles));
         $this->assertTrue(in_array($r8, $enablingRoles));
         $this->assertTrue(in_array($r4, $enablingRoles));
         $this->assertTrue(in_array($r5, $enablingRoles));
-        
+
         $enablingRoles = $roleAuthServ->authoriseAction(\Action::SITE_EDIT_CERT_STATUS, $s3, $u)->getGrantingRoles();
-        $this->assertEquals(2, count($enablingRoles)); 
+        $this->assertEquals(2, count($enablingRoles));
         $this->assertTrue(in_array($r6, $enablingRoles));
         $this->assertTrue(in_array($r5, $enablingRoles));
-        
+
         /*
          *    p1  r4-p2  p3-r5
          *    |      |  /|
          * r1-n1  r8-n2  n3-r6
-         *    |      |   | 
-         * r2-s1  r3-s2  s3-r7,r9  
+         *    |      |   |
+         * r2-s1  r3-s2  s3-r7,r9
          */
-        $r9 = TestUtil::createSampleRole($u, $siteDepManAdminRT, $s3, RoleStatus::GRANTED); 
+        $r9 = TestUtil::createSampleRole($u, $siteDepManAdminRT, $s3, RoleStatus::GRANTED);
         $this->em->persist($r9);
-        $this->em->flush(); 
+        $this->em->flush();
 
         // Assert user can edit s3 with r7, r9, r6
         $enablingRoles = $roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $s3, $u)->getGrantingRoles();
-        $this->assertEquals(3, count($enablingRoles)); 
+        $this->assertEquals(3, count($enablingRoles));
         $this->assertTrue(in_array($r7, $enablingRoles));
         $this->assertTrue(in_array($r9, $enablingRoles));
         $this->assertTrue(in_array($r6, $enablingRoles));
 
         // Assert user can change s3 cert status with r6 + r5
-        $enablingRoles = $roleAuthServ->authoriseAction(\Action::SITE_EDIT_CERT_STATUS, $s3, $u)->getGrantingRoles(); 
-        $this->assertEquals(2, count($enablingRoles)); 
-        $this->assertTrue(in_array($r6, $enablingRoles)); 
-        $this->assertTrue(in_array($r5, $enablingRoles)); 
+        $enablingRoles = $roleAuthServ->authoriseAction(\Action::SITE_EDIT_CERT_STATUS, $s3, $u)->getGrantingRoles();
+        $this->assertEquals(2, count($enablingRoles));
+        $this->assertTrue(in_array($r6, $enablingRoles));
+        $this->assertTrue(in_array($r5, $enablingRoles));
 
         /*
          *    p1  r4-p2  p3-r5
          *    |      |  /|
          * r1-n1  r8-n2  n3-r6,r10
-         *    |      |   | 
-         * r2-s1  r3-s2  s3-r7,r9  
+         *    |      |   |
+         * r2-s1  r3-s2  s3-r7,r9
          */
-        $r10 = TestUtil::createSampleRole($u, $rodRT, $n3, RoleStatus::GRANTED); 
+        $r10 = TestUtil::createSampleRole($u, $rodRT, $n3, RoleStatus::GRANTED);
         $this->em->persist($r10);
-        $this->em->flush(); 
+        $this->em->flush();
 
-        $enablingRoles = $roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $s3, $u)->getGrantingRoles(); 
-        $this->assertEquals(4, count($enablingRoles)); 
-        $this->assertTrue(in_array($r6, $enablingRoles)); 
-        $this->assertTrue(in_array($r10, $enablingRoles)); 
-        $this->assertTrue(in_array($r7, $enablingRoles)); 
-        $this->assertTrue(in_array($r9, $enablingRoles)); 
+        $enablingRoles = $roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $s3, $u)->getGrantingRoles();
+        $this->assertEquals(4, count($enablingRoles));
+        $this->assertTrue(in_array($r6, $enablingRoles));
+        $this->assertTrue(in_array($r10, $enablingRoles));
+        $this->assertTrue(in_array($r7, $enablingRoles));
+        $this->assertTrue(in_array($r9, $enablingRoles));
 
-        $enablingRoles = $roleAuthServ->authoriseAction(\Action::NGI_ADD_SITE, $n3, $u)->getGrantingRoles(); 
-        $this->assertEquals(1, count($enablingRoles)); 
-        $this->assertTrue(in_array($r6, $enablingRoles)); 
+        $enablingRoles = $roleAuthServ->authoriseAction(\Action::NGI_ADD_SITE, $n3, $u)->getGrantingRoles();
+        $this->assertEquals(1, count($enablingRoles));
+        $this->assertTrue(in_array($r6, $enablingRoles));
 
-        
-        
-        
+
+
+
     }
 
 
-    
+
     public function test_getUserRolesOnAndAboveEntity(){
         print __METHOD__ . "\n";
         include __DIR__ . '/../../resources/sampleFixtureData5.php';
-        
-        // create a user 
-        $u = TestUtil::createSampleUser("dave", "meredith", "idSTring"); 
-        $this->em->persist($u); 
-        
-        // add some roles to domain model 
+
+        // create a user
+        $u = TestUtil::createSampleUser("dave", "meredith", "idSTring");
+        $this->em->persist($u);
+
+        // add some roles to domain model
         $ngiRoleType = TestUtil::createSampleRoleType("NGI_RT");
         $siteRoleType = TestUtil::createSampleRoleType("SITE_RT");
         $siteRoleType2 = TestUtil::createSampleRoleType("SITE_RT2");
@@ -523,183 +523,183 @@ class RoleActionAuthorisationServiceTest  extends PHPUnit_Extensions_Database_Te
         $this->em->persist($siteRoleType);
         $this->em->persist($siteRoleType2);
         $this->em->persist($projRoleType);
-        
-        $this->em->flush(); 
 
-        
-        $roleActionMappingService = new org\gocdb\services\RoleActionMappingService(); 
-        // Create RoleActionAuthorisationService with dependencies 
+        $this->em->flush();
+
+
+        $roleActionMappingService = new org\gocdb\services\RoleActionMappingService();
+        // Create RoleActionAuthorisationService with dependencies
         $roleAuthServ = new org\gocdb\services\RoleActionAuthorisationService
-                ($roleActionMappingService/*, $roleService*/);  
+                ($roleActionMappingService/*, $roleService*/);
 
 
-        // We could create/inject a new em connection into the roleService 
+        // We could create/inject a new em connection into the roleService
         // to test the transactional isolation of its methods (rather than injecting
-        // $this->em instance), e.g.:  
+        // $this->em instance), e.g.:
         //   $em = $this->createEntityManager();
-        //   $roleService->setEntityManager($em); 
-        //   
-        // However, this is problematic for this test which 
-        // needs to use the in_array() method to assert that the tested methods return 
+        //   $roleService->setEntityManager($em);
+        //
+        // However, this is problematic for this test which
+        // needs to use the in_array() method to assert that the tested methods return
         // the expected roles - in_array() uses object-instance-equality to deterine
-        // if the role exists in the array, and using a different $em instance 
-        // means the returned roles will be considered different      
-        // instances. We could get round this by comparing the Ids, but this makes 
-        // checking more of hassle as we need to extract all the Ids from the roles  
-        // into another array to assert the ids are expected, as in:     
-        //   $roleIds = array(); 
+        // if the role exists in the array, and using a different $em instance
+        // means the returned roles will be considered different
+        // instances. We could get round this by comparing the Ids, but this makes
+        // checking more of hassle as we need to extract all the Ids from the roles
+        // into another array to assert the ids are expected, as in:
+        //   $roleIds = array();
         //   foreach($roles as $r){ $roleIds[] = $r->getId(); }
-        //   $this->assertTrue(in_array($r1->getId(), $roleIds)); 
+        //   $this->assertTrue(in_array($r1->getId(), $roleIds));
         //   $this->assertTrue(in_array($r2->getId(), $roleIds));
         //
-        // For this test, we will therefore re-use $this->em to ensure 
+        // For this test, we will therefore re-use $this->em to ensure
         // object-equality:
-        $roleAuthServ->setEntityManager($this->em); 
+        $roleAuthServ->setEntityManager($this->em);
 
-        $roles = $roleAuthServ->getUserRolesReachableFromEntityASC($u, $p1); 
-        $this->assertEmpty($roles); 
+        $roles = $roleAuthServ->getUserRolesReachableFromEntityASC($u, $p1);
+        $this->assertEmpty($roles);
 
 
-        // Create a Role and link to the User, ngiRoleType and ngi 
+        // Create a Role and link to the User, ngiRoleType and ngi
         /*
          * p1     p2     p3
          * |      |     /|
          * n1     n2-r1  n3
-         * |      |      | 
-         * s1     s2     s3 
+         * |      |      |
+         * s1     s2     s3
          */
-        $r1 = TestUtil::createSampleRole($u, $ngiRoleType, $n2, RoleStatus::GRANTED); 
+        $r1 = TestUtil::createSampleRole($u, $ngiRoleType, $n2, RoleStatus::GRANTED);
         $this->em->persist($r1);
-        $this->em->flush(); 
+        $this->em->flush();
 
-        $rolesDirect = $u->getRoles(); 
-        $this->assertEquals(1, count($rolesDirect)); 
+        $rolesDirect = $u->getRoles();
+        $this->assertEquals(1, count($rolesDirect));
 
-        $roles = $roleAuthServ->getUserRolesReachableFromEntityASC($u, $s1); 
-        $this->assertEmpty($roles); 
+        $roles = $roleAuthServ->getUserRolesReachableFromEntityASC($u, $s1);
+        $this->assertEmpty($roles);
 
-        $roles = $roleAuthServ->getUserRolesReachableFromEntityASC($u, $s2); 
-        $this->assertEquals(1, count($roles)); 
-        $this->assertTrue(in_array($r1, $roles));  
+        $roles = $roleAuthServ->getUserRolesReachableFromEntityASC($u, $s2);
+        $this->assertEquals(1, count($roles));
+        $this->assertTrue(in_array($r1, $roles));
 
         /*
          * p1     p2     p3
          * |      |     /|
          * n1     n2-r1  n3-r2
-         * |      |      | 
-         * s1     s2     s3 
+         * |      |      |
+         * s1     s2     s3
          */
-        $r2 = TestUtil::createSampleRole($u, $ngiRoleType, $n3, RoleStatus::GRANTED); 
+        $r2 = TestUtil::createSampleRole($u, $ngiRoleType, $n3, RoleStatus::GRANTED);
         $this->em->persist($r2);
-        $this->em->flush(); 
+        $this->em->flush();
 
-        $roles = $roleAuthServ->getUserRolesReachableFromEntityASC($u, $s2); 
-        $this->assertEquals(1, count($roles)); 
-        $this->assertTrue(in_array($r1, $roles));  
+        $roles = $roleAuthServ->getUserRolesReachableFromEntityASC($u, $s2);
+        $this->assertEquals(1, count($roles));
+        $this->assertTrue(in_array($r1, $roles));
 
-        $roles = $roleAuthServ->getUserRolesReachableFromEntityASC($u, $s3); 
-        $this->assertEquals(1, count($roles)); 
-        $this->assertTrue(in_array($r2, $roles));  
+        $roles = $roleAuthServ->getUserRolesReachableFromEntityASC($u, $s3);
+        $this->assertEquals(1, count($roles));
+        $this->assertTrue(in_array($r2, $roles));
 
          /*
          * p1     p2     p3
          * |      |     /|
          * n1     n2-r1  n3-r2
-         * |      |      | 
-         * s1     s2     s3-r3 
+         * |      |      |
+         * s1     s2     s3-r3
          */
-        $r3 = TestUtil::createSampleRole($u, $siteRoleType, $s3, RoleStatus::GRANTED); 
+        $r3 = TestUtil::createSampleRole($u, $siteRoleType, $s3, RoleStatus::GRANTED);
         $this->em->persist($r3);
-        $this->em->flush(); 
+        $this->em->flush();
 
-        $roles = $roleAuthServ->getUserRolesReachableFromEntityASC($u, $s3); 
-        $this->assertEquals(2, count($roles)); 
-        $this->assertTrue(in_array($r2, $roles)); 
-        $this->assertTrue(in_array($r3, $roles)); 
-       
+        $roles = $roleAuthServ->getUserRolesReachableFromEntityASC($u, $s3);
+        $this->assertEquals(2, count($roles));
+        $this->assertTrue(in_array($r2, $roles));
+        $this->assertTrue(in_array($r3, $roles));
+
         /*
          * p1     p2     p3-r4
          * |      |     /|
          * n1     n2-r1  n3-r2
-         * |      |      | 
-         * s1     s2     s3-r3 
+         * |      |      |
+         * s1     s2     s3-r3
          */
-        $r4 = TestUtil::createSampleRole($u, $projRoleType, $p3, RoleStatus::GRANTED); 
+        $r4 = TestUtil::createSampleRole($u, $projRoleType, $p3, RoleStatus::GRANTED);
         $this->em->persist($r4);
-        $this->em->flush(); 
+        $this->em->flush();
 
          /*
          * p1     p2     p3-r4
          * |      |     /|
          * n1     n2-r1  n3-r2
-         * |      |      | 
-         * s1     s2-r5  s3-r3 
+         * |      |      |
+         * s1     s2-r5  s3-r3
          */
-        $r5 = TestUtil::createSampleRole($u, $siteRoleType, $s2, RoleStatus::GRANTED); 
+        $r5 = TestUtil::createSampleRole($u, $siteRoleType, $s2, RoleStatus::GRANTED);
         $this->em->persist($r5);
-        $this->em->flush(); 
+        $this->em->flush();
 
         /*
          * p1     p2     p3-r4
          * |      |     /|
          * n1     n2-r1  n3-r2
-         * |      |      | 
-         * s1-r6  s2-r5  s3-r3 
+         * |      |      |
+         * s1-r6  s2-r5  s3-r3
          */
-        $r6 = TestUtil::createSampleRole($u, $siteRoleType, $s1, RoleStatus::GRANTED); 
+        $r6 = TestUtil::createSampleRole($u, $siteRoleType, $s1, RoleStatus::GRANTED);
         $this->em->persist($r6);
-        $this->em->flush(); 
+        $this->em->flush();
 
         /*
          * p1     p2     p3-r4
          * |      |     /|
          * n1     n2-r1  n3-r2
-         * |      |      | 
-         * s1-r6  s2-r5  s3-r3,r7 
+         * |      |      |
+         * s1-r6  s2-r5  s3-r3,r7
          */
-        $r7 = TestUtil::createSampleRole($u, $siteRoleType2, $s3, RoleStatus::GRANTED); 
+        $r7 = TestUtil::createSampleRole($u, $siteRoleType2, $s3, RoleStatus::GRANTED);
         $this->em->persist($r7);
-        $this->em->flush(); 
+        $this->em->flush();
 
         /*
          * p1     p2-r8  p3-r4
          * |      |     /|
          * n1     n2-r1  n3-r2
-         * |      |      | 
-         * s1-r6  s2-r5  s3-r3,r7 
+         * |      |      |
+         * s1-r6  s2-r5  s3-r3,r7
          */
-        $r8 = TestUtil::createSampleRole($u, $projRoleType, $p2, RoleStatus::GRANTED); 
+        $r8 = TestUtil::createSampleRole($u, $projRoleType, $p2, RoleStatus::GRANTED);
         $this->em->persist($r8);
-        $this->em->flush(); 
+        $this->em->flush();
 
-        $roles = $roleAuthServ->getUserRolesReachableFromEntityASC($u, $s1); 
-        $this->assertEquals(1, count($roles)); 
-        $this->assertTrue(in_array($r6, $roles)); 
-        
-        $roles = $roleAuthServ->getUserRolesReachableFromEntityASC($u, $s2); 
-        $this->assertEquals(4, count($roles)); 
-        $this->assertTrue(in_array($r5, $roles)); 
-        $this->assertTrue(in_array($r1, $roles)); 
-        $this->assertTrue(in_array($r8, $roles)); 
-        $this->assertTrue(in_array($r4, $roles)); 
+        $roles = $roleAuthServ->getUserRolesReachableFromEntityASC($u, $s1);
+        $this->assertEquals(1, count($roles));
+        $this->assertTrue(in_array($r6, $roles));
 
-        $roles = $roleAuthServ->getUserRolesReachableFromEntityASC($u, $s3); 
-        $this->assertEquals(4, count($roles)); 
-        $this->assertTrue(in_array($r2, $roles)); 
-        $this->assertTrue(in_array($r3, $roles)); 
-        $this->assertTrue(in_array($r4, $roles)); 
-        $this->assertTrue(in_array($r7, $roles)); 
-       
+        $roles = $roleAuthServ->getUserRolesReachableFromEntityASC($u, $s2);
+        $this->assertEquals(4, count($roles));
+        $this->assertTrue(in_array($r5, $roles));
+        $this->assertTrue(in_array($r1, $roles));
+        $this->assertTrue(in_array($r8, $roles));
+        $this->assertTrue(in_array($r4, $roles));
+
+        $roles = $roleAuthServ->getUserRolesReachableFromEntityASC($u, $s3);
+        $this->assertEquals(4, count($roles));
+        $this->assertTrue(in_array($r2, $roles));
+        $this->assertTrue(in_array($r3, $roles));
+        $this->assertTrue(in_array($r4, $roles));
+        $this->assertTrue(in_array($r7, $roles));
+
     }
 
 
 
     /**
-     * Persist some seed data - roletypes, user, Project, NGI, sites and SEs and 
-     * assert that the user has the expected number of roles that grant specific 
-     * actions over the owned objects. For example, assert that the user has 'n' 
-     * number of roles that allow a particular site to be edited, or 'n' number 
-     * of roles that allow an NGI certification status change.  
+     * Persist some seed data - roletypes, user, Project, NGI, sites and SEs and
+     * assert that the user has the expected number of roles that grant specific
+     * actions over the owned objects. For example, assert that the user has 'n'
+     * number of roles that allow a particular site to be edited, or 'n' number
+     * of roles that allow an NGI certification status change.
      */
     public function testAuthoriseAction2(){
         print __METHOD__ . "\n";
@@ -708,200 +708,200 @@ class RoleActionAuthorisationServiceTest  extends PHPUnit_Extensions_Database_Te
         $ngiManRT = TestUtil::createSampleRoleType(RoleTypeName::NGI_OPS_MAN/*, RoleTypeClass::REGIONAL_MANAGER*/);
         $rodRT = TestUtil::createSampleRoleType(RoleTypeName::REG_STAFF_ROD/*, RoleTypeClass::REGIONAL_USER*/);
         $codRT = TestUtil::createSampleRoleType(RoleTypeName::COD_ADMIN/*, RoleTypeClass::PROJECT*/);
-        $this->em->persist($siteAdminRT); // edit site1 (but not cert status) 
+        $this->em->persist($siteAdminRT); // edit site1 (but not cert status)
         $this->em->persist($ngiManRT); // edit owned site1/site2 and cert status
         $this->em->persist($rodRT);  // edit owned sites 1and2 (but not cert status)
-        $this->em->persist($codRT);  // edit all sites cert status only  
-    
+        $this->em->persist($codRT);  // edit all sites cert status only
+
         // Create a user
         $u = TestUtil::createSampleUser("Test", "Testing", "/c=test");
         $this->em->persist($u);
-    
-        // Create a linked object graph 
+
+        // Create a linked object graph
 /*
                                  p1
                                  |
-                                 ngi      <- ngiManRT, rodRT, 
+                                 ngi      <- ngiManRT, rodRT,
                                  |    \
              siteAdminRT  ->   site1   site2
                                  |
                                  se1
-                                 
+
  */
-        
+
         $ngi = TestUtil::createSampleNGI("MYNGI");
         $this->em->persist($ngi);
         $site1 = TestUtil::createSampleSite("SITENAME"/*, "PK01"*/);
-        //$site1->setNgiDoJoin($ngi); 
-        $ngi->addSiteDoJoin($site1); 
+        //$site1->setNgiDoJoin($ngi);
+        $ngi->addSiteDoJoin($site1);
         $this->em->persist($site1);
-        $se1 = TestUtil::createSampleService('somelabel'); 
-        $site1->addServiceDoJoin($se1); 
+        $se1 = TestUtil::createSampleService('somelabel');
+        $site1->addServiceDoJoin($se1);
         $this->em->persist($se1);
         $site2_userHasNoDirectRole = TestUtil::createSampleSite("SITENAME_2"/*, "PK01"*/);
-        $ngi->addSiteDoJoin($site2_userHasNoDirectRole); 
+        $ngi->addSiteDoJoin($site2_userHasNoDirectRole);
         //$site2_userHasNoDirectRole->setNgiDoJoin($ngi);
         $this->em->persist($site2_userHasNoDirectRole);
 
         $p1 = new \Project("EGI");
         $this->em->persist($p1);
-        $p1->addNgi($ngi); 
-        
+        $p1->addNgi($ngi);
 
-    
-        // Create ngiManagerRole, ngiUserRole, siteAdminRole and link user and owned entities  
-        $ngiManagerRole = TestUtil::createSampleRole($u, $ngiManRT, $ngi, RoleStatus::GRANTED); 
+
+
+        // Create ngiManagerRole, ngiUserRole, siteAdminRole and link user and owned entities
+        $ngiManagerRole = TestUtil::createSampleRole($u, $ngiManRT, $ngi, RoleStatus::GRANTED);
         $this->em->persist($ngiManagerRole);
-        $rodUserRole = TestUtil::createSampleRole($u, $rodRT, $ngi, RoleStatus::GRANTED); 
+        $rodUserRole = TestUtil::createSampleRole($u, $rodRT, $ngi, RoleStatus::GRANTED);
         $this->em->persist($rodUserRole);
-        $siteAdminRole = TestUtil::createSampleRole($u, $siteAdminRT, $site1, RoleStatus::GRANTED) ; 
+        $siteAdminRole = TestUtil::createSampleRole($u, $siteAdminRT, $site1, RoleStatus::GRANTED) ;
         $this->em->persist($siteAdminRole);
-        
+
         $this->em->flush();
 
-        // ********MUST******** start a new connection to test transactional 
-        // isolation of RoleService methods.  
+        // ********MUST******** start a new connection to test transactional
+        // isolation of RoleService methods.
         //$em = $this->createEntityManager();
-        //$siteService = new org\gocdb\services\Site();  
-        //$siteService->setEntityManager($em); 
-        $roleActionMappingService = new org\gocdb\services\RoleActionMappingService(); 
+        //$siteService = new org\gocdb\services\Site();
+        //$siteService->setEntityManager($em);
+        $roleActionMappingService = new org\gocdb\services\RoleActionMappingService();
         $roleActionAuthService = new org\gocdb\services\RoleActionAuthorisationService($roleActionMappingService);
-        $roleActionAuthService->setEntityManager($this->em); 
-        
-        
-        // Assert user can edit site using 3 enabling roles
-        $enablingRoles = $roleActionAuthService->authoriseAction(\Action::EDIT_OBJECT, $site1, $u)->getGrantingRoles(); 
-        $this->assertEquals(3, count($enablingRoles)); 
-        $this->assertTrue(in_array($siteAdminRole, $enablingRoles)); 
-        $this->assertTrue(in_array($rodUserRole, $enablingRoles)); 
-        $this->assertTrue(in_array($ngiManagerRole, $enablingRoles)); 
-        
+        $roleActionAuthService->setEntityManager($this->em);
 
-        // Assert user can only edit cert status through his NGI_OPS_MAN role 
-        $enablingRoles = $roleActionAuthService->authoriseAction(\Action::SITE_EDIT_CERT_STATUS, $site1, $u)->getGrantingRoles(); 
-        $this->assertEquals(1, count($enablingRoles)); 
-        $this->assertTrue(in_array($ngiManagerRole, $enablingRoles)); 
-// 
+
+        // Assert user can edit site using 3 enabling roles
+        $enablingRoles = $roleActionAuthService->authoriseAction(\Action::EDIT_OBJECT, $site1, $u)->getGrantingRoles();
+        $this->assertEquals(3, count($enablingRoles));
+        $this->assertTrue(in_array($siteAdminRole, $enablingRoles));
+        $this->assertTrue(in_array($rodUserRole, $enablingRoles));
+        $this->assertTrue(in_array($ngiManagerRole, $enablingRoles));
+
+
+        // Assert user can only edit cert status through his NGI_OPS_MAN role
+        $enablingRoles = $roleActionAuthService->authoriseAction(\Action::SITE_EDIT_CERT_STATUS, $site1, $u)->getGrantingRoles();
+        $this->assertEquals(1, count($enablingRoles));
+        $this->assertTrue(in_array($ngiManagerRole, $enablingRoles));
+//
 //        // Add a new project role and link ngi and give user COD_ADMIN Project role (use $this->em to isolate)
-        $codRole = TestUtil::createSampleRole($u, $codRT, $p1, RoleStatus::GRANTED); 
-        $this->em->persist($codRole); 
+        $codRole = TestUtil::createSampleRole($u, $codRT, $p1, RoleStatus::GRANTED);
+        $this->em->persist($codRole);
         $this->em->flush();
 
 /*
                                  p1      <- codRT
                                  |
-                                 ngi      <- ngiManRT, rodRT, 
+                                 ngi      <- ngiManRT, rodRT,
                                  |    \
              siteAdminRT  ->   site1   site2
                                  |
                                  se1
-                                 
+
 */
-       
-        // Assert user now has 2 roles that enable SITE_EDIT_CERT_STATUS change action 
-        $enablingRoles = $roleActionAuthService->authoriseAction(\Action::SITE_EDIT_CERT_STATUS, $site1, $u)->getGrantingRoles(); 
-        $this->assertEquals(2, count($enablingRoles)); 
-        $this->assertTrue(in_array($ngiManagerRole, $enablingRoles)); 
-        $this->assertTrue(in_array($codRole, $enablingRoles)); 
 
-        // Assert user can edit SE using SITE_ADMIN, NGI_OPS_MAN, REG_STAFF_ROD roles (but not COD role)  
-        $enablingRoles = $roleActionAuthService->authoriseAction(\Action::EDIT_OBJECT, $se1->getParentSite(), $u)->getGrantingRoles();  
-        $this->assertEquals(3, count($enablingRoles)); 
-        $this->assertTrue(in_array($siteAdminRole, $enablingRoles)); 
-        $this->assertTrue(in_array($ngiManagerRole, $enablingRoles));  
-        $this->assertTrue(in_array($rodUserRole, $enablingRoles)); 
-    
-        // Assert User can only edit Site2 through his 2 indirect ngi roles 
+        // Assert user now has 2 roles that enable SITE_EDIT_CERT_STATUS change action
+        $enablingRoles = $roleActionAuthService->authoriseAction(\Action::SITE_EDIT_CERT_STATUS, $site1, $u)->getGrantingRoles();
+        $this->assertEquals(2, count($enablingRoles));
+        $this->assertTrue(in_array($ngiManagerRole, $enablingRoles));
+        $this->assertTrue(in_array($codRole, $enablingRoles));
+
+        // Assert user can edit SE using SITE_ADMIN, NGI_OPS_MAN, REG_STAFF_ROD roles (but not COD role)
+        $enablingRoles = $roleActionAuthService->authoriseAction(\Action::EDIT_OBJECT, $se1->getParentSite(), $u)->getGrantingRoles();
+        $this->assertEquals(3, count($enablingRoles));
+        $this->assertTrue(in_array($siteAdminRole, $enablingRoles));
+        $this->assertTrue(in_array($ngiManagerRole, $enablingRoles));
+        $this->assertTrue(in_array($rodUserRole, $enablingRoles));
+
+        // Assert User can only edit Site2 through his 2 indirect ngi roles
         // (user don't have any direct site level roles on this site and COD don't give edit perm)
-        $enablingRoles = $roleActionAuthService->authoriseAction(\Action::EDIT_OBJECT, $site2_userHasNoDirectRole, $u)->getGrantingRoles(); 
-        $this->assertEquals(2, count($enablingRoles)); 
-        $this->assertTrue(in_array($ngiManagerRole, $enablingRoles)); 
-        $this->assertTrue(in_array($rodUserRole, $enablingRoles));  
+        $enablingRoles = $roleActionAuthService->authoriseAction(\Action::EDIT_OBJECT, $site2_userHasNoDirectRole, $u)->getGrantingRoles();
+        $this->assertEquals(2, count($enablingRoles));
+        $this->assertTrue(in_array($ngiManagerRole, $enablingRoles));
+        $this->assertTrue(in_array($rodUserRole, $enablingRoles));
 
-        // Delete the user's Project COD role 
-        $this->em->remove($codRole);  
+        // Delete the user's Project COD role
+        $this->em->remove($codRole);
         $this->em->flush();
 /*
-                                 p1      
+                                 p1
                                  |
-                                 ngi      <- ngiManRT, rodRT, 
+                                 ngi      <- ngiManRT, rodRT,
                                  |    \
              siteAdminRT  ->   site1   site2
                                  |
                                  se1
-                                 
+
 */
-        
+
         // Assert user can only SITE_EDIT_CERT_STATUS through 1 role for both sites
-        $enablingRoles =  $roleActionAuthService->authoriseAction(\Action::SITE_EDIT_CERT_STATUS, $site2_userHasNoDirectRole, $u)->getGrantingRoles(); 
-        $this->assertEquals(1, count($enablingRoles)); 
-        $this->assertTrue(in_array($ngiManagerRole, $enablingRoles)); 
-        $enablingRoles =  $roleActionAuthService->authoriseAction(\Action::SITE_EDIT_CERT_STATUS, $site1, $u)->getGrantingRoles(); 
-        $this->assertEquals(1, count($enablingRoles)); 
-        $this->assertTrue(in_array($ngiManagerRole, $enablingRoles));  
-        
-        // Delete the user's NGI manager role 
-        $this->em->remove($ngiManagerRole);  
-        $this->em->flush(); 
+        $enablingRoles =  $roleActionAuthService->authoriseAction(\Action::SITE_EDIT_CERT_STATUS, $site2_userHasNoDirectRole, $u)->getGrantingRoles();
+        $this->assertEquals(1, count($enablingRoles));
+        $this->assertTrue(in_array($ngiManagerRole, $enablingRoles));
+        $enablingRoles =  $roleActionAuthService->authoriseAction(\Action::SITE_EDIT_CERT_STATUS, $site1, $u)->getGrantingRoles();
+        $this->assertEquals(1, count($enablingRoles));
+        $this->assertTrue(in_array($ngiManagerRole, $enablingRoles));
+
+        // Delete the user's NGI manager role
+        $this->em->remove($ngiManagerRole);
+        $this->em->flush();
 /*
-                                 p1      
+                                 p1
                                  |
-                                 ngi      <- rodRT, 
+                                 ngi      <- rodRT,
                                  |    \
              siteAdminRT  ->   site1   site2
                                  |
                                  se1
-                                 
+
 */
 
-        // Assert user can't edit site2 cert status  
-        $enablingRoles = $roleActionAuthService->authoriseAction(\Action::SITE_EDIT_CERT_STATUS, $site2_userHasNoDirectRole, $u)->getGrantingRoles(); 
-        $this->assertEquals(0, count($enablingRoles)); 
-        // Assert user can still edit site via his ROD role 
-        $enablingRoles = $roleActionAuthService->authoriseAction(\Action::EDIT_OBJECT, $site2_userHasNoDirectRole, $u)->getGrantingRoles(); 
-        $this->assertEquals(1, count($enablingRoles)); 
-        $this->assertTrue(in_array($rodUserRole, $enablingRoles));  
+        // Assert user can't edit site2 cert status
+        $enablingRoles = $roleActionAuthService->authoriseAction(\Action::SITE_EDIT_CERT_STATUS, $site2_userHasNoDirectRole, $u)->getGrantingRoles();
+        $this->assertEquals(0, count($enablingRoles));
+        // Assert user can still edit site via his ROD role
+        $enablingRoles = $roleActionAuthService->authoriseAction(\Action::EDIT_OBJECT, $site2_userHasNoDirectRole, $u)->getGrantingRoles();
+        $this->assertEquals(1, count($enablingRoles));
+        $this->assertTrue(in_array($rodUserRole, $enablingRoles));
 
-        // Delete the user's NGI ROD role 
-        $this->em->remove($rodUserRole);  
-        $this->em->flush(); 
+        // Delete the user's NGI ROD role
+        $this->em->remove($rodUserRole);
+        $this->em->flush();
 
 /*
-                                 p1      
+                                 p1
                                  |
-                                 ngi      
+                                 ngi
                                  |    \
              siteAdminRT  ->   site1   site2
                                  |
                                  se1
-                                 
+
 */
 
         // User can't edit site2
-        $enablingRoles = $roleActionAuthService->authoriseAction(\Action::EDIT_OBJECT, $site2_userHasNoDirectRole, $u)->getGrantingRoles(); 
-        $this->assertEquals(0, count($enablingRoles)); 
-       
-        // Assert user can still edit SITE1 through his direct site level role (this role has not been deleted)  
-        $enablingRoles = $roleActionAuthService->authoriseAction(\Action::EDIT_OBJECT, $site1, $u)->getGrantingRoles(); 
-        $this->assertEquals(1, count($enablingRoles)); 
-        $this->assertTrue(in_array($siteAdminRole, $enablingRoles)); 
-        
-        // Delete user's remaining Site role 
-        $this->em->remove($siteAdminRole);  
-        $this->em->flush();  
+        $enablingRoles = $roleActionAuthService->authoriseAction(\Action::EDIT_OBJECT, $site2_userHasNoDirectRole, $u)->getGrantingRoles();
+        $this->assertEquals(0, count($enablingRoles));
+
+        // Assert user can still edit SITE1 through his direct site level role (this role has not been deleted)
+        $enablingRoles = $roleActionAuthService->authoriseAction(\Action::EDIT_OBJECT, $site1, $u)->getGrantingRoles();
+        $this->assertEquals(1, count($enablingRoles));
+        $this->assertTrue(in_array($siteAdminRole, $enablingRoles));
+
+        // Delete user's remaining Site role
+        $this->em->remove($siteAdminRole);
+        $this->em->flush();
 /*
-                                 p1      
+                                 p1
                                  |
-                                 ngi      
+                                 ngi
                                  |    \
                                site1   site2
                                  |
                                  se1
-                                 
+
 */
-        // User can't edit site1 
-        $enablingRoles = $roleActionAuthService->authoriseAction(\Action::EDIT_OBJECT, $site1, $u)->getGrantingRoles(); 
-        $this->assertEquals(0, count($enablingRoles)); 
+        // User can't edit site1
+        $enablingRoles = $roleActionAuthService->authoriseAction(\Action::EDIT_OBJECT, $site1, $u)->getGrantingRoles();
+        $this->assertEquals(0, count($enablingRoles));
     }
 
 
@@ -909,7 +909,7 @@ class RoleActionAuthorisationServiceTest  extends PHPUnit_Extensions_Database_Te
 
 
 
-    
+
     /*private function getRoleTypeNames($enablingRoles) {
         $enablingRoleNames = array();
         foreach ($enablingRoles as $role) {
@@ -922,34 +922,34 @@ class RoleActionAuthorisationServiceTest  extends PHPUnit_Extensions_Database_Te
 
 class TestRoleTypeName {
 
-    const GOCDB_ADMIN = 'GOCDB_ADMIN'; 
-    
-    // Roles for Sites 
+    const GOCDB_ADMIN = 'GOCDB_ADMIN';
+
+    // Roles for Sites
     const SITE_ADMIN = 'Site Administrator'; // C
-    
+
     const SITE_SECOFFICER = 'Site Security Officer'; // C'
     const SITE_OPS_DEP_MAN = 'Site Operations Deputy Manager'; // C'
     const SITE_OPS_MAN = 'Site Operations Manager'; // C'
-    
-    // Roles for NGIs 
+
+    // Roles for NGIs
     const REG_FIRST_LINE_SUPPORT = 'Regional First Line Support'; // D
     const REG_STAFF_ROD = 'Regional Staff (ROD)'; // D
-    
+
     const NGI_SEC_OFFICER = 'NGI Security Officer'; // D'
     const NGI_OPS_DEP_MAN = 'NGI Operations Deputy Manager'; // D'
     const NGI_OPS_MAN = 'NGI Operations Manager'; // D'
-    
+
     // Roles for Projects
     const COD_STAFF = 'COD Staff'; // E
     const COD_ADMIN = 'COD Administrator'; // E
     const EGI_CSIRT_OFFICER = 'EGI CSIRT Officer'; // E
     const COO = 'Chief Operations Officer'; // E
-    
+
     // Roles for ServiceGroups
     const SERVICEGROUP_ADMIN = 'Service Group Administrator'; // ServiceGroupC'
-    
-    // "Other" roles that have slipped by us (see AddRoleTypes.php) 
-    const CIC_STAFF = 'CIC Staff'; // Pretty sure this role is not required anymore: https://rt.egi.eu/rt/Ticket/Display.html?id=931 
+
+    // "Other" roles that have slipped by us (see AddRoleTypes.php)
+    const CIC_STAFF = 'CIC Staff'; // Pretty sure this role is not required anymore: https://rt.egi.eu/rt/Ticket/Display.html?id=931
     const REG_STAFF = 'Regional Staff';
 
     /**

--- a/tests/unit/lib/Gocdb_Services/RoleActionMappingServiceTest.php
+++ b/tests/unit/lib/Gocdb_Services/RoleActionMappingServiceTest.php
@@ -16,13 +16,13 @@
  require_once __DIR__.'/../../../../lib/Gocdb_Services/RoleActionMappingService.php';
 
 /**
- * Test case for the {@see \org\gocdb\services\RoleActionMappingService} service class. 
- * The tests utilise the sample xml files in test/unit/resources.  
+ * Test case for the {@see \org\gocdb\services\RoleActionMappingService} service class.
+ * The tests utilise the sample xml files in test/unit/resources.
  *
- * @author David Meredith 
+ * @author David Meredith
  */
 class RoleActionMappingServiceTest extends PHPUnit_Framework_TestCase {
-    
+
     /**
      * Called once, before any of the tests are executed.
      */
@@ -72,9 +72,9 @@ class RoleActionMappingServiceTest extends PHPUnit_Framework_TestCase {
 
     public function testValidateRoleActionMappingsAgainstSchema() {
         print __METHOD__ . "\n";
-        $roleActionService = new org\gocdb\services\RoleActionMappingService(); 
-        $errors = $roleActionService->validateRoleActionMappingFileAgainstXsd(); 
-        $this->assertEmpty($errors); 
+        $roleActionService = new org\gocdb\services\RoleActionMappingService();
+        $errors = $roleActionService->validateRoleActionMappingFileAgainstXsd();
+        $this->assertEmpty($errors);
         /*$xml = new \DOMDocument();
         $xml->load(__DIR__."/../../../../config/RoleActionMappings.xml");
         if (!$xml->schemaValidate(__DIR__."/../../../../config/RoleActionMappingsSchema.xsd")) {
@@ -88,107 +88,107 @@ class RoleActionMappingServiceTest extends PHPUnit_Framework_TestCase {
 
     public function testGetRoleNamesForProject(){
         print __METHOD__ . "\n";
-        $roleActionService = new org\gocdb\services\RoleActionMappingService(); 
-        $roleActionService->setRoleActionMappingsXmlPath(__DIR__."/../../resources/roleActionMappingSamples/TestRoleActionMappings5.xml"); 
-        
-        $rolenamesOver = $roleActionService->getRoleTypeNamesForProject('EGI'); 
-        $this->assertEquals(14, count($rolenamesOver)); 
-        //print_r($rolenamesOver); 
-    $rolenamesOver = $roleActionService->getRoleTypeNamesForProject(null); 
-        $this->assertEquals(14, count($rolenamesOver)); 
-        
-//        $rolenamesOver = $roleActionService->getRoleTypeNamesForProject('WLCG'); 
-//        $this->assertEquals(4, count($rolenamesOver)); 
-//        //print_r($rolenamesOver); 
-//        
-//        $rolenamesOver = $roleActionService->getRoleTypeNamesForProject('EUDAT'); 
-//        $this->assertEquals(5, count($rolenamesOver)); 
-//        //print_r($rolenamesOver); 
+        $roleActionService = new org\gocdb\services\RoleActionMappingService();
+        $roleActionService->setRoleActionMappingsXmlPath(__DIR__."/../../resources/roleActionMappingSamples/TestRoleActionMappings5.xml");
+
+        $rolenamesOver = $roleActionService->getRoleTypeNamesForProject('EGI');
+        $this->assertEquals(14, count($rolenamesOver));
+        //print_r($rolenamesOver);
+    $rolenamesOver = $roleActionService->getRoleTypeNamesForProject(null);
+        $this->assertEquals(14, count($rolenamesOver));
+
+//        $rolenamesOver = $roleActionService->getRoleTypeNamesForProject('WLCG');
+//        $this->assertEquals(4, count($rolenamesOver));
+//        //print_r($rolenamesOver);
 //
-//        $rolenamesOver = $roleActionService->getRoleTypeNamesForProject(NULL); 
-//        $this->assertEquals(1, count($rolenamesOver)); 
-        //print_r($rolenamesOver); 
+//        $rolenamesOver = $roleActionService->getRoleTypeNamesForProject('EUDAT');
+//        $this->assertEquals(5, count($rolenamesOver));
+//        //print_r($rolenamesOver);
+//
+//        $rolenamesOver = $roleActionService->getRoleTypeNamesForProject(NULL);
+//        $this->assertEquals(1, count($rolenamesOver));
+        //print_r($rolenamesOver);
     }
-    
+
 
     public function testGetEnablingRolesForTargetedAction1(){
         print __METHOD__ . "\n";
-        $roleActionService = new org\gocdb\services\RoleActionMappingService(); 
-        $roleActionService->setRoleActionMappingsXmlPath(__DIR__."/../../resources/roleActionMappingSamples/TestRoleActionMappings5.xml"); 
-        
+        $roleActionService = new org\gocdb\services\RoleActionMappingService();
+        $roleActionService->setRoleActionMappingsXmlPath(__DIR__."/../../resources/roleActionMappingSamples/TestRoleActionMappings5.xml");
+
         $expected = array('COD Staff', 'COD Administrator', 'EGI CSIRT Officer', 'Chief Operations Officer');
-        $enablingRoleTypeNames = $roleActionService->getRoleTypeNamesThatEnableActionOnTargetObjectType("ACTION_EDIT_OBJECT", 'PRoJect', 'EGI'); 
-        $this->assertArraySubset($expected, array_keys($enablingRoleTypeNames)); 
+        $enablingRoleTypeNames = $roleActionService->getRoleTypeNamesThatEnableActionOnTargetObjectType("ACTION_EDIT_OBJECT", 'PRoJect', 'EGI');
+        $this->assertArraySubset($expected, array_keys($enablingRoleTypeNames));
         $this->assertEquals(count($expected), count($enablingRoleTypeNames));
 
         $expected = array('COD Staff', 'COD Administrator', 'EGI CSIRT Officer', 'Chief Operations Officer', 'NGI Operations Manager', 'NGI Operations Deputy Manager', 'NGI Security Officer');
-        $enablingRoleTypeNames = $roleActionService->getRoleTypeNamesThatEnableActionOnTargetObjectType("ACTION_GRANT_ROLE", 'ngi', 'EGI'); 
-        $this->assertArraySubset($expected, array_keys($enablingRoleTypeNames)); 
+        $enablingRoleTypeNames = $roleActionService->getRoleTypeNamesThatEnableActionOnTargetObjectType("ACTION_GRANT_ROLE", 'ngi', 'EGI');
+        $this->assertArraySubset($expected, array_keys($enablingRoleTypeNames));
         $this->assertEquals(count($expected), count($enablingRoleTypeNames));
 
-        $expected = array('Service Group Administrator');  
-        $enablingRoleTypeNames = $roleActionService->getRoleTypeNamesThatEnableActionOnTargetObjectType("ACTION_EDIT_OBJECT", 'SErviceGroup', 'EGI'); 
-        $this->assertArraySubset($expected, array_keys($enablingRoleTypeNames)); 
+        $expected = array('Service Group Administrator');
+        $enablingRoleTypeNames = $roleActionService->getRoleTypeNamesThatEnableActionOnTargetObjectType("ACTION_EDIT_OBJECT", 'SErviceGroup', 'EGI');
+        $this->assertArraySubset($expected, array_keys($enablingRoleTypeNames));
         $this->assertEquals(count($expected), count($enablingRoleTypeNames));
 
         $expected = array(
-            'NGI Operations Manager' => 'Ngi', 
-            'NGI Operations Deputy Manager' => 'Ngi', 
-            'NGI Security Officer' => 'Ngi', 
-            'Regional Staff (ROD)' => 'Ngi', 
-            'Regional First Line Support' => 'Ngi');  
-        $enablingRoleTypeNames = $roleActionService->getRoleTypeNamesThatEnableActionOnTargetObjectType("ACTION_EDIT_OBJECT", 'ngi', 'egi'); 
-        $this->assertArraySubset($expected, ($enablingRoleTypeNames)); 
+            'NGI Operations Manager' => 'Ngi',
+            'NGI Operations Deputy Manager' => 'Ngi',
+            'NGI Security Officer' => 'Ngi',
+            'Regional Staff (ROD)' => 'Ngi',
+            'Regional First Line Support' => 'Ngi');
+        $enablingRoleTypeNames = $roleActionService->getRoleTypeNamesThatEnableActionOnTargetObjectType("ACTION_EDIT_OBJECT", 'ngi', 'egi');
+        $this->assertArraySubset($expected, ($enablingRoleTypeNames));
         $this->assertEquals(count($expected), count($enablingRoleTypeNames));
 
-        // the action don't exist in the XML doc, so expect an empty array 
-        $expected = array();  
-        $enablingRoleTypeNames = $roleActionService->getRoleTypeNamesThatEnableActionOnTargetObjectType("ACTION_dont_exist", 'ngi', 'egi'); 
-        $this->assertArraySubset($expected, array_keys($enablingRoleTypeNames)); 
+        // the action don't exist in the XML doc, so expect an empty array
+        $expected = array();
+        $enablingRoleTypeNames = $roleActionService->getRoleTypeNamesThatEnableActionOnTargetObjectType("ACTION_dont_exist", 'ngi', 'egi');
+        $this->assertArraySubset($expected, array_keys($enablingRoleTypeNames));
         $this->assertEquals(count($expected), count($enablingRoleTypeNames));
 
         // the Target entityType don't exist in the XML doc, so expect an empty array
-        $expected = array();  
-        $enablingRoleTypeNames = $roleActionService->getRoleTypeNamesThatEnableActionOnTargetObjectType("ACTION_EDIT_OBJECT", 'ngix_dont_exist', 'egi'); 
-        $this->assertArraySubset($expected, array_keys($enablingRoleTypeNames)); 
+        $expected = array();
+        $enablingRoleTypeNames = $roleActionService->getRoleTypeNamesThatEnableActionOnTargetObjectType("ACTION_EDIT_OBJECT", 'ngix_dont_exist', 'egi');
+        $this->assertArraySubset($expected, array_keys($enablingRoleTypeNames));
         $this->assertEquals(count($expected), count($enablingRoleTypeNames));
 
 
         $expected = array(
-            'NGI Operations Deputy Manager' => 'Ngi', 
-            'NGI Operations Manager' => 'Ngi', 
-            'NGI Security Officer' => 'Ngi', 
+            'NGI Operations Deputy Manager' => 'Ngi',
+            'NGI Operations Manager' => 'Ngi',
+            'NGI Security Officer' => 'Ngi',
             'Site Security Officer' => 'Site',
-            'Site Operations Deputy Manager' => 'Site', 
-            'Site Operations Manager' => 'Site', 
-            ); 
-        $enablingRoleTypeNames = $roleActionService->getRoleTypeNamesThatEnableActionOnTargetObjectType("ACTION_GRANT_ROLE", 'site', 'egi'); 
+            'Site Operations Deputy Manager' => 'Site',
+            'Site Operations Manager' => 'Site',
+            );
+        $enablingRoleTypeNames = $roleActionService->getRoleTypeNamesThatEnableActionOnTargetObjectType("ACTION_GRANT_ROLE", 'site', 'egi');
         $this->assertArraySubset($expected, $enablingRoleTypeNames);
         $this->assertEquals(count($expected), count($enablingRoleTypeNames));
-        $enablingRoleTypeNames = $roleActionService->getRoleTypeNamesThatEnableActionOnTargetObjectType("ACTION_REJECT_ROLE", 'site', 'egi'); 
+        $enablingRoleTypeNames = $roleActionService->getRoleTypeNamesThatEnableActionOnTargetObjectType("ACTION_REJECT_ROLE", 'site', 'egi');
         $this->assertArraySubset($expected, $enablingRoleTypeNames);
         $this->assertEquals(count($expected), count($enablingRoleTypeNames));
-        $enablingRoleTypeNames = $roleActionService->getRoleTypeNamesThatEnableActionOnTargetObjectType("ACTION_REVOKE_ROLE", 'site', 'egi'); 
+        $enablingRoleTypeNames = $roleActionService->getRoleTypeNamesThatEnableActionOnTargetObjectType("ACTION_REVOKE_ROLE", 'site', 'egi');
         $this->assertArraySubset($expected, $enablingRoleTypeNames);
         $this->assertEquals(count($expected), count($enablingRoleTypeNames));
 
         $expected = array(
-            'NGI Operations Deputy Manager' => 'Ngi', 
-            'NGI Operations Manager' => 'Ngi', 
-            'NGI Security Officer' => 'Ngi', 
-            'COD Staff' => 'Project', 
-            'COD Administrator' => 'Project', 
-            'EGI CSIRT Officer' => 'Project', 
+            'NGI Operations Deputy Manager' => 'Ngi',
+            'NGI Operations Manager' => 'Ngi',
+            'NGI Security Officer' => 'Ngi',
+            'COD Staff' => 'Project',
+            'COD Administrator' => 'Project',
+            'EGI CSIRT Officer' => 'Project',
             'Chief Operations Officer' => 'Project'
-            ); 
-        $enablingRoleTypeNames = $roleActionService->getRoleTypeNamesThatEnableActionOnTargetObjectType("ACTION_SITE_EDIT_CERT_STATUS", 'site', 'egi'); 
+            );
+        $enablingRoleTypeNames = $roleActionService->getRoleTypeNamesThatEnableActionOnTargetObjectType("ACTION_SITE_EDIT_CERT_STATUS", 'site', 'egi');
         $this->assertArraySubset($expected, $enablingRoleTypeNames);
         $this->assertEquals(count($expected), count($enablingRoleTypeNames));
 
         $expected = array(
-            'Service Group Administrator' => 'ServiceGroup', 
-            ); 
-        $enablingRoleTypeNames = $roleActionService->getRoleTypeNamesThatEnableActionOnTargetObjectType("ACTION_EDIT_OBJECT", 'serviceGroup', NULL); 
+            'Service Group Administrator' => 'ServiceGroup',
+            );
+        $enablingRoleTypeNames = $roleActionService->getRoleTypeNamesThatEnableActionOnTargetObjectType("ACTION_EDIT_OBJECT", 'serviceGroup', NULL);
         $this->assertArraySubset($expected, $enablingRoleTypeNames);
         $this->assertEquals(count($expected), count($enablingRoleTypeNames));
     }
@@ -196,80 +196,80 @@ class RoleActionMappingServiceTest extends PHPUnit_Framework_TestCase {
 
     public function testGetEnablingRolesForTargetedAction2(){
         print __METHOD__ . "\n";
-        $roleActionService = new org\gocdb\services\RoleActionMappingService(); 
-        $roleActionService->setRoleActionMappingsXmlPath(__DIR__."/../../resources/roleActionMappingSamples/TestRoleActionMappings4.xml"); 
+        $roleActionService = new org\gocdb\services\RoleActionMappingService();
+        $roleActionService->setRoleActionMappingsXmlPath(__DIR__."/../../resources/roleActionMappingSamples/TestRoleActionMappings4.xml");
 
-//        // EGI project 
-//        $expected = array('RoleH' => 'Project');  
-//        $enablingRoleTypeNames = $roleActionService->getRoleTypeNamesThatEnableActionOnTargetObjectType("AZ", 'project', 'egi'); 
-//        $this->assertArraySubset($expected, $enablingRoleTypeNames); 
-//        //print_r($enablingRoleNames); 
-//        
-//        $expected = array();  
-//        $enablingRoleTypeNames = $roleActionService->getRoleTypeNamesThatEnableActionOnTargetObjectType("AZ", 'site', 'egi'); 
-//        $this->assertArraySubset($expected, $enablingRoleTypeNames); 
+//        // EGI project
+//        $expected = array('RoleH' => 'Project');
+//        $enablingRoleTypeNames = $roleActionService->getRoleTypeNamesThatEnableActionOnTargetObjectType("AZ", 'project', 'egi');
+//        $this->assertArraySubset($expected, $enablingRoleTypeNames);
+//        //print_r($enablingRoleNames);
+//
+//        $expected = array();
+//        $enablingRoleTypeNames = $roleActionService->getRoleTypeNamesThatEnableActionOnTargetObjectType("AZ", 'site', 'egi');
+//        $this->assertArraySubset($expected, $enablingRoleTypeNames);
 
         // EGI2 project
-        // to do action 'AX' on a 'site' requires roles: 
-        $expected = array('RoleA','RoleB','RoleC','RoleD','RoleE');  
-        $enablingRoleTypeNames = $roleActionService->getRoleTypeNamesThatEnableActionOnTargetObjectType("AX", 'site', 'egi2'); 
-        $this->assertArraySubset($expected, array_keys($enablingRoleTypeNames)); 
-        //print_r($enablingRoleNames); 
+        // to do action 'AX' on a 'site' requires roles:
+        $expected = array('RoleA','RoleB','RoleC','RoleD','RoleE');
+        $enablingRoleTypeNames = $roleActionService->getRoleTypeNamesThatEnableActionOnTargetObjectType("AX", 'site', 'egi2');
+        $this->assertArraySubset($expected, array_keys($enablingRoleTypeNames));
+        //print_r($enablingRoleNames);
 
-        // to do action 'AX' on a 'service' requires roles: 
-        $expected = array('RoleA','RoleB','RoleC','RoleD','RoleE');  
-        $enablingRoleTypeNames = $roleActionService->getRoleTypeNamesThatEnableActionOnTargetObjectType("AX", 'service', 'egi2'); 
-        $this->assertArraySubset($expected, array_keys($enablingRoleTypeNames)); 
+        // to do action 'AX' on a 'service' requires roles:
+        $expected = array('RoleA','RoleB','RoleC','RoleD','RoleE');
+        $enablingRoleTypeNames = $roleActionService->getRoleTypeNamesThatEnableActionOnTargetObjectType("AX", 'service', 'egi2');
+        $this->assertArraySubset($expected, array_keys($enablingRoleTypeNames));
 
-        // to do action 'AX' on a 'project' requires roles: 
-        $expected = array('RoleD','RoleE');  
-        $enablingRoleTypeNames = $roleActionService->getRoleTypeNamesThatEnableActionOnTargetObjectType("AX", 'project', 'egi2'); 
-        $this->assertArraySubset($expected, array_keys($enablingRoleTypeNames)); 
+        // to do action 'AX' on a 'project' requires roles:
+        $expected = array('RoleD','RoleE');
+        $enablingRoleTypeNames = $roleActionService->getRoleTypeNamesThatEnableActionOnTargetObjectType("AX", 'project', 'egi2');
+        $this->assertArraySubset($expected, array_keys($enablingRoleTypeNames));
 
-        // to do action 'A1' on a 'site' requires roles: 
-        $expected = array('RoleA','RoleB','RoleC');  
-        $enablingRoleTypeNames = $roleActionService->getRoleTypeNamesThatEnableActionOnTargetObjectType("A1", 'site', 'egi2'); 
-        $this->assertArraySubset($expected, array_keys($enablingRoleTypeNames)); 
+        // to do action 'A1' on a 'site' requires roles:
+        $expected = array('RoleA','RoleB','RoleC');
+        $enablingRoleTypeNames = $roleActionService->getRoleTypeNamesThatEnableActionOnTargetObjectType("A1", 'site', 'egi2');
+        $this->assertArraySubset($expected, array_keys($enablingRoleTypeNames));
 
-        // to do action 'A5' on a 'site' requires roles: 
-        $expected = array('RoleD','RoleE');  
-        $enablingRoleTypeNames = $roleActionService->getRoleTypeNamesThatEnableActionOnTargetObjectType("A5", 'site', 'egi2'); 
-        $this->assertArraySubset($expected, array_keys($enablingRoleTypeNames)); 
+        // to do action 'A5' on a 'site' requires roles:
+        $expected = array('RoleD','RoleE');
+        $enablingRoleTypeNames = $roleActionService->getRoleTypeNamesThatEnableActionOnTargetObjectType("A5", 'site', 'egi2');
+        $this->assertArraySubset($expected, array_keys($enablingRoleTypeNames));
 
-        // to do action 'A1' on a 'service' requires roles: 
-        $expected = array('RoleA','RoleB','RoleC');  
-        $enablingRoleTypeNames = $roleActionService->getRoleTypeNamesThatEnableActionOnTargetObjectType("A1", 'service', 'egi2'); 
-        $this->assertArraySubset($expected, array_keys($enablingRoleTypeNames)); 
+        // to do action 'A1' on a 'service' requires roles:
+        $expected = array('RoleA','RoleB','RoleC');
+        $enablingRoleTypeNames = $roleActionService->getRoleTypeNamesThatEnableActionOnTargetObjectType("A1", 'service', 'egi2');
+        $this->assertArraySubset($expected, array_keys($enablingRoleTypeNames));
 
-        // to do action 'AY' on a 'project' requires roles: 
-        $expected = array('RoleF');  
-        $enablingRoleTypeNames = $roleActionService->getRoleTypeNamesThatEnableActionOnTargetObjectType("AY", 'project', 'egi2'); 
-        $this->assertArraySubset($expected, array_keys($enablingRoleTypeNames)); 
+        // to do action 'AY' on a 'project' requires roles:
+        $expected = array('RoleF');
+        $enablingRoleTypeNames = $roleActionService->getRoleTypeNamesThatEnableActionOnTargetObjectType("AY", 'project', 'egi2');
+        $this->assertArraySubset($expected, array_keys($enablingRoleTypeNames));
 
     }
- 
+
     /*
      * @expectedException \LogicException
      * @expectedExceptionCode 22
      */
 //    public function testInvalidDocMultipleDefaultElements(){
 //        print __METHOD__ . "\n";
-//        $roleActionService = new org\gocdb\services\RoleActionMappingService(); 
-//        $roleActionService->setRoleActionMappingsXmlPath(__DIR__."/../../resources/roleActionMappingSamples/TestRoleActionMappings1.xml"); 
-//        $roleActionService->getRoleTypeNamesThatEnableActionOnTargetObjectType("action", "hello", "world"); 
+//        $roleActionService = new org\gocdb\services\RoleActionMappingService();
+//        $roleActionService->setRoleActionMappingsXmlPath(__DIR__."/../../resources/roleActionMappingSamples/TestRoleActionMappings1.xml");
+//        $roleActionService->getRoleTypeNamesThatEnableActionOnTargetObjectType("action", "hello", "world");
 //    }
 
 //    public function testInvalidDocMultipleRoleActionMappingsForProject(){
 //        print __METHOD__ . "\n";
-//        $roleActionService = new org\gocdb\services\RoleActionMappingService(); 
-//        $roleActionService->setRoleActionMappingsXmlPath(__DIR__."/../../resources/roleActionMappingSamples/TestInvalidRoleActionMappings2.xml"); 
-//        try { 
-//            $roleActionService->getRoleTypeNamesThatEnableActionOnTargetObjectType("action", "hello", "EGI"); 
-//            $this->fail("shouldn't have got here"); 
+//        $roleActionService = new org\gocdb\services\RoleActionMappingService();
+//        $roleActionService->setRoleActionMappingsXmlPath(__DIR__."/../../resources/roleActionMappingSamples/TestInvalidRoleActionMappings2.xml");
+//        try {
+//            $roleActionService->getRoleTypeNamesThatEnableActionOnTargetObjectType("action", "hello", "EGI");
+//            $this->fail("shouldn't have got here");
 //        } catch (\Exception $ex){
-//            //print_r($ex->getMessage()) ; 
-//            //$errors = libxml_get_errors(); 
-//            //var_dump($errors); 
+//            //print_r($ex->getMessage()) ;
+//            //$errors = libxml_get_errors();
+//            //var_dump($errors);
 //        }
 //    }
 
@@ -278,80 +278,80 @@ class RoleActionMappingServiceTest extends PHPUnit_Framework_TestCase {
     $roleActionService = new org\gocdb\services\RoleActionMappingService();
     $roleActionService->setRoleActionMappingsXmlPath(__DIR__ . "/../../resources/roleActionMappingSamples/TestRoleActionMappings4.xml");
 
-    $enabledActionsOnTargets = $roleActionService->getEnabledActionsForRoleType('RoleA'); 
-    
-//	foreach($enabledActionsOnTargets as $enabledActionOnTarget){
-//	    print_r($enabledActionOnTarget[0].' '.$enabledActionOnTarget[1]."\n"); 
-//	}
-    $expectedActionsOnTargets = array(); 
-        $expectedActionsOnTargets[] = array('A1', 'site');  	
-        $expectedActionsOnTargets[] = array('A1', 'service');  	
-        $expectedActionsOnTargets[] = array('A2', 'site');  	
-        $expectedActionsOnTargets[] = array('A2', 'service');  	
-        $expectedActionsOnTargets[] = array('A3', 'site');  	
-        $expectedActionsOnTargets[] = array('A3', 'service');  	
-        $expectedActionsOnTargets[] = array('AX', 'site');  	
-        $expectedActionsOnTargets[] = array('AX', 'service'); 
-        // assert 
-    $this->assertEquals($expectedActionsOnTargets, $enabledActionsOnTargets); 
+    $enabledActionsOnTargets = $roleActionService->getEnabledActionsForRoleType('RoleA');
 
-    $enabledActionsOnTargets = $roleActionService->getEnabledActionsForRoleType('RoleD'); 
-    $expectedActionsOnTargets = array(); 
-        $expectedActionsOnTargets[] = array('A4', 'site');  	
-        $expectedActionsOnTargets[] = array('A4', 'service');  	
-        $expectedActionsOnTargets[] = array('A4', 'project');  	
-        $expectedActionsOnTargets[] = array('A5', 'site');  	
-        $expectedActionsOnTargets[] = array('A5', 'service');  	
-        $expectedActionsOnTargets[] = array('A5', 'project');  	
-        $expectedActionsOnTargets[] = array('AX', 'site');  	
-        $expectedActionsOnTargets[] = array('AX', 'service');  	
-        $expectedActionsOnTargets[] = array('AX', 'project');  	
-    // assert 
-    $this->assertEquals($expectedActionsOnTargets, $enabledActionsOnTargets); 
-    
+//	foreach($enabledActionsOnTargets as $enabledActionOnTarget){
+//	    print_r($enabledActionOnTarget[0].' '.$enabledActionOnTarget[1]."\n");
+//	}
+    $expectedActionsOnTargets = array();
+        $expectedActionsOnTargets[] = array('A1', 'site');
+        $expectedActionsOnTargets[] = array('A1', 'service');
+        $expectedActionsOnTargets[] = array('A2', 'site');
+        $expectedActionsOnTargets[] = array('A2', 'service');
+        $expectedActionsOnTargets[] = array('A3', 'site');
+        $expectedActionsOnTargets[] = array('A3', 'service');
+        $expectedActionsOnTargets[] = array('AX', 'site');
+        $expectedActionsOnTargets[] = array('AX', 'service');
+        // assert
+    $this->assertEquals($expectedActionsOnTargets, $enabledActionsOnTargets);
+
+    $enabledActionsOnTargets = $roleActionService->getEnabledActionsForRoleType('RoleD');
+    $expectedActionsOnTargets = array();
+        $expectedActionsOnTargets[] = array('A4', 'site');
+        $expectedActionsOnTargets[] = array('A4', 'service');
+        $expectedActionsOnTargets[] = array('A4', 'project');
+        $expectedActionsOnTargets[] = array('A5', 'site');
+        $expectedActionsOnTargets[] = array('A5', 'service');
+        $expectedActionsOnTargets[] = array('A5', 'project');
+        $expectedActionsOnTargets[] = array('AX', 'site');
+        $expectedActionsOnTargets[] = array('AX', 'service');
+        $expectedActionsOnTargets[] = array('AX', 'project');
+    // assert
+    $this->assertEquals($expectedActionsOnTargets, $enabledActionsOnTargets);
+
     }
-    
+
     public function testGetEnabledActionsForRoleType2() {
-    print __METHOD__ . "\n";	
+    print __METHOD__ . "\n";
     $roleActionService = new org\gocdb\services\RoleActionMappingService();
     $roleActionService->setRoleActionMappingsXmlPath(__DIR__ . "/../../resources/roleActionMappingSamples/TestRoleActionMappings5.xml");
 
-    $enabledActionsOnTargets = $roleActionService->getEnabledActionsForRoleType('NGI Operations Manager'); 
+    $enabledActionsOnTargets = $roleActionService->getEnabledActionsForRoleType('NGI Operations Manager');
 //	foreach($enabledActionsOnTargets as $enabledActionOnTarget){
-//	    print_r($enabledActionOnTarget[0].' '.$enabledActionOnTarget[1]."\n"); 
+//	    print_r($enabledActionOnTarget[0].' '.$enabledActionOnTarget[1]."\n");
 //	}
 
-    $expectedActionsOnTargets = array(); 
-        $expectedActionsOnTargets[] = array('ACTION_EDIT_OBJECT', 'Ngi');  	
-        $expectedActionsOnTargets[] = array('ACTION_NGI_ADD_SITE', 'Ngi');  	
-        $expectedActionsOnTargets[] = array('ACTION_GRANT_ROLE', 'Ngi');  	
-        $expectedActionsOnTargets[] = array('ACTION_REJECT_ROLE', 'Ngi');  	
-        $expectedActionsOnTargets[] = array('ACTION_REVOKE_ROLE', 'Ngi');  	
-        $expectedActionsOnTargets[] = array('ACTION_EDIT_OBJECT', 'Site');  	
-        $expectedActionsOnTargets[] = array('ACTION_SITE_ADD_SERVICE', 'Site');  	
-        $expectedActionsOnTargets[] = array('ACTION_SITE_DELETE_SERVICE', 'Site');  	
-        $expectedActionsOnTargets[] = array('ACTION_GRANT_ROLE', 'Site');  	
-        $expectedActionsOnTargets[] = array(' ACTION_REJECT_ROLE', 'Site');  	
-        $expectedActionsOnTargets[] = array(' ACTION_REVOKE_ROLE', 'Site');  	
-        $expectedActionsOnTargets[] = array('ACTION_SITE_EDIT_CERT_STATUS', 'Site');  	
-    // assert 
-    $this->assertEquals($expectedActionsOnTargets, $enabledActionsOnTargets); 
+    $expectedActionsOnTargets = array();
+        $expectedActionsOnTargets[] = array('ACTION_EDIT_OBJECT', 'Ngi');
+        $expectedActionsOnTargets[] = array('ACTION_NGI_ADD_SITE', 'Ngi');
+        $expectedActionsOnTargets[] = array('ACTION_GRANT_ROLE', 'Ngi');
+        $expectedActionsOnTargets[] = array('ACTION_REJECT_ROLE', 'Ngi');
+        $expectedActionsOnTargets[] = array('ACTION_REVOKE_ROLE', 'Ngi');
+        $expectedActionsOnTargets[] = array('ACTION_EDIT_OBJECT', 'Site');
+        $expectedActionsOnTargets[] = array('ACTION_SITE_ADD_SERVICE', 'Site');
+        $expectedActionsOnTargets[] = array('ACTION_SITE_DELETE_SERVICE', 'Site');
+        $expectedActionsOnTargets[] = array('ACTION_GRANT_ROLE', 'Site');
+        $expectedActionsOnTargets[] = array(' ACTION_REJECT_ROLE', 'Site');
+        $expectedActionsOnTargets[] = array(' ACTION_REVOKE_ROLE', 'Site');
+        $expectedActionsOnTargets[] = array('ACTION_SITE_EDIT_CERT_STATUS', 'Site');
+    // assert
+    $this->assertEquals($expectedActionsOnTargets, $enabledActionsOnTargets);
 
 
-    $enabledActionsOnTargets = $roleActionService->getEnabledActionsForRoleType('COD Staff'); 
-    $expectedActionsOnTargets = array(); 
-        $expectedActionsOnTargets[] = array('ACTION_EDIT_OBJECT', 'Project');  	
-        $expectedActionsOnTargets[] = array('ACTION_GRANT_ROLE', 'Project');  	
-        $expectedActionsOnTargets[] = array('ACTION_REJECT_ROLE', 'Project');  	
-        $expectedActionsOnTargets[] = array('ACTION_REVOKE_ROLE', 'Project');  	
-        $expectedActionsOnTargets[] = array('ACTION_GRANT_ROLE', 'Ngi');  	
-        $expectedActionsOnTargets[] = array('ACTION_REJECT_ROLE', 'Ngi');  	
-        $expectedActionsOnTargets[] = array('ACTION_REVOKE_ROLE', 'Ngi');  	
-        $expectedActionsOnTargets[] = array('ACTION_SITE_EDIT_CERT_STATUS', 'Site');  	
-    // assert 
-    $this->assertEquals($expectedActionsOnTargets, $enabledActionsOnTargets); 
-    
-    
+    $enabledActionsOnTargets = $roleActionService->getEnabledActionsForRoleType('COD Staff');
+    $expectedActionsOnTargets = array();
+        $expectedActionsOnTargets[] = array('ACTION_EDIT_OBJECT', 'Project');
+        $expectedActionsOnTargets[] = array('ACTION_GRANT_ROLE', 'Project');
+        $expectedActionsOnTargets[] = array('ACTION_REJECT_ROLE', 'Project');
+        $expectedActionsOnTargets[] = array('ACTION_REVOKE_ROLE', 'Project');
+        $expectedActionsOnTargets[] = array('ACTION_GRANT_ROLE', 'Ngi');
+        $expectedActionsOnTargets[] = array('ACTION_REJECT_ROLE', 'Ngi');
+        $expectedActionsOnTargets[] = array('ACTION_REVOKE_ROLE', 'Ngi');
+        $expectedActionsOnTargets[] = array('ACTION_SITE_EDIT_CERT_STATUS', 'Site');
+    // assert
+    $this->assertEquals($expectedActionsOnTargets, $enabledActionsOnTargets);
+
+
     }
 
 }

--- a/tests/unit/lib/Gocdb_Services/ScopeServiceTest.php
+++ b/tests/unit/lib/Gocdb_Services/ScopeServiceTest.php
@@ -11,54 +11,54 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-require_once __DIR__ . '/../../../doctrine/TestUtil.php'; 
-require_once __DIR__ . '/../../../../lib/Gocdb_Services/Scope.php'; 
-require_once __DIR__ . '/../../../../lib/Gocdb_Services/Config.php'; 
+require_once __DIR__ . '/../../../doctrine/TestUtil.php';
+require_once __DIR__ . '/../../../../lib/Gocdb_Services/Scope.php';
+require_once __DIR__ . '/../../../../lib/Gocdb_Services/Config.php';
 
-use Doctrine\ORM\EntityManager; 
+use Doctrine\ORM\EntityManager;
 require_once __DIR__ . '/../../../doctrine/bootstrap.php';
 
 /**
- * DBUnit test class for the {@see \org\gocdb\services\Scope} service.  
+ * DBUnit test class for the {@see \org\gocdb\services\Scope} service.
  *
- * @author David Meredith 
+ * @author David Meredith
  */
 class ScopeServiceTest extends PHPUnit_Extensions_Database_TestCase{
-     private $em; 
+     private $em;
 
 
 
     /**
-     * Overridden. 
+     * Overridden.
      */
     public static function setUpBeforeClass() {
         parent::setUpBeforeClass();
         echo "\n\n-------------------------------------------------\n";
         echo "Executing ScopeServiceTest. . .\n";
     }
-    
+
     /**
      * Overridden. Returns the test database connection.
      * @return PHPUnit_Extensions_Database_DB_IDatabaseConnection
      */
     protected function getConnection() {
         require_once __DIR__ . '/../../../doctrine/bootstrap_pdo.php';
-        return getConnectionToTestDB(); 
+        return getConnectionToTestDB();
     }
 
     /**
-     * Overridden. Returns the test dataset.  
-     * Defines how the initial state of the database should look before each test is executed. 
+     * Overridden. Returns the test dataset.
+     * Defines how the initial state of the database should look before each test is executed.
      * @return PHPUnit_Extensions_Database_DataSet_IDataSet
      */
-    protected function getDataSet() { 
+    protected function getDataSet() {
         return $this->createFlatXMLDataSet(__DIR__ . '/../../../doctrine/truncateDataTables.xml');
         // Use below to return an empty data set if we don't want to truncate and seed
         //return new PHPUnit_Extensions_Database_DataSet_DefaultDataSet();
     }
 
     /**
-     * Overridden. 
+     * Overridden.
      */
     protected function getSetUpOperation() {
         // CLEAN_INSERT is default
@@ -66,14 +66,14 @@ class ScopeServiceTest extends PHPUnit_Extensions_Database_TestCase{
         //return PHPUnit_Extensions_Database_Operation_Factory::UPDATE();
         //return PHPUnit_Extensions_Database_Operation_Factory::NONE();
         //
-        // Issue a DELETE from <table> which is more portable than a 
-        // TRUNCATE table <table> (some DBs require high privileges for truncate statements 
+        // Issue a DELETE from <table> which is more portable than a
+        // TRUNCATE table <table> (some DBs require high privileges for truncate statements
         // and also do not allow truncates across tables with FK contstraints e.g. Oracle)
         return PHPUnit_Extensions_Database_Operation_Factory::DELETE_ALL();
     }
 
     /**
-     * Overridden. 
+     * Overridden.
      */
     protected function getTearDownOperation() {
         // NONE is default
@@ -85,17 +85,17 @@ class ScopeServiceTest extends PHPUnit_Extensions_Database_TestCase{
      * This method is called before each test method is executed.
      */
     protected function setUp() {
-        parent::setUp();            
+        parent::setUp();
         $this->em = $this->createEntityManager();
     }
-    
+
     /**
-     * @todo Still need to setup connection to different databases. 
+     * @todo Still need to setup connection to different databases.
      * @return EntityManager
      */
     private function createEntityManager(){
         require __DIR__ . '/../../../doctrine/bootstrap_doctrine.php';
-        return $entityManager; 
+        return $entityManager;
     }
 
     /**
@@ -111,19 +111,19 @@ class ScopeServiceTest extends PHPUnit_Extensions_Database_TestCase{
             //print $tableName->getName() . "\n";
             $sql = "SELECT * FROM ".$tableName->getName();
             $result = $con->createQueryTable('results_table', $sql);
-            //echo 'row count: '.$result->getRowCount() ; 
-            if($result->getRowCount() != 0){ 
+            //echo 'row count: '.$result->getRowCount() ;
+            if($result->getRowCount() != 0){
                 throw new RuntimeException("Invalid fixture. Table has rows: ".$tableName->getName());
             }
         }
     }
 
     private function insertTestScopes(){
-        $scopeCount = 10; 
-        $scopes = array(); 
+        $scopeCount = 10;
+        $scopes = array();
         // create scopes and persist
         for($i=0; $i<$scopeCount; $i++){
-            $scopes[] = TestUtil::createSampleScope("scope ".$i, "Scope".$i); 
+            $scopes[] = TestUtil::createSampleScope("scope ".$i, "Scope".$i);
             $this->em->persist($scopes[$i]);
         }
     }
@@ -131,169 +131,169 @@ class ScopeServiceTest extends PHPUnit_Extensions_Database_TestCase{
 
     public function testGetScopes(){
         print __METHOD__ . "\n";
-        $this->insertTestScopes(); 
+        $this->insertTestScopes();
         $this->em->flush();
-          
-        $scopeService = new \org\gocdb\services\Scope(); 
-        $scopeService->setEntityManager($this->em); 
 
-        $scopes = $scopeService->getScopes(); 
+        $scopeService = new \org\gocdb\services\Scope();
+        $scopeService->setEntityManager($this->em);
+
+        $scopes = $scopeService->getScopes();
         $this->assertEquals(10, count($scopes));
-        $scopeIds = array(); 
+        $scopeIds = array();
         foreach($scopes as $scope){
-            $scopeIds[] = $scope->getId(); 
+            $scopeIds[] = $scope->getId();
         }
         $scopes = $scopeService->getScopes($scopeIds);
         $this->assertEquals(10, count($scopes));
 //        foreach($scopes as $scope){
-//            echo $scope->getId().' '.$scope->getName()."\n"; 
+//            echo $scope->getId().' '.$scope->getName()."\n";
 //        }
-        
+
     }
-    
+
     public function testGetScopesFilterByParams1() {
         print __METHOD__ . "\n";
-        $this->insertTestScopes(); 
+        $this->insertTestScopes();
         $this->em->flush();
-          
-        $scopeService = new \org\gocdb\services\Scope(); 
-        $scopeService->setEntityManager($this->em); 
-        $configService = new \org\gocdb\services\Config(); 
-        $configService->setLocalInfoFileLocation(__DIR__ . '/../../resources/sample_local_info1.xml'); 
-        $scopeService->setConfigService($configService); 
-       
-        // exclude all the 'Reserved' scopes 
-        $filterParams = array('excludeReserved' => true); 
-        $excludedScopeNames = $configService->getReservedScopeList();//'Scope0', 'Scope1', 'Scope2', 'Scope3'  
-        $filteredScopes = $scopeService->getScopesFilterByParams($filterParams, null); 
+
+        $scopeService = new \org\gocdb\services\Scope();
+        $scopeService->setEntityManager($this->em);
+        $configService = new \org\gocdb\services\Config();
+        $configService->setLocalInfoFileLocation(__DIR__ . '/../../resources/sample_local_info1.xml');
+        $scopeService->setConfigService($configService);
+
+        // exclude all the 'Reserved' scopes
+        $filterParams = array('excludeReserved' => true);
+        $excludedScopeNames = $configService->getReservedScopeList();//'Scope0', 'Scope1', 'Scope2', 'Scope3'
+        $filteredScopes = $scopeService->getScopesFilterByParams($filterParams, null);
         foreach($filteredScopes as $scope){
-            //echo $scope->getName()."\n"; 
+            //echo $scope->getName()."\n";
             if(in_array($scope->getName(), $excludedScopeNames)){
-               $this->fail("Reserved scope returned");  
+               $this->fail("Reserved scope returned");
             }
         }
-        $this->assertEquals(6, count($filteredScopes)); 
+        $this->assertEquals(6, count($filteredScopes));
 
-        // excluding all the 'Normal/Non-Reserved' scopes should leave 0  
-        $filterParams = array('excludeNonReserved' => true); 
+        // excluding all the 'Normal/Non-Reserved' scopes should leave 0
+        $filterParams = array('excludeNonReserved' => true);
         $filteredScopes = $scopeService->getScopesFilterByParams($filterParams, $filteredScopes);
-        $this->assertEquals(0, count($filteredScopes)); 
+        $this->assertEquals(0, count($filteredScopes));
     }
 
 
-    
+
     public function testGetScopesFilterByParams2() {
         print __METHOD__ . "\n";
-        $this->insertTestScopes(); 
+        $this->insertTestScopes();
         $this->em->flush();
-          
-        $scopeService = new \org\gocdb\services\Scope(); 
-        $scopeService->setEntityManager($this->em); 
-        $configService = new \org\gocdb\services\Config(); 
-        $configService->setLocalInfoFileLocation(__DIR__ . '/../../resources/sample_local_info1.xml'); 
-        $scopeService->setConfigService($configService); 
-       
-        // exclude all the 'Normal/Non-Reserved' scopes: 
-        $filterParams = array('excludeNonReserved' => true); 
-        $excludedScopeNames = array('Scope4', 'Scope5', 'Scope6', 'Scope7', 'Scope8', 'Scope9');  
-        $filteredScopes = $scopeService->getScopesFilterByParams($filterParams, null); 
+
+        $scopeService = new \org\gocdb\services\Scope();
+        $scopeService->setEntityManager($this->em);
+        $configService = new \org\gocdb\services\Config();
+        $configService->setLocalInfoFileLocation(__DIR__ . '/../../resources/sample_local_info1.xml');
+        $scopeService->setConfigService($configService);
+
+        // exclude all the 'Normal/Non-Reserved' scopes:
+        $filterParams = array('excludeNonReserved' => true);
+        $excludedScopeNames = array('Scope4', 'Scope5', 'Scope6', 'Scope7', 'Scope8', 'Scope9');
+        $filteredScopes = $scopeService->getScopesFilterByParams($filterParams, null);
         foreach($filteredScopes as $scope){
-            //echo $scope->getName()."\n"; 
+            //echo $scope->getName()."\n";
             if(in_array($scope->getName(), $excludedScopeNames)){
-               $this->fail("Normal/Non-Reserved scope returned");  
+               $this->fail("Normal/Non-Reserved scope returned");
             }
         }
-        $this->assertEquals(4, count($filteredScopes)); 
+        $this->assertEquals(4, count($filteredScopes));
 
-        // excluding all the 'Reserved' scopes should leave 0  
-        $filterParams = array('excludeReserved' => true); 
+        // excluding all the 'Reserved' scopes should leave 0
+        $filterParams = array('excludeReserved' => true);
         $filteredScopes = $scopeService->getScopesFilterByParams($filterParams, $filteredScopes);
-        $this->assertEquals(0, count($filteredScopes)); 
+        $this->assertEquals(0, count($filteredScopes));
     }
 
 
     public function testGetScopesFilterByParams3() {
         print __METHOD__ . "\n";
-        $this->insertTestScopes(); 
+        $this->insertTestScopes();
         $this->em->flush();
-          
-        $scopeService = new \org\gocdb\services\Scope(); 
-        $scopeService->setEntityManager($this->em); 
-        $configService = new \org\gocdb\services\Config(); 
-        $configService->setLocalInfoFileLocation(__DIR__ . '/../../resources/sample_local_info1.xml'); 
-        $scopeService->setConfigService($configService); 
-       
-        // exclude all the 'Default' scopes: 
-        $filterParams = array('excludeDefault' => true); 
-        $excludedScopeNames = array('Scope0');  
-        $filteredScopes = $scopeService->getScopesFilterByParams($filterParams, null); 
+
+        $scopeService = new \org\gocdb\services\Scope();
+        $scopeService->setEntityManager($this->em);
+        $configService = new \org\gocdb\services\Config();
+        $configService->setLocalInfoFileLocation(__DIR__ . '/../../resources/sample_local_info1.xml');
+        $scopeService->setConfigService($configService);
+
+        // exclude all the 'Default' scopes:
+        $filterParams = array('excludeDefault' => true);
+        $excludedScopeNames = array('Scope0');
+        $filteredScopes = $scopeService->getScopesFilterByParams($filterParams, null);
         foreach($filteredScopes as $scope){
-            //echo $scope->getName()."\n"; 
+            //echo $scope->getName()."\n";
             if(in_array($scope->getName(), $excludedScopeNames)){
-               $this->fail("Default scope returned");  
+               $this->fail("Default scope returned");
             }
         }
-        $this->assertEquals(9, count($filteredScopes)); 
+        $this->assertEquals(9, count($filteredScopes));
 
-        // excluding all the 'Non Default' scopes should leave 0  
-        $filterParams = array('excludeNonDefault' => true); 
+        // excluding all the 'Non Default' scopes should leave 0
+        $filterParams = array('excludeNonDefault' => true);
         $filteredScopes = $scopeService->getScopesFilterByParams($filterParams, $filteredScopes);
-        $this->assertEquals(0, count($filteredScopes)); 
+        $this->assertEquals(0, count($filteredScopes));
     }
 
     public function testGetScopesFilterByParams4() {
         print __METHOD__ . "\n";
-        $this->insertTestScopes(); 
+        $this->insertTestScopes();
         $this->em->flush();
-          
-        $scopeService = new \org\gocdb\services\Scope(); 
-        $scopeService->setEntityManager($this->em); 
-        $configService = new \org\gocdb\services\Config(); 
-        $configService->setLocalInfoFileLocation(__DIR__ . '/../../resources/sample_local_info1.xml'); 
-        $scopeService->setConfigService($configService); 
-       
-        // exclude all the 'Non Default' scopes: 
-        $filterParams = array('excludeNonDefault' => true); 
-        $excludedScopeNames = array('Scope1','Scope2','Scope3','Scope4','Scope5','Scope6','Scope7','Scope8','Scope9');  
-        $filteredScopes = $scopeService->getScopesFilterByParams($filterParams, null); 
+
+        $scopeService = new \org\gocdb\services\Scope();
+        $scopeService->setEntityManager($this->em);
+        $configService = new \org\gocdb\services\Config();
+        $configService->setLocalInfoFileLocation(__DIR__ . '/../../resources/sample_local_info1.xml');
+        $scopeService->setConfigService($configService);
+
+        // exclude all the 'Non Default' scopes:
+        $filterParams = array('excludeNonDefault' => true);
+        $excludedScopeNames = array('Scope1','Scope2','Scope3','Scope4','Scope5','Scope6','Scope7','Scope8','Scope9');
+        $filteredScopes = $scopeService->getScopesFilterByParams($filterParams, null);
         foreach($filteredScopes as $scope){
-            //echo $scope->getName()."\n"; 
+            //echo $scope->getName()."\n";
             if(in_array($scope->getName(), $excludedScopeNames)){
-               $this->fail("Default scope returned");  
+               $this->fail("Default scope returned");
             }
         }
-        $this->assertEquals(1, count($filteredScopes)); 
+        $this->assertEquals(1, count($filteredScopes));
 
-        // excluding all the 'Default' scopes should leave 0  
-        $filterParams = array('excludeDefault' => true); 
+        // excluding all the 'Default' scopes should leave 0
+        $filterParams = array('excludeDefault' => true);
         $filteredScopes = $scopeService->getScopesFilterByParams($filterParams, $filteredScopes);
-        $this->assertEquals(0, count($filteredScopes)); 
+        $this->assertEquals(0, count($filteredScopes));
     }
 
     public function testGetScopesFilterByParams5() {
         print __METHOD__ . "\n";
-        $this->insertTestScopes(); 
+        $this->insertTestScopes();
         $this->em->flush();
-          
-        $scopeService = new \org\gocdb\services\Scope(); 
-        $scopeService->setEntityManager($this->em); 
-        $configService = new \org\gocdb\services\Config(); 
-        $configService->setLocalInfoFileLocation(__DIR__ . '/../../resources/sample_local_info1.xml'); 
-        $scopeService->setConfigService($configService); 
-       
-        $filterParams = array('excludeDefault' => true, 'excludeNonReserved' => true); 
-        $excludedScopeNames = array('Scope0', 'Scope4','Scope5','Scope6','Scope7','Scope8','Scope9');  
-        // $expectedScopeNames=array('Scope1','Scope2','Scope3'); 
-        $filteredScopes = $scopeService->getScopesFilterByParams($filterParams, null); 
+
+        $scopeService = new \org\gocdb\services\Scope();
+        $scopeService->setEntityManager($this->em);
+        $configService = new \org\gocdb\services\Config();
+        $configService->setLocalInfoFileLocation(__DIR__ . '/../../resources/sample_local_info1.xml');
+        $scopeService->setConfigService($configService);
+
+        $filterParams = array('excludeDefault' => true, 'excludeNonReserved' => true);
+        $excludedScopeNames = array('Scope0', 'Scope4','Scope5','Scope6','Scope7','Scope8','Scope9');
+        // $expectedScopeNames=array('Scope1','Scope2','Scope3');
+        $filteredScopes = $scopeService->getScopesFilterByParams($filterParams, null);
         foreach($filteredScopes as $scope){
-            //echo $scope->getName()."\n"; 
+            //echo $scope->getName()."\n";
             if(in_array($scope->getName(), $excludedScopeNames)){
-               $this->fail("Default scope returned");  
+               $this->fail("Default scope returned");
             }
         }
-        $this->assertEquals(3, count($filteredScopes)); 
+        $this->assertEquals(3, count($filteredScopes));
     }
-    
+
 
     /**
      * @expectedException InvalidArgumentException

--- a/tests/unit/resources/sampleFixtureData5.php
+++ b/tests/unit/resources/sampleFixtureData5.php
@@ -15,39 +15,39 @@
 
 
         /*
-         * Create test data with the following structure (note p3 has two ngis) 
-         * 
+         * Create test data with the following structure (note p3 has two ngis)
+         *
          * p1  p2  p3
          * |   |  /|
          * n1  n2  n3
-         * |   |   | 
-         * s1  s2  s3 
+         * |   |   |
+         * s1  s2  s3
          */
-        $p1 = new \Project("p1");  
+        $p1 = new \Project("p1");
         $n1 = TestUtil::createSampleNGI("n1");
-        $s1 = TestUtil::createSampleSite("s1"); 
+        $s1 = TestUtil::createSampleSite("s1");
         $this->em->persist($p1);
         $this->em->persist($n1);
         $this->em->persist($s1);
-        $n1->addSiteDoJoin($s1); 
-        $p1->addNgi($n1); 
+        $n1->addSiteDoJoin($s1);
+        $p1->addNgi($n1);
 
-        $p2 = new \Project("p2");  
+        $p2 = new \Project("p2");
         $n2 = TestUtil::createSampleNGI("n2");
-        $s2 = TestUtil::createSampleSite("s2"); 
+        $s2 = TestUtil::createSampleSite("s2");
         $this->em->persist($p2);
         $this->em->persist($n2);
         $this->em->persist($s2);
-        $n2->addSiteDoJoin($s2); 
-        $p2->addNgi($n2); 
+        $n2->addSiteDoJoin($s2);
+        $p2->addNgi($n2);
 
-        $p3 = new \Project("p3");  
+        $p3 = new \Project("p3");
         $n3 = TestUtil::createSampleNGI("n3");
-        $s3 = TestUtil::createSampleSite("s3"); 
+        $s3 = TestUtil::createSampleSite("s3");
         $this->em->persist($p3);
         $this->em->persist($n3);
         $this->em->persist($s3);
-        $n3->addSiteDoJoin($s3); 
-        $p3->addNgi($n3); 
+        $n3->addSiteDoJoin($s3);
+        $p3->addNgi($n3);
         $p3->addNgi($n2);     // note the p3 is parent to n2 + n3
 

--- a/tests/unit/resources/sampleFixtureData6.php
+++ b/tests/unit/resources/sampleFixtureData6.php
@@ -15,39 +15,39 @@
 
 
         /*
-         * Create test data with the following structure (note p3 has two ngis) 
-         * 
+         * Create test data with the following structure (note p3 has two ngis)
+         *
          * p1  p2  p3
          * |   |  /|
          * n1  n2  n3
-         * |   |   | 
-         * s1  s2  s3 
+         * |   |   |
+         * s1  s2  s3
          */
-        $p1 = new \Project("p1");  
+        $p1 = new \Project("p1");
         $n1 = TestUtil::createSampleNGI("n1");
-        $s1 = TestUtil::createSampleSite("s1"); 
+        $s1 = TestUtil::createSampleSite("s1");
         $this->em->persist($p1);
         $this->em->persist($n1);
         $this->em->persist($s1);
-        $n1->addSiteDoJoin($s1); 
-        $p1->addNgi($n1); 
+        $n1->addSiteDoJoin($s1);
+        $p1->addNgi($n1);
 
-        $p2 = new \Project("p2");  
+        $p2 = new \Project("p2");
         $n2 = TestUtil::createSampleNGI("n2");
-        $s2 = TestUtil::createSampleSite("s2"); 
+        $s2 = TestUtil::createSampleSite("s2");
         $this->em->persist($p2);
         $this->em->persist($n2);
         $this->em->persist($s2);
-        $n2->addSiteDoJoin($s2); 
-        $p2->addNgi($n2); 
+        $n2->addSiteDoJoin($s2);
+        $p2->addNgi($n2);
 
-        $p3 = new \Project("p3");  
+        $p3 = new \Project("p3");
         $n3 = TestUtil::createSampleNGI("n3");
-        $s3 = TestUtil::createSampleSite("s3"); 
+        $s3 = TestUtil::createSampleSite("s3");
         $this->em->persist($p3);
         $this->em->persist($n3);
         $this->em->persist($s3);
-        $n3->addSiteDoJoin($s3); 
-        $p3->addNgi($n3); 
+        $n3->addSiteDoJoin($s3);
+        $p3->addNgi($n3);
         $p3->addNgi($n2);     // note the p3 is parent to n2 + n3
 

--- a/unused_resources/PI.php
+++ b/unused_resources/PI.php
@@ -13,7 +13,7 @@ namespace org\gocdb\services;
  * limitations under the License.
  */
 require_once __DIR__ . '/AbstractEntityService.php';
-require_once __DIR__ . '/RoleConstants.php'; 
+require_once __DIR__ . '/RoleConstants.php';
 require_once __DIR__ . '/Config.php';
 require_once __DIR__ . '/OwnedEntity.php';
 require_once __DIR__.'/../Doctrine/bootstrap.php';
@@ -48,11 +48,11 @@ class PI extends AbstractEntityService{
 
     /**
      * Return an XML document that encodes Site Certification status dates.
-     * Optionally provide an associative array of query parameters with values 
-     * used to restrict the results. Only known parameters are honoured while 
+     * Optionally provide an associative array of query parameters with values
+     * used to restrict the results. Only known parameters are honoured while
      * unknown produce and error doc. Parmeter array keys include:
      * <pre>
-     * 'roc', 'certification_status' 
+     * 'roc', 'certification_status'
      * </pre>
      * @param array $parameters Associative array of parameters to narrow the query
      * @return string XML result string
@@ -79,20 +79,20 @@ class PI extends AbstractEntityService{
         } else {
             $scopeArray = $this->convertScopesToArray($this->defaultScope());
         }
-        
+
         /*$scopeClause = "";
         if($this->containsValidScope($scopeArray)){
-            $scopeClause = $this->scopeClauseFromScopeArray($scopeArray, "sc", 
-                    $this->allScopesMustMatch($parameters), 'Site', 's') . " 
+            $scopeClause = $this->scopeClauseFromScopeArray($scopeArray, "sc",
+                    $this->allScopesMustMatch($parameters), 'Site', 's') . "
                 AND";
-        } 
+        }
         */
         // Can easily re-enable the scoping (scoping is not supported for this
-        // method in the v4 PI). 
+        // method in the v4 PI).
         $scopeClause = "";
-        
-        $dql = "SELECT s 
-            FROM Site s 
+
+        $dql = "SELECT s
+            FROM Site s
             JOIN s.certificationStatus cs
             JOIN s.ngi n
             LEFT JOIN s.scopes sc
@@ -100,36 +100,36 @@ class PI extends AbstractEntityService{
             WHERE (n.name LIKE :roc)
             AND " . $scopeClause // AND clause is already appended to $scopeClause where relevant.
             . " (i.name = 'Production')
-            AND (cs.name LIKE :certStatus)"; 
-        
+            AND (cs.name LIKE :certStatus)";
+
         $q = $this->em->createQuery($dql)
             ->setParameter('roc', $roc)
             ->setParameter('certStatus', $certification_status);
-        
+
         // Can easily re-enable the scoping (scoping is not supported for this
-        // method in the v4 PI). 
+        // method in the v4 PI).
 //        $q = $this->setScopeBindParameters($scopeArray, $q);
-        
+
         $allSites = $q->getResult();
-       
+
         // Ensure all dates are in UTC
         date_default_timezone_set("UTC");
-       
+
         $xml = new \SimpleXMLElement("<results />");
         foreach ($allSites as $site) {
             $xmlSite = $xml->addChild('site');
             $xmlSite->addChild('name', $site->getShortName());
             $xmlSite->addChild('cert_status', $site->getCertificationStatus()->getName());
-            // TODO fix import BUG: The below IF statement should not really be needed. 
-            // However, the Site.xml seed file for v5 currently (erroneously) 
-            // contains decommissioned sites e.g. GRIDOPS-CICPORTAL. These 
-            // decommissioned sites aren't listed  in the 
-            // CertStatusDate.xml file which is used to seed the 
-            // site.certificationStatusChangeDate value. Therefore, this value 
-            // is null for these decomissioned sites. 
+            // TODO fix import BUG: The below IF statement should not really be needed.
+            // However, the Site.xml seed file for v5 currently (erroneously)
+            // contains decommissioned sites e.g. GRIDOPS-CICPORTAL. These
+            // decommissioned sites aren't listed  in the
+            // CertStatusDate.xml file which is used to seed the
+            // site.certificationStatusChangeDate value. Therefore, this value
+            // is null for these decomissioned sites.
             if($site->getCertificationStatusChangeDate() != null){
                // e.g. <cert_date>29-JAN-13 05.13.08 PM</cert_date>
-               $xmlSite->addChild('cert_date', $site->getCertificationStatusChangeDate()->format('d-M-y H.i.s A')); 
+               $xmlSite->addChild('cert_date', $site->getCertificationStatusChangeDate()->format('d-M-y H.i.s A'));
             }
         }
         $dom_sxe = dom_import_simplexml($xml);
@@ -140,16 +140,16 @@ class PI extends AbstractEntityService{
         $dom->formatOutput = true;
         $xmlString = $dom->saveXML();
         return $xmlString;
-     } 
+     }
 
 
     /**
      * Return an XML document that encodes Site CertificationStatusLog entities.
-     * Optionally provide an associative array of query parameters with values 
-     * used to restrict the results. Only known parameters are honoured while 
+     * Optionally provide an associative array of query parameters with values
+     * used to restrict the results. Only known parameters are honoured while
      * unknown produce and error doc. Parmeter array keys include:
      * <pre>
-     * 'site', 'startdate', 'enddate' 
+     * 'site', 'startdate', 'enddate'
      * </pre>
      * @param array $parameters Associative array of parameters to narrow the query
      * @return string XML result string
@@ -175,35 +175,35 @@ class PI extends AbstractEntityService{
             $endDate = null;
         }
 
-        $dql = "SELECT log, s 
-            FROM CertificationStatusLog log 
-            JOIN log.parentSite s 
+        $dql = "SELECT log, s
+            FROM CertificationStatusLog log
+            JOIN log.parentSite s
             JOIN s.certificationStatus cs
             LEFT JOIN s.scopes sc
             JOIN s.infrastructure i
-            WHERE 
-            (s.shortName LIKE :site) 
-            
+            WHERE
+            (s.shortName LIKE :site)
+
             AND (
-                :startDate IS null 
+                :startDate IS null
                 OR log.addedDate > :startDate
             )
-            
+
             AND (
-                :endDate IS null 
+                :endDate IS null
                 OR log.addedDate < :endDate
-            )"; 
-        
+            )";
+
         $q = $this->em->createQuery($dql)
             ->setParameter('site', $site)
             //->setParameter('certStatus', $certification_status)
             ->setParameter('startDate', $startDate)
-            ->setParameter('endDate', $endDate); 
+            ->setParameter('endDate', $endDate);
          $allLogs = $q->getResult();
-       
+
         // Ensure all dates are in UTC
         date_default_timezone_set("UTC");
-        
+
         $xml = new \SimpleXMLElement("<results />");
         foreach ($allLogs as $log) {
             $xmlLog = $xml->addChild('result');
@@ -219,7 +219,7 @@ class PI extends AbstractEntityService{
             $xmlLog->addChild('CHANGED_BY', $log->getAddedBy());
             $xmlLog->addChild('COMMENT', $log->getReason());
         }
-       
+
         $dom_sxe = dom_import_simplexml($xml);
         $dom = new \DOMDocument('1.0');
         $dom->encoding='UTF-8';
@@ -228,25 +228,25 @@ class PI extends AbstractEntityService{
         $dom->formatOutput = true;
         $xmlString = $dom->saveXML();
         return $xmlString;
-     } 
+     }
 
 
     /**
-     * Return an XML document that encodes the Site entities. 
-     * Optionally provide an associative array of query parameters with values 
-     * used to restrict the results. Only known parameters are honoured while 
+     * Return an XML document that encodes the Site entities.
+     * Optionally provide an associative array of query parameters with values
+     * used to restrict the results. Only known parameters are honoured while
      * unknown produce and error doc. Parmeter array keys include:
      * <pre>
-     * 'sitename', 'roc', 'country', 'certification_status', 
+     * 'sitename', 'roc', 'country', 'certification_status',
      * 'exclude_certification_status', 'production_status', 'scope', 'scope_match'
-     * (where scope refers to Site scope) 
+     * (where scope refers to Site scope)
      * </pre>
-     * Uses the addIfNotEmpty method to duplicate the behavior of the Oracle XML 
+     * Uses the addIfNotEmpty method to duplicate the behavior of the Oracle XML
      * module that rendered this query in GOCDBv4.
      * @param array $parameters Associative array of parameters to narrow the query
      * @return string XML result string
      * @throws \Exception
-     */ 
+     */
     public function getSite($parameters){
         // Define supported parameters and validate given params (die if an unsupported param is given)
         $supportedQueryParams = array('sitename', 'roc', 'country'
@@ -295,22 +295,22 @@ class PI extends AbstractEntityService{
         } else {
             $scopeArray = $this->convertScopesToArray($this->defaultScope());
         }
-        
+
         $scopeClause = "";
         if($this->containsValidScope($scopeArray)){
-            $scopeClause = $this->scopeClauseFromScopeArray($scopeArray, "sc", 
-                    $this->allScopesMustMatch($parameters), 'Site', 's') . " 
+            $scopeClause = $this->scopeClauseFromScopeArray($scopeArray, "sc",
+                    $this->allScopesMustMatch($parameters), 'Site', 's') . "
                 AND";
         }
-        
-        $dql = "select s, sc 
+
+        $dql = "select s, sc
             FROM Site s
             LEFT JOIN s.scopes sc
             JOIN s.ngi n
             JOIN s.country c
             JOIN s.certificationStatus cs
             JOIN s.infrastructure i
-            WHERE " 
+            WHERE "
             . $scopeClause  // AND clause is already appended to $scopeClause where relevant.
             . " (s.shortName LIKE :site)
             AND (n.name LIKE :ngi)
@@ -319,7 +319,7 @@ class PI extends AbstractEntityService{
             AND (:excludeCertStatus = '%%' or cs.name not LIKE :excludeCertStatus)
             AND (i.name LIKE :prodStatus)
             ORDER BY s.shortName";
-        
+
         $q = $this->em->createQuery($dql)
             ->setParameter('site', $site)
             ->setParameter('ngi', $ngi)
@@ -329,7 +329,7 @@ class PI extends AbstractEntityService{
             ->setParameter('prodStatus', $prodStatus);
 
         $q = $this->setScopeBindParameters($scopeArray, $q);
-            
+
         $sites = $q->getResult();
 
         $xml = new \SimpleXMLElement("<results />");
@@ -370,10 +370,10 @@ class PI extends AbstractEntityService{
             $domain = $xmlSite->addChild('DOMAIN');
             $this->addIfNotEmpty($domain, 'DOMAIN_NAME', $site->getDomain());
 
-            // IF we need to nest a site's scope tags within the XML results: 
-            //$xmlScopeTag = $xmlSite->addChild('SCOPE_TAGS'); 
+            // IF we need to nest a site's scope tags within the XML results:
+            //$xmlScopeTag = $xmlSite->addChild('SCOPE_TAGS');
             //foreach($site->getScopes() as $siteScope){
-            //   $xmlScopeTag->addChild('SCOPE_TAG', $siteScope->getName());  
+            //   $xmlScopeTag->addChild('SCOPE_TAG', $siteScope->getName());
             //}
         }
 
@@ -389,13 +389,13 @@ class PI extends AbstractEntityService{
 
     /**
      * Return an XML document that encodes a Site list.
-     * Optionally provide an associative array of query parameters with values 
-     * used to restrict the results. Only known parameters are honoured while 
+     * Optionally provide an associative array of query parameters with values
+     * used to restrict the results. Only known parameters are honoured while
      * unknown params produce an error doc. Parmeter array keys include:
      * <pre>
-     * 'sitename', 'roc', 'country', 'certification_status', 
+     * 'sitename', 'roc', 'country', 'certification_status',
      * 'exclude_certification_status', 'production_status', 'scope', 'scope_match'
-     * (where scope refers to Site scope) 
+     * (where scope refers to Site scope)
      * </pre>
      * Uses the addIfNotEmpty method to duplicate the behavior of the Oracle XML module that
      * rendered this query in GOCDBv4.
@@ -451,14 +451,14 @@ class PI extends AbstractEntityService{
         } else {
             $scopeArray = $this->convertScopesToArray($this->defaultScope());
         }
-        
+
         $scopeClause = "";
         if($this->containsValidScope($scopeArray)){
-            $scopeClause = $this->scopeClauseFromScopeArray($scopeArray, "sc", 
-                    $this->allScopesMustMatch($parameters), 'Site', 's') . " 
+            $scopeClause = $this->scopeClauseFromScopeArray($scopeArray, "sc",
+                    $this->allScopesMustMatch($parameters), 'Site', 's') . "
                 AND";
-        } 
-        
+        }
+
         $dql = "select s FROM Site s
             LEFT JOIN s.scopes sc
             JOIN s.ngi n
@@ -473,7 +473,7 @@ class PI extends AbstractEntityService{
             AND (:excludeCertStatus = '%%' or cs.name not LIKE :excludeCertStatus)
             AND (i.name LIKE :prodStatus)
             ORDER BY s.shortName";
-        
+
         $q = $this->em->createQuery($dql)
                 ->setParameter('site', $site)
                 ->setParameter('ngi', $ngi)
@@ -483,7 +483,7 @@ class PI extends AbstractEntityService{
                 ->setParameter('prodStatus', $prodStatus);
 
         $q = $this->setScopeBindParameters($scopeArray, $q);
-        
+
         $sites = $q->getResult();
 
         $xml = new \SimpleXMLElement("<results />");
@@ -517,12 +517,12 @@ class PI extends AbstractEntityService{
 
     /**
      * Return an XML document that encodes the site contacts.
-     * Optionally provide an associative array of query parameters with values 
-     * used to restrict the results. Only known parameters are honoured while 
+     * Optionally provide an associative array of query parameters with values
+     * used to restrict the results. Only known parameters are honoured while
      * unknown params produce an error doc.
      * <pre>
-     * 'sitename', 'roc', 'country', 'roletype', 'scope', 'scope_match' 
-     * (where scope refers to Site scope) 
+     * 'sitename', 'roc', 'country', 'roletype', 'scope', 'scope_match'
+     * (where scope refers to Site scope)
      * </pre>
      * @param array $parameters Associative array of parameters to narrow the query
      * @return string XML result string
@@ -566,11 +566,11 @@ class PI extends AbstractEntityService{
 
         $scopeClause = "";
         if($this->containsValidScope($scopeArray)){
-            $scopeClause = $this->scopeClauseFromScopeArray($scopeArray, "sc", 
-                    $this->allScopesMustMatch($parameters), 'Site', 's') . " 
+            $scopeClause = $this->scopeClauseFromScopeArray($scopeArray, "sc",
+                    $this->allScopesMustMatch($parameters), 'Site', 's') . "
                 AND";
-        } 
-        
+        }
+
        $dql = "select s FROM Site s
             LEFT JOIN s.scopes sc
             JOIN s.ngi n
@@ -578,16 +578,16 @@ class PI extends AbstractEntityService{
             WHERE " . $scopeClause  // AND clause is already appended to $scopeClause where relevant.
             . " (s.shortName LIKE :site)
             AND (n.name LIKE :ngi)
-            AND (c.name LIKE :country)            
+            AND (c.name LIKE :country)
             ORDER BY s.shortName";
-        
+
         $q = $this->em->createQuery($dql)
                 ->setParameter('site', $site)
                 ->setParameter('ngi', $ngi)
-                ->setParameter('country', $country); 
+                ->setParameter('country', $country);
 
         $q = $this->setScopeBindParameters($scopeArray, $q);
-        
+
         $sites = $q->getResult();
         $xml = new \SimpleXMLElement ( "<results />" );
         foreach ( $sites as $site ) {
@@ -595,7 +595,7 @@ class PI extends AbstractEntityService{
             $xmlSite->addAttribute ( 'ID', $site->getId () . "G0" );
             $xmlSite->addAttribute ( 'PRIMARY_KEY', $site->getPrimaryKey () );
             $xmlSite->addAttribute ( 'NAME', $site->getShortName () );
-            
+
             $xmlSite->addChild ( 'PRIMARY_KEY', $site->getPrimaryKey () );
             $xmlSite->addChild ( 'SHORT_NAME', $site->getShortName () );
             foreach ( $site->getRoles () as $role ) {
@@ -684,15 +684,15 @@ class PI extends AbstractEntityService{
             $scopeArray = $this->convertScopesToArray($parameters['scope']);
         } else {
             $scopeArray = $this->convertScopesToArray($this->defaultScope());
-        }    
-        
+        }
+
         $scopeClause = "";
         if($this->containsValidScope($scopeArray)){
-            $scopeClause = $this->scopeClauseFromScopeArray($scopeArray, "sc", 
-                    $this->allScopesMustMatch($parameters), 'Site', 's') . " 
+            $scopeClause = $this->scopeClauseFromScopeArray($scopeArray, "sc",
+                    $this->allScopesMustMatch($parameters), 'Site', 's') . "
                 AND";
-        } 
-        
+        }
+
         $dql = "
             select s FROM Site s
             LEFT JOIN s.scopes sc
@@ -708,7 +708,7 @@ class PI extends AbstractEntityService{
             AND (:excludeCertStatus = '%%' or cs.name not LIKE :excludeCertStatus)
             AND (i.name LIKE :prodStatus)
             ORDER BY s.shortName";
-        
+
         $q = $this->em->createQuery($dql)
                 ->setParameter('site', $site)
                 ->setParameter('ngi', $ngi)
@@ -718,7 +718,7 @@ class PI extends AbstractEntityService{
                 ->setParameter('prodStatus', $prodStatus);
 
         $q = $this->setScopeBindParameters($scopeArray, $q);
-        
+
         $sites = $q->getResult();
 
         $xml = new \SimpleXMLElement("<results />");
@@ -885,8 +885,8 @@ class PI extends AbstractEntityService{
             $portalUrl = htmlspecialchars ( $portalUrl );
             $this->addIfNotEmpty ( $xmlNgi, 'GOCDB_PORTAL_URL', $portalUrl );
             foreach($ngi->getRoles() as $role) {
-                if ($role->getStatus() == "STATUS_GRANTED") {   //Only show users who are granted the role, not pending				
-                    $rtype = $role->getRoleType()->getName(); 
+                if ($role->getStatus() == "STATUS_GRANTED") {   //Only show users who are granted the role, not pending
+                    $rtype = $role->getRoleType()->getName();
                     if($roleType == '%%' || $rtype == $roleType) {
                         $user = $role->getUser();
                         $xmlContact = $xmlNgi->addChild('CONTACT');
@@ -898,16 +898,16 @@ class PI extends AbstractEntityService{
                         $xmlContact->addChild('EMAIL', $user->getEmail());
                         $xmlContact->addChild('TEL', $user->getTelephone());
                         $xmlContact->addChild('CERTDN', $user->getCertificateDn());
-                        
-                        $roleName = $role->getRoleType()->getName();  
+
+                        $roleName = $role->getRoleType()->getName();
                         $xmlContact->addChild('ROLE_NAME', $roleName);
-                        
-                        //$roleClass = \RoleTypeName::getRoleTypeClass($roleName); 
+
+                        //$roleClass = \RoleTypeName::getRoleTypeClass($roleName);
                         //if($roleClass != null){
-                        //    $xmlContact->addChild('ROLE_TYPE', $roleClass);  
+                        //    $xmlContact->addChild('ROLE_TYPE', $roleClass);
                         //}
                     }
-                }	
+                }
             }
         }
 
@@ -925,10 +925,10 @@ class PI extends AbstractEntityService{
 
     /**
      * Return an XML document that encodes the project contacts selected from the DB.
-     * Supported params: 
+     * Supported params:
      * <pre>'project'</pre>
-     *  
-     * @param array $parameters Associative array of parameters and values used to narrow results.  
+     *
+     * @param array $parameters Associative array of parameters and values used to narrow results.
      * @return string XML result string
      * @throws \Exception
      */
@@ -936,10 +936,10 @@ class PI extends AbstractEntityService{
         // Define supported parameters and validate given params (die if an unsupported param is given)
         $supportedQueryParams = array('project');
         $this->validateParams($supportedQueryParams, $parameters);
-        
+
         //Delete the following line to allow this method to work for user supplied project name
         //$parameters['project'] =  'EGI';
-            
+
         $qb = $this->em->createQueryBuilder();
         $qb->select('p')
         ->from('project', 'p');
@@ -948,20 +948,20 @@ class PI extends AbstractEntityService{
             $qb	->where($qb->expr()->like('p.name', ':projectName'))
                 ->setParameter('projectName', $parameters['project']);
         }
-                    
-        $query = $qb->getQuery();		
+
+        $query = $qb->getQuery();
         $projects = $query->execute();
-        
-        $xml = new \SimpleXMLElement("<results />");	
-        
-        foreach($projects as $project){			
+
+        $xml = new \SimpleXMLElement("<results />");
+
+        foreach($projects as $project){
             $xmlProjUser = $xml->addChild('Project');
             $xmlProjUser->addAttribute('NAME', $project->getName());
-            
+
             foreach($project->getRoles() as $role){
                 if($role->getStatus() == \RoleStatus::GRANTED &&
                 $role->getRoleType()->getName() != \RoleTypeName::CIC_STAFF){
-            
+
                         //$rtype = $role->getRoleType()->getName();
                         $user = $role->getUser();
                         $xmlContact = $xmlProjUser->addChild('CONTACT');
@@ -975,10 +975,10 @@ class PI extends AbstractEntityService{
                         $xmlContact->addChild ( 'WORKING_HOURS_START', $user->getWorkingHoursStart () );
                         $xmlContact->addChild ( 'WORKING_HOURS_END', $user->getWorkingHoursEnd () );
                         $xmlContact->addChild('CERTDN', $user->getCertificateDn());
-                         
+
                         $roleName = $role->getRoleType()->getName();
                         $xmlContact->addChild('ROLE_NAME', $roleName);
-                    
+
                 }
             }
         }
@@ -994,9 +994,9 @@ class PI extends AbstractEntityService{
 
         return $xmlString;
     }
-    
+
     /**
-     * A legacy method from V4 that was depreciated. This is a backup method 
+     * A legacy method from V4 that was depreciated. This is a backup method
      * to be put into production should it be required by users on short notice.
      * Return an XML document that encodes the project contacts selected from the DB.
      * Supported params:
@@ -1012,18 +1012,18 @@ class PI extends AbstractEntityService{
         ->from('project', 'p')
             ->where($qb->expr()->like('p.name', ':projectName'))
             ->setParameter('projectName', 'EGI');
-            
+
         $query = $qb->getQuery();
         $projects = $query->execute();
-    
+
         $xml = new \SimpleXMLElement("<results />");
-    
+
         foreach($projects as $project){
-            
+
             foreach($project->getRoles() as $role){
                 if($role->getStatus() == \RoleStatus::GRANTED &&
                     $role->getRoleType()->getName() != \RoleTypeName::CIC_STAFF){
-                        
+
                     $user = $role->getUser();
                     $xmlContact = $xml->addChild('CONTACT');
                     $xmlContact->addAttribute('USER_ID', $user->getId() . "G0");
@@ -1036,23 +1036,23 @@ class PI extends AbstractEntityService{
                     $xmlContact->addChild ( 'WORKING_HOURS_START', $user->getWorkingHoursStart () );
                     $xmlContact->addChild ( 'WORKING_HOURS_END', $user->getWorkingHoursEnd () );
                     $xmlContact->addChild('CERTDN', $user->getCertificateDn());
-                        
+
                     $roleName = $role->getRoleType()->getName();
                     $xmlContact->addChild('ROLE_NAME', $roleName);
-                        
+
                 }
             }
         }
-    
+
         $dom_sxe = dom_import_simplexml($xml);
         $dom = new \DOMDocument('1.0');
         $dom->encoding='UTF-8';
         $dom_sxe = $dom->importNode($dom_sxe, true);
         $dom_sxe = $dom->appendChild($dom_sxe);
         $dom->formatOutput = true;
-    
+
         $xmlString = $dom->saveXML();
-    
+
         return $xmlString;
     }
 
@@ -1101,13 +1101,13 @@ class PI extends AbstractEntityService{
     /**
      * Return an XML document that encodes the services.
      * Optionally provide an associative array of query parameters with values to restrict the results.
-     * Only known parameters are honoured while unknown params produce an error doc. 
+     * Only known parameters are honoured while unknown params produce an error doc.
      * Parmeter array keys include:
      * <pre>
-     * 'hostname', 'sitename', 'roc', 'country', 'service_type', 'monitored', 
-     * 'scope', 'scope_match' (where scope refers to Service scope) 
+     * 'hostname', 'sitename', 'roc', 'country', 'service_type', 'monitored',
+     * 'scope', 'scope_match' (where scope refers to Service scope)
      * </pre>
-     * Uses the addIfNotEmpty method to duplicate the behavior of the Oracle 
+     * Uses the addIfNotEmpty method to duplicate the behavior of the Oracle
      * XML module thatrendered this query in GOCDBv4.
      * @param array $parameters Associative array of parameters to narrow the query
      * @return string XML result string
@@ -1172,14 +1172,14 @@ class PI extends AbstractEntityService{
         } else {
             $scopeArray = $this->convertScopesToArray($this->defaultScope());
         }
-        
+
         $scopeClause = "";
         if($this->containsValidScope($scopeArray)){
-            $scopeClause = $this->scopeClauseFromScopeArray($scopeArray, "sc", 
-                    $this->allScopesMustMatch($parameters), 'Service', 'se') . " 
+            $scopeClause = $this->scopeClauseFromScopeArray($scopeArray, "sc",
+                    $this->allScopesMustMatch($parameters), 'Service', 'se') . "
                 AND";
-        } 
-        
+        }
+
         /* For performance reasons, we name the fields in the select query.
          * By SELECTing e.g. s, sc, el etc they'll already be hydrated
          * in the result set. So if we were to call Service->getParentSite()
@@ -1216,9 +1216,9 @@ class PI extends AbstractEntityService{
                 ->setParameter('country', $country)
                 ->setParameter('serviceType', $serviceType)
                 ->setParameter('monitored', $monitored);
-        
+
         $q = $this->setScopeBindParameters($scopeArray, $q);
-        
+
         $ses = $q->getResult();
 
         $xml = new \SimpleXMLElement("<results />");
@@ -1286,13 +1286,13 @@ class PI extends AbstractEntityService{
     public function getDowntime($parameters){
         return $this->getDowntimeHelper($parameters, false);
     }
-    
+
     public function getDowntimeShort($parameters){
         return $this->getDowntimeHelper($parameters, true);
     }
-    
+
     /**
-     * Return an XML document that encodes the downtimes.	 	 
+     * Return an XML document that encodes the downtimes.
      * Optionally provide an associative array of query parameters with values to restrict the results.
      * Only known parameters are honoured while unknown params produce an error doc.
      * Parmeter array keys include:
@@ -1302,7 +1302,7 @@ class PI extends AbstractEntityService{
      * </pre>
      * Uses the addIfNotEmpty method to duplicate the behavior of the Oracle XML
      * module that rendered this query in GOCDBv4.
-     * 
+     *
      * @param array $parameters
      *        	Associative array of parameters to narrow the query
      * @return string XML result string
@@ -1315,7 +1315,7 @@ class PI extends AbstractEntityService{
                 , 'startdate', 'enddate', 'windowstart',
                 'windowend', 'scope', 'scope_match', 'page', 'all_lastmonth');
         $this->validateParams($supportedQueryParams, $parameters);
-        
+
         // Ensure all dates are in UTC
         date_default_timezone_set("UTC");
         define('DATE_FORMAT', 'Y-m-d H:i');
@@ -1329,7 +1329,7 @@ class PI extends AbstractEntityService{
                 die();
             }
         }
-       
+
         if(isset($parameters['topentity'])) {
             $topEntity = $parameters['topentity'];
         } else {
@@ -1340,14 +1340,14 @@ class PI extends AbstractEntityService{
             $onGoingOnly = $parameters['ongoing_only'];
             if($onGoingOnly == 'yes'){
                 if(isset($parameters['enddate']) || isset($parameters['startdate'])){
-                    echo "<error>Invalid parameter combination - do not specify startdate or enddate with ongoing_only</error>"; 
-                    die(); 
+                    echo "<error>Invalid parameter combination - do not specify startdate or enddate with ongoing_only</error>";
+                    die();
                 }
             } else if($onGoingOnly == 'no'){
-               // else do nothing 
+               // else do nothing
             } else {
-                echo "<error>Invalid ongoing_only value - must be 'yes' or 'no'</error>"; 
-                die(); 
+                echo "<error>Invalid ongoing_only value - must be 'yes' or 'no'</error>";
+                die();
             }
         } else {
             $onGoingOnly = 'no';
@@ -1374,13 +1374,13 @@ class PI extends AbstractEntityService{
         if(isset($parameters['windowend'])) {
             $windowEnd = new \DateTime($parameters['windowend']);
             // Add 1 day to windowend so that downtimes that start on
-            // e.g. 2012-02-01 16:00 are included if the windowend is set 
+            // e.g. 2012-02-01 16:00 are included if the windowend is set
             // to 2012-02-01. This is to mirror the GOCDBv4 behaviour
             $windowEnd->add(new \DateInterval('P1D'));
             // DM: Adding one day can also be done using DQL with the DATE_ADD
-            // method used within the query, but I can't get it to work with Oracle 
-            // so add the day using $windowEnd->add(dateInterval) instead.  
-            // DATE_ADD(:windowEnd, 1, 'DAY') 
+            // method used within the query, but I can't get it to work with Oracle
+            // so add the day using $windowEnd->add(dateInterval) instead.
+            // DATE_ADD(:windowEnd, 1, 'DAY')
         } else {
             $windowEnd = null;
         }
@@ -1390,39 +1390,39 @@ class PI extends AbstractEntityService{
         } else {
             $scopeArray = $this->convertScopesToArray($this->defaultScope());
         }
-        
+
         $scopeClause = "";
         if($this->containsValidScope($scopeArray)){
-            $scopeClause = $this->scopeClauseFromScopeArray($scopeArray, "sc", 
-                    $this->allScopesMustMatch($parameters), 'Service', 'se') . " 
+            $scopeClause = $this->scopeClauseFromScopeArray($scopeArray, "sc",
+                    $this->allScopesMustMatch($parameters), 'Service', 'se') . "
                 AND";
-        }  
+        }
 
-        // Special parameter added for ATP who require all downtimes starting 
+        // Special parameter added for ATP who require all downtimes starting
         // from one month ago (including current and future DTs) to be generated
-        // in one page result. We don't want to allow the disabling of paging (using $page=-1)  
-        // for other getDowntime() queries as this circumvents paging as a saftey parameter. 
+        // in one page result. We don't want to allow the disabling of paging (using $page=-1)
+        // for other getDowntime() queries as this circumvents paging as a saftey parameter.
         // It is ok if we are only returning DTs for the last month as the number
-        // of DTs will probably be less than the page limit anyway.  
-        if(isset($parameters['all_lastmonth'])){ 
-            if(isset($parameters['page']) || 
-                    isset($parameters['ongoing_only']) || 
-                    isset($parameters['startdate']) || 
-                    isset($parameters['enddate']) || 
-                    isset($parameters['windowstart']) || 
+        // of DTs will probably be less than the page limit anyway.
+        if(isset($parameters['all_lastmonth'])){
+            if(isset($parameters['page']) ||
+                    isset($parameters['ongoing_only']) ||
+                    isset($parameters['startdate']) ||
+                    isset($parameters['enddate']) ||
+                    isset($parameters['windowstart']) ||
                     isset($parameters['windowend'])){
-               echo "<error>Invalid parameters - only scope, scope_match, 
+               echo "<error>Invalid parameters - only scope, scope_match,
                    topentity params allowed when specifying all_lastmonth</error>";
-               die(); 
+               die();
             }
-            // current date with 1 month and 1 day subtracted. 
+            // current date with 1 month and 1 day subtracted.
             $startDate = new \DateTime();
             $startDate->sub(new \DateInterval('P1M'));
             $startDate->sub(new \DateInterval('P1D'));
         }
-        
+
         //See note 1 at bottom of class
-        $dql =  "SELECT DISTINCT d, els, se, s, sc, st 
+        $dql =  "SELECT DISTINCT d, els, se, s, sc, st
                 FROM Downtime d
                 JOIN d.endpointLocations els
                 JOIN els.service se
@@ -1438,7 +1438,7 @@ class PI extends AbstractEntityService{
                     OR n.name LIKE :topEntity
                     OR c.name LIKE :topEntity
                 )
-                
+
                 AND (
                         :onGoingOnly = 'no'
                         OR
@@ -1446,14 +1446,14 @@ class PI extends AbstractEntityService{
                         AND d.startDate < :now
                         AND d.endDate > :now)
                 )
-                
+
                 AND (
-                    :startDate IS null 
+                    :startDate IS null
                     OR d.startDate > :startDate
                 )
 
                 AND (
-                    :endDate IS null 
+                    :endDate IS null
                     OR d.endDate < :endDate
                 )
 
@@ -1464,8 +1464,8 @@ class PI extends AbstractEntityService{
 
                 AND (
                     :windowEnd IS null
-                    OR d.startDate < :windowEnd 
-                ) 
+                    OR d.startDate < :windowEnd
+                )
                 ORDER BY d.startDate DESC
                 ";
 
@@ -1478,16 +1478,16 @@ class PI extends AbstractEntityService{
                     ->setParameter('endDate', $endDate)
                     ->setParameter('windowStart', $windowStart)
                     ->setParameter('windowEnd', $windowEnd);
-        
+
         $q = $this->setScopeBindParameters($scopeArray, $q);
-        
+
         // If the page parameter is specified, paginate the results
         if(isset($parameters['page'])) {
             // The maxResults we want to render in one page (todo, lookup from config)
-            // Note, don't set $maxResults to more than 1000, if >1000 is needed, you 
-            // can't use the Doctrine paginator due to issues described below. 
+            // Note, don't set $maxResults to more than 1000, if >1000 is needed, you
+            // can't use the Doctrine paginator due to issues described below.
             $maxResults = 1000;
-             
+
             if($page == 1){
                 $offset = 0; // offset is zero-offset (starts from 0 not 1)
             } elseif($page > 1) {
@@ -1495,39 +1495,39 @@ class PI extends AbstractEntityService{
             } else {
                 throw new LogicException('Coding error - invalid page ['.$page.']');
             }
-            //See note 2 at bottom of class            
+            //See note 2 at bottom of class
             $q->setFirstResult($offset)->setMaxResults($maxResults);
             $results = new Paginator($q, $fetchJoinCollection = true);
-            //If short downtime has been called return XML without repeating service endpoints 
+            //If short downtime has been called return XML without repeating service endpoints
             if($isShort){
-                return $this->getDowntimeXML($results, 1);  
+                return $this->getDowntimeXML($results, 1);
             }else{
                 return $this->getDowntimeXML($results, 2);
-            }          
+            }
         } else {
-            $results = $q->getArrayResult();        	 
-            //If short downtime has been called return XML without repeating service endpoints        	     
+            $results = $q->getArrayResult();
+            //If short downtime has been called return XML without repeating service endpoints
             if($isShort){
-                return $this->getDowntimeXML($results, 3);  
+                return $this->getDowntimeXML($results, 3);
             }else{
                 return $this->getDowntimeXML($results, 4);
-            }          
+            }
         }
     }
-    
-    
+
+
     /** 2 Different formats of XML can be returned. A short format downtime which doesn't have services
-     * repeating within a downtime. And the original longer format downtime. Both long and short format 
+     * repeating within a downtime. And the original longer format downtime. Both long and short format
      * have a method which uses pagination and get result and a method which uses get array instead of get result.
-     * 
+     *
      * @param ResultSet $results
      * @param int $type Type of downtime to render to user, standard, nested and paginated version of both
      * @return XMLString
      * @throws \Exception
      */
     private function getDowntimeXML($results, $type){
-        
-        switch($type){			
+
+        switch($type){
             case 1:
                 //Get result method for SHORT format downtime requests with page parameter
                 $xml = new \SimpleXMLElement("<results />");
@@ -1538,12 +1538,12 @@ class PI extends AbstractEntityService{
                     // Note, we are preserving the v4 primary keys here.
                     //$xmlDowntime->addAttribute("PRIMARY_KEY", $downtime->getId() . "G0");
                     $xmlDowntime->addAttribute("PRIMARY_KEY", $downtime->getPrimaryKey());
-                    
+
                     $xmlDowntime->addAttribute("CLASSIFICATION", $downtime->getClassification());
-                    
+
                     $portalUrl = '#GOCDB_BASE_PORTAL_URL#/index.php?Page_Type=Downtime&id=' . $downtime->getId();
                     $portalUrl = htmlspecialchars($portalUrl);
-                    
+
                     $this->addIfNotEmpty($xmlDowntime, 'SEVERITY', $downtime->getSeverity());
                     $description = htmlspecialchars($downtime->getDescription());
                     $this->addIfNotEmpty($xmlDowntime, 'DESCRIPTION', $description);
@@ -1553,41 +1553,41 @@ class PI extends AbstractEntityService{
                     $this->addIfNotEmpty($xmlDowntime, 'FORMATED_START_DATE', $downtime->getStartDate()->format(DATE_FORMAT));
                     $this->addIfNotEmpty($xmlDowntime, 'FORMATED_END_DATE', $downtime->getEndDate()->format(DATE_FORMAT));
                     $this->addIfNotEmpty($xmlDowntime, 'GOCDB_PORTAL_URL', $portalUrl);
-                    
-                    $xmlImpactedSE = $xmlDowntime->addChild('SERVICES');						
+
+                    $xmlImpactedSE = $xmlDowntime->addChild('SERVICES');
                     foreach($downtime->getEndpointLocations() as $els){
                         $se = $els->getService();
                         $xmlServices = $xmlImpactedSE->addChild('SERVICE');
-                        
-                        $this->addIfNotEmpty($xmlServices, 'PRIMARY_KEY', $se->getId());				
+
+                        $this->addIfNotEmpty($xmlServices, 'PRIMARY_KEY', $se->getId());
                         $this->addIfNotEmpty($xmlServices, 'HOSTNAME', $se->getHostName());
                         $this->addIfNotEmpty($xmlServices, 'SERVICE_TYPE', $se->getServiceType()->getName());
                         $endpoint = $se->getHostName() . $se->getServiceType()->getName();
                         $this->addIfNotEmpty($xmlServices, 'ENDPOINT', $endpoint);
-                        $this->addIfNotEmpty($xmlServices, 'HOSTED_BY', $se->getParentSite()->getShortName());						
+                        $this->addIfNotEmpty($xmlServices, 'HOSTED_BY', $se->getParentSite()->getShortName());
                     }
                 }
                 break;
             case 2:
-                //Get result method for LONG REPEATING format downtime requests with page parameter				
+                //Get result method for LONG REPEATING format downtime requests with page parameter
                 $xml = new \SimpleXMLElement("<results />");
                     foreach ( $results as $downtime ) {
                 foreach ( $downtime->getEndpointLocations () as $els ) {
                     $se = $els->getService ();
-                    
+
                     $xmlDowntime = $xml->addChild ( 'DOWNTIME' );
                     // ID is the internal object id/sequence
                     $xmlDowntime->addAttribute ( "ID", $downtime->getId () );
-                    
+
                     // Note, we are preserving the v4 primary keys here.
                     // $xmlDowntime->addAttribute("PRIMARY_KEY", $downtime->getId() . "G0");
                     $xmlDowntime->addAttribute ( "PRIMARY_KEY", $downtime->getPrimaryKey () );
-                    
+
                     $xmlDowntime->addAttribute ( "CLASSIFICATION", $downtime->getClassification () );
-                    
+
                     // $this->addIfNotEmpty($xmlDowntime, 'PRIMARY_KEY', $downtime->getId() . "G0");
                     $this->addIfNotEmpty ( $xmlDowntime, 'PRIMARY_KEY', $downtime->getPrimaryKey () );
-                    
+
                     $this->addIfNotEmpty ( $xmlDowntime, 'HOSTNAME', $se->getHostName () );
                     $this->addIfNotEmpty ( $xmlDowntime, 'SERVICE_TYPE', $se->getServiceType ()->getName () );
                     $endpoint = $se->getHostName () . $se->getServiceType ()->getName ();
@@ -1607,10 +1607,10 @@ class PI extends AbstractEntityService{
                 }
             }
                 break;
-            case 3:				
+            case 3:
                 //Get array method for SHORT format downtime requests without page parameter
                 $xml = new \SimpleXMLElement("<results/>");
-                
+
                 foreach ($results as $downtimeArray) {
                     $xmlDowntime = $xml->addChild('DOWNTIME');
                     //header start
@@ -1618,10 +1618,10 @@ class PI extends AbstractEntityService{
                     $xmlDowntime->addAttribute("PRIMARY_KEY", $downtimeArray['primaryKey']);
                     $xmlDowntime->addAttribute("CLASSIFICATION", $downtimeArray['classification']);
                     //header end
-                    
+
                     $this->addIfNotEmpty($xmlDowntime, 'SEVERITY', $downtimeArray['severity']);
                     $this->addIfNotEmpty($xmlDowntime, 'DESCRIPTION', htmlspecialchars ( $downtimeArray['description']));
-                        
+
                     $this->addIfNotEmpty($xmlDowntime, 'INSERT_DATE', strtotime($downtimeArray['insertDate']->format('Y-m-d H:i:s')));
                     $this->addIfNotEmpty($xmlDowntime, 'START_DATE', strtotime($downtimeArray['startDate']->format('Y-m-d H:i:s')));
                     $this->addIfNotEmpty($xmlDowntime, 'END_DATE', strtotime($downtimeArray['endDate']->format('Y-m-d H:i:s')));
@@ -1630,24 +1630,24 @@ class PI extends AbstractEntityService{
                     $portalUrl = '#GOCDB_BASE_PORTAL_URL#/index.php?Page_Type=Downtime&id=' . $downtimeArray['id'];
                     $portalUrl = htmlspecialchars ( $portalUrl );
                     $this->addIfNotEmpty($xmlDowntime, 'GOCDB_PORTAL_URL', $portalUrl);
-                    
-                    $xmlImpactedSE = $xmlDowntime->addChild('SERVICES');						
+
+                    $xmlImpactedSE = $xmlDowntime->addChild('SERVICES');
                     foreach($downtimeArray['endpointLocations'] as $affectedEndpointArray){
-                        $xmlServices = $xmlImpactedSE->addChild('SERVICE');						
+                        $xmlServices = $xmlImpactedSE->addChild('SERVICE');
                         $this->addIfNotEmpty($xmlServices, 'PRIMARY_KEY', $affectedEndpointArray['service']['id']);
                         $this->addIfNotEmpty($xmlServices, 'HOSTNAME', htmlspecialchars ( $affectedEndpointArray['service']['hostName'] ));
                         $this->addIfNotEmpty($xmlServices, 'SERVICE_TYPE', $affectedEndpointArray['service']['serviceType']['name']);
                         $this->addIfNotEmpty($xmlServices, 'ENDPOINT', $affectedEndpointArray['service']['hostName'] . $affectedEndpointArray['service']['serviceType']['name']);
                         $this->addIfNotEmpty($xmlServices, 'HOSTED_BY', $affectedEndpointArray['service']['parentSite']['shortName']);
-                        
-                
+
+
                     }
                 }
                 break;
             case 4:
                 //Get array method for LONG REPEATING downtime requests without page parameter
                 $xml = new \SimpleXMLElement("<results/>");
-                                
+
                 foreach ($results as $downtimeArray) {
                     foreach($downtimeArray['endpointLocations'] as $affectedEndpointArray){
                         $xmlDowntime = $xml->addChild('DOWNTIME');
@@ -1656,7 +1656,7 @@ class PI extends AbstractEntityService{
                         $xmlDowntime->addAttribute("PRIMARY_KEY", $downtimeArray['primaryKey']);
                         $xmlDowntime->addAttribute("CLASSIFICATION", $downtimeArray['classification']);
                         //header end
-                
+
                         $this->addIfNotEmpty($xmlDowntime, 'PRIMARY_KEY', $downtimeArray['primaryKey']);
                         $this->addIfNotEmpty($xmlDowntime, 'HOSTNAME', htmlspecialchars ( $affectedEndpointArray['service']['hostName'] ));
                         $this->addIfNotEmpty($xmlDowntime, 'SERVICE_TYPE', $affectedEndpointArray['service']['serviceType']['name']);
@@ -1667,19 +1667,19 @@ class PI extends AbstractEntityService{
                         $this->addIfNotEmpty($xmlDowntime, 'GOCDB_PORTAL_URL', $portalUrl);
                         $this->addIfNotEmpty($xmlDowntime, 'SEVERITY', $downtimeArray['severity']);
                         $this->addIfNotEmpty($xmlDowntime, 'DESCRIPTION', htmlspecialchars ( $downtimeArray['description']));
-                            
+
                         $this->addIfNotEmpty($xmlDowntime, 'INSERT_DATE', strtotime($downtimeArray['insertDate']->format('Y-m-d H:i:s')));
                         $this->addIfNotEmpty($xmlDowntime, 'START_DATE', strtotime($downtimeArray['startDate']->format('Y-m-d H:i:s')));
                         $this->addIfNotEmpty($xmlDowntime, 'END_DATE', strtotime($downtimeArray['endDate']->format('Y-m-d H:i:s')));
                         $this->addIfNotEmpty($xmlDowntime, 'FORMATED_START_DATE', $downtimeArray['startDate']->format('Y-m-d H:i'));
                         $this->addIfNotEmpty($xmlDowntime, 'FORMATED_END_DATE', $downtimeArray['endDate']->format('Y-m-d H:i'));
-                
+
                     }
                 }
                 break;
         }
-        
-        
+
+
         $dom_sxe = dom_import_simplexml($xml);
         $dom = new \DOMDocument('1.0');
         $dom->encoding='UTF-8';
@@ -1688,16 +1688,16 @@ class PI extends AbstractEntityService{
         $dom->formatOutput = true;
         $xmlString = $dom->saveXML();
         return $xmlString;
-        
+
     }
-    
+
     /**
      * Return an XML document that encodes the downtimes selected from the DB.
      * Optionally provide an associative array of query parameters with values used to restrict the results.
-     * Only known parameters are honoured while unknown params produce an error doc. 
+     * Only known parameters are honoured while unknown params produce an error doc.
      * Parmeter array keys include:
      * <pre>
-     * 'interval', 'scope', 'scope_match' (where scope refers to Service scope) 
+     * 'interval', 'scope', 'scope_match' (where scope refers to Service scope)
      * </pre>
      * @param array $parameters Associative array of parameters to narrow the query
      * @return string XML result string
@@ -1710,7 +1710,7 @@ class PI extends AbstractEntityService{
         //Ensure all dates are  UTC
         date_default_timezone_set("UTC");
         define('DATE_FORMAT', 'Y-m-d H:i');
-        
+
         if(isset($parameters['interval'])) {
             if(is_numeric($parameters['interval'])) {
                 $interval = $parameters['interval'];
@@ -1727,21 +1727,21 @@ class PI extends AbstractEntityService{
             $scopeArray = $this->convertScopesToArray($parameters['scope']);
         } else {
             $scopeArray = $this->convertScopesToArray($this->defaultScope());
-        } 
-        
+        }
+
         $scopeClause = "";
         if($this->containsValidScope($scopeArray)){
-            $scopeClause = $this->scopeClauseFromScopeArray($scopeArray, "sc", 
-                    $this->allScopesMustMatch($parameters), 'Service', 'se') . " 
+            $scopeClause = $this->scopeClauseFromScopeArray($scopeArray, "sc",
+                    $this->allScopesMustMatch($parameters), 'Service', 'se') . "
                 AND";
-        } 
-        
-        // Subtract 'interval' number days from current time. 
-        // DM: Note, you can do this using the DATE_SUB DQL function used 
-        // within the query, e.g. DATE_SUB(:now, :interval, 'DAY') however, 
-        // I can't get it to work with Oracle so am calculating the new date 
-        // in php not in DQL. 
-        $nowMinusIntervalDays = new \DateTime();  
+        }
+
+        // Subtract 'interval' number days from current time.
+        // DM: Note, you can do this using the DATE_SUB DQL function used
+        // within the query, e.g. DATE_SUB(:now, :interval, 'DAY') however,
+        // I can't get it to work with Oracle so am calculating the new date
+        // in php not in DQL.
+        $nowMinusIntervalDays = new \DateTime();
         $nowMinusIntervalDays->sub(new \DateInterval('P'.$interval.'D'));
 
         $dql = "SELECT d
@@ -1755,22 +1755,22 @@ class PI extends AbstractEntityService{
                 WHERE " . $scopeClause //includes AND
                 . " d.insertDate > :nowMinusIntervalDays"
                 ;
-        
+
         $q = $this->em->createQuery($dql)
                 ->setParameter('nowMinusIntervalDays', $nowMinusIntervalDays);
 
         $q = $this->setScopeBindParameters($scopeArray, $q);
 
         $downtimes = $q->getResult();
-        
+
         $xml = new \SimpleXMLElement("<results />");
         foreach($downtimes as $downtime) {
             //foreach($downtime->getServices() as $se) {
             foreach($downtime->getEndpointLocations() as $els){
-                $se = $els->getService(); 
+                $se = $els->getService();
                 $xmlDowntime = $xml->addChild('DOWNTIME');
                 $xmlDowntime->addAttribute("ID", $downtime->getId());
-                // Note, we are preserving the v4 primary keys here. 
+                // Note, we are preserving the v4 primary keys here.
                 //$xmlDowntime->addAttribute("PRIMARY_KEY", $downtime->getId() . "G0");
                 $xmlDowntime->addAttribute("PRIMARY_KEY", $downtime->getPrimaryKey());
 
@@ -1812,10 +1812,10 @@ class PI extends AbstractEntityService{
     /**
      * Return an XML document that encodes the NGIs selected from the DB.
      * Optionally provide an associative array of query parameters with values to restrict the results.
-     * Only known parameters are honoured while unknown params produce an error doc. 
+     * Only known parameters are honoured while unknown params produce an error doc.
      * Parmeter array keys include:
      * <pre>
-     * 'roc', 'scope', 'scope_match' (where scope refers to NGI scope)  
+     * 'roc', 'scope', 'scope_match' (where scope refers to NGI scope)
      * </pre>
      * Implemented with Doctrine.
      * @param array $parameters Associative array of parameters to narrow the query
@@ -1837,24 +1837,24 @@ class PI extends AbstractEntityService{
         } else {
             $scopeArray = $this->convertScopesToArray($this->defaultScope());
         }
-        
+
         $scopeClause = "";
         if($this->containsValidScope($scopeArray)){
-            $scopeClause = $this->scopeClauseFromScopeArray($scopeArray, "sc", 
-                    $this->allScopesMustMatch($parameters), 'NGI', 'n') . " 
+            $scopeClause = $this->scopeClauseFromScopeArray($scopeArray, "sc",
+                    $this->allScopesMustMatch($parameters), 'NGI', 'n') . "
                 AND";
-        } 
-        
+        }
+
         $dql = "SELECT n FROM NGI n
                 LEFT JOIN n.scopes sc
                 WHERE" . $scopeClause // AND clause is already appended to $scopeClause where relevant.
                 . " n.name LIKE :ngi";
-        
+
         $q = $this->em->createQuery($dql)
                     ->setParameter('ngi', $ngi);
-        
+
         $q = $this->setScopeBindParameters($scopeArray, $q);
-        
+
         $ngis = $q->getResult();
 
         $xml = new \SimpleXMLElement("<results />");
@@ -1908,62 +1908,62 @@ class PI extends AbstractEntityService{
                 'roletype'
         );
         $this->validateParams ( $supportedQueryParams, $parameters );
-        
+
         //Initialize base query
         $qb = $this->em->createQueryBuilder();
-        
+
         $qb	->select('u')
         ->from('User', 'u')
         ->leftJoin('u.roles', 'r')
         ->orderBy('u.id', 'ASC');
-        
 
-        //Add each parameter to query if it is set		
-        if (isset ( $parameters ['forename'] )) {	
-            $qb	->andWhere($qb->expr()->like('u.forename', ':forename'))	
+
+        //Add each parameter to query if it is set
+        if (isset ( $parameters ['forename'] )) {
+            $qb	->andWhere($qb->expr()->like('u.forename', ':forename'))
                 ->setParameter('forename', $parameters['forename']);
         }
-        
+
         if (isset ( $parameters ['surname'] )) {
             $qb	->andWhere($qb->expr()->like('u.surname', ':surname'))
                 ->setParameter('surname', $parameters['surname']);
         }
-        
+
         if (isset ( $parameters ['dn'] )) {
             $qb	->andWhere($qb->expr()->like('u.certificateDn', ':dn'))
                 ->setParameter('dn', $parameters['dn']);
         }
-        
+
         if (isset ( $parameters ['dnlike'] )) {
             $qb	->andWhere($qb->expr()->like('u.certificateDn', ':dnlike'))
                 ->setParameter('dnlike', $parameters['dnlike']);
         }
-        
+
         /*If the user has specified a role type generate a new subquery
          * and join this to the main query with "where r.roleType in"
-         */ 
+         */
         if (isset ( $parameters ['roletype'])) {
-            
+
             $qb1 = $this->em->createQueryBuilder();
             $qb1->select('rt.id')
                 ->from('roleType', 'rt')
-                ->where($qb1->expr()->in('rt.name', ':roleType'));			
-            
+                ->where($qb1->expr()->in('rt.name', ':roleType'));
+
             $qb ->andWhere($qb->expr()->in('r.roleType', $qb1->getDQL()));
             //If user provided comma seprated values explode it and bind the resulting array
             if(strpos($parameters['roletype'], ',')){
                 $exValues = explode(',',$parameters['roletype']);
-                $qb->setParameter('roleType', $exValues);		
+                $qb->setParameter('roleType', $exValues);
             }else{
-                $qb->setParameter('roleType', $parameters['roletype']); 
+                $qb->setParameter('roleType', $parameters['roletype']);
             }
-        }		
+        }
         //Get Results
-        $query = $qb->getQuery();		
+        $query = $qb->getQuery();
         $users = $query->execute();
-        
+
         $xml = new \SimpleXMLElement ( "<results />" );
-        
+
         foreach ( $users as $user ) {
             $xmlUser = $xml->addChild ( 'EGEE_USER' );
             $xmlUser->addAttribute ( "ID", $user->getId () . "G0" );
@@ -1984,7 +1984,7 @@ class PI extends AbstractEntityService{
             $xmlUser->addChild ( 'WORKING_HOURS_END', $user->getWorkingHoursEnd () );
             $xmlUser->addChild ( 'CERTDN', $user->getCertificateDn () );
 
-                
+
             /*
              * APPROVED and ACTIVE are always blank in the GOCDBv4 get_user output so we'll keep it blank in the GOCDBv5 output for compatibility
              */
@@ -2002,7 +2002,7 @@ class PI extends AbstractEntityService{
                 if ($role->getStatus () == "STATUS_GRANTED"){
                     $xmlRole = $xmlUser->addChild ( 'USER_ROLE' );
                     $xmlRole->addChild ( 'USER_ROLE', $role->getRoleType ()->getName () );
-                    
+
                     /*
                      * Find out what the owned entity is to get its name and type
                      */
@@ -2022,13 +2022,13 @@ class PI extends AbstractEntityService{
                     } else if ($ownedEntity instanceof \ServiceGroup) {
                         $type = 'servicegroup';
                     } // note, no subgrids but we are removing subgrids.
-                    
+
                     $xmlRole->addChild ( 'ON_ENTITY', $name );
                     $xmlRole->addChild ( 'ENTITY_TYPE', $type );
                 }
             }
         }
-        
+
         $dom_sxe = dom_import_simplexml ( $xml );
         $dom = new \DOMDocument ( '1.0' );
         $dom->encoding = 'UTF-8';
@@ -2036,7 +2036,7 @@ class PI extends AbstractEntityService{
         $dom_sxe = $dom->appendChild ( $dom_sxe );
         $dom->formatOutput = true;
         $xmlString = $dom->saveXML ();
-        
+
         return $xmlString;
     }
 
@@ -2045,12 +2045,12 @@ class PI extends AbstractEntityService{
      * Adds a new tag $tagName to $xml if $value isn't "" or null
      * @param $xml SimpleXMLElement
      * @param $tagName String Name of the tag
-     * @param $value String Tag value (nullable) 
+     * @param $value String Tag value (nullable)
      * @return string XML result string
-     * @throws Exception 
+     * @throws Exception
      */
     private function addIfNotEmpty($xml, $tagName, $value) {
-        if($value != null && $value != "") {  
+        if($value != null && $value != "") {
         //if(! empty ($value)) { // empty if val was "0" (as string), FALSE, 0.0 (as float), 0 (as int) - but these could be valid values
             $xml->addChild($tagName, $value);
         }
@@ -2068,7 +2068,7 @@ class PI extends AbstractEntityService{
         if(!is_array($supportedParams) || !is_array($testParams)) {
             throw new \InvalidArgumentException; //InvalidArgument\Exception;
         }
-        
+
         //Check the parmiter keys are supoported
         $testParamKeys = array_keys($testParams);
         foreach ($testParamKeys as $key ) {
@@ -2078,7 +2078,7 @@ class PI extends AbstractEntityService{
                  die();
             }
         }
-        
+
         //Check that the paramater does not contain invalid chracters
         $testParamValues = array_values($testParams);
         foreach($testParamValues as $value){
@@ -2087,16 +2087,16 @@ class PI extends AbstractEntityService{
                 die();
             }
         }
-        
+
     }
 
     /**
      * Return an XML document that encodes the service groups selected from the DB.
      * Optionally provide an associative array of query parameters with values used to restrict the results.
-     * Only known parameters are honoured while unknown params produce an error doc. 
+     * Only known parameters are honoured while unknown params produce an error doc.
      * Parmeter array keys include:
      * <pre>
-     * 'service_group_name', 'scope', 'scope_match' 
+     * 'service_group_name', 'scope', 'scope_match'
      * </pre>
      * @param array $parameters Associative array of parameters to narrow the query
      * @return string XML result string
@@ -2117,34 +2117,34 @@ class PI extends AbstractEntityService{
         } else {
             $scopeArray = $this->convertScopesToArray($this->defaultScope());
         }
-        
+
         $scopeClause = "";
         if($this->containsValidScope($scopeArray)){
-            $scopeClause = $this->scopeClauseFromScopeArray($scopeArray, "sc", 
-                    $this->allScopesMustMatch($parameters), 'ServiceGroup', 'sg') . " 
+            $scopeClause = $this->scopeClauseFromScopeArray($scopeArray, "sc",
+                    $this->allScopesMustMatch($parameters), 'ServiceGroup', 'sg') . "
                 AND";
-        } 
+        }
 
         $q = $this->em->createQuery("
-                SELECT sg, s, st 
+                SELECT sg, s, st
                 FROM ServiceGroup sg
                 LEFT JOIN sg.services s
                 LEFT JOIN s.serviceType st
                 LEFT JOIN sg.scopes sc
                 WHERE " . $scopeClause   // AND clause is already appended to $scopeClause where relevant.
-                ." sg.name LIKE :name") 
-             ->setParameter('name', $name); 
-        
+                ." sg.name LIKE :name")
+             ->setParameter('name', $name);
+
          $q = $this->setScopeBindParameters($scopeArray, $q);
          $sgs = $q->getResult();
-        
+
         $xml = new \SimpleXMLElement("<results />");
         foreach($sgs as $sg) {
             $xmlSg = $xml->addChild('SERVICE_GROUP');
             $xmlSg->addAttribute("PRIMARY_KEY", $sg->getId() . "G0");
             $xmlSg->addChild('NAME', $sg->getName());
             $xmlSg->addChild('DESCRIPTION', htmlspecialchars($sg->getDescription()));
-            $mon = ($sg->getMonitored()) ? 'Y' : 'N'; 
+            $mon = ($sg->getMonitored()) ? 'Y' : 'N';
             $xmlSg->addChild('MONITORED', $mon);
             $xmlSg->addChild('CONTACT_EMAIL', $sg->getEmail());
             $url = '#GOCDB_BASE_PORTAL_URL#/index.php?Page_Type=Service_Group&id=' . $sg->getId();
@@ -2152,22 +2152,22 @@ class PI extends AbstractEntityService{
             $xmlSg->addChild('GOCDB_PORTAL_URL', $url);
 
             foreach($sg->getServices() as $service){
-               $xmlService = $xmlSg->addChild('SERVICE_ENDPOINT'); 
-               $xmlService->addChild('HOSTNAME', $service->getHostName());  
-               $url = '#GOCDB_BASE_PORTAL_URL#/index.php?Page_Type=Service&id=' . $service->getId(); 
-               $xmlService->addChild('GOCDB_PORTAL_URL', htmlspecialchars($url));  
-               $xmlService->addChild('SERVICE_TYPE', $service->getServiceType()->getName());  
-               $xmlService->addChild('HOST_IP', $service->getIpAddress());  
-               $xmlService->addChild('HOSTDN', $service->getDN()); 
-               $prod = ($service->getProduction()) ? 'Y' : 'N';  
-               $xmlService->addChild('IN_PRODUCTION', $prod);  
-               $mon = ($service->getMonitored()) ? 'Y' : 'N'; 
-               $xmlService->addChild('NODE_MONITORED', $mon);  
-               // Will need to add the service DN when the central security ACL are 
-               // setup using a service group. 
-               //$xmlService->addChild('DN', htmlspecialchars($service->getDN())); 
+               $xmlService = $xmlSg->addChild('SERVICE_ENDPOINT');
+               $xmlService->addChild('HOSTNAME', $service->getHostName());
+               $url = '#GOCDB_BASE_PORTAL_URL#/index.php?Page_Type=Service&id=' . $service->getId();
+               $xmlService->addChild('GOCDB_PORTAL_URL', htmlspecialchars($url));
+               $xmlService->addChild('SERVICE_TYPE', $service->getServiceType()->getName());
+               $xmlService->addChild('HOST_IP', $service->getIpAddress());
+               $xmlService->addChild('HOSTDN', $service->getDN());
+               $prod = ($service->getProduction()) ? 'Y' : 'N';
+               $xmlService->addChild('IN_PRODUCTION', $prod);
+               $mon = ($service->getMonitored()) ? 'Y' : 'N';
+               $xmlService->addChild('NODE_MONITORED', $mon);
+               // Will need to add the service DN when the central security ACL are
+               // setup using a service group.
+               //$xmlService->addChild('DN', htmlspecialchars($service->getDN()));
             }
-            // rendering the scope is not supported by this method yet. 
+            // rendering the scope is not supported by this method yet.
             //$xmlSg->addChild('SCOPE', $sg->getScopes()->first()->getName());
         }
 
@@ -2184,7 +2184,7 @@ class PI extends AbstractEntityService{
     /**
      * Return an XML document that encodes the service groups selected from the DB.
      * Optionally provide an associative array of query parameters with values used to restrict the results.
-     * Only known parameters are honoured while unknown params produce error doc. 
+     * Only known parameters are honoured while unknown params produce error doc.
      * Parmeter array keys include:
      * <pre>
      * 'service_group_name'
@@ -2210,16 +2210,16 @@ class PI extends AbstractEntityService{
         } else {
             $scopeArray = $this->convertScopesToArray($this->defaultScope());
         }
-        
+
         $scopeClause = "";
         if($this->containsValidScope($scopeArray)){
-            $scopeClause = $this->scopeClauseFromScopeArray($scopeArray, "sc", 
-                    $this->allScopesMustMatch($parameters), 'ServiceGroup', 'sg') . " 
+            $scopeClause = $this->scopeClauseFromScopeArray($scopeArray, "sc",
+                    $this->allScopesMustMatch($parameters), 'ServiceGroup', 'sg') . "
                 AND";
-        } 
+        }
 
         /*$sgs = $this->em->createQuery("
-                SELECT oe, r, u, rt 
+                SELECT oe, r, u, rt
                 FROM OwnedEntity oe
                 JOIN oe.roles r
                 JOIN r.user u
@@ -2232,7 +2232,7 @@ class PI extends AbstractEntityService{
                    ->getResult();*/
 
         $q = $this->em->createQuery("
-                SELECT sg, r, u, rt 
+                SELECT sg, r, u, rt
                 FROM ServiceGroup sg
                 LEFT JOIN sg.roles r
                 LEFT JOIN r.user u
@@ -2240,8 +2240,8 @@ class PI extends AbstractEntityService{
                 LEFT JOIN sg.scopes sc
                 WHERE ". $scopeClause   // AND clause is already appended to $scopeClause where relevant.
                 . " sg.name LIKE :name")
-                ->setParameter('name', $name); 
-       
+                ->setParameter('name', $name);
+
         $q = $this->setScopeBindParameters($scopeArray, $q);
         $sgs = $q->getResult();
 
@@ -2251,7 +2251,7 @@ class PI extends AbstractEntityService{
             $xmlSg->addAttribute("PRIMARY_KEY", $sg->getId() . "G0");
             $xmlSg->addChild('NAME', $sg->getName());
             $xmlSg->addChild('DESCRIPTION', htmlspecialchars($sg->getDescription()));
-            $mon = ($sg->getMonitored()) ? 'Y' : 'N'; 
+            $mon = ($sg->getMonitored()) ? 'Y' : 'N';
             $xmlSg->addChild('MONITORED', $mon);
             $xmlSg->addChild('CONTACT_EMAIL', $sg->getEmail());
             $url = '#GOCDB_BASE_PORTAL_URL#/index.php?Page_Type=Service_Group&id=' . $sg->getId();
@@ -2279,10 +2279,10 @@ class PI extends AbstractEntityService{
         $xmlString = $dom->saveXML();
         return $xmlString;
     }
-    
+
     /**
-     * Gets the name of the default scope from the config service. 
-     * 
+     * Gets the name of the default scope from the config service.
+     *
      * @return string
      */
     private function defaultScope(){
@@ -2290,36 +2290,36 @@ class PI extends AbstractEntityService{
         $scopes = $configService->getDefaultScopeName();
         return $scopes;
     }
-    
+
     /**
-     * Takes a string containing a comma seperated list of strings and creates 
+     * Takes a string containing a comma seperated list of strings and creates
      * an associative array. The key is used as a bind variab name  the value is
      * the name of the scope.
-     * 
+     *
      * @param string $scopes
      * @return array associative array
      */
     private function convertScopesToArray($scopes){
         //explode the scopes string into an array
         $scopesNameArray = explode(",", $scopes);
-        
+
         $scopeArray = array();
         $count=0;
-        
+
         foreach($scopesNameArray as $scopeName){
             $scopeArray["scope".++$count] = $scopeName;
         }
-        
+
         return $scopeArray;
     }
-    
+
 
     /**
      * using the scope array and other paramater this function forms a dql string
-     * to select entities based on the scope specified by the matching method 
+     * to select entities based on the scope specified by the matching method
      * specified
-     * 
-     * @param array $scopeArray key-value array. Keys are used as bind variable 
+     *
+     * @param array $scopeArray key-value array. Keys are used as bind variable
      *                          names values are the names of scopes
      * @param string $scopeAlias  alias for scope in DQL, usually 'sc'
      * @param boolean $shouldMatchAll if true all scopes specified must be matched
@@ -2329,11 +2329,11 @@ class PI extends AbstractEntityService{
      * @param string $entityAlias alias for the above, e.g. 's' or 'n' or 'se'
      * @return string DQL WHERE clause
      */
-    private function scopeClauseFromScopeArray($scopeArray, $scopeAlias, $shouldMatchAll, 
+    private function scopeClauseFromScopeArray($scopeArray, $scopeAlias, $shouldMatchAll,
                                                 $entityName, $entityAlias){
         $clause = "";
         $count = 0;
-        
+
         if ($shouldMatchAll){
             //Match every scope
             foreach(array_keys($scopeArray) as $bindName){
@@ -2345,32 +2345,32 @@ class PI extends AbstractEntityService{
                                 WHERE ". $scopeAlias.$count .".name = :" . $bindName . "
                                 AND " . $entityAlias . ".id" . " = " . $entityAlias . $count . ".id
                             ) AND";
-            } 
+            }
             //remove the last AND
             $clause = substr($clause, 0, -3);
         }
         else{
             // match any scope
             $clause=" (";
-                
+
             foreach(array_keys($scopeArray) as $bindName){
                 $clause .= $scopeAlias . ".name = :". $bindName . " OR ";
             }
 
             //remove last comma and space
             $clause = substr($clause, 0, -3);
-            $clause .= ")"; 
+            $clause .= ")";
         }
-        
+
         return $clause;
     }
 
-    
-    
+
+
     /**
-     * Sets the scope bind parameters in the query using an array containing 
+     * Sets the scope bind parameters in the query using an array containing
      * scope names and bind parameter names
-     * 
+     *
      * @param array $scopeArray array containing a seriese of arrays which contain
      *                          a scope name and a bind parameter name
      * @param  $doctrineQuery   Doctrine query to have bind parameters set in.
@@ -2384,15 +2384,15 @@ class PI extends AbstractEntityService{
                 $doctrineQuery = $doctrineQuery->setParameter($bindName,$scopeArray[$bindName]);
             }
         }
-        
+
         return $doctrineQuery;
     }
-    
+
     /**
-     * if the Scope array contains anything over than a scopename with an empty 
-     * string as a name return true. Will return false when the user has not 
+     * if the Scope array contains anything over than a scopename with an empty
+     * string as a name return true. Will return false when the user has not
      * specified a scope and the instance has no default scope specified
-     * 
+     *
      * @param array $scopeArray
      * @return boolean
      */
@@ -2402,17 +2402,17 @@ class PI extends AbstractEntityService{
                 return true;
             }
         }
-   
+
         return false;
     }
-    
+
     /**
-     * If all the scopes specified should be matched it returns true, if any of 
+     * If all the scopes specified should be matched it returns true, if any of
      * the scopes specified  being matched to an object is suffecient for it to
      * be included in the results then it retuns false. This is first determined
-     * by the scope_match parameter, if this has not been set, the default 
+     * by the scope_match parameter, if this has not been set, the default
      * decision is used
-     * 
+     *
      * @param array $parameters
      * @return boolean
      */
@@ -2436,11 +2436,11 @@ class PI extends AbstractEntityService{
         }
     }
 
-    
+
     private function is_whole_number($var){
        return (is_numeric($var)&&(intval($var)==floatval($var)));
     }
-    
+
 
 
 

--- a/unused_resources/ParseAtlasDataRunner.php
+++ b/unused_resources/ParseAtlasDataRunner.php
@@ -14,11 +14,11 @@
  */
 
 
-// Simple script to extract 'name' value from 'rcsite' json array/structure 
-// and print this to standard output. This output can be re-directed to a 
-// text file and modified to produce a php file that contains an array of site 
-// names for subsequent import into: 
-// e.g. 'resources/ApplyScopeTagsToSitesAndServicesRunner.php'. 
+// Simple script to extract 'name' value from 'rcsite' json array/structure
+// and print this to standard output. This output can be re-directed to a
+// text file and modified to produce a php file that contains an array of site
+// names for subsequent import into:
+// e.g. 'resources/ApplyScopeTagsToSitesAndServicesRunner.php'.
 
 // download json file for atlas from: http://atlas-agis-api.cern.ch/request/site/query/list/?json&vo_name=atlas
 $jsonstring = file_get_contents("atlas-agis-api.cern.json");
@@ -34,21 +34,21 @@ foreach ($jsonIterator as $key => $val) {
     if(is_array($val)) {
         //echo "$key:\n";
     if($key == 'rcsite'){
-        //echo "$key\n"; 
-        if(isset($val['name'])){ 
-          $siteArray[] = $val['name']; 
+        //echo "$key\n";
+        if(isset($val['name'])){
+          $siteArray[] = $val['name'];
         }
-        
-        //echo $val."\n"; 
+
+        //echo $val."\n";
     }
     } else {
 //        echo "$key => $val\n";
     }
 }
 
-// remove duplicates 
-$siteArray = array_unique($siteArray); 
+// remove duplicates
+$siteArray = array_unique($siteArray);
 foreach($siteArray as $siteName){
-    echo $siteName."\n"; 
+    echo $siteName."\n";
 }
 


### PR DESCRIPTION
Remove any trailing whitespace from lines in .php files, generated
using: for file in $(find . -type f -name \*.php | grep -v "^./vendor" |
grep -v "^./lib/Doctrine/compiledEntities/"); do echo $file && sed
-i "s/\s*$//" $file; done