### PR TITLE
Fix monitoring checks on SL7 and hopefully future proof

### DIFF
--- a/htdocs/web_portal/GOCDB_monitor/tests.php
+++ b/htdocs/web_portal/GOCDB_monitor/tests.php
@@ -83,12 +83,12 @@ function get_https2($url){
             CURLOPT_HEADER         => false,
             CURLOPT_FOLLOWLOCATION => false,
             CURLOPT_MAXREDIRS      => 1,
-            CURLOPT_SSL_VERIFYHOST => '1',
-            CURLOPT_SSL_VERIFYPEER => '0',
+            CURLOPT_SSL_VERIFYHOST => 2,
+            CURLOPT_SSL_VERIFYPEER => 0,
             CURLOPT_USERAGENT      => 'GOCDB monitor',
             CURLOPT_VERBOSE        => false,
             CURLOPT_URL            => $url,
-            CURLOPT_RETURNTRANSFER => '1',
+            CURLOPT_RETURNTRANSFER => true,
             CURLOPT_CAPATH => '/etc/grid-security/certificates/'
     );
     if( defined('SERVER_SSLCERT') && defined('SERVER_SSLKEY') ){


### PR DESCRIPTION
Resolves #153 

- Change `CURLOPT_SSL_VERIFYHOST` from `'1'` to `2` as `'1'` breaks on SL7 and as per what seems like [totally legit documentation](https://curl.haxx.se/libcurl/c/CURLOPT_SSL_VERIFYHOST.html).
- Change `CURLOPT_SSL_VERIFYPEER` from `'0'` to `0` as per what seems like [totally legit documentation](https://curl.haxx.se/libcurl/c/CURLOPT_SSL_VERIFYPEER.html). Hopefully this avoids similar future<sup>TM</sup> problems.
- Change `CURLOPT_RETURNTRANSFER` from `'1'` to `true`. This seems like it might be a php specific option and https://www.php.net/manual/en/book.curl.php says to set it to `true` not `'1'`. Hopefully this avoids similar future<sup>TM</sup> problems.

I've tested this change on gocdb-test and it doesn't break anything, so huzzah!