### PR TITLE
Refactor to make service URLs less exceptional and minor other things

### DIFF
--- a/config/gocdb_schema.xml
+++ b/config/gocdb_schema.xml
@@ -163,6 +163,12 @@
 	    <length>255</length>
 	    <regex>/^(([0-9a-zA-Z]+[-._])*[0-9a-zA-Z]+@([-0-9a-zA-Z]+[.])+[a-zA-Z]{2,6}[,;]?)+$/</regex>
 	</field>
+  <field>
+      <fname>URL</fname>
+      <length>255</length>
+      <!-- Support for all URI chars (unreserved, gen-delims, sub-delims and percent) RFC 3986 -->
+	    <regex>/^[0-9a-zA-Z:\/\.\&amp;\?\_\$\+\!\*\'\(\)\,\-#\[\]@;=~%]*$/</regex>
+  </field>
     </entity>
     <!-- ==========================================================  -->
     <entity>
@@ -306,19 +312,6 @@
 	</field>
 	<field>
 	    <fname>CONFIRMATION_CODE</fname>
-	</field>
-    </entity>
-
-    <!-- ====================================================
-    This can be deleted once add service form is redone.
-    -->
-    <entity>
-	<name>endpoint_location</name>
-	<field>
-	    <fname>URL</fname>
-	    <length>255</length>
-	    <!-- Support for all URI chars (unreserved, gen-delims, sub-delims and percent) RFC 3986 -->
-	    <regex>/^[0-9a-zA-Z:\/\.\&amp;\?\_\$\+\!\*\'\(\)\,\-#\[\]@;=~%]*$/</regex>
 	</field>
     </entity>
 

--- a/htdocs/web_portal/controllers/utils.php
+++ b/htdocs/web_portal/controllers/utils.php
@@ -382,10 +382,9 @@ function getSGroupDataFromWeb() {
  * @return array an array representation of a service
  */
 function getSeDataFromWeb() {
-    // Fields that are used to link other objects to the site
+
     $fields = array (
             'serviceType',
-            'endpointUrl'
     );
 
     foreach($fields as $field){
@@ -409,6 +408,7 @@ function getSeDataFromWeb() {
     $se_data ['SE'] ['HOST_OS'] = $_REQUEST ['HOST_OS'];
     $se_data ['SE'] ['HOST_ARCH'] = $_REQUEST ['HOST_ARCH'];
     $se_data ['SE'] ['EMAIL'] = $_REQUEST ['EMAIL'];
+    $se_data ['SE'] ['URL'] = $_REQUEST ['endpointUrl'];
     $se_data ['BETA'] = $_REQUEST ['HOST_BETA'];
     $se_data ['PRODUCTION_LEVEL'] = $_REQUEST ['PRODUCTION_LEVEL'];
     $se_data ['IS_MONITORED'] = $_REQUEST ['IS_MONITORED'];

--- a/lib/Gocdb_Services/ServiceService.php
+++ b/lib/Gocdb_Services/ServiceService.php
@@ -535,7 +535,6 @@ class ServiceService extends AbstractEntityService {
         $st = $this->getServiceType ( $newValues ['serviceType'] );
 
         $this->validate ( $newValues ['SE'], 'service' );
-        $this->validateEndpointUrl ( $newValues ['endpointUrl'] );
         $this->uniqueCheck ( $newValues ['SE'] ['HOSTNAME'], $st, $se->getParentSite () );
         // validate production/monitored combination
         $this->validateProductionMonitoredCombination($newValues);
@@ -653,12 +652,9 @@ class ServiceService extends AbstractEntityService {
             $se->setOperatingSystem ( $newValues ['SE'] ['HOST_OS'] );
             $se->setArchitecture ( $newValues ['SE'] ['HOST_ARCH'] );
             $se->setEmail ( $newValues ['SE'] ['EMAIL'] );
+            $se->setUrl ( $newValues ['SE'] ['URL'] );
 
             $se->setServiceType ( $st );
-
-            // $el = $se->getEndpointLocations()->first();
-            // $el->setUrl($newValues['endpointUrl']);
-            $se->setUrl ( $newValues ['endpointUrl'] );
 
             // Update the service's scope
             // firstly remove all existing scope links
@@ -789,24 +785,6 @@ class ServiceService extends AbstractEntityService {
         }
     }
 
-    /**
-     * Validates the user inputted service data against the
-     * checks in the gocdb_schema.xml.
-     *
-     * @param string $endpoint_url the new URL
-     * @throws \Exception If the new URL isn't
-     *         valid. The \Exception's message will contain a human
-     *         readable error message.
-     * @return null
-     */
-    private function validateEndpointUrl($endpoint_url) {
-        require_once __DIR__ . '/Validate.php';
-        $serv = new \org\gocdb\services\Validate ();
-        $valid = $serv->validate ( 'endpoint_location', "URL", $endpoint_url );
-        if (! $valid) {
-            throw new \Exception ( "Invalid URL: $endpoint_url" );
-        }
-    }
 
     /**
      * Array
@@ -850,7 +828,6 @@ class ServiceService extends AbstractEntityService {
         }
 
         $this->validate ( $values ['SE'], 'service' );
-        $this->validateEndpointUrl ( $values ['endpointUrl'] );
         $this->uniqueCheck ( $values ['SE'] ['HOSTNAME'], $st, $site );
 
         // validate production/monitored combination
@@ -949,7 +926,7 @@ class ServiceService extends AbstractEntityService {
             $se->setHostName ( $values ['SE'] ['HOSTNAME'] );
             $se->setDescription ( $values ['SE'] ['DESCRIPTION'] );
             $se->setEmail ( $values ['SE'] ['EMAIL'] );
-            $se->setUrl ( $values ['endpointUrl'] );
+            $se->setUrl ( $values ['SE'] ['URL'] );
 
             $this->em->persist ( $se );
             $this->em->flush ();


### PR DESCRIPTION
* For legacy reasons the URLS of services have been treated as a seperate
entity for the purposes of validation. This no longer makes sense, so I
have updated the codebase to reflect that url is just another property
of a service.