### PR TITLE
 Allow "org.squid-cache.Squid" to be production and not monitored and improve handling of these cases

### DIFF
--- a/lib/Gocdb_Services/ServiceService.php
+++ b/lib/Gocdb_Services/ServiceService.php
@@ -511,7 +511,7 @@ class ServiceService extends AbstractEntityService {
         // validate production/monitored combination
         if ($st != 'VOMS' && $st != 'emi.ARGUS' && $st != 'org.squid-cache.Squid') {
             if ($newValues ['PRODUCTION_LEVEL'] == "Y" && $newValues ['IS_MONITORED'] != "Y") {
-                throw new \Exception ( "If Production flat is set to True, Monitored flag must also be True (except for VOMS, emi.ARGUS and org.squid-cache.Squid)" );
+                throw new \Exception ( "For the '".$st."' service type, if the Production flag is set to True, the Monitored flag must also be True." );
             }
         }
 
@@ -831,7 +831,7 @@ class ServiceService extends AbstractEntityService {
         // validate production/monitored combination
         if ($st != 'VOMS' && $st != 'emi.ARGUS' && $st != 'org.squid-cache.Squid') {
             if ($values ['PRODUCTION_LEVEL'] == "Y" && $values ['IS_MONITORED'] != "Y") {
-                throw new \Exception ( "If Production flag is set to True, Monitored flag must also be True (except for VOMS, emi.ARGUS and org.squid-cache.Squid)" );
+                throw new \Exception ( "For the '".$st."' service type, if the Production flag is set to True, the Monitored flag must also be True." );
             }
         }
 

--- a/lib/Gocdb_Services/ServiceService.php
+++ b/lib/Gocdb_Services/ServiceService.php
@@ -474,13 +474,16 @@ class ServiceService extends AbstractEntityService {
         // 'production => monitored' rule.
         $ruleExceptions = array('VOMS', 'emi.ARGUS', 'org.squid-cache.Squid');
 
-        $st = $this->getServiceType($serviceValues['serviceType']);
+        $serviceType = $this->getServiceType($serviceValues['serviceType']);
 
         // Check that the service type is not an exception to the
         // 'production => monitored'.
-        if (!in_array ($st, $ruleExceptions)) {
+        if (!in_array ($serviceType, $ruleExceptions)) {
             if ($serviceValues['PRODUCTION_LEVEL'] == "Y" && $serviceValues['IS_MONITORED'] != "Y") {
-                throw new \Exception("For the '".$st."' service type, if the Production flag is set to True, the Monitored flag must also be True.");
+                throw new \Exception(
+                    "For the '".$serviceType."' service type, if the ".
+                    "Production flag is set to True, the Monitored flag must ".
+                    "also be True.");
             }
         }
     }

--- a/lib/Gocdb_Services/ServiceService.php
+++ b/lib/Gocdb_Services/ServiceService.php
@@ -459,6 +459,32 @@ class ServiceService extends AbstractEntityService {
         return $types;
     }
 
+    /*
+     * Validates the the 'production => monitored' rule for the user inputted 
+     * service data.
+
+     * @param array $serviceValues
+     * @throws \Exception If the serviceValues production/monitored combination
+     * is invalid. The \Exception's message will contain a human readable error
+     * message.
+     * @return null
+     */
+    private function validateProductionMonitoredCombination($serviceValues) {
+        // Service types that are exceptions to the
+        // 'production => monitored' rule.
+        $ruleExceptions = array('VOMS', 'emi.ARGUS', 'org.squid-cache.Squid');
+
+        $st = $this->getServiceType($serviceValues['serviceType']);
+
+        // Check that the service type is not an exception to the
+        // 'production => monitored'.
+        if (!in_array ($st, $ruleExceptions)) {
+            if ($serviceValues['PRODUCTION_LEVEL'] == "Y" && $serviceValues['IS_MONITORED'] != "Y") {
+                throw new \Exception("For the '".$st."' service type, if the Production flag is set to True, the Monitored flag must also be True.");
+            }
+        }
+    }
+
     /**
      * Updates a Service.
      * Returns the updated SE
@@ -509,15 +535,7 @@ class ServiceService extends AbstractEntityService {
         $this->validateEndpointUrl ( $newValues ['endpointUrl'] );
         $this->uniqueCheck ( $newValues ['SE'] ['HOSTNAME'], $st, $se->getParentSite () );
         // validate production/monitored combination
-        // Service types that are exceptions to the
-        // 'production => monitored' rule.
-        $ruleExceptions = array('VOMS', 'emi.ARGUS', 'org.squid-cache.Squid');
-        // Check that the service type is not an exception to the 'production => monitored' rule.
-        if (!in_array($st, $ruleExceptions)) {
-            if ($newValues ['PRODUCTION_LEVEL'] == "Y" && $newValues ['IS_MONITORED'] != "Y") {
-                throw new \Exception ( "For the '".$st."' service type, if the Production flag is set to True, the Monitored flag must also be True." );
-            }
-        }
+        $this->validateProductionMonitoredCombination($newValues);
 
         // EDIT SCOPE TAGS:
         // collate selected scopeIds (reserved and non-reserved)
@@ -833,15 +851,7 @@ class ServiceService extends AbstractEntityService {
         $this->uniqueCheck ( $values ['SE'] ['HOSTNAME'], $st, $site );
 
         // validate production/monitored combination
-        // Service types that are exceptions to the
-        // 'production => monitored' rule.
-        $ruleExceptions = array('VOMS', 'emi.ARGUS', 'org.squid-cache.Squid');
-        // Check that the service type is not an exception to the 'production => monitored' rule.
-        if (!in_array($st, $ruleExceptions)) {
-            if ($values ['PRODUCTION_LEVEL'] == "Y" && $values ['IS_MONITORED'] != "Y") {
-                throw new \Exception ( "For the '".$st."' service type, if the Production flag is set to True, the Monitored flag must also be True." );
-            }
-        }
+        $this->validateProductionMonitoredCombination($values);
 
         // ADD SCOPE TAGS:
         // collate selected reserved and non-reserved scopeIds.

--- a/lib/Gocdb_Services/ServiceService.php
+++ b/lib/Gocdb_Services/ServiceService.php
@@ -509,9 +509,9 @@ class ServiceService extends AbstractEntityService {
         $this->validateEndpointUrl ( $newValues ['endpointUrl'] );
         $this->uniqueCheck ( $newValues ['SE'] ['HOSTNAME'], $st, $se->getParentSite () );
         // validate production/monitored combination
-        if ($st != 'VOMS' && $st != 'emi.ARGUS') {
+        if ($st != 'VOMS' && $st != 'emi.ARGUS' && $st != 'org.squid-cache.Squid') {
             if ($newValues ['PRODUCTION_LEVEL'] == "Y" && $newValues ['IS_MONITORED'] != "Y") {
-                throw new \Exception ( "If Production flat is set to True, Monitored flag must also be True (except for VOMS and emi.ARGUS)" );
+                throw new \Exception ( "If Production flat is set to True, Monitored flag must also be True (except for VOMS, emi.ARGUS and org.squid-cache.Squid)" );
             }
         }
 
@@ -829,9 +829,9 @@ class ServiceService extends AbstractEntityService {
         $this->uniqueCheck ( $values ['SE'] ['HOSTNAME'], $st, $site );
 
         // validate production/monitored combination
-        if ($st != 'VOMS' && $st != 'emi.ARGUS') {
+        if ($st != 'VOMS' && $st != 'emi.ARGUS' && $st != 'org.squid-cache.Squid') {
             if ($values ['PRODUCTION_LEVEL'] == "Y" && $values ['IS_MONITORED'] != "Y") {
-                throw new \Exception ( "If Production flag is set to True, Monitored flag must also be True (except for VOMS and emi.ARGUS)" );
+                throw new \Exception ( "If Production flag is set to True, Monitored flag must also be True (except for VOMS, emi.ARGUS and org.squid-cache.Squid)" );
             }
         }
 

--- a/lib/Gocdb_Services/ServiceService.php
+++ b/lib/Gocdb_Services/ServiceService.php
@@ -509,7 +509,11 @@ class ServiceService extends AbstractEntityService {
         $this->validateEndpointUrl ( $newValues ['endpointUrl'] );
         $this->uniqueCheck ( $newValues ['SE'] ['HOSTNAME'], $st, $se->getParentSite () );
         // validate production/monitored combination
-        if ($st != 'VOMS' && $st != 'emi.ARGUS' && $st != 'org.squid-cache.Squid') {
+        // Service types that are exceptions to the
+        // 'production => monitored' rule.
+        $ruleExceptions = array('VOMS', 'emi.ARGUS', 'org.squid-cache.Squid');
+        // Check that the service type is not an exception to the 'production => monitored' rule.
+        if (!in_array($st, $ruleExceptions)) {
             if ($newValues ['PRODUCTION_LEVEL'] == "Y" && $newValues ['IS_MONITORED'] != "Y") {
                 throw new \Exception ( "For the '".$st."' service type, if the Production flag is set to True, the Monitored flag must also be True." );
             }
@@ -829,7 +833,11 @@ class ServiceService extends AbstractEntityService {
         $this->uniqueCheck ( $values ['SE'] ['HOSTNAME'], $st, $site );
 
         // validate production/monitored combination
-        if ($st != 'VOMS' && $st != 'emi.ARGUS' && $st != 'org.squid-cache.Squid') {
+        // Service types that are exceptions to the
+        // 'production => monitored' rule.
+        $ruleExceptions = array('VOMS', 'emi.ARGUS', 'org.squid-cache.Squid');
+        // Check that the service type is not an exception to the 'production => monitored' rule.
+        if (!in_array($st, $ruleExceptions)) {
             if ($values ['PRODUCTION_LEVEL'] == "Y" && $values ['IS_MONITORED'] != "Y") {
                 throw new \Exception ( "For the '".$st."' service type, if the Production flag is set to True, the Monitored flag must also be True." );
             }


### PR DESCRIPTION
As per https://ggus.eu/index.php?mode=ticket_info&ticket_id=139924

- Change the message on "production =/> monitored". Rather than list an potentially ever growing list of ServiceTypes, just say that the 'production => monitored' rule applies to the ServiceType in question. When we move to having this rule as a property of the ServiceType, we probably wouldn't want to enumerate the exceptions anyway.
- Replace three `if` statements with an `in_array` call. Atleast for now, once this is a property of the service type this may change again. This seems cleaner than a potentially ever growing number of `if` statements.
- Move 'production => monitored' rule into function

I'll open an issue stating that the 'production => monitored' rule should be a property of the ServiceType in the database and not hardcoded. But I want to be able to throw up databases in a quattorized fashion before tackling that. 
