### PR TITLE
Update Travis build file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
-# N.B. Ubuntu Precise available on Travis until March 2018
-dist: precise
+os: linux
+dist: trusty
 language: php
 before_install:
     - mysql -e 'CREATE DATABASE doctrine;'
@@ -8,20 +8,30 @@ script: .travis/run_tests.sh
 services:
     - mysql
 php:
-    - '5.3'
     - '5.4'
     - '5.5'
-env:
-    - DB=sqlite
-    - DB=mysql
-matrix:
+    - '5.6'
+    - '7.0'
+    - '7.1'
+    - '7.2'
+    - '7.3'
+    - '7.4'
+env: DB=mysql
+
+jobs:
     include:
-    - dist: trusty
+      # N.B. Ubuntu Precise required to use PHP 5.3
+    - dist: precise
       env: DB=mysql
-      php: '5.4'
-    - dist: trusty
-      env: DB=mysql
-      php: '5.5'
+      php: '5.3'
+    - env: DB=sqlite
+      php: '5.6'
     allow_failures:
     - env: DB=sqlite
+    - env: DB=mysql
+      php: '7.2'
+    - env: DB=mysql
+      php: '7.3'
+    - env: DB=mysql
+      php: '7.4'
     fast_finish: true


### PR DESCRIPTION
- Move from Ubuntu Precise to Trusty as base build, keeping Precise for
PHP 5.3 build.
- Simplify to one sqlite build as it fails.
- Add later versions of PHP to test against, adding currently failing
ones to allowed failures.
- Specify OS explicitly.

Example build here: https://travis-ci.org/tofu-rocketry/gocdb/builds/645386379