### PR TITLE
Provide a configuration for travis to run unit tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: php
+before_script: .travis/setup
+script: vendor/bin/phpunit tests/DoctrineTestSuite1.php
+php:
+  - '5.3'
+env:
+  - DB=sqlite

--- a/.travis/setup
+++ b/.travis/setup
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+composer install
+
+doctrine="$PWD/vendor/bin/doctrine"
+
+if [[ -n "$DB" ]]; then
+    echo "Configuring unit tests for a $DB database"
+    cp .travis/${DB}_bootstrap_doctrine.php tests/doctrine/bootstrap_doctrine.php
+    cp .travis/${DB}_bootstrap_pdo.php tests/doctrine/bootstrap_pdo.php
+
+    cd tests/doctrine
+    $doctrine orm:schema-tool:create
+else
+    echo 'Cannot setup unit tests, $DB is not defined.'
+    exit 1
+fi

--- a/.travis/sqlite_bootstrap_doctrine.php
+++ b/.travis/sqlite_bootstrap_doctrine.php
@@ -1,0 +1,22 @@
+<?php
+// bootstrap_doctrine.php
+
+// See :doc:`Configuration <../reference/configuration>` for up to date autoloading details.
+use Doctrine\ORM\Tools\Setup;
+use Doctrine\Common\EventManager;
+use Doctrine\DBAL\Event\Listeners\OracleSessionInit;
+
+require_once  __DIR__."/../../vendor/autoload.php";
+
+// Create a simple "default" Doctrine ORM configuration for XML Mapping
+$isDevMode = true;
+$config = Setup::createAnnotationMetadataConfiguration(array(__DIR__."/../../lib/Doctrine/entities"), $isDevMode);
+
+$conn = array(
+    'driver' => 'pdo_sqlite',
+    'path' => '/tmp/gocdb.sqlite',
+);
+
+$evm = new EventManager();
+
+$entityManager = \Doctrine\ORM\EntityManager::create($conn, $config, $evm);

--- a/.travis/sqlite_bootstrap_pdo.php
+++ b/.travis/sqlite_bootstrap_pdo.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * Provides a connection to the test database. Copy this file and rename it
+ * to 'bootstrap_pdo.php' in the same directory.
+ * The DBUnit tests then require these methods to get a connection to the
+ * test db.
+ *
+ * @author David Meredith
+ */
+
+/**
+ * Returns the database connection to your test databse.
+ * Modify as required to return a connection to your test db.
+ * @return PHPUnit_Extensions_Database_DB_IDatabaseConnection
+ */
+function getConnectionToTestDB() {
+     $sqliteFile = '/tmp/gocdb.sqlite';
+     $pdo = new PDO("sqlite:" . $sqliteFile);
+     return new PHPUnit_Extensions_Database_DB_DefaultDatabaseConnection($pdo, 'sqlite');
+}
+
+?>


### PR DESCRIPTION
Add a self-contained bootstrap configuration and setup script under `.travis/` that can be run in a CI environment

Currently runs tests using PHP 5.3 against a sqlite database backend, but this can be extended to a larger build matrix in `.travis.yml` by:
* Adding more versions of PHP to the `php` list.
* Adding more DB entries to the `env` list with matching bootstrap configs.