### PR TITLE
Exclude deleted files from PHP lint checks

### DIFF
--- a/.travis/run_tests.sh
+++ b/.travis/run_tests.sh
@@ -4,7 +4,7 @@ if [[ $TRAVIS ]]; then
     cd "$TRAVIS_BUILD_DIR" || exit 2
 
     # Check modified PHP files with PHP's internal syntax checker
-    git diff --name-only HEAD^ | grep '\.php$' | xargs -r -n 1 php -l || exit 1
+    git diff --name-only --diff-filter=ACMRTUXB HEAD^ | grep '\.php$' | xargs -r -n 1 php -l || exit 1
 
     # Run test suite
     vendor/bin/phpunit tests/DoctrineTestSuite1.php


### PR DESCRIPTION
Otherwise tests will fail, which will make us sad.