### PR TITLE
Always produce a table body even when empty

### DIFF
--- a/htdocs/web_portal/views/site/view_site.php
+++ b/htdocs/web_portal/views/site/view_site.php
@@ -513,6 +513,7 @@ $extensionProperties = $site->getSiteProperties();
             <th>To</th>
         </tr>
         </thead>
+        <tbody>
         <?php
         //$num = 2;
         foreach ($downtimes as $dt) {
@@ -531,6 +532,7 @@ $extensionProperties = $site->getSiteProperties();
         //if ($num == 1) { $num = 2; } else { $num = 1; }
         }
         ?>
+        </tbody>
         </table>
 
     <!--  only show this link if we're in read / write mode -->


### PR DESCRIPTION
Without the empty tbody the tablesorter plugin will crash and break sorting on all tables on the page.

Don't think about it too hard, too too hard.
It's a mobius strip...