### PR TITLE
Tidying and bug fixes for endpointlocation

### DIFF
--- a/config/gocdb_schema.xml
+++ b/config/gocdb_schema.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <schema>
-    
+
     <!--
 	This file defines the validation necessary for each entity's fields.
     -->
@@ -71,7 +71,7 @@
 	    <fname>DESCRIPTION</fname>
 	    <length>2000</length>
 	    <!--<regex>/^[a-zA-Z0-9\-\._\(\)\[\],;:\/'"\s]*$/</regex>-->
-	    <regex>/^[^`'\";&lt;&gt;]+$/</regex> 
+	    <regex>/^[^`'\";&lt;&gt;]+$/</regex>
 	</field>
 	<field>
 	    <fname>CREATION_DATE</fname>
@@ -117,7 +117,7 @@
 	    <regex>/^([a-zA-Z_-]+(\/[a-zA-Z_-]+)*)+$/</regex>
 	</field>
     </entity>
-	
+
     <!-- ==========================================================  -->
     <entity>
 	<name>service</name>
@@ -156,8 +156,8 @@
 	    <fname>DESCRIPTION</fname>
 	    <length>255</length>
 	    <!--<regex>/^[a-zA-Z0-9\-\._\(\)\[\],;+:\/'"\s]*$/</regex>-->
-	    <regex>/^[^`'\";&lt;&gt;]+$/</regex> 
-	</field>        
+	    <regex>/^[^`'\";&lt;&gt;]+$/</regex>
+	</field>
 	<field>
 	    <fname>EMAIL</fname>
 	    <length>255</length>
@@ -180,7 +180,7 @@
 	    <fname>DESCRIPTION</fname>
 	    <length>4000</length>
 	    <!--<regex>/^[a-zA-Z0-9\-\._\(\)\[\],;:\/'\s]+$/</regex>-->
-	    <regex>/^[^`'\";&lt;&gt;]+$/</regex> 
+	    <regex>/^[^`'\";&lt;&gt;]+$/</regex>
 	</field>
 	<field>
 	    <fname>DECLARATION_TIMESTAMP</fname>
@@ -244,7 +244,7 @@
 	    <regex>/^(\+?[0-9\-\.\s\)\(]+)?$/</regex>
 	</field>
     </entity>
-	
+
     <!-- ==========================================================  -->
     <entity>
 	<name>ngi</name>
@@ -257,7 +257,7 @@
 	    <fname>DESCRIPTION</fname>
 	    <length>255</length>
 	    <!--<regex>/^[a-zA-Z0-9\-\._\(\)\[\],;+:\/'"\s]*$/</regex>-->
-	    <regex>/^[^`'\";&lt;&gt;]+$/</regex> 
+	    <regex>/^[^`'\";&lt;&gt;]+$/</regex>
 	</field>
 	<field>
 	    <fname>EMAIL</fname>
@@ -308,9 +308,9 @@
 	    <fname>CONFIRMATION_CODE</fname>
 	</field>
     </entity>
-	
-    <!-- ====================================================  
-    This can be deleted once add service form is redone. 
+
+    <!-- ====================================================
+    This can be deleted once add service form is redone.
     -->
     <entity>
 	<name>endpoint_location</name>
@@ -337,9 +337,9 @@
 	</field>
 	<field>
 	    <fname>DESCRIPTION</fname>
-	    <length>2000</length>
+	    <length>255</length>
 	    <!--<regex>/^[a-zA-Z0-9\-\._\(\)\[\],;+:\/'"\s]*$/</regex>-->
-	    <regex>/^[^`'\";&lt;&gt;]+$/</regex> 
+	    <regex>/^[^`'\";&lt;&gt;]*$/</regex>
 	</field>
 	<field>
 	    <fname>URL</fname>
@@ -351,14 +351,14 @@
 	    <fname>INTERFACENAME</fname>
 	    <length>255</length>
 	    <regex>/^[a-zA-Z0-9\-\._\(\)\[\],;+:\/'"\s]*$/</regex>
-	</field>	
+	</field>
 	<field>
 	    <fname>ENDPOINTID</fname>
 	    <length>255</length>
 	    <regex>/^[0-9]+$/</regex>
 	</field>
     </entity>
-    
+
     <!-- ==========================================================  -->
     <entity>
 	<name>service_group</name>
@@ -370,7 +370,7 @@
 	<field>
 	    <fname>DESCRIPTION</fname>
 	    <length>255</length>
-	    <regex>/^[^`'\";&lt;&gt;]+$/</regex> 
+	    <regex>/^[^`'\";&lt;&gt;]+$/</regex>
 	</field>
 	<field>
 	    <fname>EMAIL</fname>
@@ -390,7 +390,7 @@
 	    <fname>DESCRIPTION</fname>
 	    <length>2000</length>
 	    <!--<regex>/^[a-zA-Z0-9\-\._\(\)\[\],;+:\/'"\s]*$/</regex>-->
-	    <regex>/^[^`'\";&lt;&gt;]+$/</regex> 
+	    <regex>/^[^`'\";&lt;&gt;]+$/</regex>
 	</field>
     </entity>
     <!-- ==========================================================  -->
@@ -405,7 +405,7 @@
 	    <fname>DESCRIPTION</fname>
 	    <length>255</length>
 	    <!--<regex>/^[a-zA-Z0-9\-\._\(\)\[\],;+:\/'"\s]*$/</regex>-->
-	    <regex>/^[^`'\";&lt;&gt;]+$/</regex> 
+	    <regex>/^[^`'\";&lt;&gt;]+$/</regex>
 	</field>
     </entity>
     <!-- ==========================================================  -->
@@ -420,7 +420,7 @@
 	    <fname>DESCRIPTION</fname>
 	    <length>255</length>
 	    <!--<regex>/^[a-zA-Z0-9\-\._\(\)\[\],;+:\/'"\s]*$/</regex>-->
-	    <regex>/^[^`'\";&lt;&gt;]+$/</regex> 
+	    <regex>/^[^`'\";&lt;&gt;]+$/</regex>
 	</field>
     </entity>
     <!-- ==========================================================  -->
@@ -452,9 +452,9 @@
 	    <fname>PROP</fname>
 	    <length>255</length>
 	    <regex>/^[a-zA-Z0-9\-\._]+$/</regex>
-	</field>		
+	</field>
     </entity>
-    <!-- ==========================================================  -->	
+    <!-- ==========================================================  -->
     <entity>
 	<name>serviceproperty</name>
 	<field>
@@ -479,7 +479,7 @@
 	    <fname>PROP</fname>
 	    <length>255</length>
 	    <regex>/^[a-zA-Z0-9\-\._]+$/</regex>
-	</field>		
+	</field>
     </entity>
     <!-- ==========================================================  -->
     <entity>
@@ -533,8 +533,8 @@
 	    <fname>PROP</fname>
 	    <length>255</length>
 	    <regex>/^[a-zA-Z0-9\-\._]+$/</regex>
-	</field>		
-    </entity>		
+	</field>
+    </entity>
     <!-- ==========================================================  -->
     <entity>
 	<name>cert_status_change</name>
@@ -542,8 +542,7 @@
 	    <fname>REASON</fname>
 	    <length>300</length>
 	    <!--<regex>/^[a-zA-Z0-9è\-\._\(\)\[\],;:\/'"\s]*$/</regex>-->
-	    <regex>/^[^`'\";&lt;&gt;]+$/</regex> 
+	    <regex>/^[^`'\";&lt;&gt;]+$/</regex>
 	</field>
     </entity>
 </schema>
-

--- a/htdocs/web_portal/controllers/service/add_service_endpoint.php
+++ b/htdocs/web_portal/controllers/service/add_service_endpoint.php
@@ -2,7 +2,7 @@
 /*______________________________________________________
  *======================================================
  * File: add_service_endpoint.php
- * Author: James McCarthy
+ * Author: James McCarthy, George Ryall
  * Description: Adds a new endpoint to a service
  *
  * License information
@@ -18,7 +18,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  /*======================================================*/
-
 require_once __DIR__.'/../../../../lib/Gocdb_Services/Factory.php';
 require_once __DIR__.'/../utils.php';
 require_once __DIR__.'/../../../web_portal/components/Get_User_Principle.php';
@@ -48,11 +47,19 @@ function add_service_endpoint() {
  * @param \User $user current user
  * @return null */
 function submit(\User $user = null) {
-    $serv = \Factory::getServiceService();
-    $newValues = getEndpointDataFromWeb();
-    $serviceid = $newValues['SERVICEENDPOINT']['SERVICE'];
-    $serv->addEndpoint($newValues, $user);
-    show_view("service/added_service_endpoint.php", $serviceid);
+    try {
+        $serv = \Factory::getServiceService();
+        $newValues = getEndpointDataFromWeb();
+        $endpoint = $serv->addEndpoint($newValues, $user);
+
+        $params['endpointID'] = $endpoint->getID();
+        $params['serviceID'] = $newValues['SERVICEENDPOINT']['SERVICE'];
+        show_view("service/added_service_endpoint.php", $params);
+
+    } catch(Exception $e) {
+        show_view('error.php', $e->getMessage());
+        die();
+    }
 }
 
 /**

--- a/htdocs/web_portal/views/service/added_service_endpoint.php
+++ b/htdocs/web_portal/views/service/added_service_endpoint.php
@@ -1,6 +1,9 @@
 <div class="rightPageContainer">
-    <h1 class="Success">Success</h1><br />
+    <h1 class="Success">Success</h1>
     New endpoint successfully added. <br />
-    <a href="index.php?Page_Type=Service&id=<?php echo $params ?>">
-    View service</a>
+    <a href="index.php?Page_Type=View_Service_Endpoint&id=<?php echo $params['endpointID'] ?>">
+    View Endpoint </a>
+    <br>
+    <a href="index.php?Page_Type=Service&id=<?php echo $params['serviceID'] ?>">
+    View Service </a>
 </div>

--- a/htdocs/web_portal/views/service/view_service_endpoint.php
+++ b/htdocs/web_portal/views/service/view_service_endpoint.php
@@ -74,12 +74,15 @@ $seId = $se->getId();
                     <td class="site_table">Name</td><td class="site_table"><?php xecho($endpoint->getName()) ?></td>
                 </tr>
                 <tr class="site_table_row_2">
-                    <td class="site_table">Url</td><td class="site_table"><?php xecho($endpoint->getUrl()) ?></td>
+                    <td class="site_table">Description</td><td class="site_table"><?php xecho($endpoint->getDescription()) ?></td>
                 </tr>
                 <tr class="site_table_row_1">
-                    <td class="site_table">Interface Name</td><td class="site_table"><?php xecho($endpoint->getInterfaceName()) ?></td>
+                    <td class="site_table">Url</td><td class="site_table"><?php xecho($endpoint->getUrl()) ?></td>
                 </tr>
                 <tr class="site_table_row_2">
+                    <td class="site_table">Interface Name</td><td class="site_table"><?php xecho($endpoint->getInterfaceName()) ?></td>
+                </tr>
+                <tr class="site_table_row_1">
                     <td class="site_table">Id</td><td class="site_table"><?php echo $endpoint->getId() ?></td>
                 </tr>
 

--- a/lib/Gocdb_Services/ServiceService.php
+++ b/lib/Gocdb_Services/ServiceService.php
@@ -1521,10 +1521,13 @@ class ServiceService extends AbstractEntityService {
         $this->checkPortalIsNotReadOnlyOrUserIsAdmin ( $user );
         $this->validate ( $values ['SERVICEENDPOINT'], 'endpoint' );
 
-        $name = $values ['SERVICEENDPOINT'] ['NAME'];
-        $url = $values ['SERVICEENDPOINT'] ['URL'];
         $serviceID = $values ['SERVICEENDPOINT'] ['SERVICE'];
         $service = $this->getService ( $serviceID );
+
+        $name = $values ['SERVICEENDPOINT'] ['NAME'];
+        $url = $values ['SERVICEENDPOINT'] ['URL'];
+        $description = $values ['SERVICEENDPOINT'] ['DESCRIPTION'];
+
 
         if ($values ['SERVICEENDPOINT'] ['INTERFACENAME'] != '') {
             $interfaceName = $values ['SERVICEENDPOINT'] ['INTERFACENAME'];
@@ -1551,7 +1554,7 @@ class ServiceService extends AbstractEntityService {
             $endpoint->setName ( $name );
             $endpoint->setUrl ( $url );
             $endpoint->setInterfaceName ( $interfaceName );
-            $service = $this->em->find ( "Service", $serviceID );
+            $endpoint->setDescription ( $description );
             $service->addEndpointLocationDoJoin ( $endpoint );
             $this->em->persist ( $endpoint );
 
@@ -1578,17 +1581,18 @@ class ServiceService extends AbstractEntityService {
     public function editEndpoint(\Service $service, \User $user, \EndpointLocation $endpoint, $newValues) {
         // Check the portal is not in read only mode, throws exception if it is
         $this->checkPortalIsNotReadOnlyOrUserIsAdmin ( $user );
+        $this->validate ( $newValues ['SERVICEENDPOINT'], 'endpoint' );
 
         $name = $newValues ['SERVICEENDPOINT'] ['NAME'];
         $url = $newValues ['SERVICEENDPOINT'] ['URL'];
+        $description = $newValues ['SERVICEENDPOINT'] ['DESCRIPTION'];
+
         if ($newValues ['SERVICEENDPOINT'] ['INTERFACENAME'] != '') {
             $interfaceName = $newValues ['SERVICEENDPOINT'] ['INTERFACENAME'];
         } else {
             $interfaceName = ( string ) $service->getServiceType ();
         }
-        $description = $newValues ['SERVICEENDPOINT'] ['DESCRIPTION'];
 
-        $this->validate ( $newValues ['SERVICEENDPOINT'], 'endpoint' );
 
         if (empty ( $name )) {
             throw new \Exception ( "An endpoint must have a name." );


### PR DESCRIPTION
* Fixes bug that meant endpoint descriptions weren't saved when creating new endpoints
* Added endpoint description tot he table of properties on the show endpoint page
* Reorders some code for add and edit endpoint so they do things in a consistent order
* Updates the 'description' property in the gocdb xml schema for endpoints. Allows for empty strings and limits characters to 255. This reflects the in page validation that was already in place for adding and editing endpoints.
* After a new endpoint is added a a link to the new SE as well as the parent service is now displayed.