### PR TITLE
Make the FedCloud scope reserved

### DIFF
--- a/config/local_info.xml
+++ b/config/local_info.xml
@@ -91,6 +91,7 @@
             <scope>cms</scope>
             <scope>lhcb</scope>
             <scope>elixir</scope>
+            <scope>FedCloud</scope>
         </reserved_scopes>
 
         <!-- Define the max amount of extensions a user can define when using the extensions feature -->


### PR DESCRIPTION
Marks the FedCloud as reserved in the local_info.xml config file.