### PR TITLE
Refactor services for extension props

### DIFF
--- a/htdocs/web_portal/controllers/service/delete_endpoint_properties.php
+++ b/htdocs/web_portal/controllers/service/delete_endpoint_properties.php
@@ -57,7 +57,7 @@ function submit(array $propertyArray, \Service $service, \EndpointLocation $endp
 
     //remove property
     try {
-        $serv->deleteEndpointProperties($user, $propertyArray);
+        $serv->deleteEndpointProperties($service, $user, $propertyArray);
     } catch(\Exception $e) {
         show_view('error.php', $e->getMessage());
         die();

--- a/lib/Gocdb_Services/ServiceService.php
+++ b/lib/Gocdb_Services/ServiceService.php
@@ -1027,7 +1027,7 @@ class ServiceService extends AbstractEntityService {
     }
 
     /**
-     * Adds key value pairs to a service
+     * Adds extension properties to a service
      *
      * @param \Service $service
      * @param \User $user
@@ -1037,11 +1037,24 @@ class ServiceService extends AbstractEntityService {
      */
     public function addProperties(\Service $service, \User $user, array $propArr, $preventOverwrite = false) {
         // Check the portal is not in read only mode, throws exception if it is
-        $this->checkPortalIsNotReadOnlyOrUserIsAdmin ( $user );
-        // throw new \Exception(var_dump($propArr));
+        $this->checkPortalIsNotReadOnlyOrUserIsAdmin($user);
 
-        $this->validateAddEditDeleteActions ( $user, $service );
+        //Check that the user has the requisite permissions
+        $this->validateAddEditDeleteActions ($user,$service);
 
+        //Make the change
+        $this->addPropertiesLogic($service,$propArr,$preventOverwrite);
+    }
+
+    /**
+     * Logic to add extension properties to a service
+     *
+     * @param \Service $service
+     * @param array $propArr
+     * @param bool $preventOverwrite
+     * @throws \Exception
+     */
+    protected function addPropertiesLogic(\Service $service, array $propArr, $preventOverwrite = false) {
         $existingProperties = $service->getServiceProperties ();
 
         // Check to see if adding the new properties will exceed the max limit defined in local_info.xml, and throw an exception if so
@@ -1089,7 +1102,7 @@ class ServiceService extends AbstractEntityService {
     }
 
     /**
-     * Adds a key value pair to a service endpoint
+     * Adds extension properties to a service endpoint
      *
      * @param \EndpointLocation $endpoint
      * @param \User $user
@@ -1099,11 +1112,24 @@ class ServiceService extends AbstractEntityService {
      */
     public function addEndpointProperties(\EndpointLocation $endpoint, \User $user, array $propArr, $preventOverwrite = false) {
         // Check the portal is not in read only mode, throws exception if it is
-        $this->checkPortalIsNotReadOnlyOrUserIsAdmin ( $user );
-        // throw new \Exception(var_dump($propArr));
+        $this->checkPortalIsNotReadOnlyOrUserIsAdmin ($user);
 
-        $this->validateAddEditDeleteActions ( $user, $endpoint->getService () );
+        //Check the user has the requisite permissions
+        $this->validateAddEditDeleteActions ($user, $endpoint->getService());
 
+        //Make the change
+        $this->addEndpointPropertiesLogic($endpoint,$propArr,$preventOverwrite);
+    }
+
+    /**
+     * Logic to add extension properties to a service endpoint
+     *
+     * @param \EndpointLocation $endpoint
+     * @param array $propArr
+     * @param bool $preventOverwrite
+     * @throws \Exception
+     */
+    protected function addEndpointPropertiesLogic(\EndpointLocation $endpoint, array $propArr, $preventOverwrite = false) {
         $existingProperties = $endpoint->getEndpointProperties ();
 
         // Check to see if adding the new properties will exceed the max limit defined in local_info.xml, and throw an exception if so
@@ -1154,6 +1180,8 @@ class ServiceService extends AbstractEntityService {
     /**
      * Deletes service properties
      *
+     * Checks user permissions and then calls required logic
+     *
      * @param \Service $service
      * @param \User $user
      * @param array $propArr
@@ -1161,8 +1189,21 @@ class ServiceService extends AbstractEntityService {
     public function deleteServiceProperties(\Service $service, \User $user, array $propArr) {
         // Check the portal is not in read only mode, throws exception if it is
         $this->checkPortalIsNotReadOnlyOrUserIsAdmin ( $user );
+
+        //Ensure the user has the requisite permissions
         $this->validateAddEditDeleteActions ( $user, $service );
 
+        //Make the change
+        $this->deleteServicePropertiesLogic($service, $propArr);
+    }
+
+    /**
+     * Logic to delete service properties
+     *
+     * @param \Service $service
+     * @param array $propArr
+     */
+    protected function deleteServicePropertiesLogic(\Service $service, array $propArr) {
         $this->em->getConnection ()->beginTransaction ();
         try {
             foreach ( $propArr as $prop ) {
@@ -1189,9 +1230,8 @@ class ServiceService extends AbstractEntityService {
 
     /**
      * Deletes the given EndpointProperties in the array from their parent Endpoints (if set).
-     * If the parent Endpoint has not been set (<code>$prop->getParentEndpoint()</code> returns null
-     * then the function throws an exception because the user permissions to delete
-     * the EP can't be determined on a null Endpoint.
+     *
+     * First the users permissions are checked
      *
      * @param \User $user
      * @param array $propArr
@@ -1200,6 +1240,34 @@ class ServiceService extends AbstractEntityService {
         // Check the portal is not in read only mode, throws exception if it is
         $this->checkPortalIsNotReadOnlyOrUserIsAdmin ( $user );
 
+        /**
+        * TODO:refactor codebase so that this function takes $service as a variable,
+        * like all the other extension properties functions. For now we iterate
+        * over all props (as this maintains the functional equivalance - there
+        * is an outside chance that somthing could be feeding this properties
+        * from multiple services)
+        */
+        foreach ( $propArr as $prop ) {
+            $endpoint = $prop->getParentEndpoint ();
+            // check user has permissions over the service associated with the endpoint
+            $service = $endpoint->getService ();
+            $this->validateAddEditDeleteActions ( $user, $service );
+        }
+
+        // Carry out the change
+        $this->deleteEndpointPropertiesLogic($propArr);
+    }
+
+    /**
+     * Logic to delete the given EndpointProperties in the array from their parent Endpoints (if set).
+     * If the parent Endpoint has not been set (<code>$prop->getParentEndpoint()</code> returns null
+     * then the function throws an exception because the user permissions to delete
+     * the EP can't be determined on a null Endpoint.
+     *
+     * @param \User $user
+     * @param array $propArr
+     */
+    protected function deleteEndpointPropertiesLogic(array $propArr) {
         $this->em->getConnection ()->beginTransaction ();
 
         try {
@@ -1211,10 +1279,6 @@ class ServiceService extends AbstractEntityService {
                     $id = $prop->getId ();
                     throw new \Exception ( "Property {$id} does not have a parent endpoint" );
                 }
-
-                // check user has permissions over the service associated with the endpoint
-                $service = $endpoint->getService ();
-                $this->validateAddEditDeleteActions ( $user, $service );
 
                 // Endoint is the owning side so remove elements from endpoint.
                 $endpoint->getEndpointProperties ()->removeElement ( $prop );
@@ -1233,8 +1297,8 @@ class ServiceService extends AbstractEntityService {
     /**
      * Edits an existing service property that already belongs to the service.
      *
-     * A check is performed to confirm the given property is from the parent
-     * service, and an exception is thrown if not.
+     * A check is made to ensure the user has the requred permissions then the
+     * required logic is called.
      *
      * @param \Service $service
      * @param \User $user
@@ -1244,8 +1308,26 @@ class ServiceService extends AbstractEntityService {
     public function editServiceProperty(\Service $service, \User $user, \ServiceProperty $prop, $newValues) {
         // Check the portal is not in read only mode, throws exception if it is
         $this->checkPortalIsNotReadOnlyOrUserIsAdmin ( $user );
-        $this->validate ( $newValues ['SERVICEPROPERTIES'], 'serviceproperty' );
+
+        // Validate the user has permission to edit properties
         $this->validateAddEditDeleteActions ( $user, $service );
+
+        //Make the change
+        $this->editServicePropertyLogic($service, $prop, $newValues);
+    }
+
+    /**
+     * Logic to edit an existing service property that already belongs to the service.
+     *
+     * A check is performed to confirm the given property is from the parent
+     * service, and an exception is thrown if not.
+     *
+     * @param \Service $service
+     * @param \ServiceProperty $prop
+     * @param array $newValues
+     */
+    protected function editServicePropertyLogic(\Service $service, \ServiceProperty $prop, $newValues) {
+        $this->validate ( $newValues ['SERVICEPROPERTIES'], 'serviceproperty' );
         $keyname = $newValues ['SERVICEPROPERTIES'] ['NAME'];
         $keyvalue = $newValues ['SERVICEPROPERTIES'] ['VALUE'];
 
@@ -1273,8 +1355,8 @@ class ServiceService extends AbstractEntityService {
     /**
      * Edits an existing endpoint property that already belongs to the endpoint.
      *
-     * A check is performed to confirm the given property is from the endpoint's
-     * parent service, and an exception is thrown if not.
+     * A check is made to ensure the user has the requred permissions then the
+     * required logic is called.
      *
      * @param \Service $service
      * @param \User $user
@@ -1284,8 +1366,27 @@ class ServiceService extends AbstractEntityService {
      */
     public function editEndpointProperty(\Service $service, \User $user, \EndpointProperty $prop, $newValues) {
         // Check the portal is not in read only mode, throws exception if it is
-        $this->checkPortalIsNotReadOnlyOrUserIsAdmin ( $user );
-        $this->validateAddEditDeleteActions ( $user, $service );
+        $this->checkPortalIsNotReadOnlyOrUserIsAdmin ($user);
+
+        // Validate the user has permission to edit properties
+        $this->validateAddEditDeleteActions ($user, $service);
+
+        //Make the change
+        $this->editEndpointPropertyLogic($service, $prop, $newValues);
+    }
+
+    /**
+     * Logic to edit an existing endpoint property that already belongs to the endpoint.
+     *
+     * A check is performed to confirm the given property is from the endpoint's
+     * parent service, and an exception is thrown if not.
+     *
+     * @param \Service $service
+     * @param \EndpointProperty $prop
+     * @param array $newValues
+     * @throws \Exception
+     */
+    protected function editEndpointPropertyLogic(\Service $service, \EndpointProperty $prop, $newValues) {
         $this->validate ( $newValues ['ENDPOINTPROPERTIES'], 'endpointproperty' );
         $keyname = $newValues ['ENDPOINTPROPERTIES'] ['NAME'];
         $keyvalue = $newValues ['ENDPOINTPROPERTIES'] ['VALUE'];

--- a/lib/Gocdb_Services/Site.php
+++ b/lib/Gocdb_Services/Site.php
@@ -960,7 +960,7 @@ class Site extends AbstractEntityService{
     }
 
     /**
-     * Adds a key value pair to a site
+     * Adds sets of extension property key/value pairs to a site.
      * @param \Site $site
      * @param \User $user
      * @param array $propArr
@@ -970,10 +970,22 @@ class Site extends AbstractEntityService{
     public function addProperties(\Site $site, \User $user, array $propArr, $preventOverwrite = false) {
         //Check the portal is not in read only mode, throws exception if it is
         $this->checkPortalIsNotReadOnlyOrUserIsAdmin($user);
-        //throw new \Exception(var_dump($propArr));
 
+        // Validate the user has permission to add properties
         $this->validatePropertyActions($user, $site);
 
+        //Add the properties
+        $this->addPropertiesLogic($site, $propArr, $preventOverwrite);
+    }
+
+    /**
+     * Logic to sets of extension property key/value pairs to a site.
+     * @param \Site $site
+     * @param array $propArr
+     * @param bool $preventOverwrite
+     * @throws \Exception
+     */
+    protected function addPropertiesLogic(\Site $site, array $propArr, $preventOverwrite = false) {
         $existingProperties = $site->getSiteProperties();
 
         //Check to see if adding the new properties will exceed the max limit defined in local_info.xml, and throw an exception if so
@@ -1024,9 +1036,8 @@ class Site extends AbstractEntityService{
     }
 
     /**
-     * Deletes site properties, before deletion a check is done to confirm the property
-     * is from the parent site specified by the request, and an exception is thrown if this is
-     * not the case
+     * Deletes site properties: validates the user has permission then calls the
+     * required logic
      * @param \Site $site
      * @param \User $user
      * @param array $propArr
@@ -1038,6 +1049,18 @@ class Site extends AbstractEntityService{
         // Validate the user has permission to delete a property
         $this->validatePropertyActions($user, $site);
 
+        //Make the change
+        $this->deleteSitePropertiesLogic($site, $propArr);
+    }
+
+    /**
+     * All the logic to delete a site's properties, before deletion a check is done to confirm the property
+     * is from the parent site specified by the request, and an exception is thrown if this is
+     * not the case
+     * @param \Site $site
+     * @param array $propArr
+     */
+    protected function deleteSitePropertiesLogic(\Site $site, array $propArr) {
         $this->em->getConnection()->beginTransaction();
         try {
             foreach ($propArr as $prop) {
@@ -1061,9 +1084,8 @@ class Site extends AbstractEntityService{
     }
 
     /**
-     * Edit a site's property. A check is performed to confirm the given property
-     * is from the parent site specified by the request, and an exception is thrown if this is
-     * not the case.
+     * Edit a site's property. The user is validated then the logic to make the
+     * change called
      *
      * @param \Site $site
      * @param \User $user
@@ -1077,6 +1099,22 @@ class Site extends AbstractEntityService{
 
         //Validate User to perform this action
         $this->validatePropertyActions($user, $site);
+
+        //Make the change
+        $this->editSitePropertyLogic($site, $prop, $newValues);
+    }
+
+    /**
+     * All the logic to edit a site's property, without the user validation.
+     * A check is performed to confirm the given property is from the parent site
+     * specified by the request, and an exception is thrown if this is not the case.
+     *
+     * @param \Site $site
+     * @param \SiteProperty $prop
+     * @param array $newValues
+     * @throws \Exception
+     */
+    protected function editSitePropertyLogic(\Site $site,\SiteProperty $prop, $newValues) {
 
         $this->validate($newValues['SITEPROPERTIES'], 'siteproperty');
 

--- a/tests/doctrine/ExtensionsTest.php
+++ b/tests/doctrine/ExtensionsTest.php
@@ -451,7 +451,7 @@ class ExtensionsTest extends PHPUnit_Extensions_Database_TestCase {
     $roleActionAuthService->setEntityManager($this->em);
     $serviceService->setRoleActionAuthorisationService($roleActionAuthService);
 
-    $serviceService->deleteEndpointProperties($adminUser, array($prop1));
+    $serviceService->deleteEndpointProperties($service, $adminUser, array($prop1));
 
     //Check that the service endpoint now only has 2 properties
     $properties = $endpoint->getEndpointProperties();

--- a/tests/doctrine/ExtensionsTest.php
+++ b/tests/doctrine/ExtensionsTest.php
@@ -405,7 +405,7 @@ class ExtensionsTest extends PHPUnit_Extensions_Database_TestCase {
     $site = TestUtil::createSampleSite("TestSite");
     $endpoint = TestUtil::createSampleEndpointLocation();
 
-    //Join service to site, and site to NGI.
+    //Join Service endpoint to site, service to site, and site to NGI.
     $ngi->addSiteDoJoin($site);
     $site->addServiceDoJoin($service);
     $service->addEndpointLocationDoJoin($endpoint);
@@ -451,19 +451,18 @@ class ExtensionsTest extends PHPUnit_Extensions_Database_TestCase {
     $roleActionAuthService->setEntityManager($this->em);
     $serviceService->setRoleActionAuthorisationService($roleActionAuthService);
 
-    //$serviceService->deleteEndpointProperty($adminUser, $prop1);
     $serviceService->deleteEndpointProperties($adminUser, array($prop1));
 
-    //Check that the service now only has 2 properties
+    //Check that the service endpoint now only has 2 properties
     $properties = $endpoint->getEndpointProperties();
     $this->assertTrue(count($properties) == 2);
     $this->em->flush();
 
     //Print names of properties
-    foreach ($properties as $prop) {
-        print($prop->getKeyName() . "-");
-        print($prop->getKeyValue() . "\n");
-    }
+    //foreach ($properties as $prop) {
+    //    print($prop->getKeyName() . "-");
+    //    print($prop->getKeyValue() . "\n");
+    //}
 
     //Check this via the database
     $con = $this->getConnection();


### PR DESCRIPTION
- Refactors the extension properties functions in the site ans service services in order to allow for future development of the write API. In particular it abstracts out the logic of making changes to extension properties from the permissions this will allow non-user entities to make changes (e.g. Robot DNs).
- Commented out code which was echoing extension properties as part of the unit test
- Expansion and correction of a couple of comments in the Extension Properties unit test
- The code for deleting service endpoint extension properties now more closely matches that used elsewhere for deleting extension properties. This includes a change the the variables for the delete endpoint properties function, so the unit tests and web portal have been updated
to reflect this (the portal functionality has been tested and the unit
tests pass).
- Remove the unused function 'checkNotReserved()' from the service service. It currently confuses the logic of the existing code and can be reimplemented easily enough if reserved custom properties are required in the future. It is also not present in the site service, which is inconsistent.