### PR TITLE
Allow ':' in HOST_DN field

### DIFF
--- a/config/gocdb_schema.xml
+++ b/config/gocdb_schema.xml
@@ -140,7 +140,7 @@
 	<field>
 	    <fname>HOST_DN</fname>
 	    <length>255</length>
-	    <regex>/^(\/[A-Za-z]+=[a-zA-Z0-9\/\-\_\s\.,'@\/]+)*$/</regex>
+	    <regex>/^(\/[A-Za-z]+=[a-zA-Z0-9\/\-\_\s\.,'@:\/]+)*$/</regex>
 	</field>
 	<field>
 	    <fname>HOST_OS</fname>


### PR DESCRIPTION
Allows for the use of colons in DNs
