### PR TITLE
Add a constraint on custom properties

### DIFF
--- a/htdocs/web_portal/controllers/service/add_endpoint_properties.php
+++ b/htdocs/web_portal/controllers/service/add_endpoint_properties.php
@@ -43,7 +43,7 @@ function add_endpoint_properties() {
     if($_POST) {     	// If we receive a POST request it's for new properties
 
         //COMMENT
-        $preventOverwrite = false;
+        $preventOverwrite = true;
 
         //Get the parent service we want to add properties to.
         //I'm trying to use "parent" rather than "service" wherever possible to make this code more generic.
@@ -87,7 +87,7 @@ function add_endpoint_properties() {
         }
 
         if(isset($_REQUEST['PREVENTOVERWRITE'])){
-            $preventOverwrite = true;
+            $preventOverwrite = false;
         }
 
         //quick sanity check, are we actually adding any properties?

--- a/htdocs/web_portal/controllers/service/add_service_properties.php
+++ b/htdocs/web_portal/controllers/service/add_service_properties.php
@@ -43,7 +43,7 @@ function add_service_properties() {
     if($_POST) {     	// If we receive a POST request it's for new properties
 
         //COMMENT
-        $preventOverwrite = false;
+        $preventOverwrite = true;
 
         //Get the parent service we want to add properties to.
         //I'm trying to use "parent" rather than "service" wherever possible to make this code more generic.
@@ -88,7 +88,7 @@ function add_service_properties() {
         }
 
         if(isset($_REQUEST['PREVENTOVERWRITE'])){
-            $preventOverwrite = true;
+            $preventOverwrite = false;
         }
 
         //quick sanity check, are we actually adding any properties?

--- a/htdocs/web_portal/controllers/service_group/add_service_group_properties.php
+++ b/htdocs/web_portal/controllers/service_group/add_service_group_properties.php
@@ -42,7 +42,7 @@ function add_service_group_properties() {
 
     if($_POST) {     	// If we receive a POST request it's for new properties
 
-        $preventOverwrite = false;
+        $preventOverwrite = true;
 
         //Get the parent service we want to add properties to.
         //I'm trying to use "parent" rather than "service" wherever possible to make this code more generic.
@@ -80,7 +80,7 @@ function add_service_group_properties() {
             //will go straight to submit()
             $_REQUEST['UserConfirmed'] = "true";
             //since the user is only adding a single property, warn them if it already exists
-            $preventOverwrite = true;
+            $preventOverwrite = false;
         } else {
             //you really shouldn't end up here unless you are mangling your post requests
             throw new Exception("Properties could not be parsed");

--- a/htdocs/web_portal/controllers/site/add_site_properties.php
+++ b/htdocs/web_portal/controllers/site/add_site_properties.php
@@ -43,7 +43,7 @@ function add_site_properties() {
     if($_POST) {     	// If we receive a POST request it's for new properties
 
         //COMMENT
-        $preventOverwrite = false;
+        $preventOverwrite = true;
 
         //Get the parent service we want to add properties to.
         //I'm trying to use "parent" rather than "service" wherever possible to make this code more generic.
@@ -88,7 +88,7 @@ function add_site_properties() {
         }
 
         if(isset($_REQUEST['PREVENTOVERWRITE'])){
-            $preventOverwrite = true;
+            $preventOverwrite = false;
         }
 
         //quick sanity check, are we actually adding any properties?

--- a/htdocs/web_portal/views/fragments/addPropertiesConfirmation.php
+++ b/htdocs/web_portal/views/fragments/addPropertiesConfirmation.php
@@ -38,7 +38,7 @@
         <input class="input_input_hidden" type="hidden" name="UserConfirmed" value="true" />
         <input class="input_input_text" type="hidden" name ="PARENT" value="<?php echo $parent->getId();?>" />
         <input type="checkbox" id="preventOverwriteCheckbox" name="PREVENTOVERWRITE" style="padding-top: 50px"/>
-        Fail on duplicate property
+        Overwrite values for existing keys (if left unchecked pre-existing keys will prevent all of the properties selected above from being added)
         <br/>
         <br/>
 

--- a/lib/Doctrine/entities/EndpointProperty.php
+++ b/lib/Doctrine/entities/EndpointProperty.php
@@ -1,5 +1,4 @@
 <?php
-
 /*
  * Copyright (C) 2015 STFC
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,16 +18,17 @@
  * object with additional attributes. These properties can also be used for
  * the purposes of resource matching.
  * <p>
- * A unique constraint is defined on the DB preventing duplicate key=value pairs.
- * Note, duplicate key names with different values ARE allowed for the purpose
- * of defning multi-valued properties.
+ * A unique constraint is defined on the DB preventing duplicate keys for a given endpointLocation.
+ * Pairs with duplicate pkeys were intiially permitted, but are no longer.
+ * This allows the pairs to be upadated based enitrely on the key name and entity
+ * unique identifier, rather than needing the custom property id. 
  * <p>
  * When the owning parent EndpointLocation is deleted, its EndpointProperties
  * are also cascade-deleted.
  *
  * @author David Meredith <david.meredith@stfc.ac.uk>
  *
- * @Entity @Table(name="Endpoint_Properties", uniqueConstraints={@UniqueConstraint(name="endpointproperty_keypairs", columns={"parentEndpoint_id", "keyName", "keyValue"})})
+ * @Entity @Table(name="Endpoint_Properties", uniqueConstraints={@UniqueConstraint(name="endpointproperty_keypairs", columns={"parentEndpoint_id", "keyName"})})
  */
 class EndpointProperty {
 

--- a/lib/Doctrine/entities/ServiceGroupProperty.php
+++ b/lib/Doctrine/entities/ServiceGroupProperty.php
@@ -18,16 +18,17 @@
  * object with additional attributes. These properties can also be used for
  * the purposes of resource matching.
  * <p>
- * A unique constraint is defined on the DB preventing key=value duplicates.
- * Note, duplicate key names with different values are allowed for the purpose
- * of defning multi-valued properties.
+ * A unique constraint is defined on the DB preventing duplicate keys for a given service.
+ * Pairs with duplicate pkeys were intiially permitted, but are no longer.
+ * This allows the pairs to be upadated based enitrely on the key name and entity
+ * unique identifier, rather than needing the custom property id.
  * <p>
  * When the owning parent ServiceGroup is deleted, its ServiceGroupProperties
  * are also cascade-deleted.
  *
  * @author James McCarthy
  * @author David Meredith <david.meredith@stfc.ac.uk>
- * @Entity @Table(name="ServiceGroup_Properties", uniqueConstraints={@UniqueConstraint(name="sgroup_keypairs", columns={"parentServiceGroup_id", "keyName", "keyValue"})})
+ * @Entity @Table(name="ServiceGroup_Properties", uniqueConstraints={@UniqueConstraint(name="sgroup_keypairs", columns={"parentServiceGroup_id", "keyName"})})
  */
 class ServiceGroupProperty {
 

--- a/lib/Doctrine/entities/ServiceProperty.php
+++ b/lib/Doctrine/entities/ServiceProperty.php
@@ -14,20 +14,21 @@
 //use Doctrine\Common\Collections\ArrayCollection;
 
 /**
- * Custom Key=Value pairs (extension properties) used to augment a {@see Service}
+ * A custom Key=Value pair (extension property) used to augment a {@see Service}
  * object with additional attributes. These properties can also be used for
  * the purposes of resource matching.
  * <p>
- * A unique constraint is defined on the DB preventing key=value duplicates.
- * Note, duplicate key names with different values are allowed for the purpose
- * of defning multi-valued properties.
+ * A unique constraint is defined on the DB preventing duplicate keys for a given service.
+ * Pairs with duplicate pkeys were intiially permitted, but are no longer.
+ * This allows the pairs to be upadated based enitrely on the key name and entity
+ * unique identifier, rather than needing the custom property id.
  * <p>
  * When the owning parent Service is deleted, its ServiceProperties
  * are also cascade-deleted.
  *
  * @author James McCarthy
  * @author David Meredith
- * @Entity @Table(name="Service_Properties", uniqueConstraints={@UniqueConstraint(name="serv_keypairs", columns={"parentService_id", "keyName", "keyValue"})})
+ * @Entity @Table(name="Service_Properties", uniqueConstraints={@UniqueConstraint(name="serv_keypairs", columns={"parentService_id", "keyName"})})
  */
 class ServiceProperty {
 

--- a/lib/Doctrine/entities/SiteProperty.php
+++ b/lib/Doctrine/entities/SiteProperty.php
@@ -14,20 +14,21 @@
 //use Doctrine\Common\Collections\ArrayCollection;
 
 /**
- * Custom Key=Value pairs (extension properties) used to augment a {@see Site}
+ * A custom Key=Value pair (extension property) used to augment a {@see Site}
  * object with additional attributes. These properties can also be used for
  * the purposes of resource matching.
  * <p>
- * A unique constraint is defined on the DB preventing key=value duplicates.
- * Note, duplicate key names with different values are allowed for the purpose
- * of defning multi-valued properties.
+ * A unique constraint is defined on the DB preventing duplicate keys for a given site.
+ * Pairs with duplicate pkeys were intiially permitted, but are no longer.
+ * This allows the pairs to be upadated based enitrely on the key name and entity
+ * unique identifier, rather than needing the custom property id.
  * <p>
  * When the owning parent Site is deleted, its SiteProperties
  * are also cascade-deleted.
  *
  * @author James McCarthy
  * @author David Meredith
- * @Entity @Table(name="Site_Properties",uniqueConstraints={@UniqueConstraint(name="site_keypairs", columns={"parentSite_id", "keyName", "keyValue"})})
+ * @Entity @Table(name="Site_Properties",uniqueConstraints={@UniqueConstraint(name="site_keypairs", columns={"parentSite_id", "keyName"})})
  */
 class SiteProperty {
 

--- a/lib/Gocdb_Services/ServiceService.php
+++ b/lib/Gocdb_Services/ServiceService.php
@@ -1043,7 +1043,16 @@ class ServiceService extends AbstractEntityService {
         $this->validateAddEditDeleteActions ($user,$service);
 
         //Make the change
-        $this->addPropertiesLogic($service,$propArr,$preventOverwrite);
+        $this->em->getConnection ()->beginTransaction ();
+        try {
+            $this->addPropertiesLogic($service,$propArr,$preventOverwrite);
+            $this->em->flush ();
+            $this->em->getConnection ()->commit ();
+        } catch ( \Exception $e ) {
+            $this->em->getConnection ()->rollback ();
+            $this->em->close ();
+            throw $e;
+        }
     }
 
     /**
@@ -1063,41 +1072,31 @@ class ServiceService extends AbstractEntityService {
             throw new \Exception ( "Property(s) could not be added due to the property limit of $extensionLimit" );
         }
 
-        $this->em->getConnection ()->beginTransaction ();
-        try {
-            foreach ( $propArr as $i => $prop ) {
-                $key = $prop [0];
-                $value = $prop [1];
-                // Check that we are not trying to add an existing key, and skip if we are, unless the user has selected the prevent overwrite mode
+        foreach ( $propArr as $i => $prop ) {
+            $key = $prop [0];
+            $value = $prop [1];
+            // Check that we are not trying to add an existing key, and skip if we are, unless the user has selected the prevent overwrite mode
 
-                foreach ( $existingProperties as $existProp ) {
-                    if ($existProp->getKeyName () == $key && $existProp->getKeyValue () == $value) {
-                        if ($preventOverwrite == false) {
-                            continue 2;
-                        } else {
-                            throw new \Exception ( "A property with name \"$key\" and value \"$value\" already exists for this object, no properties were added." );
-                        }
+            foreach ( $existingProperties as $existProp ) {
+                if ($existProp->getKeyName () == $key && $existProp->getKeyValue () == $value) {
+                    if ($preventOverwrite == false) {
+                        continue 2;
+                    } else {
+                        throw new \Exception ( "A property with name \"$key\" and value \"$value\" already exists for this object, no properties were added." );
                     }
                 }
-
-                // validate key value
-                $validateArray ['NAME'] = $key;
-                $validateArray ['VALUE'] = $value;
-                $this->validate ( $validateArray, 'serviceproperty' );
-
-                $serviceProperty = new \ServiceProperty ();
-                $serviceProperty->setKeyName ( $key );
-                $serviceProperty->setKeyValue ( $value );
-                $service->addServicePropertyDoJoin ( $serviceProperty );
-                $this->em->persist ( $serviceProperty );
             }
 
-            $this->em->flush ();
-            $this->em->getConnection ()->commit ();
-        } catch ( \Exception $e ) {
-            $this->em->getConnection ()->rollback ();
-            $this->em->close ();
-            throw $e;
+            // validate key value
+            $validateArray ['NAME'] = $key;
+            $validateArray ['VALUE'] = $value;
+            $this->validate ( $validateArray, 'serviceproperty' );
+
+            $serviceProperty = new \ServiceProperty ();
+            $serviceProperty->setKeyName ( $key );
+            $serviceProperty->setKeyValue ( $value );
+            $service->addServicePropertyDoJoin ( $serviceProperty );
+            $this->em->persist ( $serviceProperty );
         }
     }
 
@@ -1118,7 +1117,16 @@ class ServiceService extends AbstractEntityService {
         $this->validateAddEditDeleteActions ($user, $endpoint->getService());
 
         //Make the change
-        $this->addEndpointPropertiesLogic($endpoint,$propArr,$preventOverwrite);
+        $this->em->getConnection ()->beginTransaction ();
+        try {
+            $this->addEndpointPropertiesLogic($endpoint,$propArr,$preventOverwrite);
+            $this->em->flush ();
+            $this->em->getConnection ()->commit ();
+        } catch ( \Exception $e ) {
+            $this->em->getConnection ()->rollback ();
+            $this->em->close ();
+            throw $e;
+        }
     }
 
     /**
@@ -1138,42 +1146,32 @@ class ServiceService extends AbstractEntityService {
             throw new \Exception ( "Property(s) could not be added due to the property limit of $extensionLimit" );
         }
 
-        $this->em->getConnection ()->beginTransaction ();
-        try {
-            foreach ( $propArr as $i => $prop ) {
-                $key = $prop [0];
-                $value = $prop [1];
-                // Check that we are not trying to add an existing key, and skip if we are, unless the user has selected the prevent overwrite mode
+        foreach ( $propArr as $i => $prop ) {
+            $key = $prop [0];
+            $value = $prop [1];
+            // Check that we are not trying to add an existing key, and skip if we are, unless the user has selected the prevent overwrite mode
 
-                foreach ( $existingProperties as $existProp ) {
-                    if ($existProp->getKeyName () == $key && $existProp->getKeyValue () == $value) {
-                        if ($preventOverwrite == false) {
-                            continue 2;
-                        } else {
-                            throw new \Exception ( "A property with name \"$key\" and value \"$value\" already exists for this object, no properties were added." );
-                        }
+            foreach ( $existingProperties as $existProp ) {
+                if ($existProp->getKeyName () == $key && $existProp->getKeyValue () == $value) {
+                    if ($preventOverwrite == false) {
+                        continue 2;
+                    } else {
+                        throw new \Exception ( "A property with name \"$key\" and value \"$value\" already exists for this object, no properties were added." );
                     }
                 }
-
-                // validate key value
-                $validateArray ['NAME'] = $key;
-                $validateArray ['VALUE'] = $value;
-                $validateArray ['ENDPOINTID'] = $endpoint->getId ();
-                $this->validate ( $validateArray, 'endpointproperty' );
-
-                $property = new \EndpointProperty ();
-                $property->setKeyName ( $key );
-                $property->setKeyValue ( $value );
-                $endpoint->addEndpointPropertyDoJoin ( $property );
-                $this->em->persist ( $property );
             }
 
-            $this->em->flush ();
-            $this->em->getConnection ()->commit ();
-        } catch ( \Exception $e ) {
-            $this->em->getConnection ()->rollback ();
-            $this->em->close ();
-            throw $e;
+            // validate key value
+            $validateArray ['NAME'] = $key;
+            $validateArray ['VALUE'] = $value;
+            $validateArray ['ENDPOINTID'] = $endpoint->getId ();
+            $this->validate ( $validateArray, 'endpointproperty' );
+
+            $property = new \EndpointProperty ();
+            $property->setKeyName ( $key );
+            $property->setKeyValue ( $value );
+            $endpoint->addEndpointPropertyDoJoin ( $property );
+            $this->em->persist ( $property );
         }
     }
 
@@ -1194,7 +1192,16 @@ class ServiceService extends AbstractEntityService {
         $this->validateAddEditDeleteActions ( $user, $service );
 
         //Make the change
-        $this->deleteServicePropertiesLogic($service, $propArr);
+        $this->em->getConnection ()->beginTransaction ();
+        try {
+            $this->deleteServicePropertiesLogic($service, $propArr);
+            $this->em->flush ();
+            $this->em->getConnection ()->commit ();
+        } catch ( \Exception $e ) {
+            $this->em->getConnection ()->rollback ();
+            $this->em->close ();
+            throw $e;
+        }
     }
 
     /**
@@ -1204,27 +1211,18 @@ class ServiceService extends AbstractEntityService {
      * @param array $propArr
      */
     protected function deleteServicePropertiesLogic(\Service $service, array $propArr) {
-        $this->em->getConnection ()->beginTransaction ();
-        try {
-            foreach ( $propArr as $prop ) {
-                // throw new \Exception(var_dump($prop));
-                // check property is in service
-                if ($prop->getParentService () != $service) {
-                    $id = $prop->getId ();
-                    throw new \Exception ( "Property {$id} does not belong to the specified service" );
-                }
-
-                // Service is the owning side so remove elements from service.
-                $service->getServiceProperties ()->removeElement ( $prop );
-                // Once relationship is removed delete the actual element
-                $this->em->remove ( $prop );
+        foreach ( $propArr as $prop ) {
+            // throw new \Exception(var_dump($prop));
+            // check property is in service
+            if ($prop->getParentService () != $service) {
+                $id = $prop->getId ();
+                throw new \Exception ( "Property {$id} does not belong to the specified service" );
             }
-            $this->em->flush ();
-            $this->em->getConnection ()->commit ();
-        } catch ( \Exception $e ) {
-            $this->em->getConnection ()->rollback ();
-            $this->em->close ();
-            throw $e;
+
+            // Service is the owning side so remove elements from service.
+            $service->getServiceProperties ()->removeElement ( $prop );
+            // Once relationship is removed delete the actual element
+            $this->em->remove ( $prop );
         }
     }
 
@@ -1244,7 +1242,16 @@ class ServiceService extends AbstractEntityService {
         $this->validateAddEditDeleteActions ($user, $service);
 
         // Carry out the change
-        $this->deleteEndpointPropertiesLogic($service, $propArr);
+        $this->em->getConnection ()->beginTransaction ();
+        try {
+            $this->deleteEndpointPropertiesLogic($service, $propArr);
+            $this->em->flush ();
+            $this->em->getConnection ()->commit ();
+        } catch ( \Exception $e ) {
+            $this->em->getConnection ()->rollback ();
+            $this->em->close ();
+            throw $e;
+        }
     }
 
     /**
@@ -1257,36 +1264,26 @@ class ServiceService extends AbstractEntityService {
      * @param array $propArr
      */
     protected function deleteEndpointPropertiesLogic(\Service $service, array $propArr) {
-        $this->em->getConnection ()->beginTransaction ();
+        foreach ( $propArr as $prop ) {
 
-        try {
-            foreach ( $propArr as $prop ) {
-
-                // check endpoint property has a parent endpoint
-                $endpoint = $prop->getParentEndpoint ();
-                if ($endpoint == null) {
-                    $id = $prop->getId ();
-                    throw new \Exception ( "Property {$id} does not have a parent endpoint" );
-                }
-
-                if ($endpoint->getService() != $service) {
-                    $id = $prop->getId ();
-                    throw new \Exception (
-                        "Property {$id} does not belong to an endpoint of the specified service"
-                    );
-                }
-
-                // Endoint is the owning side so remove elements from endpoint.
-                $endpoint->getEndpointProperties ()->removeElement ( $prop );
-                // Once relationship is removed delete the actual element
-                $this->em->remove ( $prop );
+            // check endpoint property has a parent endpoint
+            $endpoint = $prop->getParentEndpoint ();
+            if ($endpoint == null) {
+                $id = $prop->getId ();
+                throw new \Exception ( "Property {$id} does not have a parent endpoint" );
             }
-            $this->em->flush ();
-            $this->em->getConnection ()->commit ();
-        } catch ( \Exception $e ) {
-            $this->em->getConnection ()->rollback ();
-            $this->em->close ();
-            throw $e;
+
+            if ($endpoint->getService() != $service) {
+                $id = $prop->getId ();
+                throw new \Exception (
+                    "Property {$id} does not belong to an endpoint of the specified service"
+                );
+            }
+
+            // Endoint is the owning side so remove elements from endpoint.
+            $endpoint->getEndpointProperties ()->removeElement ( $prop );
+            // Once relationship is removed delete the actual element
+            $this->em->remove ( $prop );
         }
     }
 
@@ -1309,7 +1306,16 @@ class ServiceService extends AbstractEntityService {
         $this->validateAddEditDeleteActions ( $user, $service );
 
         //Make the change
-        $this->editServicePropertyLogic($service, $prop, $newValues);
+        $this->em->getConnection ()->beginTransaction ();
+        try {
+            $this->editServicePropertyLogic($service, $prop, $newValues);
+            $this->em->flush ();
+            $this->em->getConnection ()->commit ();
+        } catch ( \Exception $ex ) {
+            $this->em->getConnection ()->rollback ();
+            $this->em->close ();
+            throw $ex;
+        }
     }
 
     /**
@@ -1327,25 +1333,16 @@ class ServiceService extends AbstractEntityService {
         $keyname = $newValues ['SERVICEPROPERTIES'] ['NAME'];
         $keyvalue = $newValues ['SERVICEPROPERTIES'] ['VALUE'];
 
-        $this->em->getConnection ()->beginTransaction ();
-        try {
-            // Check that the prop is from the service
-            if ($prop->getParentService () != $service) {
-                $id = $prop->getId ();
-                throw new \Exception ( "Property {$id} does not belong to the specified service" );
-            }
-            // Set the service propertys new member variables
-            $prop->setKeyName ( $keyname );
-            $prop->setKeyValue ( $keyvalue );
-
-            $this->em->merge ( $prop );
-            $this->em->flush ();
-            $this->em->getConnection ()->commit ();
-        } catch ( \Exception $ex ) {
-            $this->em->getConnection ()->rollback ();
-            $this->em->close ();
-            throw $ex;
+        // Check that the prop is from the service
+        if ($prop->getParentService () != $service) {
+            $id = $prop->getId ();
+            throw new \Exception ( "Property {$id} does not belong to the specified service" );
         }
+        // Set the service propertys new member variables
+        $prop->setKeyName ( $keyname );
+        $prop->setKeyValue ( $keyvalue );
+
+        $this->em->merge ( $prop );
     }
 
     /**
@@ -1368,7 +1365,16 @@ class ServiceService extends AbstractEntityService {
         $this->validateAddEditDeleteActions ($user, $service);
 
         //Make the change
-        $this->editEndpointPropertyLogic($service, $prop, $newValues);
+        $this->em->getConnection ()->beginTransaction ();
+        try {
+            $this->editEndpointPropertyLogic($service, $prop, $newValues);
+            $this->em->flush ();
+            $this->em->getConnection ()->commit ();
+        } catch ( \Exception $ex ) {
+            $this->em->getConnection ()->rollback ();
+            $this->em->close ();
+            throw $ex;
+        }
     }
 
     /**
@@ -1387,26 +1393,17 @@ class ServiceService extends AbstractEntityService {
         $keyname = $newValues ['ENDPOINTPROPERTIES'] ['NAME'];
         $keyvalue = $newValues ['ENDPOINTPROPERTIES'] ['VALUE'];
 
-        $this->em->getConnection ()->beginTransaction ();
-        try {
-            // Check that the prop is from the endpoint
-            if ($prop->getParentEndpoint ()->getService () != $service) {
-                $id = $prop->getId ();
-                throw new \Exception ( "Property {$id} does not belong to the specified service endpoint" );
-            }
-
-            // Set the endpoints propertys new member variables
-            $prop->setKeyName ( $keyname );
-            $prop->setKeyValue ( $keyvalue );
-
-            $this->em->merge ( $prop );
-            $this->em->flush ();
-            $this->em->getConnection ()->commit ();
-        } catch ( \Exception $ex ) {
-            $this->em->getConnection ()->rollback ();
-            $this->em->close ();
-            throw $ex;
+        // Check that the prop is from the endpoint
+        if ($prop->getParentEndpoint ()->getService () != $service) {
+            $id = $prop->getId ();
+            throw new \Exception ( "Property {$id} does not belong to the specified service endpoint" );
         }
+
+        // Set the endpoints propertys new member variables
+        $prop->setKeyName ( $keyname );
+        $prop->setKeyValue ( $keyvalue );
+
+        $this->em->merge ( $prop );
     }
 
     /**


### PR DESCRIPTION
* Add constraints to the schema so that keys of custom Properties are unique to each entity.
* Re-factors the code for sites, service and endpoints to abstract out the transactional logic
* Updates the front-end to reflect this as well as changing the edit functions so that the values of existing keys can, optionally, be overwritten.