### PR TITLE
Modified scope handling.

### DIFF
--- a/config/gocdb_schema.xml
+++ b/config/gocdb_schema.xml
@@ -442,6 +442,11 @@
 	    <!--<regex>/^[a-zA-Z0-9\-\._\(\)\[\],;+:\/'"\s]*$/</regex>-->
 	    <regex>/^[^`'\";&lt;&gt;]+$/</regex>
 	</field>
+  <field>
+    <fname>RESERVED</fname>
+    <length>1</length>
+    <regex>/^[01]$/</regex>
+  </field>
     </entity>
     <!-- ==========================================================  -->
     <entity>

--- a/config/local_info.xml
+++ b/config/local_info.xml
@@ -83,33 +83,6 @@
       <service_group>1</service_group>
     </minimum_scopes>
 
-    <!--
-        Specify a list of RESERVED scope tag names:
-        - New Reserved tags can only be directly assigned to resources by the gocdb-admins
-         (resources include NGIs, Sites, Services, SGs but not Projects - don't currently need to tag projects)
-        - When creating a new child resource (e.g. a child Site or child Service),
-          the scopes that are assigned to the parent are automatically inherited and assigned to the child.
-        - Reserved tags assigned to a resource are optional.
-        - Users can reapply Reserved tags to a resource ONLY if the tag can be
-          inherited from the parent ScopedEntity (parents include NGIs/Sites).
-        - For Sites: If a Reserved tag is removed from a Site, then the same tag is also removed
-          from all the child services - a Service can't have a reserved tag that
-          is not supported by its parent Site.
-        - For NGIs: If a Reserved tag is removed from an NGI, then the same tag is NOT
-          removed from all the child Sites - this is intentionally different from the Site->Service relationship.
-        -->
-    <reserved_scopes>
-      <scope>wlcg</scope>
-      <scope>tier1</scope>
-      <scope>tier2</scope>
-      <scope>alice</scope>
-      <scope>atlas</scope>
-      <scope>cms</scope>
-      <scope>lhcb</scope>
-      <scope>elixir</scope>
-      <scope>FedCloud</scope>
-    </reserved_scopes>
-
     <!-- Define the max amount of extensions a user can define when using the extensions feature -->
     <extensions>
       <max>20</max>

--- a/htdocs/web_portal/controllers/admin/edit_scope.php
+++ b/htdocs/web_portal/controllers/admin/edit_scope.php
@@ -57,7 +57,8 @@ function draw() {
 
     $params = array('Name' => $scope->getName(),
                     'Id' => $scope->getId(),
-                    'Description' => $scope->getDescription());
+                    'Description' => $scope->getDescription(),
+                    'Reserved' => $scope->getReserved());
 
     //show the add service type view
     show_view("admin/edit_scope.php", $params, "Edit Scope");
@@ -83,12 +84,13 @@ function submit() {
     $user = \Factory::getUserService()->getUserByPrinciple($dn);
 
     try {
-        //function will through error if user does not have the correct permissions
+        //function will throw an error if user does not have the correct permissions
         $scope = $serv->editScope($scope, $values, $user);
         $params = array('Name' => $scope->getName(),
                         'ID'=> $scope->getId(),
-                        'Description' => $scope->getDescription());
-        show_view("admin/edited_scope.php", $params, $params['Name']. " succesffully updated");
+                        'Description' => $scope->getDescription(),
+                        'Reserved' => $scope->getReserved());
+        show_view("admin/edited_scope.php", $params, $params['Name']. " successfully updated");
     } catch (Exception $e) {
          show_view('error.php', $e->getMessage());
          die();

--- a/htdocs/web_portal/controllers/scope.php
+++ b/htdocs/web_portal/controllers/scope.php
@@ -40,6 +40,7 @@ function view_scope() {
     $params['Name'] = $scope->getName();
     $params['Description'] = $scope->getDescription();
     $params['ID'] = $scope->getId();
+    $params['Reserved'] = $scope->getReserved();
     $params['NGIs'] = $serv->getNgisFromScope($scope);
     $params['Sites'] = $serv->getSitesFromScope($scope);
     $params['ServiceGroups'] = $serv->getServiceGroupsFromScope($scope);

--- a/htdocs/web_portal/controllers/utils.php
+++ b/htdocs/web_portal/controllers/utils.php
@@ -113,7 +113,7 @@ function getEntityScopesAsJSON2($targetScopedEntity = null, $parentScopedEntity 
         $parentScopes = $parentScopedEntity->getScopes()->toArray();
     }
 
-    $reservedScopeNames = \Factory::getConfigService()->getReservedScopeList();
+    // $reservedScopeNames = \Factory::getConfigService()->getReservedScopeList();
     $allScopes = \Factory::getScopeService()->getScopes();
     $optionalScopeIds = array();
     $reservedOptionalScopeIds = array();
@@ -139,7 +139,7 @@ function getEntityScopesAsJSON2($targetScopedEntity = null, $parentScopedEntity 
         }
 
         // Is scope tag in the reserved list ?
-        if(in_array($scope->getName(), $reservedScopeNames)){
+        if($scope->getReserved()){
             // A reserved scope tag:
             if($parentChecked || $targetChecked){
                 if($parentChecked){
@@ -656,6 +656,10 @@ function getDateFormat() {
 function getScopeDataFromWeb() {
     $scopeData ['Name'] = trim($_REQUEST ['Name']);
     $scopeData ['Description'] = trim($_REQUEST ['Description']);
+    // 'Reserved' value is a checkbox ==>> absent if not checked
+    if (array_key_exists('Reserved', $_REQUEST)){
+      $scopeData ['Reserved'] = ($_REQUEST ['Reserved'] == '1');
+    }
     if (array_key_exists('Id', $_REQUEST)){
         $scopeData ['Id'] = $_REQUEST ['Id'];
     }

--- a/htdocs/web_portal/css/web_portal.php
+++ b/htdocs/web_portal/css/web_portal.php
@@ -311,14 +311,13 @@ li {
     margin-bottom: 0.3em;
 }
 
-.input_input_text,
-.input_input_date,
-.input_input_check {
-    margin-left: 2em;
+.input_input_checkbox, .input_input_date, .input_input_text {
+    margin-bottom: 1em;
+    margin-left: 2em !important;
 }
 
-.input_input_text,
-.input_input_date {
+
+.input_input_text, .input_input_date {
     width: 90%;
     margin-bottom: 1em;
 }

--- a/htdocs/web_portal/views/admin/add_scope.php
+++ b/htdocs/web_portal/views/admin/add_scope.php
@@ -6,6 +6,8 @@
         <input type="text" value="" name="Name" class="input_input_text">
         <span class="input_name">Description</span>
         <input type="text" value="" name="Description" class="input_input_text">
+        <span class="input_name">Reserved - check to create a reserved scope</span>
+        <input type="checkbox" value="1" <?php echo (($params['Reserved'] == true) ? 'checked' : ''); ?> name="Reserved" class="input_input_checkbox">
         <br />
         <input type="submit" value="Add Scope" class="input_button">
     </form>

--- a/htdocs/web_portal/views/admin/edit_scope.php
+++ b/htdocs/web_portal/views/admin/edit_scope.php
@@ -6,7 +6,8 @@
         <input type="text" value="<?php xecho($params['Name']) ?>" name="Name" class="input_input_text">
         <span class="input_name">Description</span>
         <input type="text" value="<?php xecho($params['Description']) ?>" name="Description" class="input_input_text">
-
+        <span class="input_name">Reserved - check to set scope as Reserved</span>
+        <input type="checkbox" value="1" <?php echo (($params['Reserved'] == true) ? 'checked' : ''); ?> name="Reserved" class="input_input_checkbox"> 
         <br />
         <input class="input_input_hidden" type="hidden" name="Id" value="<?php echo $params['Id'] ?>" />
         <br />

--- a/htdocs/web_portal/views/admin/edited_scope.php
+++ b/htdocs/web_portal/views/admin/edited_scope.php
@@ -1,14 +1,17 @@
 <div class="rightPageContainer">
     <h1 class="Success">Success</h1><br />
     <p>
-       <a href="index.php?Page_Type=Scope&amp;id=<?php echo $params['ID']?>">
-           <?php xecho($params['Name'])?>
-       </a> has been successfully edited as follows:
+        <a href="index.php?Page_Type=Scope&amp;id=<?php echo $params['ID']?>">
+            <?php xecho($params['Name'])?>
+        </a> has been successfully edited as follows:
     </p>
     <p>
         Name: <?php xecho($params['Name'])?>
         <br />
         Description: <?php xecho($params['Description'])?>
+        <br />
+        Reserved scope: <?php xecho(($params['Reserved'] == true) ? 'Yes' : 'No') ?>
+        <br />
     </p>
     <p>
         <a href="index.php?Page_Type=Admin_Edit_Scope&amp;id=<?php echo $params['ID']?>">
@@ -16,5 +19,4 @@
 
     </p>
 </div>
-
 

--- a/htdocs/web_portal/views/scope.php
+++ b/htdocs/web_portal/views/scope.php
@@ -4,6 +4,7 @@ $id = $params['ID'];
 $description = $params['Description'];
 $ngis = $params['NGIs'];
 $ngiCount = count($ngis);
+$reserved = $params['Reserved'];
 $sites = $params['Sites'];
 $siteCount = count($sites);
 $serviceGroups = $params['ServiceGroups'];
@@ -19,6 +20,9 @@ $totalCount = $siteCount + $ngiCount + $serviceCount +$serviceGroupsCount;
     <div style="float: left; width: 50em;">
         <h1 style="float: left; margin-left: 0em;">Scope: <?php echo $name?></h1>
         <span style="clear: both; float: left; padding-bottom: 0.4em;"><?php echo $description ?></span>
+        <span style="clear: both; float: left; padding-bottom: 0.4em;">
+            This scope is <?php echo(($reserved) ? 'reserved' : 'not reserved') ?>.
+        </span>
         <span style="clear: both; float: left; padding-bottom: 0.4em;">
             <?php if($totalCount>0):?>
                 In total, there are <?php if($totalCount==1){echo "is";}else{echo "are";}?>

--- a/htdocs/web_portal/views/scopes.php
+++ b/htdocs/web_portal/views/scopes.php
@@ -149,8 +149,18 @@
                             </span>
                         </div>
                     </td>
-                    <td class="site_table"><?php xecho($scope->getDescription()); ?></td>
-                    <td class="site_table"><?= in_array($scope, $params['reservedScopes']) ? '&check;': '&cross;';?></td>
+                    <td class="site_table" style="width: 60%">
+                        <div style="background-color: inherit;">
+                            <span style="vertical-align: middle;">
+                              <?php xecho($scope->getDescription()); ?>
+                            </span>
+                        </div>
+                    </td>
+                    <td class="site_table" style="width: 10%">
+                      <?php if($scope->getReserved() == 1):?>
+                        <img src="<?php echo \GocContextPath::getPath()?>img/tick.png" height="22px" style="vertical-align: middle;" />
+                      <?php endif ?>
+                    </td>
                     <?php if(!$params['portalIsReadOnly'] && $params['UserIsAdmin']):?>
                         <td class="site_table"  style="width: 10%">
                             <script type="text/javascript" src="<?php echo \GocContextPath::getPath()?>javascript/confirm.js"></script>

--- a/lib/Doctrine/deploy/AddScopes.php
+++ b/lib/Doctrine/deploy/AddScopes.php
@@ -13,12 +13,19 @@ $scopes = simplexml_load_file($scopesFileName);
 foreach($scopes as $scope) {
     $doctrineScope = new Scope();
     $name = "";
+    $reserved = false;
     foreach($scope as $key => $value) {
-        if($key == "name") {
-            $name = (string) $value;
-        }
+      switch ($key) {
+        case "name":
+          $name = (string) $value;
+          break;
+        case "reserved":
+          $reserved = ( $value == 1 );
+          break;
+      }
     }
     $doctrineScope->setName($name);
+    $doctrineScope->setReserved($reserved);
     $entityManager->persist($doctrineScope);
 }
 

--- a/lib/Doctrine/deploy/sampleData/Scopes.xml
+++ b/lib/Doctrine/deploy/sampleData/Scopes.xml
@@ -3,8 +3,14 @@
 <results>
     <tag grid_id="0">
         <name key="primary">Local</name>
+        <reserved>0</reserved>
     </tag>
     <tag grid_id="0">
         <name key="primary">EGI</name>
+        <reserved>0</reserved>
+    </tag>
+    <tag grid_id="0">
+        <name key="primary">wlcg</name>
+        <reserved>1</reserved>
     </tag>
 </results>

--- a/lib/Doctrine/entities/Scope.php
+++ b/lib/Doctrine/entities/Scope.php
@@ -36,6 +36,9 @@ class Scope {
 
     /** @Column(type="string", nullable=true)  */
     protected $description;
+    
+    /** @Column(type="boolean", options={"default": false}) */
+    protected $reserved = false;
 
     /**
      * @return int The PK of this entity or null if not persisted
@@ -59,6 +62,14 @@ class Scope {
     public function getDescription() {
         return $this->description;
     }
+    
+    /**
+     * Get the reserved status of this scope.
+     * @return boolean
+     */
+    public function getReserved() {
+        return $this->reserved;
+    }
 
     /**
      * Set the unique name of this Scope instance.
@@ -75,7 +86,15 @@ class Scope {
     public function setDescription($description) {
         $this->description = $description;
     }
-
+    
+    /**
+     * Set the reserved status of this scope.
+     * @param boolean $reserved
+     */
+    public function setReserved($reserved) {
+        $this->reserved = $reserved;
+    }
+    
     /**
      * Returns the unique name of this Scope instance.
      * @return string

--- a/lib/Gocdb_Services/Config.php
+++ b/lib/Gocdb_Services/Config.php
@@ -411,28 +411,6 @@ class Config {
         return intval($numScopesRequired);
     }
 
-    /**
-     * Get an array of 'reserved' scope strings or an empty array if non are configured.
-     *
-     * <p>
-     * Reserved scopes can only be assiged by gocdb admin (and in future by selected roles);
-     * they can't be freely assigned to resources by their users/owners.
-     *
-     * @return array Reserved scopes as Strings
-     */
-    public function getReservedScopeList() {
-        $reservedScopes = array ();
-        /* @var $reserved_scopes \SimpleXMLElement */
-        $reserved_scopes = $this->GetLocalInfoXML()->reserved_scopes;
-        if ($reserved_scopes != null) {
-            /* @var $scope \SimpleXMLElement */
-            foreach ( $reserved_scopes->children () as $scope ) {
-                $reservedScopes [] = ( string ) $scope;
-            }
-        }
-        return $reservedScopes;
-    }
-
     public function getDefaultFilterByScope () {
 
         if (strtolower($this->GetLocalInfoXML()->default_filter_by_scope) == 'true'){

--- a/lib/Gocdb_Services/Scope.php
+++ b/lib/Gocdb_Services/Scope.php
@@ -91,9 +91,9 @@ class Scope extends AbstractEntityService{
      *       default value listed in the 'local_info.xml' config file</li>
      *   <li>'excludeNonDefault' => boolean (if true exclude scopes that are not default)</li>
      *   <li>'excludeReserved' => boolean (if true, exclude 'reserved' scopes,
-     *      i.e. those that are listed as reserved in the the 'local_info.xml' config file</li>
+     *      i.e. those that are flagged as reserved in the database scopes table</li>
      *   <li>'excludeNonReserved' => boolean (if true, exclude 'normal' scopes,
-     *     i.e. those that are not listed as reserved in the the 'local_info.xml' config file</li>
+     *     i.e. those that are not flagged as reserved in the database scopes table</li>
      * </ul>
      *
      * @param array $filterParams Associative array

--- a/tests/unit/lib/Gocdb_Services/ScopeServiceTest.php
+++ b/tests/unit/lib/Gocdb_Services/ScopeServiceTest.php
@@ -138,9 +138,12 @@ class ScopeServiceTest extends PHPUnit_Extensions_Database_TestCase
     {
         $scopeCount = 10;
         $scopes = array();
-      // create scopes and persist
-        for ($i = 0; $i < $scopeCount; $i++) {
-            $scopes[] = TestUtil::createSampleScope("scope " . $i, "Scope" . $i);
+        // create scopes and persist
+        for($i=0; $i<$scopeCount; $i++){
+            $scopes[] = TestUtil::createSampleScope("scope ".$i, "Scope".$i);
+            if($i <= 3){
+              $scopes[$i]->setReserved(TRUE);
+            }
             $this->em->persist($scopes[$i]);
         }
     }
@@ -178,7 +181,7 @@ class ScopeServiceTest extends PHPUnit_Extensions_Database_TestCase
 
       // exclude all the 'Reserved' scopes
         $filterParams = array('excludeReserved' => true);
-        $excludedScopeNames = $configService->getReservedScopeList();//'Scope0', 'Scope1', 'Scope2', 'Scope3'
+        $excludedScopeNames = array('Scope0', 'Scope1', 'Scope2', 'Scope3');
         $filteredScopes = $scopeService->getScopesFilterByParams($filterParams, null);
         foreach ($filteredScopes as $scope) {
             if (in_array($scope->getName(), $excludedScopeNames)) {


### PR DESCRIPTION
Closes #99.

Moves reserved scopes definition out of the local config xml and into the scopes table in the database as a 'reserved' boolean associated with each scope entry. Addition of consequent changes to the interface to allow those with admin privileges to set/unset the reserved state flag on a scope at creation and if editting.

Would prefer not to use '!important' in web_portal.css which serves to left-align the 'reserved' checkbox correctly under the text entry boxes for name and description in the add/edit scope dialogues. 