### PR TITLE
Change to SG edit properties function

### DIFF
--- a/lib/Gocdb_Services/ServiceGroup.php
+++ b/lib/Gocdb_Services/ServiceGroup.php
@@ -689,6 +689,8 @@ class ServiceGroup extends AbstractEntityService{
         // Check the portal is not in read only mode, throws exception if it is
         $this->checkPortalIsNotReadOnlyOrUserIsAdmin ( $user );
 
+        $this->validatePropertyActions($user, $serviceGroup);
+
         $this->validate($newValues['SERVICEGROUPPROPERTIES'], 'servicegroupproperty');
 
         $keyname = $newValues ['SERVICEGROUPPROPERTIES'] ['NAME'];


### PR DESCRIPTION
Ensures that that users calling the function that edits Service group
custom proeprties are actually allowed to do this.