### PR TITLE
mariadb stores table Ngis_Scopes

### DIFF
--- a/lib/Doctrine/entities/NGI.php
+++ b/lib/Doctrine/entities/NGI.php
@@ -66,7 +66,7 @@ class NGI extends OwnedEntity implements IScopedEntity {
      * Unidirectional - Scope tags associated with the NGI
      *
      * @ManyToMany(targetEntity="Scope")
-     * @JoinTable(name="NGIs_Scopes",
+     * @JoinTable(name="Ngis_Scopes",
      *      joinColumns={@JoinColumn(name="ngi_Id", referencedColumnName="id")},
      *      inverseJoinColumns={@JoinColumn(name="scope_Id", referencedColumnName="id")}
      *      )


### PR DESCRIPTION
After updating to the latest version i got an error for the table `NGIs_Scopes` as non existing, although the table is created in the DB with a lower case name `Ngis_Scopes`
```
An exception occurred while executing 'SELECT o0_.id AS id0, n1_.name AS name1, n1_.email AS email2, n1_.rodEmail AS rodEmail3, n1_.helpdeskEmail AS helpdeskEmail4, n1_.securityEmail AS securityEmail5, n1_.description AS description6, n1_.ggus_Su AS ggus_Su7, n1_.creationDate AS creationDate8, s2_.id AS id9, s2_.name AS name10, s2_.description AS description11, o0_.discr AS discr12 FROM NGIs n1_ INNER JOIN OwnedEntities o0_ ON n1_.id = o0_.id LEFT JOIN NGIs_Scopes n3_ ON n1_.id = n3_.ngi_Id LEFT JOIN Scopes s2_ ON s2_.id = n3_.scope_Id ORDER BY n1_.name ASC': SQLSTATE[42S02]: Base table or view not found: 1146 Table 'GOCDB5.NGIs_Scopes' doesn't exist
```