### PR TITLE
Moves logos up the page

### DIFF
--- a/htdocs/web_portal/components/Draw_Components/draw_page_components.php
+++ b/htdocs/web_portal/components/Draw_Components/draw_page_components.php
@@ -31,21 +31,17 @@
         // container for the page
         $HTML .= "<div class=\"page_container\">";
 
+        //Logo box and version
+        $HTML .= Get_top_logos_Box_HTML();
+
         // menu bar
         $HTML .= "<div class=\"left_box_menu\">";
-        $HTML .= Get_File_Contents(__DIR__."/../../static_html/goc5_logo.html");
-        //Insert a portal is in read only warning message, if it is
-        if(\Factory::getConfigService()->IsPortalReadOnly()){
-            $HTML.= Get_File_Contents(__DIR__."/../../static_html/read_only_warning.html");
-        }
         require_once "menu.php";
         $HTML .= draw_menu("main_menu");
         $HTML .= "</div>";
-        //$HTML .= "<h3 class=\"spacer\">Test</h3>";
 
         $HTML .= Get_Search_Box_HTML();
         $HTML .= Get_User_Info_Box_HTML();
-        $HTML .= Get_bottom_logos_Box_HTML();
 
         // right side of the page
         $HTML .= "<div class=\"right_box\">";
@@ -118,10 +114,17 @@
     }
 
     /* Draws a box showing the EGI and other logos */
-    function Get_bottom_logos_Box_HTML()
+    function Get_top_logos_Box_HTML()
     {
         $HTML = "";
         $HTML .= '<div class="Left_Logo_Box left_box_menu">';
+        $HTML .= Get_File_Contents(__DIR__."/../../static_html/goc5_logo.html");
+        //Insert a portal is in read only warning message, if it is
+        if(\Factory::getConfigService()->IsPortalReadOnly()){
+            $HTML.= Get_File_Contents(__DIR__."/../../static_html/read_only_warning.html");
+        }
+        $HTML .= '<br>';
+        $HTML .= "<hr style=\"clear: both;\"/>";
         $HTML .= '<div align="center"><a href="http://www.stfc.ac.uk" target="_blank"><img src="'.\GocContextPath::getPath().'img/STFC.jpg" height="25"/></a>&nbsp;&nbsp;';
         $HTML .= '<a href="http://europa.eu" target="_blank"><img src="'.\GocContextPath::getPath().'img/eu.jpg" height="25"/></a>&nbsp;&nbsp;';
         //$HTML .= '<a href="http://www.egi.eu" target="_blank"><img src="img/egi.gif" height="25"/></a></div>';

--- a/htdocs/web_portal/components/Draw_Components/draw_page_components.php
+++ b/htdocs/web_portal/components/Draw_Components/draw_page_components.php
@@ -119,7 +119,7 @@
         $HTML = "";
         $HTML .= '<div class="Left_Logo_Box left_box_menu">';
         $HTML .= Get_File_Contents(__DIR__."/../../static_html/goc5_logo.html");
-        //Insert a portal is in read only warning message, if it is
+        //Insert a "portal is in read only" warning message, if it is
         if(\Factory::getConfigService()->IsPortalReadOnly()){
             $HTML.= Get_File_Contents(__DIR__."/../../static_html/read_only_warning.html");
         }

--- a/htdocs/web_portal/components/Draw_Components/menu.php
+++ b/htdocs/web_portal/components/Draw_Components/menu.php
@@ -41,7 +41,6 @@ function draw_menu($menu_name)
 function xml_to_menu($menu_name, $menus_xml)
 {
     $html = "";
-    $html .= "<hr style=\"clear: both;\"/>";
     $html .= "<ul class=\"Smaller_Left_Padding Smaller_Top_Margin\">";
     foreach($menus_xml->$menu_name->children() as $key => $value)
     {

--- a/htdocs/web_portal/css/web_portal.css
+++ b/htdocs/web_portal/css/web_portal.css
@@ -111,14 +111,14 @@ h1 {
 }
 
 
- 
+
 /*
     *	Containing DIV's
 	*	Page Container is the whole page
 	*	Left Box is the menu
 	*	Right Box is the smaller page contents
 	*/
-.page_container { 
+.page_container {
 	position: relative;
 	margin-left: auto;
 	margin-right: auto;
@@ -133,12 +133,13 @@ h1 {
 /* Credit for this section of CSS goes to Matt Lira of STFC, 2009 */
 .left_box_menu {
 	float: left;
+    clear: left;
 	margin: 0.5em 0.5em 0.5em 0.5em;
 	padding: 0.5em 0.5em 0.5em 0.5em;
 	border: 1px solid #b4b4b4;
 	width: 13em;
 	box-shadow: 2px 2px 1px 0px #c5d0e3;
-	
+
 	background-color: #fcfcfc;
 	border-radius: 0.4em;
 }
@@ -166,7 +167,6 @@ div.Left_User_Status_Box {
 
 div.Left_Logo_Box {
 	float: left;
-	clear: left;
 }
 
 div.Indented {
@@ -522,8 +522,8 @@ img.decoration {
 
 img.titleIcon{
 	height:25px;
-	float: right; 
-	margin:2% 1% 1% 0%; 
+	float: right;
+	margin:2% 1% 1% 0%;
 }
 
 input.vSiteSearch {
@@ -586,7 +586,7 @@ img.centered {
 
 span.topMargin {
     margin-top: 1em;
-}	
+}
 
 span.block {
     display: block;
@@ -658,7 +658,7 @@ div.rightPageContainer {
     padding: 1em;
     box-shadow: 2px 2px 1px 0px #c5d0e3;
     border-radius: 0.4em;
-    
+
 }
 
 div.tableContainer {
@@ -684,8 +684,8 @@ div.tableContainer {
 
 .smallLabelText{
 	margin-left:8px;
-	font-size:11px; 
-	font-weight: normal; 
+	font-size:11px;
+	font-weight: normal;
 	font-style:italic;
 	display:inline-block;
 }
@@ -699,9 +699,8 @@ label.error {
 }
 
 .selectService{
-background-color: #D5D5D5;	
+background-color: #D5D5D5;
 }
 
 .selectEndpoint{
 }
-


### PR DESCRIPTION
There was a request for the egi logo to be at the top of the page (https://rt.egi.eu/rt/Ticket/Display.html?id=11546). This is a mock up of a possible way of doing it. It is more to show what it could look like than to recommend we do it. As a minimum it probably needs more refinement before merging. A screen-shot is attached. 
![2016logosattop](https://cloud.githubusercontent.com/assets/4125374/18545689/1bae83a4-7b32-11e6-82c6-ea457522a507.png)
