### PR TITLE
Correct capitalisation of table names in unit tests

### DIFF
--- a/lib/Doctrine/entities/NGI.php
+++ b/lib/Doctrine/entities/NGI.php
@@ -66,7 +66,7 @@ class NGI extends OwnedEntity implements IScopedEntity {
      * Unidirectional - Scope tags associated with the NGI
      *
      * @ManyToMany(targetEntity="Scope")
-     * @JoinTable(name="Ngis_Scopes",
+     * @JoinTable(name="NGIs_Scopes",
      *      joinColumns={@JoinColumn(name="ngi_Id", referencedColumnName="id")},
      *      inverseJoinColumns={@JoinColumn(name="scope_Id", referencedColumnName="id")}
      *      )

--- a/tests/doctrine/DoctrineCleanInsert1Test.php
+++ b/tests/doctrine/DoctrineCleanInsert1Test.php
@@ -368,11 +368,11 @@ class DoctrineCleanInsert1Test extends PHPUnit_Extensions_Database_TestCase {
 
         $testConn = $this->getConnection();
         $result = $testConn->createQueryTable('results_table',
-                "SELECT sites.id FROM sites
-                    inner join sites_scopes
-                    on sites.id = sites_scopes.site_id
-                    inner join scopes
-                    on scopes.id = sites_scopes.scope_id");
+                "SELECT Sites.id FROM Sites
+                    inner join Sites_Scopes
+                    on Sites.id = Sites_Scopes.site_id
+                    inner join Scopes
+                    on Scopes.id = Sites_Scopes.scope_id");
         $this->assertTrue($result->getRowCount() == $n);
     }
 

--- a/tests/doctrine/ServiceMoveTest.php
+++ b/tests/doctrine/ServiceMoveTest.php
@@ -157,12 +157,12 @@ class ServiceMoveTest extends PHPUnit_Extensions_Database_TestCase {
              * Check both that each Site is present and that the ID matches the doctrine one
              */
             $S1_ID = $S1->getId();
-            $sql = "SELECT 1 FROM sites WHERE shortname = 'Site1' AND ID = '$S1_ID'";
+            $sql = "SELECT 1 FROM Sites WHERE shortname = 'Site1' AND ID = '$S1_ID'";
             $result = $con->createQueryTable('', $sql);
             $this->assertEquals(1, $result->getRowCount());
 
             $S2_ID = $S2->getId();
-            $sql = "SELECT 1 FROM sites WHERE shortname = 'Site2' AND ID = '$S2_ID'";
+            $sql = "SELECT 1 FROM Sites WHERE shortname = 'Site2' AND ID = '$S2_ID'";
             $result = $con->createQueryTable('', $sql);
             $this->assertEquals(1, $result->getRowCount());
 
@@ -170,17 +170,17 @@ class ServiceMoveTest extends PHPUnit_Extensions_Database_TestCase {
              * Check each service endpoint is: present, has the right ID & parent Site
              */
             $SE1_id= $SE1->getId();
-            $sql = "SELECT 1 FROM services WHERE hostname = 'SEP1' AND ID = '$SE1_id' AND PARENTSITE_ID = '$S1_ID'";
+            $sql = "SELECT 1 FROM Services WHERE hostname = 'SEP1' AND ID = '$SE1_id' AND PARENTSITE_ID = '$S1_ID'";
             $result = $con->createQueryTable('', $sql);
             $this->assertEquals(1, $result->getRowCount());
 
             $SE2_id= $SE2->getId();
-            $sql = "SELECT 1 FROM services WHERE hostname = 'SEP2' AND ID = '$SE2_id' AND PARENTSITE_ID = '$S2_ID'";
+            $sql = "SELECT 1 FROM Services WHERE hostname = 'SEP2' AND ID = '$SE2_id' AND PARENTSITE_ID = '$S2_ID'";
             $result = $con->createQueryTable('', $sql);
             $this->assertEquals(1, $result->getRowCount());
 
             $SE3_id= $SE3->getId();
-            $sql = "SELECT 1 FROM services WHERE hostname = 'SEP3' AND ID = '$SE3_id' AND PARENTSITE_ID = '$S2_ID'";
+            $sql = "SELECT 1 FROM Services WHERE hostname = 'SEP3' AND ID = '$SE3_id' AND PARENTSITE_ID = '$S2_ID'";
             $result = $con->createQueryTable('', $sql);
             $this->assertEquals(1, $result->getRowCount());
 
@@ -220,39 +220,39 @@ class ServiceMoveTest extends PHPUnit_Extensions_Database_TestCase {
             $con = $this->getConnection();
 
             //Check Sites are still present and their ID is unchanged
-            $sql = "SELECT 1 FROM sites WHERE shortname = 'Site1' AND ID = '$S1_ID'";
+            $sql = "SELECT 1 FROM Sites WHERE shortname = 'Site1' AND ID = '$S1_ID'";
             $result = $con->createQueryTable('', $sql);
             $this->assertEquals(1, $result->getRowCount());
 
-            $sql = "SELECT 1 FROM sites WHERE shortname = 'Site2' AND ID = '$S2_ID'";
+            $sql = "SELECT 1 FROM Sites WHERE shortname = 'Site2' AND ID = '$S2_ID'";
             $result = $con->createQueryTable('', $sql);
             $this->assertEquals(1, $result->getRowCount());
 
 
             //Check each Site has the correct number of service endpoints
                 //Site 1
-                $sql = "SELECT 1 FROM services WHERE parentsite_id = '$S1_ID'";
+                $sql = "SELECT 1 FROM Services WHERE parentsite_id = '$S1_ID'";
                 $result = $con->createQueryTable('', $sql);
                 $this->assertEquals(1, $result->getRowCount());
 
                 //Site 2
-                $sql = "SELECT 1 FROM services WHERE parentsite_id = '$S2_ID'";
+                $sql = "SELECT 1 FROM Services WHERE parentsite_id = '$S2_ID'";
                 $result = $con->createQueryTable('', $sql);
                 $this->assertEquals(2, $result->getRowCount());
 
             //check Site IDs are unchanged and they are assigned to the correct NGI
                 //Site 1
-                $sql = "SELECT 1 FROM services WHERE hostname = 'SEP1' AND id = '$SE1_id' AND parentsite_id = '$S2_ID'";
+                $sql = "SELECT 1 FROM Services WHERE hostname = 'SEP1' AND id = '$SE1_id' AND parentsite_id = '$S2_ID'";
                 $result = $con->createQueryTable('', $sql);
                 $this->assertEquals(1, $result->getRowCount());
 
                 //Site 2
-                $sql = "SELECT 1 FROM services WHERE hostname = 'SEP2' AND id = '$SE2_id' AND parentsite_id = '$S1_ID'";
+                $sql = "SELECT 1 FROM Services WHERE hostname = 'SEP2' AND id = '$SE2_id' AND parentsite_id = '$S1_ID'";
                 $result = $con->createQueryTable('', $sql);
                 $this->assertEquals(1, $result->getRowCount());
 
                 //Site 3
-                $sql = "SELECT 1 FROM services WHERE hostname = 'SEP3' AND id = '$SE3_id' AND parentsite_id = '$S2_ID'";
+                $sql = "SELECT 1 FROM Services WHERE hostname = 'SEP3' AND id = '$SE3_id' AND parentsite_id = '$S2_ID'";
                 $result = $con->createQueryTable('', $sql);
                 $this->assertEquals(1, $result->getRowCount());
 

--- a/tests/doctrine/SiteMoveTest.php
+++ b/tests/doctrine/SiteMoveTest.php
@@ -166,12 +166,12 @@ class SiteMoveTest extends PHPUnit_Extensions_Database_TestCase {
              * Check both that each NGI is present and that the ID matches the doctrine one
              */
             $N1_ID = $N1->getId();
-            $sql = "SELECT 1 FROM ngis WHERE name = 'NGI1' AND ID = '$N1_ID'";
+            $sql = "SELECT 1 FROM NGIs WHERE name = 'NGI1' AND ID = '$N1_ID'";
             $result = $con->createQueryTable('', $sql);
             $this->assertEquals(1, $result->getRowCount());
 
             $N2_ID = $N2->getId();
-            $sql = "SELECT 1 FROM ngis WHERE name = 'NGI2' AND ID = '$N2_ID'";
+            $sql = "SELECT 1 FROM NGIs WHERE name = 'NGI2' AND ID = '$N2_ID'";
             $result = $con->createQueryTable('', $sql);
             $this->assertEquals(1, $result->getRowCount());
 
@@ -179,22 +179,22 @@ class SiteMoveTest extends PHPUnit_Extensions_Database_TestCase {
              * Check each site is: present, has the right ID & parent NGI
              */
             $S1_id= $S1->getId();
-            $sql = "SELECT 1 FROM sites WHERE shortname = 'Site1' AND ID = '$S1_id' AND NGI_ID = '$N1_ID'";
+            $sql = "SELECT 1 FROM Sites WHERE shortname = 'Site1' AND ID = '$S1_id' AND NGI_ID = '$N1_ID'";
             $result = $con->createQueryTable('', $sql);
             $this->assertEquals(1, $result->getRowCount());
 
             $S2_id= $S2->getId();
-            $sql = "SELECT 1 FROM sites WHERE shortname = 'Site2' AND ID = '$S2_id' AND NGI_ID = '$N2_ID'";
+            $sql = "SELECT 1 FROM Sites WHERE shortname = 'Site2' AND ID = '$S2_id' AND NGI_ID = '$N2_ID'";
             $result = $con->createQueryTable('', $sql);
             $this->assertEquals(1, $result->getRowCount());
 
             $S3_id= $S3->getId();
-            $sql = "SELECT 1 FROM sites WHERE shortname = 'Site3' AND ID = '$S3_id' AND NGI_ID = '$N2_ID'";
+            $sql = "SELECT 1 FROM Sites WHERE shortname = 'Site3' AND ID = '$S3_id' AND NGI_ID = '$N2_ID'";
             $result = $con->createQueryTable('', $sql);
             $this->assertEquals(1, $result->getRowCount());
 
             //Check the SEP has correct id and Site
-            $sql = "SELECT 1 FROM services WHERE hostname = 'SEP1' AND parentsite_id = '$S1_id'";
+            $sql = "SELECT 1 FROM Services WHERE hostname = 'SEP1' AND parentsite_id = '$S1_id'";
             $result = $con->createQueryTable('', $sql);
             $this->assertEquals(1, $result->getRowCount());
 
@@ -235,39 +235,39 @@ class SiteMoveTest extends PHPUnit_Extensions_Database_TestCase {
             $con = $this->getConnection();
 
             //Check NGIs are still present and their ID is unchanged
-            $sql = "SELECT 1 FROM ngis WHERE name = 'NGI1' AND ID = '$N1_ID'";
+            $sql = "SELECT 1 FROM NGIs WHERE name = 'NGI1' AND ID = '$N1_ID'";
             $result = $con->createQueryTable('', $sql);
             $this->assertEquals(1, $result->getRowCount());
 
-            $sql = "SELECT 1 FROM ngis WHERE name = 'NGI2' AND ID = '$N2_ID'";
+            $sql = "SELECT 1 FROM NGIs WHERE name = 'NGI2' AND ID = '$N2_ID'";
             $result = $con->createQueryTable('', $sql);
             $this->assertEquals(1, $result->getRowCount());
 
 
             //Check each NGI has the correct number of sites
                 //NGI1
-                $sql = "SELECT 1 FROM sites WHERE NGI_ID = '$N1_ID'";
+                $sql = "SELECT 1 FROM Sites WHERE NGI_ID = '$N1_ID'";
                 $result = $con->createQueryTable('', $sql);
                 $this->assertEquals(1, $result->getRowCount());
 
                 //NGI2
-                $sql = "SELECT 1 FROM sites WHERE NGI_ID = '$N2_ID'";
+                $sql = "SELECT 1 FROM Sites WHERE NGI_ID = '$N2_ID'";
                 $result = $con->createQueryTable('', $sql);
                 $this->assertEquals(2, $result->getRowCount());
 
             //check Site IDs are unchanged and they are assigned to the correct NGI
                 //Site 1
-                $sql = "SELECT 1 FROM sites WHERE shortname = 'Site1' AND ID = '$S1_id' AND NGI_ID = '$N2_ID'";
+                $sql = "SELECT 1 FROM Sites WHERE shortname = 'Site1' AND ID = '$S1_id' AND NGI_ID = '$N2_ID'";
                 $result = $con->createQueryTable('', $sql);
                 $this->assertEquals(1, $result->getRowCount());
 
                 //Site 2
-                $sql = "SELECT 1 FROM sites WHERE shortname = 'Site2' AND ID = '$S2_id' AND NGI_ID = '$N1_ID'";
+                $sql = "SELECT 1 FROM Sites WHERE shortname = 'Site2' AND ID = '$S2_id' AND NGI_ID = '$N1_ID'";
                 $result = $con->createQueryTable('', $sql);
                 $this->assertEquals(1, $result->getRowCount());
 
                 //Site 3
-                $sql = "SELECT 1 FROM sites WHERE shortname = 'Site3' AND ID = '$S3_id' AND NGI_ID = '$N2_ID'";
+                $sql = "SELECT 1 FROM Sites WHERE shortname = 'Site3' AND ID = '$S3_id' AND NGI_ID = '$N2_ID'";
                 $result = $con->createQueryTable('', $sql);
                 $this->assertEquals(1, $result->getRowCount());
 

--- a/tests/doctrine/resources/sampleFixtureData2.php
+++ b/tests/doctrine/resources/sampleFixtureData2.php
@@ -184,7 +184,7 @@
         $result = $testConn->createQueryTable('results_table', "SELECT * FROM Scopes");
         $this->assertTrue($result->getRowCount() == $scopeCount);
 
-        $result = $testConn->createQueryTable('results_table', "SELECT * FROM Ngis");
+        $result = $testConn->createQueryTable('results_table', "SELECT * FROM NGIs");
         $this->assertTrue($result->getRowCount() == 5);
 
         $result = $testConn->createQueryTable('results_table', "SELECT * FROM Sites");


### PR DESCRIPTION
As MySQL tables are files on disk, MySQL follows the  case-sensitivity of the Operating System,
so tests using mangled capitalisation fail.

These may have been missed before as Oracle and MySQL on Windows are case-insensitive.

This corrects the capitalisation to match that generated by Doctrine.