### PR TITLE
Add service notify field to schema (missed in #161)

### DIFF
--- a/config/gocdb_schema.xml
+++ b/config/gocdb_schema.xml
@@ -182,6 +182,10 @@
       <fname>MONITORED</fname>
       <ftype>boolean</ftype>
   </field>
+  <field>
+      <fname>NOTIFY</fname>
+      <ftype>boolean</ftype>
+  </field>
     </entity>
     <!-- ==========================================================  -->
     <entity>


### PR DESCRIPTION
Adds a new entry to the GOCDB schema under service for a boolean "notify" field.

This should have been included in #161 