### PR TITLE
Recalculate timezone offsets if site is changed

### DIFF
--- a/htdocs/web_portal/views/downtime/add_downtime.php
+++ b/htdocs/web_portal/views/downtime/add_downtime.php
@@ -215,6 +215,7 @@ rather than the Site entities themselves, and specify tz, offset in the DTO/JSON
 
        // Add the jQuery form change event handlers
        $("#addDTForm").find(":input").change(function(){
+           updateStartEndTimesInUtc();
            validate();
        });
 


### PR DESCRIPTION
Otherwise the first site selected or UTC is used, despite what the page may imply.

Fixes #100 :tada: :balloon: :fireworks: