### PR TITLE
Fix host dn regexp

### DIFF
--- a/config/gocdb_schema.xml
+++ b/config/gocdb_schema.xml
@@ -140,7 +140,7 @@
 	<field>
 	    <fname>HOST_DN</fname>
 	    <length>255</length>
-	    <regex>/^(\/[a-zA-Z]+=[a-zA-Z0-9\-\_\s\.@,'\/\)\(]+)+$/</regex>
+	    <regex>/^(\/[a-zA-Z]+=[a-zA-Z0-9\-\_\s\.@,'\/\)\(]+)*$/</regex>
 	</field>
 	<field>
 	    <fname>HOST_OS</fname>

--- a/config/gocdb_schema.xml
+++ b/config/gocdb_schema.xml
@@ -140,7 +140,7 @@
 	<field>
 	    <fname>HOST_DN</fname>
 	    <length>255</length>
-	    <regex>/^(\/[A-Za-z]+=[a-zA-Z0-9\/\-\_\s\.,'@\/]+)*$/</regex>
+      <regex>/^(\/[a-zA-Z]+=[a-zA-Z0-9\-\_\s\.@,'\/\)\(]+)+$/</regex>
 	</field>
 	<field>
 	    <fname>HOST_OS</fname>

--- a/config/gocdb_schema.xml
+++ b/config/gocdb_schema.xml
@@ -140,7 +140,7 @@
 	<field>
 	    <fname>HOST_DN</fname>
 	    <length>255</length>
-      <regex>/^(\/[a-zA-Z]+=[a-zA-Z0-9\-\_\s\.@,'\/\)\(]+)+$/</regex>
+	    <regex>/^(\/[a-zA-Z]+=[a-zA-Z0-9\-\_\s\.@,'\/\)\(]+)+$/</regex>
 	</field>
 	<field>
 	    <fname>HOST_OS</fname>


### PR DESCRIPTION
Resolves #110 

Copied existing regexp for user certificate dn (which is commented out but includes bracket characters) to be used for the host dn.