### PR TITLE
Enable ShibAuthToken authentication by default

### DIFF
--- a/lib/Authentication/MyConfig1.php
+++ b/lib/Authentication/MyConfig1.php
@@ -35,7 +35,7 @@ class MyConfig1 implements IConfigFirewallComponent {
 
        $this->tokenClassList = array();
        $this->tokenClassList[] = 'org\gocdb\security\authentication\X509AuthenticationToken';
-       //$this->tokenClassList[] = 'org\gocdb\security\authentication\ShibAuthToken';
+       $this->tokenClassList[] = 'org\gocdb\security\authentication\ShibAuthToken';
        //$this->tokenClassList[] = 'org\gocdb\security\authentication\SimpleSamlPhpAuthToken';
        //$this->tokenClassList[] = 'org\gocdb\security\authentication\UsernamePasswordAuthenticationToken';
     }


### PR DESCRIPTION
- it is enabled by uncommenting this line on the production instance
  anyway and this change should be merged into the main codebase
  to make deployment easier.