### PR TITLE
Add Precise MySQL Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+# N.B. Ubuntu Precise available on Travis until March 2018
+dist: precise
+sudo: required
 language: php
 before_install:
     - mysql -e 'CREATE DATABASE doctrine;'
@@ -13,6 +16,15 @@ env:
     - DB=sqlite
     - DB=mysql
 matrix:
+    include:
+    - dist: trusty
+      sudo: false
+      env: DB=mysql
+      php: '5.4'
+    - dist: trusty
+      sudo: false
+      env: DB=mysql
+      php: '5.5'
     allow_failures:
     - env: DB=sqlite
     fast_finish: true


### PR DESCRIPTION
- Add Precise MySQL builds to Travis config which should enable PHP 5.3 tests to work.
- Allow Trusty PHP 5.3 build to fail as this combination is no longer supported.