### PR TITLE
Fix typo in user 'not authenticated' error message

### DIFF
--- a/htdocs/web_portal/index.php
+++ b/htdocs/web_portal/index.php
@@ -64,7 +64,7 @@ function rejectIfNotAuthenticated($message = null){
     if(empty($authPrincipleStr)){
         // prob better to do a re-direct here to error page.
         if($message == null){
-            die('Access Denined, authentication failed - A valid user certificate was not found');
+            die('Access Denied, authentication failed - A valid user certificate was not found');
             //or your EGI SSO user account is not associated with a valid certificate.');
         } else {
             die($message);


### PR DESCRIPTION
- Change: "Denined" to "Denied"