### PR TITLE
Fix bugs from case sensitivity in write API

### DIFF
--- a/htdocs/PI/write/class.php
+++ b/htdocs/PI/write/class.php
@@ -21,8 +21,8 @@
 /*====================================================== */
 namespace org\gocdb\services;
 
-require_once __DIR__ . '/../../../lib/Gocdb_Services/config.php';
-require_once __DIR__ . '/../../../lib/Gocdb_Services/validate.php';
+require_once __DIR__ . '/../../../lib/Gocdb_Services/Config.php';
+require_once __DIR__ . '/../../../lib/Gocdb_Services/Validate.php';
 require_once __DIR__ . '/../../../lib/Doctrine/bootstrap.php';
 require_once __DIR__ . '/../../web_portal/components/Get_User_Principle.php';
 require_once __DIR__ . '/../../../lib/Gocdb_Services/Factory.php';


### PR DESCRIPTION
A pair of include statements in the write API class break due to case
sensitivity. This was not noticed soone because the development
envireoment did not have case sensitive file paths.