### PR TITLE
Improve write API code readability by correcting error in #180

### DIFF
--- a/htdocs/PI/write/PIWriteRequest.php
+++ b/htdocs/PI/write/PIWriteRequest.php
@@ -647,7 +647,7 @@ class PIWriteRequest {
           break;
         }
         case 'DELETE':{
-          $this->updateSiteExtensionPropertiesDELETE($siteService, $site, $extensionPropKVArray);
+          $this->updateSiteExtensionPropertiesDelete($siteService, $site, $extensionPropKVArray);
           break;
         }
         default: {


### PR DESCRIPTION
Whilst PHP is not case sensitive when it comes to functions, it would be
better that we respect case, so this corrects an error that crept in
in #180.