### PR TITLE
Add support for EGI Dev IdP out of the box

### DIFF
--- a/lib/Authentication/AuthTokens/ShibAuthToken.php
+++ b/lib/Authentication/AuthTokens/ShibAuthToken.php
@@ -146,7 +146,26 @@ class ShibAuthToken implements IAuthentication {
             return;
 
         }
-
+        else if($idp == 'https://aai-dev.egi.eu/proxy/saml2/idp/metadata.php'){
+            if( empty($_SERVER['epuid'])){
+                die('Did not recieve required epuid attributes from the EGI Dev Proxy Identity Provider to complete authentication, please contact gocdb-admins');
+            }
+            if(empty($_SERVER['entitlement'])){
+                die('Did not recieve the required entitlement attribute from the EGI Dev Proxy IdP, please contact gocdb-admins');
+            } 
+            $entitlementValuesArray = explode(';', $_SERVER['entitlement']); 
+            if( !in_array('urn:mace:egi.eu:aai.egi.eu:gocdb', $entitlementValuesArray) ){
+                 $HTML = '<ul><li>You authenticated to the EGI Dev Identity Provider using a method that does not provide a GOCDB entitlement.</li><li>Login is required with a gocdb entitlement.</li><li>To gain access, you will need to login to the Proxy IdP using a scheme that provides a gocdb entitlement.</li><li>Please logout or restart your browser and attempt to login again.</li></ul>';
+                 $HTML .= "<div style='text-align: center;'>";
+                 $HTML .= '<a href="'.htmlspecialchars(\Factory::$properties['LOGOUTURL']).'"><b><font colour="red">Logout</font></b></a>';
+                 $HTML .= "</div>";
+                 echo ($HTML);
+                 die();
+            }
+            $this->principal = $_SERVER['epuid'];
+            $this->userDetails = array('AuthenticationRealm' => array('EGI Proxy IdP'));
+            return;
+        }
 
 
 //        else {

--- a/lib/Authentication/AuthTokens/ShibAuthToken.php
+++ b/lib/Authentication/AuthTokens/ShibAuthToken.php
@@ -148,10 +148,10 @@ class ShibAuthToken implements IAuthentication {
         }
         else if($idp == 'https://aai-dev.egi.eu/proxy/saml2/idp/metadata.php'){
             if( empty($_SERVER['epuid'])){
-                die('Did not recieve required epuid attributes from the EGI Dev Proxy Identity Provider to complete authentication, please contact gocdb-admins');
+                die('Did not receive required ePUID attributes from the EGI Dev Proxy Identity Provider to complete authentication, please contact gocdb-admins');
             }
             if(empty($_SERVER['entitlement'])){
-                die('Did not recieve the required entitlement attribute from the EGI Dev Proxy IdP, please contact gocdb-admins');
+                die('Did not receive the required entitlement attribute from the EGI Dev Proxy IdP, please contact gocdb-admins');
             } 
             $entitlementValuesArray = explode(';', $_SERVER['entitlement']); 
             if( !in_array('urn:mace:egi.eu:aai.egi.eu:gocdb', $entitlementValuesArray) ){


### PR DESCRIPTION
I have added the uncommented out code from the local commit on gocdb-test.

Currently running [here](https://gocdb-www-preprod.gridpp.rl.ac.uk/portal/).