### PR TITLE
Tidy testing framework code

### DIFF
--- a/tests/DoctrineTestSuite1.php
+++ b/tests/DoctrineTestSuite1.php
@@ -1,11 +1,9 @@
 <?php
-
 require_once __DIR__ . '/doctrine/DoctrineCleanInsert1Test.php';
 require_once __DIR__ . '/doctrine/NGIServiceTest.php';
 require_once __DIR__ . '/doctrine/RoleCascadeDeletionsTest.php';
 require_once __DIR__ . '/doctrine/RoleServiceTest.php';
 require_once __DIR__ . '/doctrine/RolesTest.php';
-//require_once __DIR__.'/doctrine/ServiceAuthorizeActionTest.php';
 require_once __DIR__ . '/doctrine/ServiceDAOTest.php';
 require_once __DIR__ . '/doctrine/ServiceMoveTest.php';
 require_once __DIR__ . '/doctrine/Site_CertStatusLogCascadeDeletionsTest.php';
@@ -24,13 +22,8 @@ require_once __DIR__ . '/unit/lib/Gocdb_Services/ScopeServiceTest.php';
 class DoctrineTestSuite1 {
     public static function suite() {
 
-
         echo "\n\n-------------------------------------------------\n";
         echo "Executing Test Suite 1\n";
-        //chdir('doctrine');
-        //echo "Drop and recreate the test DB tables before executing tests?\n "
-        //. "(Required for the first-time execution of tests, but not required for subsequent test runs)...\n";
-        //shell_exec('sh recreateTestDB.sh');
 
         $suite = new PHPUnit_Framework_TestSuite('Test Suite 1');
 
@@ -39,7 +32,6 @@ class DoctrineTestSuite1 {
         $suite->addTestSuite('RoleCascadeDeletionsTest');
         $suite->addTestSuite('RoleServiceTest');
         $suite->addTestSuite('RolesTest');
-        //$suite->addTestSuite('ServiceAuthorizeActionTest');
         $suite->addTestSuite('ServiceDAOTest');
         $suite->addTestSuite('ServiceMoveTest');
         $suite->addTestSuite('Site_CertStatusLogCascadeDeletionsTest');

--- a/tests/DoctrineTestSuite1.php
+++ b/tests/DoctrineTestSuite1.php
@@ -20,32 +20,31 @@ require_once __DIR__ . '/unit/lib/Gocdb_Services/ScopeServiceTest.php';
  * @author David Meredith <david.meredith@stfc.ac.uk>
  */
 class DoctrineTestSuite1 {
-    public static function suite() {
+  public static function suite() {
+    echo "\n\n-------------------------------------------------\n";
+    echo "Executing Test Suite 1\n";
 
-        echo "\n\n-------------------------------------------------\n";
-        echo "Executing Test Suite 1\n";
+    $suite = new PHPUnit_Framework_TestSuite('Test Suite 1');
 
-        $suite = new PHPUnit_Framework_TestSuite('Test Suite 1');
+    $suite->addTestSuite('DoctrineCleanInsert1Test');
+    $suite->addTestSuite('NGIServiceTest');
+    $suite->addTestSuite('RoleCascadeDeletionsTest');
+    $suite->addTestSuite('RoleServiceTest');
+    $suite->addTestSuite('RolesTest');
+    $suite->addTestSuite('ServiceDAOTest');
+    $suite->addTestSuite('ServiceMoveTest');
+    $suite->addTestSuite('Site_CertStatusLogCascadeDeletionsTest');
+    $suite->addTestSuite('SiteMoveTest');
+    $suite->addTestSuite('ExtensionsTest');
+    $suite->addTestSuite('Scoped_IPIQuery_Test1');
+    $suite->addTestSuite('DowntimeServiceEndpointTest1');
 
-        $suite->addTestSuite('DoctrineCleanInsert1Test');
-        $suite->addTestSuite('NGIServiceTest');
-        $suite->addTestSuite('RoleCascadeDeletionsTest');
-        $suite->addTestSuite('RoleServiceTest');
-        $suite->addTestSuite('RolesTest');
-        $suite->addTestSuite('ServiceDAOTest');
-        $suite->addTestSuite('ServiceMoveTest');
-        $suite->addTestSuite('Site_CertStatusLogCascadeDeletionsTest');
-        $suite->addTestSuite('SiteMoveTest');
-        $suite->addTestSuite('ExtensionsTest');
-        $suite->addTestSuite('Scoped_IPIQuery_Test1');
-        $suite->addTestSuite('DowntimeServiceEndpointTest1');
+    $suite->addTestSuite('RoleActionAuthorisationServiceTest');
+    $suite->addTestSuite('RoleActionMappingServiceTest');
+    $suite->addTestSuite('ScopeServiceTest');
 
-        $suite->addTestSuite('RoleActionAuthorisationServiceTest');
-        $suite->addTestSuite('RoleActionMappingServiceTest');
-        $suite->addTestSuite('ScopeServiceTest');
-
-        return $suite;
-    }
+    return $suite;
+  }
 }
 
 ?>

--- a/tests/doctrine/DoctrineCleanInsert1Test.php
+++ b/tests/doctrine/DoctrineCleanInsert1Test.php
@@ -18,885 +18,888 @@ use Doctrine\ORM\EntityManager;
  */
 class DoctrineCleanInsert1Test extends PHPUnit_Extensions_Database_TestCase {
 
-   private $em;
-   private $egiScope;
-   private $localScope;
-   private $eudatScope;
+  private $em;
+  private $egiScope;
+  private $localScope;
+  private $eudatScope;
 
-    /**
-     * Overridden.
+  /**
+   * Overridden.
+   */
+  public static function setUpBeforeClass() {
+    parent::setUpBeforeClass();
+
+    echo "\n\n-------------------------------------------------\n";
+    echo "Executing DoctrineCleanInsert1Test. . .\n";
+  }
+
+  /**
+   * Overridden. Returns the test database connection.
+   * @return PHPUnit_Extensions_Database_DB_IDatabaseConnection
+   */
+  protected function getConnection() {
+    require_once dirname(__FILE__) . '/bootstrap_pdo.php';
+    return getConnectionToTestDB();
+  }
+
+  /**
+   * Overridden. Returns the test dataset.
+   * Defines how the initial state of the database should look before each test is executed.
+   * @return PHPUnit_Extensions_Database_DataSet_IDataSet
+   */
+  protected function getDataSet() {
+    return $this->createFlatXMLDataSet(dirname(__FILE__) . '/truncateDataTables.xml');
+    // Use below to return an empty data set if we don't want to truncate and seed
+    //return new PHPUnit_Extensions_Database_DataSet_DefaultDataSet();
+  }
+
+  /**
+   * Overridden.
+   */
+  protected function getSetUpOperation() {
+    // CLEAN_INSERT is default
+    //return PHPUnit_Extensions_Database_Operation_Factory::CLEAN_INSERT();
+    //return PHPUnit_Extensions_Database_Operation_Factory::UPDATE();
+    //return PHPUnit_Extensions_Database_Operation_Factory::NONE();
+    //
+    // Issue a DELETE from <table> which is more portable than a
+    // TRUNCATE table <table> (some DBs require high privileges for truncate statements
+    // and also do not allow truncates across tables with FK contstraints e.g. Oracle)
+    return PHPUnit_Extensions_Database_Operation_Factory::DELETE_ALL();
+  }
+
+  /**
+   * Overridden.
+   */
+  protected function getTearDownOperation() {
+    // NONE is default
+    return PHPUnit_Extensions_Database_Operation_Factory::NONE();
+  }
+
+  /**
+   * Sets up the fixture, e.g create a new entityManager for each test run
+   * This method is called before each test method is executed.
+   */
+  protected function setUp() {
+    parent::setUp();
+    $this->em = $this->createEntityManager();
+  }
+
+  /**
+   * @todo Still need to setup connection to different databases.
+   * @return EntityManager
+   */
+  private function createEntityManager(){
+    //require dirname(__FILE__).'/../bootstrap.php';
+    require dirname(__FILE__).'/bootstrap_doctrine.php';
+    return $entityManager;
+  }
+
+  /**
+   * Called after setUp() and before each test. Used for common assertions
+   * across all tests.
+   */
+  protected function assertPreConditions() {
+    $con = $this->getConnection();
+    $fixture = dirname(__FILE__) . '/truncateDataTables.xml';
+    $tables = simplexml_load_file($fixture);
+
+    foreach($tables as $tableName) {
+      //print $tableName->getName() . "\n";
+      $sql = "SELECT * FROM ".$tableName->getName();
+      $result = $con->createQueryTable('results_table', $sql);
+      //echo 'row count: '.$result->getRowCount() ;
+      if($result->getRowCount() != 0)
+        throw new RuntimeException("Invalid fixture. Table has rows: ".$tableName->getName());
+    }
+  }
+
+  public function testAssertTestEntityMangersAreDifferent(){
+    print __METHOD__ . "\n";
+    $em1 = $this->createEntityManager();
+    $em2 = $this->createEntityManager();
+    // Below asserts that two variables do not have the same type and value.
+    // Used on objects, it asserts that two variables do not reference the same object.
+    $this->assertNotSame($em1, $em2);
+    if($em1 === $em2){
+      $this->fail();
+    }
+  }
+
+
+  public function testJoinServicesToSite_RefetchSiteLazyLoadSEs() {
+    print __METHOD__ . "\n";
+    // create a sinlge site and add 3 service endpoints
+    $n = 3;
+    $site = TestUtil::createSampleSite('site' . $n);
+    $this->em->persist($site);
+    for ($i = 0; $i < $n; $i++) {
+      $se = TestUtil::createSampleService("serv" . $i);
+      $site->addServiceDoJoin($se);
+      $se->setParentSiteDoJoin($site);
+      $this->em->persist($se);
+    }
+    $seCount = count($site->getServices());
+    $this->assertTrue($seCount == $n);
+    $this->em->flush();
+    $this->em->clear();
+    $this->em->close();
+
+    $em2 = $this->createEntityManager();
+    $refetchedSite = $em2->getRepository('Site')->findOneBy(array('shortName' => 'site' . $n));
+    $this->assertNotNull($refetchedSite);
+    $em2->clear();
+    $em2->close();
+    // close causes all managed entities ($refetchedSite) to become detached
+    // and the em2 can't be used again.
+
+                                            /** Why the following works **/
+    /* When doctrine fetches an entity its default is to lazy load related entities - it does
+     * not directly hydrate them it creates a proxy. Although the entity manager is closed the
+     * code below is able to get the service count, name and parent site. This is because when
+     * doctrine creates a proxy the proxy also contains an instance of the EntityManager and it's
+     * dependancies which can then be used when the proxy is called to hydrate the entity and provide
+     * the required data.
      */
-    public static function setUpBeforeClass() {
-        parent::setUpBeforeClass();
 
-        echo "\n\n-------------------------------------------------\n";
-        echo "Executing DoctrineCleanInsert1Test. . .\n";
+
+    $seList = $refetchedSite->getServices();
+
+    $this->assertCount(3, $seList);
+  }
+
+
+  /**
+   * @link http://stackoverflow.com/questions/7877987/read-objects-persisted-but-not-yet-flushed-with-doctrine issue with doctrine
+   */
+  public function testShowDoctrineReadFailiureUntilCommitted(){
+    print __METHOD__ . "\n";
+    $n = 1;
+    // create a new site and persist (but do not flush yet)
+    $site = TestUtil::createSampleSite('site' . $n/*, 'pk' . $n*/);
+    $this->em->beginTransaction();
+    $this->em->persist($site);
+    // After persist, Doctrine querying does not return our site until we flush, hence we get 0
+    // returned from our repository.
+    $this->assertEquals(0, count($this->em->getRepository('Site')->findOneBy(array('shortName' => 'site' . $n))));
+    // When we flush or commit we get one.
+    $this->em->commit();
+    $this->em->flush();
+    $this->assertEquals(1, count($this->em->getRepository('Site')->findOneBy(array('shortName' => 'site' . $n))));
+  }
+
+
+  /**
+   * Show how BiDirectional relationships must be correctly managed in
+   * userland/application code. (See Doctrine the tutorial:
+   * "Consistency of bi-directional references on the inverse side of a
+   * relation have to be managed in userland application code. Doctrine
+   * cannot magically update your collections to be consistent.").
+   */
+  public function testShowBiDirectionalJoinConsitencyManagement() {
+    print __METHOD__ . "\n";
+    $ngi = TestUtil::createSampleNGI('myngi');
+    $site = TestUtil::createSampleSite('mysite'/*, 'pk1'*/);
+
+    // Important:
+    // The inverse side of a bi-directional relationship MUST be correctly managed.
+    // If  $ngi->addSiteDoJoin($site) is not called (try commenting out next line),
+    // the commented out assertion on next line would fail as $ngi->getSites()
+    // will return 0 when running in same TX.
+    // "$siteCount = $ngi->getSites(); $this->assertTrue($siteCount == 1);"
+    $ngi->addSiteDoJoin($site);
+    //$site->setNgiDoJoin($ngi);  // optional, calling this does no harm.
+
+    // Important:
+    // Similarly, two invocations of "$ngi->addSiteDoJoin($site)" in the same TX
+    // will add two sites to NGI causing getSites() to return 2 !
+    // (looks like Doctrine's ArrayCollection can
+    // only distinguish object instances based on obj FK ID).
+
+    $this->em->persist($site); // is now managed
+    $this->em->persist($ngi);  // is now managed
+    $siteCount = count($ngi->getSites());
+    $this->assertTrue($siteCount == 1);
+    $this->em->flush();
+
+    // start new TX
+    $this->em = $this->createEntityManager();
+    $this->assertTrue(
+      count($this->em->getRepository('NGI')->findOneBy(array('name' => 'myngi'))->getSites()) == 1
+    );
+
+    $testConn = $this->getConnection();
+    $result = $testConn->createQueryTable('results_table', "SELECT * FROM NGIs");
+    $this->assertTrue($result->getRowCount() == 1);
+    $result = $testConn->createQueryTable('results_table', "SELECT * FROM Sites");
+    $this->assertTrue($result->getRowCount() == 1);
+
+    // Assert that the FK joins worked as expected.
+    $result = $testConn->createQueryTable(
+      'results_table',"SELECT * FROM NGIs inner join Sites on NGIs.id = Sites.ngi_id"
+    );
+    $this->assertTrue($result->getRowCount() == 1);
+  }
+
+  public function testJoinServicesToSite() {
+    print __METHOD__ . "\n";
+
+    $n = 3;
+    $site = TestUtil::createSampleSite('site' . $n/*, 'pk' . $n*/);
+    $this->em->persist($site);
+    for ($i = 0; $i < $n; $i++) {
+      $se = TestUtil::createSampleService("serv" . $i);
+      $site->addServiceDoJoin($se);
+      // below is ok but not striclty required.
+      $se->setParentSiteDoJoin($site);
+      $this->em->persist($se);
     }
+    $seCount = count($site->getServices());
+    //print 'debug '.$seCount."\n";
+    $this->assertTrue($seCount == $n);
+    $this->em->flush();
 
-    /**
-     * Overridden. Returns the test database connection.
-     * @return PHPUnit_Extensions_Database_DB_IDatabaseConnection
-     */
-    protected function getConnection() {
-        require_once dirname(__FILE__) . '/bootstrap_pdo.php';
-        return getConnectionToTestDB();
+    // with same connection
+    $this->assertTrue(
+      count($this->em->getRepository('Site')->findOneBy(array('shortName'=>'site'.$n))->getServices()) == $n
+    );
+
+    // start new connection
+    $this->em->close();
+    $this->em = $this->createEntityManager();
+    $this->assertTrue(
+      count($this->em->getRepository('Site')->findOneBy(array('shortName'=>'site'.$n))->getServices()) == $n
+    );
+  }
+
+  public function testJoinCertStatusLogToSite(){
+     print __METHOD__ . "\n";
+     $n = 3;
+     $site = TestUtil::createSampleSite('mysite1');
+     $this->em->persist($site);
+     for ($i = 0; $i < $n; $i++) {
+      $certLog = new \CertificationStatusLog();
+      $certLog->setAddedBy("/some/dn_$i");
+      $this->em->persist($certLog);
+      $site->addCertificationStatusLog($certLog);
+     }
+     $this->em->merge($site);
+     $logCount = count($site->getCertificationStatusLog());
+     $this->assertTrue($logCount == $n);
+     $this->em->flush();
+
+     // start new connection
+     $this->em->close();
+     $this->em = $this->createEntityManager();
+
+     // fetch the site and check that the logs are present
+     $siteRefetched = $this->em->getRepository('Site')->findOneBy(array('shortName' => 'mysite1'));
+     $this->assertTrue(count($siteRefetched->getCertificationStatusLog()) == $n);
+
+     // check that the cascade delete removes all the certStatusLogs too
+     $this->em->remove($siteRefetched);
+     $this->em->flush();
+
+      $testConn = $this->getConnection();
+      $result = $testConn->createQueryTable(
+        'results_table',"SELECT CertificationStatusLogs.id FROM CertificationStatusLogs"
+      );
+      $this->assertTrue($result->getRowCount() == 0);
+
+      // check deletion of cert log don't delete site
+
+  }
+
+
+  /**
+   * Ensure that a Site may have many scope associations
+   */
+  public function testSiteScopeMultiplicity(){
+    print __METHOD__ . "\n";
+    $this->createAndPersistScopes();
+    $n = 1;
+    $this->em->beginTransaction();
+    $site = TestUtil::createSampleSite('site' . $n/*, 'pk' . $n*/);
+    $site->addScope($this->localScope);
+    $site->addScope($this->egiScope);
+    $site->addScope($this->eudatScope);
+    $this->em->persist($site);
+    $this->em->commit();
+    $this->em->flush();
+  }
+
+  /**
+   * Ensure that a SE may have many scope associations
+   */
+  public function testSEScopeMultiplicity(){
+    print __METHOD__ . "\n";
+    $this->createAndPersistScopes();
+    $this->em->beginTransaction();
+    $se = TestUtil::createSampleService("serv");
+    $se->addScope($this->localScope);
+    $se->addScope($this->egiScope);
+    $se->addScope($this->eudatScope);
+    $this->em->persist($se);
+    $this->em->commit();
+    $this->em->flush();
+  }
+
+  public function testJoinSiteToScopes(){
+    print __METHOD__ . "\n";
+    $this->createAndPersistScopes();
+    $n = 1; // TODO - change this to 3 and un-comment the add egiScope and eudatScope lines below
+    $site = TestUtil::createSampleSite('site' . $n/*, 'pk' . $n*/);
+    $site->addScope($this->localScope);
+    //$site->addScope($this->egiScope);
+    //$site->addScope($this->eudatScope);
+
+    $this->em->persist($site);
+    $this->em->flush();
+    $this->assertTrue(count($site->getScopes()) == $n);
+
+    $testConn = $this->getConnection();
+    $result = $testConn->createQueryTable('results_table',
+      "SELECT Sites.id FROM Sites
+       inner join Sites_Scopes
+       on Sites.id = Sites_Scopes.site_id
+       inner join Scopes
+       on Scopes.id = Sites_Scopes.scope_id"
+    );
+    $this->assertTrue($result->getRowCount() == $n);
+  }
+
+
+  public function testJoinServiceToScopes() {
+    print __METHOD__ . "\n";
+    $n = 1; // TODO - change this to 3 and un-comment the add egiScope and eudatScope lines below
+    $this->createAndPersistScopes();
+    $se = TestUtil::createSampleService("serv");
+    $se->addScope($this->egiScope);
+    //$se->addScope($this->localScope);
+    //$se->addScope($this->eudatScope);
+    $this->assertTrue(count($se->getScopes()) == $n);
+    $this->em->persist($se);
+    $this->em->flush();
+    $this->assertTrue(count($se->getScopes()) == $n);
+
+    $testConn = $this->getConnection();
+    $result = $testConn->createQueryTable('results_table',
+      "SELECT Services.id FROM Services
+       inner join Services_Scopes
+       on Services.id = Services_Scopes.service_id
+       inner join Scopes
+       on Scopes.id = Services_Scopes.scope_id"
+    );
+    $this->assertTrue($result->getRowCount() == $n);
+  }
+
+  /**
+   * Add multiple endpointLocations to a single Service
+   */
+  public function testJoinServiceToManyEndpointLocations(){
+    print __METHOD__ . "\n";
+    $n = 3; // we will want to be able to add many endpointLocations to a service
+    $se = TestUtil::createSampleService("myservicehostname");
+    $this->em->persist($se);
+    for ($i = 0; $i < $n; $i++) {
+      $el = TestUtil::createSampleEndpointLocation();
+      $se->addEndpointLocationDoJoin($el);
+      // below is ok but not striclty required.
+      //$el->setServiceDoJoin($se);
+      $this->em->persist($el);
     }
+    $elCount = count($se->getEndpointLocations());
+    $this->assertTrue($elCount == $n);
+    // flush is the line that throws the expected exe
+    $this->em->flush();
 
-    /**
-     * Overridden. Returns the test dataset.
-     * Defines how the initial state of the database should look before each test is executed.
-     * @return PHPUnit_Extensions_Database_DataSet_IDataSet
-     */
-    protected function getDataSet() {
-        return $this->createFlatXMLDataSet(dirname(__FILE__) . '/truncateDataTables.xml');
-        // Use below to return an empty data set if we don't want to truncate and seed
-        //return new PHPUnit_Extensions_Database_DataSet_DefaultDataSet();
+    // in same TX
+    $this->assertTrue(
+      count($this->em->getRepository('Service')->findOneBy(array('hostName'=>'myservicehostname'))->getEndpointLocations()) == $n
+    );
+
+    // start new TX
+    $this->em->close();
+    $this->em = $this->createEntityManager();
+    $this->assertTrue(
+      count($this->em->getRepository('Service')->findOneBy(array('hostName'=>'myservicehostname'))->getEndpointLocations()) == $n
+    );
+  }
+
+  /**
+   * Test that rollback works as expected by creating a site, adding services,
+   * persisting then calling rollback (note am not flushing or commiting) and
+   * checking that there are no sites and servcies in the DB.
+   */
+  public function testRollback() {
+    print __METHOD__ . "\n";
+    $n = 3;
+    $site = TestUtil::createSampleSite('site' . $n/*, 'pk' . $n*/);
+    // need to start new TX to do a later rollback.
+    $this->em->beginTransaction();
+    $this->em->persist($site); // is now managed
+    for ($i = 0; $i < $n; $i++) {
+      $se = TestUtil::createSampleService("serv" . $i);
+      $site->addServiceDoJoin($se);
+      // below is ok but not striclty required.
+      $se->setParentSiteDoJoin($site);
+      $this->em->persist($se);  // is now managed
     }
+    $seCount = count($site->getServices());
+    $this->assertTrue($seCount == $n);
+    $this->em->rollback();
 
-    /**
-     * Overridden.
-     */
-    protected function getSetUpOperation() {
-        // CLEAN_INSERT is default
-        //return PHPUnit_Extensions_Database_Operation_Factory::CLEAN_INSERT();
-        //return PHPUnit_Extensions_Database_Operation_Factory::UPDATE();
-        //return PHPUnit_Extensions_Database_Operation_Factory::NONE();
-        //
-        // Issue a DELETE from <table> which is more portable than a
-        // TRUNCATE table <table> (some DBs require high privileges for truncate statements
-        // and also do not allow truncates across tables with FK contstraints e.g. Oracle)
-        return PHPUnit_Extensions_Database_Operation_Factory::DELETE_ALL();
+    $testConn = $this->getConnection();
+    $result = $testConn->createQueryTable('results_table', "SELECT * FROM Sites");
+    $this->assertTrue($result->getRowCount() == 0);
+    $result = $testConn->createQueryTable('results_table', "SELECT * FROM Services");
+    $this->assertTrue($result->getRowCount() == 0);
+  }
+
+
+  /**
+   * Tests asserts that we shouldn't be able to delete a site with child services
+   * because we do not use a cascade-delete rule when deleting the site. We
+   * first have to delete the services that holds the FK to the site (one site
+   * to many services).
+   *
+   * @expectedException \Doctrine\DBAL\DBALException
+   */
+  public function testExpectedFK_ViolationOnSiteDeleteWithoutCascade(){
+    print __METHOD__ . "\n";
+    $n = 1;
+    $site = TestUtil::createSampleSite('site' . $n/*, 'pk' . $n*/);
+    $this->em->persist($site); // is now managed
+    for ($i = 0; $i < $n; $i++) {
+      $se = TestUtil::createSampleService("serv" . $i);
+      $site->addServiceDoJoin($se);
+      // below is ok but not striclty required.
+      $se->setParentSiteDoJoin($site);
+      $this->em->persist($se);  // is now managed
     }
-
-    /**
-     * Overridden.
-     */
-    protected function getTearDownOperation() {
-        // NONE is default
-        return PHPUnit_Extensions_Database_Operation_Factory::NONE();
-    }
-
-    /**
-     * Sets up the fixture, e.g create a new entityManager for each test run
-     * This method is called before each test method is executed.
-     */
-    protected function setUp() {
-        parent::setUp();
-        $this->em = $this->createEntityManager();
-    }
-
-    /**
-     * @todo Still need to setup connection to different databases.
-     * @return EntityManager
-     */
-    private function createEntityManager(){
-        //require dirname(__FILE__).'/../bootstrap.php';
-        require dirname(__FILE__).'/bootstrap_doctrine.php';
-        return $entityManager;
-    }
-
-    /**
-     * Called after setUp() and before each test. Used for common assertions
-     * across all tests.
-     */
-    protected function assertPreConditions() {
-        $con = $this->getConnection();
-        $fixture = dirname(__FILE__) . '/truncateDataTables.xml';
-        $tables = simplexml_load_file($fixture);
-
-        foreach($tables as $tableName) {
-            //print $tableName->getName() . "\n";
-            $sql = "SELECT * FROM ".$tableName->getName();
-            $result = $con->createQueryTable('results_table', $sql);
-            //echo 'row count: '.$result->getRowCount() ;
-            if($result->getRowCount() != 0)
-                throw new RuntimeException("Invalid fixture. Table has rows: ".$tableName->getName());
-        }
-    }
-
-    public function testAssertTestEntityMangersAreDifferent(){
-        print __METHOD__ . "\n";
-        $em1 = $this->createEntityManager();
-        $em2 = $this->createEntityManager();
-        // Below asserts that two variables do not have the same type and value.
-        // Used on objects, it asserts that two variables do not reference the same object.
-        $this->assertNotSame($em1, $em2);
-        if($em1 === $em2){
-            $this->fail();
-        }
-    }
-
-
-    public function testJoinServicesToSite_RefetchSiteLazyLoadSEs() {
-        print __METHOD__ . "\n";
-        // create a sinlge site and add 3 service endpoints
-        $n = 3;
-        $site = TestUtil::createSampleSite('site' . $n);
-        $this->em->persist($site);
-        for ($i = 0; $i < $n; $i++) {
-            $se = TestUtil::createSampleService("serv" . $i);
-            $site->addServiceDoJoin($se);
-            $se->setParentSiteDoJoin($site);
-            $this->em->persist($se);
-        }
-        $seCount = count($site->getServices());
-        $this->assertTrue($seCount == $n);
-        $this->em->flush();
-        $this->em->clear();
-        $this->em->close();
-
-        $em2 = $this->createEntityManager();
-        $refetchedSite = $em2->getRepository('Site')->findOneBy(array('shortName' => 'site' . $n));
-        $this->assertNotNull($refetchedSite);
-        $em2->clear();
-        $em2->close();
-        // close causes all managed entities ($refetchedSite) to become detached
-        // and the em2 can't be used again.
-
-                                                /** Why the following works **/
-        /* When doctrine fetches an entity its default is to lazy load related entities - it does
-         * not directly hydrate them it creates a proxy. Although the entity manager is closed the
-         * code below is able to get the service count, name and parent site. This is because when
-         * doctrine creates a proxy the proxy also contains an instance of the EntityManager and it's
-         * dependancies which can then be used when the proxy is called to hydrate the entity and provide
-         * the required data.
-         */
-
-
-        $seList = $refetchedSite->getServices();
-
-        $this->assertCount(3, $seList);
-    }
-
-
-    /**
-     * @link http://stackoverflow.com/questions/7877987/read-objects-persisted-but-not-yet-flushed-with-doctrine issue with doctrine
-     */
-    public function testShowDoctrineReadFailiureUntilCommitted(){
-        print __METHOD__ . "\n";
-        $n = 1;
-        // create a new site and persist (but do not flush yet)
-        $site = TestUtil::createSampleSite('site' . $n/*, 'pk' . $n*/);
-        $this->em->beginTransaction();
-        $this->em->persist($site);
-        // After persist, Doctrine querying does not return our site until we flush, hence we get 0
-        // returned from our repository.
-        $this->assertEquals(0, count($this->em->getRepository('Site')->findOneBy(array('shortName' => 'site' . $n))));
-        // When we flush or commit we get one.
-        $this->em->commit();
-        $this->em->flush();
-        $this->assertEquals(1, count($this->em->getRepository('Site')->findOneBy(array('shortName' => 'site' . $n))));
-    }
-
-
-    /**
-     * Show how BiDirectional relationships must be correctly managed in
-     * userland/application code. (See Doctrine the tutorial:
-     * "Consistency of bi-directional references on the inverse side of a
-     * relation have to be managed in userland application code. Doctrine
-     * cannot magically update your collections to be consistent.").
-     */
-    public function testShowBiDirectionalJoinConsitencyManagement() {
-        print __METHOD__ . "\n";
-        $ngi = TestUtil::createSampleNGI('myngi');
-        $site = TestUtil::createSampleSite('mysite'/*, 'pk1'*/);
-
-        // Important:
-        // The inverse side of a bi-directional relationship MUST be correctly managed.
-        // If  $ngi->addSiteDoJoin($site) is not called (try commenting out next line),
-        // the commented out assertion on next line would fail as $ngi->getSites()
-        // will return 0 when running in same TX.
-        // "$siteCount = $ngi->getSites(); $this->assertTrue($siteCount == 1);"
-        $ngi->addSiteDoJoin($site);
-        //$site->setNgiDoJoin($ngi);  // optional, calling this does no harm.
-
-        // Important:
-        // Similarly, two invocations of "$ngi->addSiteDoJoin($site)" in the same TX
-        // will add two sites to NGI causing getSites() to return 2 !
-        // (looks like Doctrine's ArrayCollection can
-        // only distinguish object instances based on obj FK ID).
-
-        $this->em->persist($site); // is now managed
-        $this->em->persist($ngi);  // is now managed
-        $siteCount = count($ngi->getSites());
-        $this->assertTrue($siteCount == 1);
-        $this->em->flush();
-
-        // start new TX
-        $this->em = $this->createEntityManager();
-        $this->assertTrue(
-                count($this->em->getRepository('NGI')->
-                        findOneBy(array('name' => 'myngi'))->getSites()) == 1);
-
-        $testConn = $this->getConnection();
-        $result = $testConn->createQueryTable('results_table', "SELECT * FROM NGIs");
-        $this->assertTrue($result->getRowCount() == 1);
-        $result = $testConn->createQueryTable('results_table', "SELECT * FROM Sites");
-        $this->assertTrue($result->getRowCount() == 1);
-
-        // Assert that the FK joins worked as expected.
-        $result = $testConn->createQueryTable('results_table',
-                "SELECT * FROM NGIs inner join Sites on NGIs.id = Sites.ngi_id");
-        $this->assertTrue($result->getRowCount() == 1);
-    }
-
-    public function testJoinServicesToSite() {
-        print __METHOD__ . "\n";
-
-        $n = 3;
-        $site = TestUtil::createSampleSite('site' . $n/*, 'pk' . $n*/);
-        $this->em->persist($site);
-        for ($i = 0; $i < $n; $i++) {
-            $se = TestUtil::createSampleService("serv" . $i);
-            $site->addServiceDoJoin($se);
-            // below is ok but not striclty required.
-            $se->setParentSiteDoJoin($site);
-            $this->em->persist($se);
-        }
-        $seCount = count($site->getServices());
-        //print 'debug '.$seCount."\n";
-        $this->assertTrue($seCount == $n);
-        $this->em->flush();
-
-        // with same connection
-        $this->assertTrue(count($this->em->getRepository('Site')->
-                        findOneBy(array('shortName' => 'site' . $n))->getServices()) == $n);
-
-        // start new connection
-        $this->em->close();
-        $this->em = $this->createEntityManager();
-        $this->assertTrue(count($this->em->getRepository('Site')->
-                        findOneBy(array('shortName' => 'site' . $n))->getServices()) == $n);
-    }
-
-    public function testJoinCertStatusLogToSite(){
-       print __METHOD__ . "\n";
-       $n = 3;
-       $site = TestUtil::createSampleSite('mysite1');
-       $this->em->persist($site);
-       for ($i = 0; $i < $n; $i++) {
-          $certLog = new \CertificationStatusLog();
-          $certLog->setAddedBy("/some/dn_$i");
-          $this->em->persist($certLog);
-          $site->addCertificationStatusLog($certLog);
-       }
-       $this->em->merge($site);
-       $logCount = count($site->getCertificationStatusLog());
-       $this->assertTrue($logCount == $n);
-       $this->em->flush();
-
-       // start new connection
-       $this->em->close();
-       $this->em = $this->createEntityManager();
-
-       // fetch the site and check that the logs are present
-       $siteRefetched = $this->em->getRepository('Site')->findOneBy(array('shortName' => 'mysite1'));
-       $this->assertTrue(count($siteRefetched->getCertificationStatusLog()) == $n);
-
-       // check that the cascade delete removes all the certStatusLogs too
-       $this->em->remove($siteRefetched);
-       $this->em->flush();
-
-        $testConn = $this->getConnection();
-        $result = $testConn->createQueryTable('results_table',
-                "SELECT CertificationStatusLogs.id FROM CertificationStatusLogs");
-        $this->assertTrue($result->getRowCount() == 0);
-
-        // check deletion of cert log don't delete site
-
-    }
-
-
-    /**
-     * Ensure that a Site may have many scope associations
-     */
-    public function testSiteScopeMultiplicity(){
-        print __METHOD__ . "\n";
-        $this->createAndPersistScopes();
-        $n = 1;
-        $this->em->beginTransaction();
-        $site = TestUtil::createSampleSite('site' . $n/*, 'pk' . $n*/);
-        $site->addScope($this->localScope);
-        $site->addScope($this->egiScope);
-        $site->addScope($this->eudatScope);
-        $this->em->persist($site);
-        $this->em->commit();
-        $this->em->flush();
-    }
-
-    /**
-     * Ensure that a SE may have many scope associations
-     */
-    public function testSEScopeMultiplicity(){
-        print __METHOD__ . "\n";
-        $this->createAndPersistScopes();
-        $this->em->beginTransaction();
-        $se = TestUtil::createSampleService("serv");
-        $se->addScope($this->localScope);
-        $se->addScope($this->egiScope);
-        $se->addScope($this->eudatScope);
-        $this->em->persist($se);
-        $this->em->commit();
-        $this->em->flush();
-    }
-
-
-    public function testJoinSiteToScopes(){
-        print __METHOD__ . "\n";
-        $this->createAndPersistScopes();
-        $n = 1; // TODO - change this to 3 and un-comment the add egiScope and eudatScope lines below
-        $site = TestUtil::createSampleSite('site' . $n/*, 'pk' . $n*/);
-        $site->addScope($this->localScope);
-        //$site->addScope($this->egiScope);
-        //$site->addScope($this->eudatScope);
-
-        $this->em->persist($site);
-        $this->em->flush();
-        $this->assertTrue(count($site->getScopes()) == $n);
-
-        $testConn = $this->getConnection();
-        $result = $testConn->createQueryTable('results_table',
-                "SELECT Sites.id FROM Sites
-                    inner join Sites_Scopes
-                    on Sites.id = Sites_Scopes.site_id
-                    inner join Scopes
-                    on Scopes.id = Sites_Scopes.scope_id");
-        $this->assertTrue($result->getRowCount() == $n);
-    }
-
-
-    public function testJoinServiceToScopes() {
-        print __METHOD__ . "\n";
-        $n = 1; // TODO - change this to 3 and un-comment the add egiScope and eudatScope lines below
-        $this->createAndPersistScopes();
-        $se = TestUtil::createSampleService("serv");
-        $se->addScope($this->egiScope);
-        //$se->addScope($this->localScope);
-        //$se->addScope($this->eudatScope);
-        $this->assertTrue(count($se->getScopes()) == $n);
-        $this->em->persist($se);
-        $this->em->flush();
-        $this->assertTrue(count($se->getScopes()) == $n);
-
-        $testConn = $this->getConnection();
-        $result = $testConn->createQueryTable('results_table',
-                "SELECT Services.id FROM Services
-                    inner join Services_Scopes
-                    on Services.id = Services_Scopes.service_id
-                    inner join Scopes
-                    on Scopes.id = Services_Scopes.scope_id");
-        $this->assertTrue($result->getRowCount() == $n);
-    }
-
-    /**
-     * Add multiple endpointLocations to a single Service
-     */
-    public function testJoinServiceToManyEndpointLocations(){
-        print __METHOD__ . "\n";
-        $n = 3; // we will want to be able to add many endpointLocations to a service
-        $se = TestUtil::createSampleService("myservicehostname");
-        $this->em->persist($se);
-        for ($i = 0; $i < $n; $i++) {
-            $el = TestUtil::createSampleEndpointLocation();
-            $se->addEndpointLocationDoJoin($el);
-            // below is ok but not striclty required.
-            //$el->setServiceDoJoin($se);
-            $this->em->persist($el);
-        }
-        $elCount = count($se->getEndpointLocations());
-        $this->assertTrue($elCount == $n);
-        // flush is the line that throws the expected exe
-        $this->em->flush();
-
-        // in same TX
-        $this->assertTrue(count($this->em->getRepository('Service')->
-                        findOneBy(array('hostName' => 'myservicehostname'))->getEndpointLocations()) == $n);
-
-         // start new TX
-        $this->em->close();
-        $this->em = $this->createEntityManager();
-        $this->assertTrue(count($this->em->getRepository('Service')->
-                        findOneBy(array('hostName' => 'myservicehostname'))->getEndpointLocations()) == $n);
-
-    }
-
-    /**
-     * Test that rollback works as expected by creating a site, adding services,
-     * persisting then calling rollback (note am not flushing or commiting) and
-     * checking that there are no sites and servcies in the DB.
-     */
-    public function testRollback() {
-        print __METHOD__ . "\n";
-        $n = 3;
-        $site = TestUtil::createSampleSite('site' . $n/*, 'pk' . $n*/);
-        // need to start new TX to do a later rollback.
-        $this->em->beginTransaction();
-        $this->em->persist($site); // is now managed
-        for ($i = 0; $i < $n; $i++) {
-            $se = TestUtil::createSampleService("serv" . $i);
-            $site->addServiceDoJoin($se);
-            // below is ok but not striclty required.
-            $se->setParentSiteDoJoin($site);
-            $this->em->persist($se);  // is now managed
-        }
-        $seCount = count($site->getServices());
-        $this->assertTrue($seCount == $n);
-        $this->em->rollback();
-
-        $testConn = $this->getConnection();
-        $result = $testConn->createQueryTable('results_table', "SELECT * FROM Sites");
-        $this->assertTrue($result->getRowCount() == 0);
-        $result = $testConn->createQueryTable('results_table', "SELECT * FROM Services");
-        $this->assertTrue($result->getRowCount() == 0);
-    }
-
-
-    /**
-     * Tests asserts that we shouldn't be able to delete a site with child services
-     * because we do not use a cascade-delete rule when deleting the site. We
-     * first have to delete the services that holds the FK to the site (one site
-     * to many services).
-     *
-     * @expectedException \Doctrine\DBAL\DBALException
-     */
-    public function testExpectedFK_ViolationOnSiteDeleteWithoutCascade(){
-        print __METHOD__ . "\n";
-        $n = 1;
-        $site = TestUtil::createSampleSite('site' . $n/*, 'pk' . $n*/);
-        $this->em->persist($site); // is now managed
-        for ($i = 0; $i < $n; $i++) {
-            $se = TestUtil::createSampleService("serv" . $i);
-            $site->addServiceDoJoin($se);
-            // below is ok but not striclty required.
-            $se->setParentSiteDoJoin($site);
-            $this->em->persist($se);  // is now managed
-        }
-        $this->em->flush();
-
-        // start new TX
-        $this->em->close();
-        $this->em = $this->createEntityManager();
-        $refetchedSite = $this->em->getRepository('Site')->findOneBy(array('shortName' => 'site' . $n));
-        $this->assertTrue($refetchedSite->getShortName() == 'site'.$n);
-
-        // Now try to delete site.
-        // We expect a FK violation wrapped as a DBALException.
-        // If the fail statement is called below, then it could be an issue with
-        // with the DB. For example, Sqlite with Doctrine does not enforce FK constraints !
-        // see: http://stackoverflow.com/a/4599894
-
-        // We shouldn't be able to remove the site as we need to remove the
-        // services first as we have no cascade-delete option set.
-        $this->em->remove($refetchedSite);
-        $this->em->flush();
-        $this->fail('Should not get to this point - DBALException expected');
-
-    }
-
-
-    /**
-     * Assert that deletion of an OwnedEntity superclass will delete its joined
-     * extending class (e.g. Site and NGI).
-     */
-    public function testCascadeDeleteFromOwnedEntity(){
-        print __METHOD__ . "\n";
-        // create and commit a new site
-        $s = TestUtil::createSampleSite("SITENAME"/*, "PK01"*/);
-        $this->em->persist($s);
-        $this->em->flush();
-
-        // lookup the site's super class (OwnedEntity)
-        $siteID = $s->getId();
-        $ownedEntity = $this->em->find("OwnedEntity", $siteID);
-        $this->assertNotNull($ownedEntity);
-        $this->assertTrue($ownedEntity instanceof OwnedEntity);
-        $this->assertEquals($siteID, $ownedEntity->getId());
-
-        // remove the super class - this should cascade delete the site
-        $this->em->remove($ownedEntity);
-        $this->em->flush();
-
-        // Assert that the super class was deleted and site was cascade deleted
-        // first using doctrine
-        $siteAgain = $this->em->find("Site", $siteID);
-        $this->assertNull($siteAgain);
-        $ownedEntityAgain = $this->em->find("OwnedEntity", $siteID);
-        $this->assertNull($ownedEntityAgain);
-        // second using separate db connection
-        $testConn = $this->getConnection();
-        $result = $testConn->createQueryTable('results_table', "SELECT * FROM OwnedEntities");
-        $this->assertTrue($result->getRowCount() == 0);
-        $result = $testConn->createQueryTable('results_table', "SELECT * FROM Sites");
-        $this->assertTrue($result->getRowCount() == 0);
-    }
-
-
-    /**
-     * @expectedException \Doctrine\ORM\ORMInvalidArgumentException
-     */
-    public function testShowMergeIsRequiredBetweenDifferentPersistenceCtxt(){
-        print __METHOD__ . "\n";
-        // User
-        $u = TestUtil::createSampleUser("Test", "Testing", "/c=test");
-        $regFLSupportRT = TestUtil::createSampleRoleType(RoleTypeName::REG_FIRST_LINE_SUPPORT/*, RoleTypeClass::REGIONAL_USER*/);
-        $this->em->persist($u);
-        $this->em->persist($regFLSupportRT);
-        $this->em->flush();
-
-        // If we create a new $this->em as below, we would need to merge detatched $u
-        // and $regFLSupportRT entities back into this persistence context
-        // before we can call a persist again (a persist on these entities
-        // called either by a CASCADE or direct call)!
-        $this->em = $this->createEntityManager(); // simply requires bootstrap_doctrine.php
-        //$u = $this->em->merge($u);
-        //$regFLSupportRT = $this->em->merge($regFLSupportRT);
-
-        // Create new NGI
-        $n = TestUtil::createSampleNGI("MYNGI");
-        $this->em->persist($n);
-
-        $roleNgi = TestUtil::createSampleRole($u, $regFLSupportRT, $n, RoleStatus::GRANTED);
-        $this->em->persist($roleNgi);
-        // the flush below is what causes the expected exception
-        $this->em->flush();
-    }
-
-
-    public function testSiteV4PK(){
-        print __METHOD__ . "\n";
-        $this->em->getConnection()->beginTransaction();
-        $pk = new \PrimaryKey();
-        $this->em->persist($pk);
-        // Below line is interesting - Oracle returns a value for $pk->getId()
-        // (i.e. before flush) while MySQL does not return a value until the
-        // flush. Either way, the subsequent rollback causes the PK to be removed
-        // which is the required behaviour.
-        //$this->assertEmpty($pk->getId());
-        //print "the pk is before: [".$pk->getId()."]\n";
-
-        $this->em->flush(); // sync in-memory state with db so that the pk Id has a value
-        //print "the pk is after: [".$pk->getId()."]\n";
-        // We expect after the flush the pk to have an id value
-        $this->assertNotEmpty($pk->getId());
-        $site = new \Site();
-        $site->setPrimaryKey($pk->getId() . "G0");
-        $site->setShortName('testshortname');
-        $this->em->persist($site);
-        $this->em->flush();
-
-        // Rollback so that we don't commit the new pks and site to the DB
-        $this->em->getConnection()->rollback();
-
-        $testConn = $this->getConnection();
-        $result = $testConn->createQueryTable('results_table', "SELECT * FROM Sites");
-        $this->assertTrue($result->getRowCount() == 0);
-        $result = $testConn->createQueryTable('results_table', "SELECT * FROM PrimaryKeys");
-        $this->assertTrue($result->getRowCount() == 0);
-    }
-
-
-    /**
-     * Assert that the onDelete="CASCADE" FK mapping defined on 'EndpointLocation.service'
-     * attribute does actually cascade delete a services endpoints when those
-     * endpoints don't have any other joined associations, e.g. with Downtimes.
-     */
-    public function testServiceToEndpointCascadeDelete_WithNoDTs(){
-        print __METHOD__ . "\n";
-        // create a linked entity graph as below:
-        //
-        //     se        (1 service)
-        //    / | \
-        // el1 el2 el3   (3 endpoints)
-
-        $se = TestUtil::createSampleService('service1');
-        $el1 = TestUtil::createSampleEndpointLocation();
-        $el2 = TestUtil::createSampleEndpointLocation();
-        $el3 = TestUtil::createSampleEndpointLocation();
-        $se->addEndpointLocationDoJoin($el1);
-        $se->addEndpointLocationDoJoin($el2);
-        $se->addEndpointLocationDoJoin($el3);
-
-        // persist and flush
-        $this->em->persist($se);
-        $this->em->persist($el1);
-        $this->em->persist($el2);
-        $this->em->persist($el3);
-        $this->em->flush();
-
-        // Delete the service, and assert the endpoints are cascade deleted too !
-        // Impt: This should work because we have NOT joined any downtimes to the
-        // endpoints and so the cascade is free to work at the DB level using
-        // the onDelete="CASCADE" FK mapping defined on 'EndpointLocation.service' attribute.
-        // see: See: http://docs.doctrine-project.org/en/2.0.x/reference/working-with-objects.html#removing-entities
-        //
-        $this->em->remove($se);
-        $this->em->flush();
-
-        // Assert that there are still three EndpointLocations and one Downtimes in the database
-        $testConn = $this->getConnection();
-        $result = $testConn->createQueryTable('results_table', "SELECT * FROM EndpointLocations");
-        $this->assertTrue($result->getRowCount() == 0);
-        $result = $testConn->createQueryTable('results_table', "SELECT * FROM Downtimes");
-        $this->assertTrue($result->getRowCount() == 0);
-        $result = $testConn->createQueryTable('results_table', "SELECT * FROM Services");
-        $this->assertTrue($result->getRowCount() == 0);
-        $result = $testConn->createQueryTable('results_table', "SELECT * FROM Downtimes_EndpointLocations");
-        $this->assertTrue($result->getRowCount() == 0);
-    }
-
-    /**
-     * Assert that the onDelete="CASCADE" FK mapping defined on 'EndpointLocation.service'
-     * annotation fails due to a FK violation exception caused by the endpoint's
-     * association to a downtime (this relationship would need to be deleted first
-     * to allow the endpoint to be deleted cleanly by the cascade).
-     *
-     * @expectedException \Doctrine\DBAL\DBALException
-     */
-    public function testExpectedFK_ViolationOnServiceToEndpointCascadeDelete_WithDTs(){
-         print __METHOD__ . "\n";
-        // create a linked entity graph as beow:
-        //
-        //     se        (1 service)
-        //    /
-        // el1           (1 endpoints)
-        //    \
-        //     dt1       (1 downtime)
-
-        $se = TestUtil::createSampleService('service1');
-        $el1 = TestUtil::createSampleEndpointLocation();
-        $se->addEndpointLocationDoJoin($el1);
-
-        $dt1 = new Downtime();
-        $dt1->setDescription('downtime description');
-        $dt1->setSeverity("WARNING");
-        $dt1->setClassification("UNSCHEDULED");
-
-        $dt1->addEndpointLocation($el1);
-
-        // persist and flush
-        $this->em->persist($se);
-        $this->em->persist($el1);
-        $this->em->persist($dt1);
-        $this->em->flush();
-
-        // Assert that there are expected EndpointLocations and one Downtimes in the database
-        $testConn = $this->getConnection();
-        $result = $testConn->createQueryTable('results_table', "SELECT * FROM EndpointLocations");
-        $this->assertTrue($result->getRowCount() == 1);
-        $result = $testConn->createQueryTable('results_table', "SELECT * FROM Downtimes");
-        $this->assertTrue($result->getRowCount() == 1);
-        $result = $testConn->createQueryTable('results_table', "SELECT * FROM Downtimes_EndpointLocations");
-        $this->assertTrue($result->getRowCount() == 1);
-
-        // Try and delete the service
-        // We expect a FK violation wrapped as a DBALException.
-        // If the fail statement is called below, then it could be an issue with
-        // with the DB. For example, Sqlite with Doctrine does not enforce FK constraints !
-        // see: http://stackoverflow.com/a/4599894
-
-        // We shouldn't be able to remove the site as we need to remove the
-        // services first as we have no cascade-delete option set.
-        $this->em->remove($se);
-        $this->em->flush();
-        $this->fail('Should not get to this point - DBALException expected');
-    }
-
-    /**
-     * Show how Bidirectional relationships must be correctly managed in
-     * userland/application code. (See Doctrine the tutorial:
-     * "Consistency of bi-directional references on the inverse side of a
-     * relation have to be managed in userland application code. Doctrine
-     * cannot magically update your collections to be consistent.").
-     */
-    public function testDowntimeEndpoint_BidirectionalJoinConsistencyManagement(){
-        print __METHOD__ . "\n";
-        // create a linked entity graph as beow:
-        //
-        //     se        (1 service)
-        //    / | \
-        // el1 el2 el3   (3 endpoints)
-        //    \ | /
-        //     dt1       (1 downtime)
-
-        $se = TestUtil::createSampleService('service1');
-        $el1 = TestUtil::createSampleEndpointLocation();
-        $el2 = TestUtil::createSampleEndpointLocation();
-        $el3 = TestUtil::createSampleEndpointLocation();
-        $se->addEndpointLocationDoJoin($el1);
-        $se->addEndpointLocationDoJoin($el2);
-        $se->addEndpointLocationDoJoin($el3);
-
-        $dt1 = new Downtime();
-        $dt1->setDescription('downtime description');
-        $dt1->setSeverity("WARNING");
-        $dt1->setClassification("UNSCHEDULED");
-
-        $dt1->addEndpointLocation($el1);
-        $dt1->addEndpointLocation($el2);
-        $dt1->addEndpointLocation($el3);
-
-        // persist and flush
-        $this->em->persist($se);
-        $this->em->persist($el1);
-        $this->em->persist($el2);
-        $this->em->persist($el3);
-        $this->em->persist($dt1);
-        $this->em->flush();
-
-        // Now delete the relationship between dt1 and el1 + el2 using OWNING
-        // SIDE ONLY; since downtime is the OWNING side we must remove el1 + el2
-        // from downtime to actually delete the relationships in the DB
-        // (on the subsequent flush). Since we have only removed the relationship
-        // on the downtime side, our in-mem entity model is now inconsistent !
-        $dt1->getEndpointLocations()->removeElement($el1);
-        //$el1->getDowntimes()->removeElement($dt1);
-        $dt1->getEndpointLocations()->removeElement($el2);
-        //$el2->getDowntimes()->removeElement($dt1);
-
-        $this->em->flush();
-
-        // Entity model in DB now looks like this:
-        //     se
-        //    / | \
-        // el1 el2 el3
-        //        /
-        //     dt1      (note FKs/relationships have been removed)
-
-        // Assert that there are still three EndpointLocations and one Downtimes in the database
-        $testConn = $this->getConnection();
-        $result = $testConn->createQueryTable('results_table', "SELECT * FROM EndpointLocations");
-        $this->assertTrue($result->getRowCount() == 3);
-        $result = $testConn->createQueryTable('results_table', "SELECT * FROM Downtimes");
-        $this->assertTrue($result->getRowCount() == 1);
-        $result = $testConn->createQueryTable('results_table', "SELECT * FROM Downtimes_EndpointLocations");
-        $this->assertTrue($result->getRowCount() == 1);
-
-        // Assert that our in-mem entity model is now inconsistent with DB
-        // when VIEWED FROM THE ENDPOINT SIDE.
-        $this->assertEquals(1, count($el1->getDowntimes()));
-        $this->assertEquals(1, count($el2->getDowntimes()));
-        $this->assertEquals(1, count($el3->getDowntimes()));
-
-        // Assert that our in-mem entity model is consistent with DB
-        // when VIEWED FROM THE DOWNTIME SIDE:
-        // dt1 still has el3 linked (as expected) but not el1 or el2.
-        // Note we use first() method to fetch first array collection entry!
-        // (calling get(0) would not work as expected because the collection
-        // is a map so array key values are preserved - el3 was added 3rd so it
-        // preserves its zero-offset key value of 2).
-        $this->assertEquals(1, count($dt1->getEndpointLocations()));
-        $this->assertSame($el3, $dt1->getEndpointLocations()->first());
-        $this->assertSame($el3, $dt1->getEndpointLocations()->get(2));
-
-        // Next lines keep our in-mem inverse side consistent with DB. If we
-        // didn't do this, then our first assertion on the following lines below
-        // would fail! This shows that you have to keep your bi-directional
-        // relationships consistent in userland/application code, doctrine
-        // won't do this for you!
-        $el1->getDowntimes()->removeElement($dt1);
-        $el2->getDowntimes()->removeElement($dt1);
-
-        // After updating the 'in-memory' entity model, check that el1 and el2
-        // have no linked downtimes while el3 still has dt linked.
-        // This mirrors what we have in the DB.
-        $this->assertEquals(0, count($el1->getDowntimes()));
-        $this->assertEquals(0, count($el2->getDowntimes()));
-        $this->assertEquals(1, count($el3->getDowntimes()));
-
-        // our collection key value is still same
-        $this->assertSame($el3, $dt1->getEndpointLocations()->get(2));
-    }
-
-
-
-    private function createAndPersistScopes(){
-        $this->egiScope = new Scope();
-        $this->egiScope->setName('EGI');
-        $this->egiScope->setDescription('The egi project');
-
-        $this->localScope = new Scope();
-        $this->localScope->setDescription('Local scope means no project');
-        $this->localScope->setName('Local');
-
-        $this->eudatScope = new Scope();
-        $this->eudatScope->setName('EUDAT');
-        $this->eudatScope->setDescription('The eudat project');
-
-        $this->em->persist($this->egiScope);
-        $this->em->persist($this->localScope);
-        $this->em->persist($this->eudatScope);
-    }
-
-
-    // below two tests have now been deprecated, but they are good to keep
-    // commented out because they are still useful to explain join behaviour
-    /*public function testNgiSiteNotJoined(){
-        print __METHOD__ . "\n";
-        $this->doNgiSiteJoins(false);
-    }
-    public function testNgiSiteJoined(){
-        print __METHOD__ . "\n";
-        $this->doNgiSiteJoins(true);
-    }*/
-
-    /**
-     * Helper function to show that setting the join/assocition is only set
-     * on one side of a bi-directional relationship. If $setJoinCorrectly is
-     * true, then the newly created sites will be joined to the NGIs. If false,
-     * then the the join will not be set.
-     *
-     * @deprecated since the entity model was updated, but good to keep for reference.
-     * @param boolean $setJoinCorrectly
-     */
-    /*private function doNgiSiteJoins($setJoinCorrectly) {
-        $n = 1;
-        for ($i = 0; $i < $n; $i++) {
-            $ngi = $this->createSampleNGI('ngi' . $i);
-            $site = $this->createSampleSite('site' . $i, 'pk' . $i);
-            if ($setJoinCorrectly) {
-                // This will set the join/association
-                $site->setNgiDoJoin($ngi);
-                //
-                // **Note** setNgiDoJoin() MUST have the following definition for this test to work as expected:
-                //
-                //   public function setNgiDoJoin(NGI $ngi) {
-            //       $this->ngi = $ngi;
-                //       $ngi->addSiteNoJoin($this);
-            //   }
-            } else {
-                // This will NOT set the join/association (only setting on the inverse side)
-                $ngi->addSiteNoJoin($site);
-                //
-                // **Note** addSiteNoJoin() MUST have the following definition for this test to work as expected:
-                //
-                //   public function addSiteNoJoin(Site $site) {
-        //       $this->sites[] = $site;
-            //   }
-            }
-            $this->em->persist($site); // is now managed
-            $this->em->persist($ngi);  // is now managed
-            $this->assertTrue($this->em->contains($site));
-            $this->assertTrue($this->em->contains($ngi));
-        }
-        $this->em->flush(); // commit
-
-        // Do not trust what Doctrine tells us and assert the rows have
-        // actually been added using test connection
-        $testConn = $this->getConnection();
-        $result = $testConn->createQueryTable('results_table', "SELECT * FROM NGIs");
-        $this->assertTrue($result->getRowCount() == $n);
-        $result = $testConn->createQueryTable('results_table', "SELECT * FROM Sites");
-        $this->assertTrue($result->getRowCount() == $n);
-
-        // Assert that the FK joins worked as expected.
-        $result = $testConn->createQueryTable('results_table',
-                "SELECT * FROM NGIs inner join Sites on NGIs.id = Sites.ngi_id");
-        if($setJoinCorrectly) {
-            $this->assertTrue($result->getRowCount() == $n);
-        } else {
-            $this->assertTrue($result->getRowCount() == 0);
-        }
-    }*/
+    $this->em->flush();
+
+    // start new TX
+    $this->em->close();
+    $this->em = $this->createEntityManager();
+    $refetchedSite = $this->em->getRepository('Site')->findOneBy(array('shortName' => 'site' . $n));
+    $this->assertTrue($refetchedSite->getShortName() == 'site'.$n);
+
+    // Now try to delete site.
+    // We expect a FK violation wrapped as a DBALException.
+    // If the fail statement is called below, then it could be an issue with
+    // with the DB. For example, Sqlite with Doctrine does not enforce FK constraints !
+    // see: http://stackoverflow.com/a/4599894
+
+    // We shouldn't be able to remove the site as we need to remove the
+    // services first as we have no cascade-delete option set.
+    $this->em->remove($refetchedSite);
+    $this->em->flush();
+    $this->fail('Should not get to this point - DBALException expected');
+
+  }
+
+
+  /**
+   * Assert that deletion of an OwnedEntity superclass will delete its joined
+   * extending class (e.g. Site and NGI).
+   */
+  public function testCascadeDeleteFromOwnedEntity(){
+    print __METHOD__ . "\n";
+    // create and commit a new site
+    $s = TestUtil::createSampleSite("SITENAME"/*, "PK01"*/);
+    $this->em->persist($s);
+    $this->em->flush();
+
+    // lookup the site's super class (OwnedEntity)
+    $siteID = $s->getId();
+    $ownedEntity = $this->em->find("OwnedEntity", $siteID);
+    $this->assertNotNull($ownedEntity);
+    $this->assertTrue($ownedEntity instanceof OwnedEntity);
+    $this->assertEquals($siteID, $ownedEntity->getId());
+
+    // remove the super class - this should cascade delete the site
+    $this->em->remove($ownedEntity);
+    $this->em->flush();
+
+    // Assert that the super class was deleted and site was cascade deleted
+    // first using doctrine
+    $siteAgain = $this->em->find("Site", $siteID);
+    $this->assertNull($siteAgain);
+    $ownedEntityAgain = $this->em->find("OwnedEntity", $siteID);
+    $this->assertNull($ownedEntityAgain);
+    // second using separate db connection
+    $testConn = $this->getConnection();
+    $result = $testConn->createQueryTable('results_table', "SELECT * FROM OwnedEntities");
+    $this->assertTrue($result->getRowCount() == 0);
+    $result = $testConn->createQueryTable('results_table', "SELECT * FROM Sites");
+    $this->assertTrue($result->getRowCount() == 0);
+  }
+
+
+  /**
+   * @expectedException \Doctrine\ORM\ORMInvalidArgumentException
+   */
+  public function testShowMergeIsRequiredBetweenDifferentPersistenceCtxt(){
+    print __METHOD__ . "\n";
+    // User
+    $u = TestUtil::createSampleUser("Test", "Testing", "/c=test");
+    $regFLSupportRT = TestUtil::createSampleRoleType(RoleTypeName::REG_FIRST_LINE_SUPPORT/*, RoleTypeClass::REGIONAL_USER*/);
+    $this->em->persist($u);
+    $this->em->persist($regFLSupportRT);
+    $this->em->flush();
+
+    // If we create a new $this->em as below, we would need to merge detatched $u
+    // and $regFLSupportRT entities back into this persistence context
+    // before we can call a persist again (a persist on these entities
+    // called either by a CASCADE or direct call)!
+    $this->em = $this->createEntityManager(); // simply requires bootstrap_doctrine.php
+    //$u = $this->em->merge($u);
+    //$regFLSupportRT = $this->em->merge($regFLSupportRT);
+
+    // Create new NGI
+    $n = TestUtil::createSampleNGI("MYNGI");
+    $this->em->persist($n);
+
+    $roleNgi = TestUtil::createSampleRole($u, $regFLSupportRT, $n, RoleStatus::GRANTED);
+    $this->em->persist($roleNgi);
+    // the flush below is what causes the expected exception
+    $this->em->flush();
+  }
+
+  public function testSiteV4PK(){
+    print __METHOD__ . "\n";
+    $this->em->getConnection()->beginTransaction();
+    $pk = new \PrimaryKey();
+    $this->em->persist($pk);
+    // Below line is interesting - Oracle returns a value for $pk->getId()
+    // (i.e. before flush) while MySQL does not return a value until the
+    // flush. Either way, the subsequent rollback causes the PK to be removed
+    // which is the required behaviour.
+    //$this->assertEmpty($pk->getId());
+    //print "the pk is before: [".$pk->getId()."]\n";
+
+    $this->em->flush(); // sync in-memory state with db so that the pk Id has a value
+    //print "the pk is after: [".$pk->getId()."]\n";
+    // We expect after the flush the pk to have an id value
+    $this->assertNotEmpty($pk->getId());
+    $site = new \Site();
+    $site->setPrimaryKey($pk->getId() . "G0");
+    $site->setShortName('testshortname');
+    $this->em->persist($site);
+    $this->em->flush();
+
+    // Rollback so that we don't commit the new pks and site to the DB
+    $this->em->getConnection()->rollback();
+
+    $testConn = $this->getConnection();
+    $result = $testConn->createQueryTable('results_table', "SELECT * FROM Sites");
+    $this->assertTrue($result->getRowCount() == 0);
+    $result = $testConn->createQueryTable('results_table', "SELECT * FROM PrimaryKeys");
+    $this->assertTrue($result->getRowCount() == 0);
+  }
+
+  /**
+   * Assert that the onDelete="CASCADE" FK mapping defined on 'EndpointLocation.service'
+   * attribute does actually cascade delete a services endpoints when those
+   * endpoints don't have any other joined associations, e.g. with Downtimes.
+   */
+  public function testServiceToEndpointCascadeDelete_WithNoDTs(){
+    print __METHOD__ . "\n";
+    // create a linked entity graph as below:
+    //
+    //     se        (1 service)
+    //    / | \
+    // el1 el2 el3   (3 endpoints)
+
+    $se = TestUtil::createSampleService('service1');
+    $el1 = TestUtil::createSampleEndpointLocation();
+    $el2 = TestUtil::createSampleEndpointLocation();
+    $el3 = TestUtil::createSampleEndpointLocation();
+    $se->addEndpointLocationDoJoin($el1);
+    $se->addEndpointLocationDoJoin($el2);
+    $se->addEndpointLocationDoJoin($el3);
+
+    // persist and flush
+    $this->em->persist($se);
+    $this->em->persist($el1);
+    $this->em->persist($el2);
+    $this->em->persist($el3);
+    $this->em->flush();
+
+    // Delete the service, and assert the endpoints are cascade deleted too !
+    // Impt: This should work because we have NOT joined any downtimes to the
+    // endpoints and so the cascade is free to work at the DB level using
+    // the onDelete="CASCADE" FK mapping defined on 'EndpointLocation.service' attribute.
+    // see: See: http://docs.doctrine-project.org/en/2.0.x/reference/working-with-objects.html#removing-entities
+    //
+    $this->em->remove($se);
+    $this->em->flush();
+
+    // Assert that there are still three EndpointLocations and one Downtimes in the database
+    $testConn = $this->getConnection();
+    $result = $testConn->createQueryTable('results_table', "SELECT * FROM EndpointLocations");
+    $this->assertTrue($result->getRowCount() == 0);
+    $result = $testConn->createQueryTable('results_table', "SELECT * FROM Downtimes");
+    $this->assertTrue($result->getRowCount() == 0);
+    $result = $testConn->createQueryTable('results_table', "SELECT * FROM Services");
+    $this->assertTrue($result->getRowCount() == 0);
+    $result = $testConn->createQueryTable('results_table', "SELECT * FROM Downtimes_EndpointLocations");
+    $this->assertTrue($result->getRowCount() == 0);
+  }
+
+  /**
+   * Assert that the onDelete="CASCADE" FK mapping defined on 'EndpointLocation.service'
+   * annotation fails due to a FK violation exception caused by the endpoint's
+   * association to a downtime (this relationship would need to be deleted first
+   * to allow the endpoint to be deleted cleanly by the cascade).
+   *
+   * @expectedException \Doctrine\DBAL\DBALException
+   */
+  public function testExpectedFK_ViolationOnServiceToEndpointCascadeDelete_WithDTs(){
+    print __METHOD__ . "\n";
+    // create a linked entity graph as beow:
+    //
+    //     se        (1 service)
+    //    /
+    // el1           (1 endpoints)
+    //    \
+    //     dt1       (1 downtime)
+
+    $se = TestUtil::createSampleService('service1');
+    $el1 = TestUtil::createSampleEndpointLocation();
+    $se->addEndpointLocationDoJoin($el1);
+
+    $dt1 = new Downtime();
+    $dt1->setDescription('downtime description');
+    $dt1->setSeverity("WARNING");
+    $dt1->setClassification("UNSCHEDULED");
+
+    $dt1->addEndpointLocation($el1);
+
+    // persist and flush
+    $this->em->persist($se);
+    $this->em->persist($el1);
+    $this->em->persist($dt1);
+    $this->em->flush();
+
+    // Assert that there are expected EndpointLocations and one Downtimes in the database
+    $testConn = $this->getConnection();
+    $result = $testConn->createQueryTable('results_table', "SELECT * FROM EndpointLocations");
+    $this->assertTrue($result->getRowCount() == 1);
+    $result = $testConn->createQueryTable('results_table', "SELECT * FROM Downtimes");
+    $this->assertTrue($result->getRowCount() == 1);
+    $result = $testConn->createQueryTable('results_table', "SELECT * FROM Downtimes_EndpointLocations");
+    $this->assertTrue($result->getRowCount() == 1);
+
+    // Try and delete the service
+    // We expect a FK violation wrapped as a DBALException.
+    // If the fail statement is called below, then it could be an issue with
+    // with the DB. For example, Sqlite with Doctrine does not enforce FK constraints !
+    // see: http://stackoverflow.com/a/4599894
+
+    // We shouldn't be able to remove the site as we need to remove the
+    // services first as we have no cascade-delete option set.
+    $this->em->remove($se);
+    $this->em->flush();
+    $this->fail('Should not get to this point - DBALException expected');
+  }
+
+  /**
+   * Show how Bidirectional relationships must be correctly managed in
+   * userland/application code. (See Doctrine the tutorial:
+   * "Consistency of bi-directional references on the inverse side of a
+   * relation have to be managed in userland application code. Doctrine
+   * cannot magically update your collections to be consistent.").
+   */
+  public function testDowntimeEndpoint_BidirectionalJoinConsistencyManagement(){
+    print __METHOD__ . "\n";
+    // create a linked entity graph as beow:
+    //
+    //     se        (1 service)
+    //    / | \
+    // el1 el2 el3   (3 endpoints)
+    //    \ | /
+    //     dt1       (1 downtime)
+
+    $se = TestUtil::createSampleService('service1');
+    $el1 = TestUtil::createSampleEndpointLocation();
+    $el2 = TestUtil::createSampleEndpointLocation();
+    $el3 = TestUtil::createSampleEndpointLocation();
+    $se->addEndpointLocationDoJoin($el1);
+    $se->addEndpointLocationDoJoin($el2);
+    $se->addEndpointLocationDoJoin($el3);
+
+    $dt1 = new Downtime();
+    $dt1->setDescription('downtime description');
+    $dt1->setSeverity("WARNING");
+    $dt1->setClassification("UNSCHEDULED");
+
+    $dt1->addEndpointLocation($el1);
+    $dt1->addEndpointLocation($el2);
+    $dt1->addEndpointLocation($el3);
+
+    // persist and flush
+    $this->em->persist($se);
+    $this->em->persist($el1);
+    $this->em->persist($el2);
+    $this->em->persist($el3);
+    $this->em->persist($dt1);
+    $this->em->flush();
+
+    // Now delete the relationship between dt1 and el1 + el2 using OWNING
+    // SIDE ONLY; since downtime is the OWNING side we must remove el1 + el2
+    // from downtime to actually delete the relationships in the DB
+    // (on the subsequent flush). Since we have only removed the relationship
+    // on the downtime side, our in-mem entity model is now inconsistent !
+    $dt1->getEndpointLocations()->removeElement($el1);
+    //$el1->getDowntimes()->removeElement($dt1);
+    $dt1->getEndpointLocations()->removeElement($el2);
+    //$el2->getDowntimes()->removeElement($dt1);
+
+    $this->em->flush();
+
+    // Entity model in DB now looks like this:
+    //     se
+    //    / | \
+    // el1 el2 el3
+    //        /
+    //     dt1      (note FKs/relationships have been removed)
+
+    // Assert that there are still three EndpointLocations and one Downtimes in the database
+    $testConn = $this->getConnection();
+    $result = $testConn->createQueryTable('results_table', "SELECT * FROM EndpointLocations");
+    $this->assertTrue($result->getRowCount() == 3);
+    $result = $testConn->createQueryTable('results_table', "SELECT * FROM Downtimes");
+    $this->assertTrue($result->getRowCount() == 1);
+    $result = $testConn->createQueryTable('results_table', "SELECT * FROM Downtimes_EndpointLocations");
+    $this->assertTrue($result->getRowCount() == 1);
+
+    // Assert that our in-mem entity model is now inconsistent with DB
+    // when VIEWED FROM THE ENDPOINT SIDE.
+    $this->assertEquals(1, count($el1->getDowntimes()));
+    $this->assertEquals(1, count($el2->getDowntimes()));
+    $this->assertEquals(1, count($el3->getDowntimes()));
+
+    // Assert that our in-mem entity model is consistent with DB
+    // when VIEWED FROM THE DOWNTIME SIDE:
+    // dt1 still has el3 linked (as expected) but not el1 or el2.
+    // Note we use first() method to fetch first array collection entry!
+    // (calling get(0) would not work as expected because the collection
+    // is a map so array key values are preserved - el3 was added 3rd so it
+    // preserves its zero-offset key value of 2).
+    $this->assertEquals(1, count($dt1->getEndpointLocations()));
+    $this->assertSame($el3, $dt1->getEndpointLocations()->first());
+    $this->assertSame($el3, $dt1->getEndpointLocations()->get(2));
+
+    // Next lines keep our in-mem inverse side consistent with DB. If we
+    // didn't do this, then our first assertion on the following lines below
+    // would fail! This shows that you have to keep your bi-directional
+    // relationships consistent in userland/application code, doctrine
+    // won't do this for you!
+    $el1->getDowntimes()->removeElement($dt1);
+    $el2->getDowntimes()->removeElement($dt1);
+
+    // After updating the 'in-memory' entity model, check that el1 and el2
+    // have no linked downtimes while el3 still has dt linked.
+    // This mirrors what we have in the DB.
+    $this->assertEquals(0, count($el1->getDowntimes()));
+    $this->assertEquals(0, count($el2->getDowntimes()));
+    $this->assertEquals(1, count($el3->getDowntimes()));
+
+    // our collection key value is still same
+    $this->assertSame($el3, $dt1->getEndpointLocations()->get(2));
+  }
+
+  private function createAndPersistScopes(){
+    $this->egiScope = new Scope();
+    $this->egiScope->setName('EGI');
+    $this->egiScope->setDescription('The egi project');
+
+    $this->localScope = new Scope();
+    $this->localScope->setDescription('Local scope means no project');
+    $this->localScope->setName('Local');
+
+    $this->eudatScope = new Scope();
+    $this->eudatScope->setName('EUDAT');
+    $this->eudatScope->setDescription('The eudat project');
+
+    $this->em->persist($this->egiScope);
+    $this->em->persist($this->localScope);
+    $this->em->persist($this->eudatScope);
+  }
+
+
+  // below two tests have now been deprecated, but they are good to keep
+  // commented out because they are still useful to explain join behaviour
+
+  /*public function testNgiSiteNotJoined(){
+      print __METHOD__ . "\n";
+      $this->doNgiSiteJoins(false);
+  }
+  public function testNgiSiteJoined(){
+    print __METHOD__ . "\n";
+    $this->doNgiSiteJoins(true);
+  }*/
+
+  /**
+   * Helper function to show that setting the join/assocition is only set
+   * on one side of a bi-directional relationship. If $setJoinCorrectly is
+   * true, then the newly created sites will be joined to the NGIs. If false,
+   * then the the join will not be set.
+   *
+   * @deprecated since the entity model was updated, but good to keep for reference.
+   * @param boolean $setJoinCorrectly
+   */
+  /*private function doNgiSiteJoins($setJoinCorrectly) {
+      $n = 1;
+      for ($i = 0; $i < $n; $i++) {
+          $ngi = $this->createSampleNGI('ngi' . $i);
+          $site = $this->createSampleSite('site' . $i, 'pk' . $i);
+          if ($setJoinCorrectly) {
+              // This will set the join/association
+              $site->setNgiDoJoin($ngi);
+              //
+              // **Note** setNgiDoJoin() MUST have the following definition for this test to work as expected:
+              //
+              //   public function setNgiDoJoin(NGI $ngi) {
+          //       $this->ngi = $ngi;
+              //       $ngi->addSiteNoJoin($this);
+          //   }
+          } else {
+              // This will NOT set the join/association (only setting on the inverse side)
+              $ngi->addSiteNoJoin($site);
+              //
+              // **Note** addSiteNoJoin() MUST have the following definition for this test to work as expected:
+              //
+              //   public function addSiteNoJoin(Site $site) {
+      //       $this->sites[] = $site;
+          //   }
+          }
+          $this->em->persist($site); // is now managed
+          $this->em->persist($ngi);  // is now managed
+          $this->assertTrue($this->em->contains($site));
+          $this->assertTrue($this->em->contains($ngi));
+      }
+      $this->em->flush(); // commit
+
+      // Do not trust what Doctrine tells us and assert the rows have
+      // actually been added using test connection
+      $testConn = $this->getConnection();
+      $result = $testConn->createQueryTable('results_table', "SELECT * FROM NGIs");
+      $this->assertTrue($result->getRowCount() == $n);
+      $result = $testConn->createQueryTable('results_table', "SELECT * FROM Sites");
+      $this->assertTrue($result->getRowCount() == $n);
+
+      // Assert that the FK joins worked as expected.
+      $result = $testConn->createQueryTable('results_table',
+              "SELECT * FROM NGIs inner join Sites on NGIs.id = Sites.ngi_id");
+      if($setJoinCorrectly) {
+          $this->assertTrue($result->getRowCount() == $n);
+      } else {
+          $this->assertTrue($result->getRowCount() == 0);
+      }
+  }*/
 }
 
 ?>

--- a/tests/doctrine/DoctrineCleanInsert1Test.php
+++ b/tests/doctrine/DoctrineCleanInsert1Test.php
@@ -1,12 +1,7 @@
 <?php
-
-//require_once 'PHPUnit/Extensions/Database/TestCase.php';
-//require_once 'PHPUnit/Extensions/Database/DataSet/DefaultDataSet.php';
 require_once dirname(__FILE__) . '/TestUtil.php';
-
-use Doctrine\ORM\EntityManager;
 require_once dirname(__FILE__) . "/bootstrap.php";
-
+use Doctrine\ORM\EntityManager;
 
 /**
  * This test case truncates the test database (a clean insert with no seed data)
@@ -119,11 +114,6 @@ class DoctrineCleanInsert1Test extends PHPUnit_Extensions_Database_TestCase {
         }
     }
 
-//    public function testSimpleAssert(){
-//        print __METHOD__ . "\n";
-//        $this->assertTrue(2 == 2);
-//    }
-
     public function testAssertTestEntityMangersAreDifferent(){
         print __METHOD__ . "\n";
         $em1 = $this->createEntityManager();
@@ -174,9 +164,7 @@ class DoctrineCleanInsert1Test extends PHPUnit_Extensions_Database_TestCase {
 
 
         $seList = $refetchedSite->getServices();
-        /*foreach($seList as $se){
-            print $se->getId().' '.$se->getHostName()."\n";
-        }*/
+
         $this->assertCount(3, $seList);
     }
 
@@ -230,7 +218,7 @@ class DoctrineCleanInsert1Test extends PHPUnit_Extensions_Database_TestCase {
 
         $this->em->persist($site); // is now managed
         $this->em->persist($ngi);  // is now managed
-        $siteCount = count($ngi->getSites()); //echo('siteCount: '.$siteCount);
+        $siteCount = count($ngi->getSites());
         $this->assertTrue($siteCount == 1);
         $this->em->flush();
 
@@ -452,7 +440,6 @@ class DoctrineCleanInsert1Test extends PHPUnit_Extensions_Database_TestCase {
             $this->em->persist($se);  // is now managed
         }
         $seCount = count($site->getServices());
-        //print 'debug '.$seCount."\n";
         $this->assertTrue($seCount == $n);
         $this->em->rollback();
 
@@ -497,15 +484,12 @@ class DoctrineCleanInsert1Test extends PHPUnit_Extensions_Database_TestCase {
         // If the fail statement is called below, then it could be an issue with
         // with the DB. For example, Sqlite with Doctrine does not enforce FK constraints !
         // see: http://stackoverflow.com/a/4599894
-        //try {
-            // We shouldn't be able to remove the site as we need to remove the
-            // services first as we have no cascade-delete option set.
-            $this->em->remove($refetchedSite);
-            $this->em->flush();
-            $this->fail('Should not get to this point - DBALException expected');
-        //} catch (Exception $ex){
-        //    print_r('yup, and exception was thrown dave'.$ex);
-        //}
+
+        // We shouldn't be able to remove the site as we need to remove the
+        // services first as we have no cascade-delete option set.
+        $this->em->remove($refetchedSite);
+        $this->em->flush();
+        $this->fail('Should not get to this point - DBALException expected');
 
     }
 
@@ -601,7 +585,6 @@ class DoctrineCleanInsert1Test extends PHPUnit_Extensions_Database_TestCase {
         $this->em->flush();
 
         // Rollback so that we don't commit the new pks and site to the DB
-        //$this->em->getConnection()->commit();
         $this->em->getConnection()->rollback();
 
         $testConn = $this->getConnection();
@@ -710,15 +693,12 @@ class DoctrineCleanInsert1Test extends PHPUnit_Extensions_Database_TestCase {
         // If the fail statement is called below, then it could be an issue with
         // with the DB. For example, Sqlite with Doctrine does not enforce FK constraints !
         // see: http://stackoverflow.com/a/4599894
-        //try {
-            // We shouldn't be able to remove the site as we need to remove the
-            // services first as we have no cascade-delete option set.
-            $this->em->remove($se);
-            $this->em->flush();
-            $this->fail('Should not get to this point - DBALException expected');
-        //} catch (Exception $ex){
-        //    print_r('yup, and exception was thrown dave'.$ex);
-        //}
+
+        // We shouldn't be able to remove the site as we need to remove the
+        // services first as we have no cascade-delete option set.
+        $this->em->remove($se);
+        $this->em->flush();
+        $this->fail('Should not get to this point - DBALException expected');
     }
 
     /**

--- a/tests/doctrine/DoctrineCleanInsert1Test.php
+++ b/tests/doctrine/DoctrineCleanInsert1Test.php
@@ -109,8 +109,9 @@ class DoctrineCleanInsert1Test extends PHPUnit_Extensions_Database_TestCase {
       $sql = "SELECT * FROM ".$tableName->getName();
       $result = $con->createQueryTable('results_table', $sql);
       //echo 'row count: '.$result->getRowCount() ;
-      if($result->getRowCount() != 0)
+      if($result->getRowCount() != 0){
         throw new RuntimeException("Invalid fixture. Table has rows: ".$tableName->getName());
+      }
     }
   }
 

--- a/tests/doctrine/DowntimeServiceEndpointTest1.php
+++ b/tests/doctrine/DowntimeServiceEndpointTest1.php
@@ -13,359 +13,360 @@ require_once dirname(__FILE__) . '/../../lib/DAOs/ServiceDAO.php';
  * @author David Meredith
  */
 class DowntimeServiceEndpointTest1 extends PHPUnit_Extensions_Database_TestCase {
-    private $em;
+  private $em;
 
-    /**
-     * Overridden.
-     */
-    public static function setUpBeforeClass() {
-        parent::setUpBeforeClass();
-        echo "\n\n-------------------------------------------------\n";
-        echo "Executing DowntimeServiceEndpointTest1. . .\n";
+  /**
+  * Overridden.
+  */
+  public static function setUpBeforeClass() {
+    parent::setUpBeforeClass();
+    echo "\n\n-------------------------------------------------\n";
+    echo "Executing DowntimeServiceEndpointTest1. . .\n";
+  }
+
+  /**
+  * Overridden. Returns the test database connection.
+  * @return PHPUnit_Extensions_Database_DB_IDatabaseConnection
+  */
+  protected function getConnection() {
+    require_once dirname(__FILE__) . '/bootstrap_pdo.php';
+    return getConnectionToTestDB();
+  }
+
+  /**
+  * Overridden. Returns the test dataset.
+  * Defines how the initial state of the database should look before each test is executed.
+  * @return PHPUnit_Extensions_Database_DataSet_IDataSet
+  */
+  protected function getDataSet() {
+    return $this->createFlatXMLDataSet(dirname(__FILE__) . '/truncateDataTables.xml');
+    // Use below to return an empty data set if we don't want to truncate and seed
+    //return new PHPUnit_Extensions_Database_DataSet_DefaultDataSet();
+  }
+
+  /**
+  * Overridden.
+  */
+  protected function getSetUpOperation() {
+    // CLEAN_INSERT is default
+    //return PHPUnit_Extensions_Database_Operation_Factory::CLEAN_INSERT();
+    //return PHPUnit_Extensions_Database_Operation_Factory::UPDATE();
+    //return PHPUnit_Extensions_Database_Operation_Factory::NONE();
+    //
+    // Issue a DELETE from <table> which is more portable than a
+    // TRUNCATE table <table> (some DBs require high privileges for truncate statements
+    // and also do not allow truncates across tables with FK contstraints e.g. Oracle)
+    return PHPUnit_Extensions_Database_Operation_Factory::DELETE_ALL();
+  }
+
+  /**
+  * Overridden.
+  */
+  protected function getTearDownOperation() {
+    // NONE is default
+    return PHPUnit_Extensions_Database_Operation_Factory::NONE();
+  }
+
+  /**
+  * Sets up the fixture, e.g create a new entityManager for each test run
+  * This method is called before each test method is executed.
+  */
+  protected function setUp() {
+    parent::setUp();
+    $this->em = $this->createEntityManager();
+  }
+
+  /**
+  * @todo Still need to setup connection to different databases.
+  * @return EntityManager
+  */
+  private function createEntityManager() {
+    require dirname(__FILE__) . '/bootstrap_doctrine.php';
+    return $entityManager;
+  }
+
+  /**
+  * Called after setUp() and before each test. Used for common assertions
+  * across all tests.
+  */
+  protected function assertPreConditions() {
+    $con = $this->getConnection();
+    $fixture = dirname(__FILE__) . '/truncateDataTables.xml';
+    $tables = simplexml_load_file($fixture);
+
+    foreach ($tables as $tableName) {
+      $sql = "SELECT * FROM " . $tableName->getName();
+      $result = $con->createQueryTable('results_table', $sql);
+      if ($result->getRowCount() != 0)
+        throw new RuntimeException("Invalid fixture. Table has rows: " . $tableName->getName());
     }
+  }
 
-    /**
-     * Overridden. Returns the test database connection.
-     * @return PHPUnit_Extensions_Database_DB_IDatabaseConnection
-     */
-    protected function getConnection() {
-        require_once dirname(__FILE__) . '/bootstrap_pdo.php';
-        return getConnectionToTestDB();
-    }
+  /**
+  * Delete service1 and ensure the DAO cascade deletes the service's
+  * joined endpoints and downtimes, leaving downtimes that are either reachable
+  * from other services and any orphan downtimes that were never joined
+  * to the service in the first place.
+  */
+  public function testServiceDAO_removeServiceAndJoinedDTs() {
+    print __METHOD__ . "\n";
+    include __DIR__ . '/resources/sampleFixtureData4.php';
 
-    /**
-     * Overridden. Returns the test dataset.
-     * Defines how the initial state of the database should look before each test is executed.
-     * @return PHPUnit_Extensions_Database_DataSet_IDataSet
-     */
-    protected function getDataSet() {
-        return $this->createFlatXMLDataSet(dirname(__FILE__) . '/truncateDataTables.xml');
-        // Use below to return an empty data set if we don't want to truncate and seed
-        //return new PHPUnit_Extensions_Database_DataSet_DefaultDataSet();
-    }
+    // Remove Service
+    // Impt: When deleting a service, we can't rely solely on the
+    // 'onDelete=cascade' defined on the 'EndpointLocation->service'
+    // to correctly cascade-delete the EL. This is because downtimes can also be linked
+    // to the EL.  Therefore, if we don't invoke an $em->remove() on the EL
+    // (either via cascade="remove" or manually invoking em->remove() on each EL),
+    // Doctrine will not have flagged the EL as removed and so will not automatically delete the
+    // relevant row(s) in 'DOWNTIMES_ENDPOINTLOCATIONS' join table.
+    // This would cause a FK integrity/violation constraint exception
+    // on the 'DOWNTIMES_ENDPOINTLOCATIONS.ENDPOINTLOCATION_ID' FK column.
+    // This is why we need to do a managed delete using the ServiceDAO
+    $serviceDao = new ServiceDAO();
+    $serviceDao->setEntityManager($this->em);
+    $serviceDao->removeService($service1);
+    $this->em->flush();
 
-    /**
-     * Overridden.
-     */
-    protected function getSetUpOperation() {
-        // CLEAN_INSERT is default
-        //return PHPUnit_Extensions_Database_Operation_Factory::CLEAN_INSERT();
-        //return PHPUnit_Extensions_Database_Operation_Factory::UPDATE();
-        //return PHPUnit_Extensions_Database_Operation_Factory::NONE();
-        //
-        // Issue a DELETE from <table> which is more portable than a
-        // TRUNCATE table <table> (some DBs require high privileges for truncate statements
-        // and also do not allow truncates across tables with FK contstraints e.g. Oracle)
-        return PHPUnit_Extensions_Database_Operation_Factory::DELETE_ALL();
-    }
+    // use DB connection to check data has been deleted
+    $con = $this->getConnection();
+    $result = $con->createQueryTable('results_table', "SELECT * FROM EndpointLocations");
+    $this->assertTrue($result->getRowCount() == 2);
+    $result = $con->createQueryTable('results_table', "SELECT * FROM Downtimes");
+    $this->assertTrue($result->getRowCount() == 4); // 3 DTs linked to service2 and orphanDT
+  }
 
-    /**
-     * Overridden.
-     */
-    protected function getTearDownOperation() {
-        // NONE is default
-        return PHPUnit_Extensions_Database_Operation_Factory::NONE();
-    }
+  /**
+  * Delete service2 and ensure the DAO cascade deletes the service's
+  * joined endpoints and downtimes, leaving downtimes that are either reachable
+  * from other services and any orphan downtimes that were never joined
+  * to the service in the first place.
+  */
+  public function testServiceDAO_removeService2AndJoinedDTs() {
+    print __METHOD__ . "\n";
+    include __DIR__ . '/resources/sampleFixtureData4.php';
 
-    /**
-     * Sets up the fixture, e.g create a new entityManager for each test run
-     * This method is called before each test method is executed.
-     */
-    protected function setUp() {
-        parent::setUp();
-        $this->em = $this->createEntityManager();
-    }
+    $serviceDao = new ServiceDAO();
+    $serviceDao->setEntityManager($this->em);
+    $serviceDao->removeService($service2);
+    $this->em->flush();
 
-    /**
-     * @todo Still need to setup connection to different databases.
-     * @return EntityManager
-     */
-    private function createEntityManager() {
-        require dirname(__FILE__) . '/bootstrap_doctrine.php';
-        return $entityManager;
-    }
+    // use DB connection to check data has been deleted
+    $con = $this->getConnection();
+    $result = $con->createQueryTable('results_table', "SELECT * FROM EndpointLocations");
+    $this->assertTrue($result->getRowCount() == 2);
+    $result = $con->createQueryTable('results_table', "SELECT * FROM Downtimes");
+    $this->assertTrue($result->getRowCount() == 7); // 6 DTs linked to service1 and orphanDT
+  }
 
-    /**
-     * Called after setUp() and before each test. Used for common assertions
-     * across all tests.
-     */
-    protected function assertPreConditions() {
-        $con = $this->getConnection();
-        $fixture = dirname(__FILE__) . '/truncateDataTables.xml';
-        $tables = simplexml_load_file($fixture);
+  /**
+  * Delete both services and enure the DAO cascade deletes both servcies
+  * joined endpoints and downtimes, leaving only the sites and the single orphan downtime.
+  */
+  public function testServiceDAO_removeService1And2AndJoinedDTs() {
+    print __METHOD__ . "\n";
+    include __DIR__ . '/resources/sampleFixtureData4.php';
 
-        foreach ($tables as $tableName) {
-            $sql = "SELECT * FROM " . $tableName->getName();
-            $result = $con->createQueryTable('results_table', $sql);
-            if ($result->getRowCount() != 0)
-                throw new RuntimeException("Invalid fixture. Table has rows: " . $tableName->getName());
-        }
-    }
+    $serviceDao = new ServiceDAO();
+    $serviceDao->setEntityManager($this->em);
+    $serviceDao->removeService($service2);
+    $serviceDao->removeService($service1);
+    $this->em->flush();
 
-    /**
-     * Delete service1 and ensure the DAO cascade deletes the service's
-     * joined endpoints and downtimes, leaving downtimes that are either reachable
-     * from other services and any orphan downtimes that were never joined
-     * to the service in the first place.
-     */
-    public function testServiceDAO_removeServiceAndJoinedDTs() {
-        print __METHOD__ . "\n";
-        include __DIR__ . '/resources/sampleFixtureData4.php';
+    // use DB connection to check data has been deleted
+    $con = $this->getConnection();
+    $result = $con->createQueryTable('results_table', "SELECT * FROM EndpointLocations");
+    $this->assertTrue($result->getRowCount() == 0);
+    $result = $con->createQueryTable('results_table', "SELECT * FROM Downtimes");
+    $this->assertTrue($result->getRowCount() == 1); // orphanDT
+    $result = $con->createQueryTable('results_table', "SELECT * FROM Sites");
+    $this->assertTrue($result->getRowCount() == 2); // site1 and site2
+  }
 
-        // Remove Service
-        // Impt: When deleting a service, we can't rely solely on the
-        // 'onDelete=cascade' defined on the 'EndpointLocation->service'
-        // to correctly cascade-delete the EL. This is because downtimes can also be linked
-        // to the EL.  Therefore, if we don't invoke an $em->remove() on the EL
-        // (either via cascade="remove" or manually invoking em->remove() on each EL),
-        // Doctrine will not have flagged the EL as removed and so will not automatically delete the
-        // relevant row(s) in 'DOWNTIMES_ENDPOINTLOCATIONS' join table.
-        // This would cause a FK integrity/violation constraint exception
-        // on the 'DOWNTIMES_ENDPOINTLOCATIONS.ENDPOINTLOCATION_ID' FK column.
-        // This is why we need to do a managed delete using the ServiceDAO
-        $serviceDao = new ServiceDAO();
-        $serviceDao->setEntityManager($this->em);
-        $serviceDao->removeService($service1);
-        $this->em->flush();
+  /**
+  * Delete site1 and ensure only site2 and the orphan downtime remain.
+  */
+  public function testSiteService_removeSite() {
+    print __METHOD__ . "\n";
+    include __DIR__ . '/resources/sampleFixtureData4.php';
 
-        // use DB connection to check data has been deleted
-        $con = $this->getConnection();
-        $result = $con->createQueryTable('results_table', "SELECT * FROM EndpointLocations");
-        $this->assertTrue($result->getRowCount() == 2);
-        $result = $con->createQueryTable('results_table', "SELECT * FROM Downtimes");
-        $this->assertTrue($result->getRowCount() == 4); // 3 DTs linked to service2 and orphanDT
-    }
+    $adminUser = TestUtil::createSampleUser('some', 'admin', '/some/admin');
+    $adminUser->setAdmin(TRUE);
+    $this->em->persist($adminUser);
 
-    /**
-     * Delete service2 and ensure the DAO cascade deletes the service's
-     * joined endpoints and downtimes, leaving downtimes that are either reachable
-     * from other services and any orphan downtimes that were never joined
-     * to the service in the first place.
-     */
-    public function testServiceDAO_removeService2AndJoinedDTs() {
-        print __METHOD__ . "\n";
-        include __DIR__ . '/resources/sampleFixtureData4.php';
+    $siteService = new org\gocdb\services\Site();
+    $siteService->setEntityManager($this->em);
+    $siteService->deleteSite($site1, $adminUser, false);
 
-        $serviceDao = new ServiceDAO();
-        $serviceDao->setEntityManager($this->em);
-        $serviceDao->removeService($service2);
-        $this->em->flush();
+    // use DB connection to check data has been deleted
+    $con = $this->getConnection();
+    $result = $con->createQueryTable('results_table', "SELECT * FROM EndpointLocations");
+    $this->assertTrue($result->getRowCount() == 0);
+    $result = $con->createQueryTable('results_table', "SELECT * FROM Downtimes");
+    $this->assertTrue($result->getRowCount() == 1); // orphanDT
+    $result = $con->createQueryTable('results_table', "SELECT * FROM Sites");
+    $this->assertTrue($result->getRowCount() == 1); // site2
+  }
 
-        // use DB connection to check data has been deleted
-        $con = $this->getConnection();
-        $result = $con->createQueryTable('results_table', "SELECT * FROM EndpointLocations");
-        $this->assertTrue($result->getRowCount() == 2);
-        $result = $con->createQueryTable('results_table', "SELECT * FROM Downtimes");
-        $this->assertTrue($result->getRowCount() == 7); // 6 DTs linked to service1 and orphanDT
-    }
+  /**
+  * Delete the parent NGI and ensure all sites, servcies, endponts and downtimes
+  * are deleted leaving only the orphan dowmtime.
+  */
+  public function testNgiService_removeNgi() {
+    print __METHOD__ . "\n";
+    include __DIR__ . '/resources/sampleFixtureData4.php';
 
-    /**
-     * Delete both services and enure the DAO cascade deletes both servcies
-     * joined endpoints and downtimes, leaving only the sites and the single orphan downtime.
-     */
-    public function testServiceDAO_removeService1And2AndJoinedDTs() {
-        print __METHOD__ . "\n";
-        include __DIR__ . '/resources/sampleFixtureData4.php';
+    $adminUser = TestUtil::createSampleUser('some', 'admin', '/some/admin');
+    $adminUser->setAdmin(TRUE);
+    $this->em->persist($adminUser);
 
-        $serviceDao = new ServiceDAO();
-        $serviceDao->setEntityManager($this->em);
-        $serviceDao->removeService($service2);
-        $serviceDao->removeService($service1);
-        $this->em->flush();
+    $ngiService = new org\gocdb\services\NGI();
+    $ngiService->setEntityManager($this->em);
+    $ngiService->deleteNgi($ngi, $adminUser, FALSE);
 
-        // use DB connection to check data has been deleted
-        $con = $this->getConnection();
-        $result = $con->createQueryTable('results_table', "SELECT * FROM EndpointLocations");
-        $this->assertTrue($result->getRowCount() == 0);
-        $result = $con->createQueryTable('results_table', "SELECT * FROM Downtimes");
-        $this->assertTrue($result->getRowCount() == 1); // orphanDT
-        $result = $con->createQueryTable('results_table', "SELECT * FROM Sites");
-        $this->assertTrue($result->getRowCount() == 2); // site1 and site2
-    }
-
-    /**
-     * Delete site1 and ensure only site2 and the orphan downtime remain.
-     */
-    public function testSiteService_removeSite() {
-        print __METHOD__ . "\n";
-        include __DIR__ . '/resources/sampleFixtureData4.php';
-
-        $adminUser = TestUtil::createSampleUser('some', 'admin', '/some/admin');
-        $adminUser->setAdmin(TRUE);
-        $this->em->persist($adminUser);
-
-        $siteService = new org\gocdb\services\Site();
-        $siteService->setEntityManager($this->em);
-        $siteService->deleteSite($site1, $adminUser, false);
-
-        // use DB connection to check data has been deleted
-        $con = $this->getConnection();
-        $result = $con->createQueryTable('results_table', "SELECT * FROM EndpointLocations");
-        $this->assertTrue($result->getRowCount() == 0);
-        $result = $con->createQueryTable('results_table', "SELECT * FROM Downtimes");
-        $this->assertTrue($result->getRowCount() == 1); // orphanDT
-        $result = $con->createQueryTable('results_table', "SELECT * FROM Sites");
-        $this->assertTrue($result->getRowCount() == 1); // site2
-    }
-
-    /**
-     * Delete the parent NGI and ensure all sites, servcies, endponts and downtimes
-     * are deleted leaving only the orphan dowmtime.
-     */
-    public function testNgiService_removeNgi() {
-        print __METHOD__ . "\n";
-        include __DIR__ . '/resources/sampleFixtureData4.php';
-
-        $adminUser = TestUtil::createSampleUser('some', 'admin', '/some/admin');
-        $adminUser->setAdmin(TRUE);
-        $this->em->persist($adminUser);
-
-        $ngiService = new org\gocdb\services\NGI();
-        $ngiService->setEntityManager($this->em);
-        $ngiService->deleteNgi($ngi, $adminUser, FALSE);
-
-        // use DB connection to check data has been deleted
-        $con = $this->getConnection();
-        $result = $con->createQueryTable('results_table', "SELECT * FROM EndpointLocations");
-        $this->assertTrue($result->getRowCount() == 0);
-        $result = $con->createQueryTable('results_table', "SELECT * FROM Downtimes");
-        $this->assertTrue($result->getRowCount() == 1); // orphanDT
-        $result = $con->createQueryTable('results_table', "SELECT * FROM Sites");
-        $this->assertTrue($result->getRowCount() == 0); // site2
-    }
+    // use DB connection to check data has been deleted
+    $con = $this->getConnection();
+    $result = $con->createQueryTable('results_table', "SELECT * FROM EndpointLocations");
+    $this->assertTrue($result->getRowCount() == 0);
+    $result = $con->createQueryTable('results_table', "SELECT * FROM Downtimes");
+    $this->assertTrue($result->getRowCount() == 1); // orphanDT
+    $result = $con->createQueryTable('results_table', "SELECT * FROM Sites");
+    $this->assertTrue($result->getRowCount() == 0); // site2
+  }
 
 
-    /**
-     * Test the <code>$serviceDAO->removeEndpoint($endpoint)</code> method.
-     */
-    public function testServiceDAORemoveEndpoint(){
-        print __METHOD__ . "\n";
-        // create a linked entity graph as beow:
-        //
-        //      se -----|    (1 service)
-        //     / | \    |
-        //  el1 el2 el3 |    (3 endpoints)
-        //  |  \ | /    |
-        // dt0  dt1 ----|    (1 downtime)
+  /**
+  * Test the <code>$serviceDAO->removeEndpoint($endpoint)</code> method.
+  */
+  public function testServiceDAORemoveEndpoint(){
+    print __METHOD__ . "\n";
+    /* create a linked entity graph as beow:
+    *
+    *         se  -----|    (1 service)
+    *       / | \      |
+    *    el1 el2 el3   |    (3 endpoints)
+    *     |  \ | /     |
+    *    dt0  dt1  ----|    (1 downtime)
+    */
 
-        $dt1 = new Downtime();
-        $dt1->setDescription('downtime description');
-        $dt1->setSeverity("WARNING");
-        $dt1->setClassification("UNSCHEDULED");
+    $dt1 = new Downtime();
+    $dt1->setDescription('downtime description');
+    $dt1->setSeverity("WARNING");
+    $dt1->setClassification("UNSCHEDULED");
 
-        $dt0 = new Downtime();
-        $dt0->setDescription('downtime description');
-        $dt0->setSeverity("WARNING");
-        $dt0->setClassification("UNSCHEDULED");
+    $dt0 = new Downtime();
+    $dt0->setDescription('downtime description');
+    $dt0->setSeverity("WARNING");
+    $dt0->setClassification("UNSCHEDULED");
 
-        $se = TestUtil::createSampleService('service1');
-        $el1 = TestUtil::createSampleEndpointLocation();
-        $el2 = TestUtil::createSampleEndpointLocation();
-        $el3 = TestUtil::createSampleEndpointLocation();
-        $se->addEndpointLocationDoJoin($el1);
-        $se->addEndpointLocationDoJoin($el2);
-        $se->addEndpointLocationDoJoin($el3);
-        //$se->_addDowntime($dt1); // we don't call this in client code !
+    $se = TestUtil::createSampleService('service1');
+    $el1 = TestUtil::createSampleEndpointLocation();
+    $el2 = TestUtil::createSampleEndpointLocation();
+    $el3 = TestUtil::createSampleEndpointLocation();
+    $se->addEndpointLocationDoJoin($el1);
+    $se->addEndpointLocationDoJoin($el2);
+    $se->addEndpointLocationDoJoin($el3);
+    //$se->_addDowntime($dt1); // we don't call this in client code !
 
-        $dt1->addEndpointLocation($el1);
-        $dt1->addEndpointLocation($el2);
-        $dt1->addEndpointLocation($el3);
-        $dt1->addService($se);
+    $dt1->addEndpointLocation($el1);
+    $dt1->addEndpointLocation($el2);
+    $dt1->addEndpointLocation($el3);
+    $dt1->addService($se);
 
-        $dt0->addEndpointLocation($el1);
-        //$dt0->addService($se); // note we don't add this relationship for purposes of the test
+    $dt0->addEndpointLocation($el1);
+    //$dt0->addService($se); // note we don't add this relationship for purposes of the test
 
-        // persist and flush
-        $this->em->persist($se);
-        $this->em->persist($el1);
-        $this->em->persist($el2);
-        $this->em->persist($el3);
-        $this->em->persist($dt1);
-        $this->em->persist($dt0);
-        $this->em->flush();
+    // persist and flush
+    $this->em->persist($se);
+    $this->em->persist($el1);
+    $this->em->persist($el2);
+    $this->em->persist($el3);
+    $this->em->persist($dt1);
+    $this->em->persist($dt0);
+    $this->em->flush();
 
-        // create DAO to test
-        $serviceDao = new ServiceDAO();
-        $serviceDao->setEntityManager($this->em);
+    // create DAO to test
+    $serviceDao = new ServiceDAO();
+    $serviceDao->setEntityManager($this->em);
 
-        // remove first endpoint causing dt0 to be orphaned
-        $serviceDao->removeEndpoint($el1);
-        $this->em->flush();
+    // remove first endpoint causing dt0 to be orphaned
+    $serviceDao->removeEndpoint($el1);
+    $this->em->flush();
 
-        // Assert expected object graph
-        //     se -----|   (1 service)
-        //      | \    |
-        //     el2 el3 |   (2 endpoints)
-        //      | /    |
-        // dt0 dt1-----|   (2 downtime)
-        //
-        $testConn = $this->getConnection();
-        $result = $testConn->createQueryTable('results_table', "SELECT * FROM EndpointLocations");
-        $this->assertTrue($result->getRowCount() == 2);
-        $result = $testConn->createQueryTable('results_table', "SELECT * FROM Downtimes");
-        $this->assertTrue($result->getRowCount() == 2);
-        $result = $testConn->createQueryTable('results_table', "SELECT * FROM Downtimes_EndpointLocations");
-        $this->assertTrue($result->getRowCount() == 2);
+    /* Assert expected object graph
+    *       se   -----|   (1 service)
+    *      |  \       |
+    *     el2 el3     |   (2 endpoints)
+    *       |  |      |
+    *     dt0 dt1-----|   (2 downtime)
+    */
+    $testConn = $this->getConnection();
+    $result = $testConn->createQueryTable('results_table', "SELECT * FROM EndpointLocations");
+    $this->assertTrue($result->getRowCount() == 2);
+    $result = $testConn->createQueryTable('results_table', "SELECT * FROM Downtimes");
+    $this->assertTrue($result->getRowCount() == 2);
+    $result = $testConn->createQueryTable('results_table', "SELECT * FROM Downtimes_EndpointLocations");
+    $this->assertTrue($result->getRowCount() == 2);
 
-         // Assert expected object graph in ORM Mem
-        $this->assertEquals(1, count($el2->getDowntimes()));
-        $this->assertEquals(1, count($el3->getDowntimes()));
-        $this->assertEquals(2, count($se->getEndpointLocations()));
-        $this->assertEquals(1, count($se->getDowntimes()));
-        $this->assertEquals(2, count($dt1->getEndpointLocations()));
-        $this->assertEquals(1, count($dt1->getServices()));
+     // Assert expected object graph in ORM Mem
+    $this->assertEquals(1, count($el2->getDowntimes()));
+    $this->assertEquals(1, count($el3->getDowntimes()));
+    $this->assertEquals(2, count($se->getEndpointLocations()));
+    $this->assertEquals(1, count($se->getDowntimes()));
+    $this->assertEquals(2, count($dt1->getEndpointLocations()));
+    $this->assertEquals(1, count($dt1->getServices()));
 
-        // remove another el
-        $serviceDao->removeEndpoint($el2);
-        $this->em->flush();
+    // remove another el
+    $serviceDao->removeEndpoint($el2);
+    $this->em->flush();
 
-        // Assert expected object graph in DB
-        //     se -----| (1 service)
-        //       \     |
-        //        el3  | (1 endpoints)
-        //        /    |
-        // dt0 dt1-----| (2 downtime)
-        //
-        $testConn = $this->getConnection();
-        $result = $testConn->createQueryTable('results_table', "SELECT * FROM EndpointLocations");
-        $this->assertTrue($result->getRowCount() == 1);
-        $result = $testConn->createQueryTable('results_table', "SELECT * FROM Downtimes");
-        $this->assertTrue($result->getRowCount() == 2);
-        $result = $testConn->createQueryTable('results_table', "SELECT * FROM Downtimes_EndpointLocations");
-        $this->assertTrue($result->getRowCount() == 1);
+    /* Assert expected object graph in DB
+    *      se -----| (1 service)
+    *        \     |
+    *         el3  | (1 endpoints)
+    *         /    |
+    *  dt0 dt1-----| (2 downtime)
+    */
+    $testConn = $this->getConnection();
+    $result = $testConn->createQueryTable('results_table', "SELECT * FROM EndpointLocations");
+    $this->assertTrue($result->getRowCount() == 1);
+    $result = $testConn->createQueryTable('results_table', "SELECT * FROM Downtimes");
+    $this->assertTrue($result->getRowCount() == 2);
+    $result = $testConn->createQueryTable('results_table', "SELECT * FROM Downtimes_EndpointLocations");
+    $this->assertTrue($result->getRowCount() == 1);
 
-        // Assert expected object graph in ORM Mem
-        $this->assertEquals(1, count($el3->getDowntimes()));
-        $this->assertEquals(1, count($se->getEndpointLocations()));
-        $this->assertEquals(1, count($se->getDowntimes()));
-        $this->assertEquals(1, count($dt1->getEndpointLocations()));
-        $this->assertEquals(1, count($dt1->getServices()));
+    // Assert expected object graph in ORM Mem
+    $this->assertEquals(1, count($el3->getDowntimes()));
+    $this->assertEquals(1, count($se->getEndpointLocations()));
+    $this->assertEquals(1, count($se->getDowntimes()));
+    $this->assertEquals(1, count($dt1->getEndpointLocations()));
+    $this->assertEquals(1, count($dt1->getServices()));
 
-        // remove another el
-        $serviceDao->removeEndpoint($el3);
-        $this->em->flush();
+    // remove another el
+    $serviceDao->removeEndpoint($el3);
+    $this->em->flush();
 
-         // Assert expected object graph in DB
-        //     se -----| (1 service)
-        //             |
-        //             | (1 endpoints)
-        //             |
-        // dt0 dt1-----| (2 downtime)
-        //
-        $testConn = $this->getConnection();
-        $result = $testConn->createQueryTable('results_table', "SELECT * FROM EndpointLocations");
-        $this->assertTrue($result->getRowCount() == 0);
-        $result = $testConn->createQueryTable('results_table', "SELECT * FROM Downtimes");
-        $this->assertTrue($result->getRowCount() == 2);
-        $result = $testConn->createQueryTable('results_table', "SELECT * FROM Downtimes_EndpointLocations");
-        $this->assertTrue($result->getRowCount() == 0);
+    /* Assert expected object graph in DB
+    *      se -----| (1 service)
+    *              |
+    *              | (1 endpoints)
+    *              |
+    *  dt0 dt1-----| (2 downtime)
+    */
+    $testConn = $this->getConnection();
+    $result = $testConn->createQueryTable('results_table', "SELECT * FROM EndpointLocations");
+    $this->assertTrue($result->getRowCount() == 0);
+    $result = $testConn->createQueryTable('results_table', "SELECT * FROM Downtimes");
+    $this->assertTrue($result->getRowCount() == 2);
+    $result = $testConn->createQueryTable('results_table', "SELECT * FROM Downtimes_EndpointLocations");
+    $this->assertTrue($result->getRowCount() == 0);
 
-        // Assert expected object graph in ORM Mem
-        $this->assertEquals(0, count($se->getEndpointLocations()));
-        $this->assertEquals(1, count($se->getDowntimes()));
-        $this->assertEquals(0, count($dt1->getEndpointLocations()));
-        $this->assertEquals(1, count($dt1->getServices()));
-    }
+    // Assert expected object graph in ORM Mem
+    $this->assertEquals(0, count($se->getEndpointLocations()));
+    $this->assertEquals(1, count($se->getDowntimes()));
+    $this->assertEquals(0, count($dt1->getEndpointLocations()));
+    $this->assertEquals(1, count($dt1->getServices()));
+  }
 
 }
 ?>

--- a/tests/doctrine/DowntimeServiceEndpointTest1.php
+++ b/tests/doctrine/DowntimeServiceEndpointTest1.php
@@ -97,8 +97,9 @@ class DowntimeServiceEndpointTest1 extends PHPUnit_Extensions_Database_TestCase 
     foreach ($tables as $tableName) {
       $sql = "SELECT * FROM " . $tableName->getName();
       $result = $con->createQueryTable('results_table', $sql);
-      if ($result->getRowCount() != 0)
+      if ($result->getRowCount() != 0) {
         throw new RuntimeException("Invalid fixture. Table has rows: " . $tableName->getName());
+      }
     }
   }
 

--- a/tests/doctrine/DowntimeServiceEndpointTest1.php
+++ b/tests/doctrine/DowntimeServiceEndpointTest1.php
@@ -1,11 +1,6 @@
 <?php
-
-//require_once 'PHPUnit/Extensions/Database/TestCase.php';
-//require_once 'PHPUnit/Extensions/Database/DataSet/DefaultDataSet.php';
 require_once dirname(__FILE__) . '/TestUtil.php';
-
 use Doctrine\ORM\EntityManager;
-
 require_once dirname(__FILE__) . '/bootstrap.php';
 require_once dirname(__FILE__) . '/../../lib/Gocdb_Services/Site.php';
 require_once dirname(__FILE__) . '/../../lib/Gocdb_Services/NGI.php';
@@ -18,12 +13,7 @@ require_once dirname(__FILE__) . '/../../lib/DAOs/ServiceDAO.php';
  * @author David Meredith
  */
 class DowntimeServiceEndpointTest1 extends PHPUnit_Extensions_Database_TestCase {
-
     private $em;
-
-    //private $egiScope;
-    //private $localScope;
-    //private $eudatScope;
 
     /**
      * Overridden.
@@ -91,7 +81,6 @@ class DowntimeServiceEndpointTest1 extends PHPUnit_Extensions_Database_TestCase 
      * @return EntityManager
      */
     private function createEntityManager() {
-        //require dirname(__FILE__).'/../lib/Doctrine/bootstrap.php';
         require dirname(__FILE__) . '/bootstrap_doctrine.php';
         return $entityManager;
     }
@@ -106,10 +95,8 @@ class DowntimeServiceEndpointTest1 extends PHPUnit_Extensions_Database_TestCase 
         $tables = simplexml_load_file($fixture);
 
         foreach ($tables as $tableName) {
-            //print $tableName->getName() . "\n";
             $sql = "SELECT * FROM " . $tableName->getName();
             $result = $con->createQueryTable('results_table', $sql);
-            //echo 'row count: '.$result->getRowCount() ;
             if ($result->getRowCount() != 0)
                 throw new RuntimeException("Invalid fixture. Table has rows: " . $tableName->getName());
         }
@@ -380,9 +367,5 @@ class DowntimeServiceEndpointTest1 extends PHPUnit_Extensions_Database_TestCase 
         $this->assertEquals(1, count($dt1->getServices()));
     }
 
-
-
 }
-
-//close class
 ?>

--- a/tests/doctrine/ExtensionsTest.php
+++ b/tests/doctrine/ExtensionsTest.php
@@ -96,8 +96,9 @@ class ExtensionsTest extends PHPUnit_Extensions_Database_TestCase {
     foreach ($tables as $tableName) {
       $sql = "SELECT * FROM " . $tableName->getName();
       $result = $con->createQueryTable('results_table', $sql);
-      if ($result->getRowCount() != 0)
+      if ($result->getRowCount() != 0) {
         throw new RuntimeException("Invalid fixture. Table has rows: " . $tableName->getName());
+      }
     }
   }
 

--- a/tests/doctrine/ExtensionsTest.php
+++ b/tests/doctrine/ExtensionsTest.php
@@ -7,46 +7,46 @@ use Doctrine\ORM\EntityManager;
 require_once dirname(__FILE__) . '/bootstrap.php';
 
 /**
- * A template that includes all the setup and tear down functions for writting
- * a PHPUnit test to test doctrine.
- *
- * @author James McCarthy
- */
+* A template that includes all the setup and tear down functions for writting
+* a PHPUnit test to test doctrine.
+*
+* @author James McCarthy
+*/
 class ExtensionsTest extends PHPUnit_Extensions_Database_TestCase {
 
-    private $em;
+  private $em;
 
-    /**
-     * Overridden.
-     */
-    public static function setUpBeforeClass() {
+  /**
+   * Overridden.
+   */
+  public static function setUpBeforeClass() {
     parent::setUpBeforeClass();
     echo "\n\n-------------------------------------------------\n";
     echo "Executing ExtensionsTest. . .\n";
-    }
+  }
 
-    /**
-     * Overridden. Returns the test database connection.
-     * @return PHPUnit_Extensions_Database_DB_IDatabaseConnection
-     */
-    protected function getConnection() {
+  /**
+   * Overridden. Returns the test database connection.
+   * @return PHPUnit_Extensions_Database_DB_IDatabaseConnection
+   */
+  protected function getConnection() {
     require_once dirname(__FILE__) . '/bootstrap_pdo.php';
     return getConnectionToTestDB();
-    }
+  }
 
-    /**
-     * Overridden. Returns the test dataset.
-     * Defines how the initial state of the database should look before each test is executed.
-     * @return PHPUnit_Extensions_Database_DataSet_IDataSet
-     */
-    protected function getDataSet() {
+  /**
+   * Overridden. Returns the test dataset.
+   * Defines how the initial state of the database should look before each test is executed.
+   * @return PHPUnit_Extensions_Database_DataSet_IDataSet
+   */
+  protected function getDataSet() {
     return $this->createFlatXMLDataSet(dirname(__FILE__) . '/truncateDataTables.xml');
-    }
+  }
 
-    /**
-     * Overridden.
-     */
-    protected function getSetUpOperation() {
+  /**
+   * Overridden.
+   */
+  protected function getSetUpOperation() {
     // CLEAN_INSERT is default
     //return PHPUnit_Extensions_Database_Operation_Factory::CLEAN_INSERT();
     //return PHPUnit_Extensions_Database_Operation_Factory::UPDATE();
@@ -56,56 +56,56 @@ class ExtensionsTest extends PHPUnit_Extensions_Database_TestCase {
     // TRUNCATE table <table> (some DBs require high privileges for truncate statements
     // and also do not allow truncates across tables with FK contstraints e.g. Oracle)
     return PHPUnit_Extensions_Database_Operation_Factory::DELETE_ALL();
-    }
+  }
 
-    /**
-     * Overridden.
-     */
-    protected function getTearDownOperation() {
+  /**
+   * Overridden.
+   */
+  protected function getTearDownOperation() {
     // NONE is default
     return PHPUnit_Extensions_Database_Operation_Factory::NONE();
-    }
+  }
 
-    /**
-     * Sets up the fixture, e.g create a new entityManager for each test run
-     * This method is called before each test method is executed.
-     */
-    protected function setUp() {
+  /**
+   * Sets up the fixture, e.g create a new entityManager for each test run
+   * This method is called before each test method is executed.
+   */
+  protected function setUp() {
     parent::setUp();
     $this->em = $this->createEntityManager();
-    }
+  }
 
-    /**
-     * @todo Still need to setup connection to different databases.
-     * @return EntityManager
-     */
-    private function createEntityManager() {
+  /**
+   * @todo Still need to setup connection to different databases.
+   * @return EntityManager
+   */
+  private function createEntityManager() {
     require dirname(__FILE__) . '/bootstrap_doctrine.php';
     return $entityManager;
-    }
+  }
 
-    /**
-     * Called after setUp() and before each test. Used for common assertions
-     * across all tests.
-     */
-    protected function assertPreConditions() {
+  /**
+   * Called after setUp() and before each test. Used for common assertions
+   * across all tests.
+   */
+  protected function assertPreConditions() {
     $con = $this->getConnection();
     $fixture = dirname(__FILE__) . '/truncateDataTables.xml';
     $tables = simplexml_load_file($fixture);
 
     foreach ($tables as $tableName) {
-        $sql = "SELECT * FROM " . $tableName->getName();
-        $result = $con->createQueryTable('results_table', $sql);
-        if ($result->getRowCount() != 0)
+      $sql = "SELECT * FROM " . $tableName->getName();
+      $result = $con->createQueryTable('results_table', $sql);
+      if ($result->getRowCount() != 0)
         throw new RuntimeException("Invalid fixture. Table has rows: " . $tableName->getName());
     }
-    }
+  }
 
-    /**
-     * An example test showing the creation of a site and properties and that
-     * all data is removed on deletion of a site or property
-     */
-    public function testSitePropertyDeletions() {
+  /**
+   * An example test showing the creation of a site and properties and that
+   * all data is removed on deletion of a site or property
+   */
+  public function testSitePropertyDeletions() {
     print __METHOD__ . "\n";
 
     //Create a site
@@ -181,13 +181,13 @@ class ExtensionsTest extends PHPUnit_Extensions_Database_TestCase {
     //Check properties are gone
     $result = $con->createQueryTable('results', "SELECT * FROM Site_Properties WHERE PARENTSITE_ID = '$siteId'");
     $this->assertEquals(0, $result->getRowCount());
-    }
+  }
 
-    /**
-     * An example test showing the creation of a service and properties and that
-     * all data is removed on deletion of a service or property
-     */
-    public function testServicePropertyDeletions() {
+  /**
+   * An example test showing the creation of a service and properties and that
+   * all data is removed on deletion of a service or property
+   */
+  public function testServicePropertyDeletions() {
     print __METHOD__ . "\n";
 
     //Create a service
@@ -212,7 +212,6 @@ class ExtensionsTest extends PHPUnit_Extensions_Database_TestCase {
     $service->addServicePropertyDoJoin($prop2);
     $service->addServicePropertyDoJoin($prop3);
 
-
     //Persist the service & property in the entity manager
     $this->em->persist($service);
     $this->em->persist($ngi);
@@ -221,14 +220,12 @@ class ExtensionsTest extends PHPUnit_Extensions_Database_TestCase {
     $this->em->persist($prop2);
     $this->em->persist($prop3);
 
-
     //Commit the service to the database
     $this->em->flush();
 
     //Check that the service has 3 properties associated with it
     $properties = $service->getServiceProperties();
     $this->assertTrue(count($properties) == 3);
-
 
     //Create an admin user that can delete a property
     $adminUser = TestUtil::createSampleUser('my', 'admin', '/my/admin');
@@ -274,13 +271,13 @@ class ExtensionsTest extends PHPUnit_Extensions_Database_TestCase {
     //Check properties are gone
     $result = $con->createQueryTable('results', "SELECT * FROM Service_Properties WHERE PARENTSERVICE_ID = '$servId'");
     $this->assertEquals(0, $result->getRowCount());
-    }
+  }
 
-    /**
-     * An example test showing the creation of a service group and properties
-     * and that all data is removed on deletion of a service group or property
-     */
-    public function testServiceGroupPropertyDeletions() {
+  /**
+   * An example test showing the creation of a service group and properties
+   * and that all data is removed on deletion of a service group or property
+   */
+  public function testServiceGroupPropertyDeletions() {
     print __METHOD__ . "\n";
 
     //Create a service
@@ -310,7 +307,6 @@ class ExtensionsTest extends PHPUnit_Extensions_Database_TestCase {
     $sg->addServiceGroupPropertyDoJoin($prop2);
     $sg->addServiceGroupPropertyDoJoin($prop3);
 
-
     //Persist the service, ngi, site, service group & property in the entity manager
     $this->em->persist($service);
     $this->em->persist($ngi);
@@ -320,14 +316,12 @@ class ExtensionsTest extends PHPUnit_Extensions_Database_TestCase {
     $this->em->persist($prop2);
     $this->em->persist($prop3);
 
-
     //Commit the entites to the database
     $this->em->flush();
 
     //Check that the service group has 3 properties associated with it
     $properties = $sg->getServiceGroupProperties();
     $this->assertTrue(count($properties) == 3);
-
 
     //Create an admin user that can delete a property
     $adminUser = TestUtil::createSampleUser('my', 'admin', '/my/admin');
@@ -376,13 +370,13 @@ class ExtensionsTest extends PHPUnit_Extensions_Database_TestCase {
     //Check properties are gone
     $result = $con->createQueryTable('results', "SELECT * FROM ServiceGroup_Properties WHERE PARENTSERVICEGROUP_ID = '$sgId'");
     $this->assertEquals(0, $result->getRowCount());
-    }
+  }
 
-    /**
-     * Show the creation of an endpoint and properties and that
-     * all data is removed on deletion of an endpoint or property
-     */
-    public function testEndpointPropertyDeletions() {
+  /**
+   * Show the creation of an endpoint and properties and that
+   * all data is removed on deletion of an endpoint or property
+   */
+  public function testEndpointPropertyDeletions() {
     print __METHOD__ . "\n";
 
     $service = TestUtil::createSampleService("TestService");
@@ -468,8 +462,7 @@ class ExtensionsTest extends PHPUnit_Extensions_Database_TestCase {
     //Check properties are gone
     $result = $con->createQueryTable('results', "SELECT * FROM Endpoint_Properties WHERE PARENTENDPOINT_ID = '$endpointId'");
     $this->assertEquals(0, $result->getRowCount());
-    }
+  }
 
 }
-
 ?>

--- a/tests/doctrine/ExtensionsTest.php
+++ b/tests/doctrine/ExtensionsTest.php
@@ -1,14 +1,9 @@
 <?php
-
-//require_once 'PHPUnit/Extensions/Database/TestCase.php';
-//require_once 'PHPUnit/Extensions/Database/DataSet/DefaultDataSet.php';
 require_once dirname(__FILE__) . '/TestUtil.php';
 require_once dirname(__FILE__) . '/../../lib/Gocdb_Services/ServiceService.php';
 require_once dirname(__FILE__) . '/../../lib/Gocdb_Services/RoleActionMappingService.php';
 require_once dirname(__FILE__) . '/../../lib/Gocdb_Services/RoleActionAuthorisationService.php';
-
 use Doctrine\ORM\EntityManager;
-
 require_once dirname(__FILE__) . '/bootstrap.php';
 
 /**
@@ -99,10 +94,8 @@ class ExtensionsTest extends PHPUnit_Extensions_Database_TestCase {
     $tables = simplexml_load_file($fixture);
 
     foreach ($tables as $tableName) {
-        //print $tableName->getName() . "\n";
         $sql = "SELECT * FROM " . $tableName->getName();
         $result = $con->createQueryTable('results_table', $sql);
-        //echo 'row count: '.$result->getRowCount() ;
         if ($result->getRowCount() != 0)
         throw new RuntimeException("Invalid fixture. Table has rows: " . $tableName->getName());
     }
@@ -260,11 +253,6 @@ class ExtensionsTest extends PHPUnit_Extensions_Database_TestCase {
     $this->assertTrue(count($properties) == 2);
     $this->em->flush();
 
-    //Print names of properties
-    //foreach($properties as $prop){
-    //	print($prop->getKeyName()."-");
-    //	print($prop->getKeyValue()."\n");
-    //}
     //Check this via the database
     $con = $this->getConnection();
 
@@ -367,11 +355,6 @@ class ExtensionsTest extends PHPUnit_Extensions_Database_TestCase {
     $this->assertTrue(count($properties) == 2);
     $this->em->flush();
 
-    //Print names of properties
-    //foreach($properties as $prop){
-    //	print($prop->getKeyName()."-");
-    //	print($prop->getKeyValue()."\n");
-    //}
     //Check this via the database
     $con = $this->getConnection();
 
@@ -462,12 +445,6 @@ class ExtensionsTest extends PHPUnit_Extensions_Database_TestCase {
     $properties = $endpoint->getEndpointProperties();
     $this->assertTrue(count($properties) == 2);
     $this->em->flush();
-
-    //Print names of properties
-    //foreach ($properties as $prop) {
-    //    print($prop->getKeyName() . "-");
-    //    print($prop->getKeyValue() . "\n");
-    //}
 
     //Check this via the database
     $con = $this->getConnection();

--- a/tests/doctrine/NGIServiceTest.php
+++ b/tests/doctrine/NGIServiceTest.php
@@ -1,7 +1,4 @@
 <?php
-
-//require_once 'PHPUnit/Extensions/Database/TestCase.php';
-//require_once 'PHPUnit/Extensions/Database/DataSet/DefaultDataSet.php';
 require_once dirname(__FILE__) . '/TestUtil.php';
 
 use Doctrine\ORM\EntityManager;
@@ -18,10 +15,6 @@ require_once dirname(__FILE__) . '/../../lib/Gocdb_Services/NGI.php';
 class NGIServiceTest extends PHPUnit_Extensions_Database_TestCase {
 
     private $em;
-
-    //private $egiScope;
-    //private $localScope;
-    //private $eudatScope;
 
     /**
      * Overridden.
@@ -89,7 +82,6 @@ class NGIServiceTest extends PHPUnit_Extensions_Database_TestCase {
      * @return EntityManager
      */
     private function createEntityManager() {
-        //require dirname(__FILE__).'/../lib/Doctrine/bootstrap.php';
         require dirname(__FILE__) . '/bootstrap_doctrine.php';
         return $entityManager;
     }
@@ -104,10 +96,8 @@ class NGIServiceTest extends PHPUnit_Extensions_Database_TestCase {
         $tables = simplexml_load_file($fixture);
 
         foreach ($tables as $tableName) {
-            //print $tableName->getName() . "\n";
             $sql = "SELECT * FROM " . $tableName->getName();
             $result = $con->createQueryTable('results_table', $sql);
-            //echo 'row count: '.$result->getRowCount() ;
             if ($result->getRowCount() != 0)
                 throw new RuntimeException("Invalid fixture. Table has rows: " . $tableName->getName());
         }
@@ -156,6 +146,4 @@ class NGIServiceTest extends PHPUnit_Extensions_Database_TestCase {
     }
 
 }
-
-
 ?>

--- a/tests/doctrine/NGIServiceTest.php
+++ b/tests/doctrine/NGIServiceTest.php
@@ -13,137 +13,136 @@ require_once dirname(__FILE__) . '/../../lib/Gocdb_Services/NGI.php';
  * @author David Meredith
  */
 class NGIServiceTest extends PHPUnit_Extensions_Database_TestCase {
+  private $em;
 
-    private $em;
+  /**
+   * Overridden.
+   */
+  public static function setUpBeforeClass() {
+    parent::setUpBeforeClass();
+    echo "\n\n-------------------------------------------------\n";
+    echo "Executing NGIServiceTest. . .\n";
+  }
 
-    /**
-     * Overridden.
-     */
-    public static function setUpBeforeClass() {
-        parent::setUpBeforeClass();
-        echo "\n\n-------------------------------------------------\n";
-        echo "Executing NGIServiceTest. . .\n";
+  /**
+   * Overridden. Returns the test database connection.
+   * @return PHPUnit_Extensions_Database_DB_IDatabaseConnection
+   */
+  protected function getConnection() {
+    require_once dirname(__FILE__) . '/bootstrap_pdo.php';
+    return getConnectionToTestDB();
+  }
+
+  /**
+   * Overridden. Returns the test dataset.
+   * Defines how the initial state of the database should look before each test is executed.
+   * @return PHPUnit_Extensions_Database_DataSet_IDataSet
+   */
+  protected function getDataSet() {
+    return $this->createFlatXMLDataSet(dirname(__FILE__) . '/truncateDataTables.xml');
+    // Use below to return an empty data set if we don't want to truncate and seed
+    //return new PHPUnit_Extensions_Database_DataSet_DefaultDataSet();
+  }
+
+  /**
+   * Overridden.
+   */
+  protected function getSetUpOperation() {
+    // CLEAN_INSERT is default
+    //return PHPUnit_Extensions_Database_Operation_Factory::CLEAN_INSERT();
+    //return PHPUnit_Extensions_Database_Operation_Factory::UPDATE();
+    //return PHPUnit_Extensions_Database_Operation_Factory::NONE();
+    //
+    // Issue a DELETE from <table> which is more portable than a
+    // TRUNCATE table <table> (some DBs require high privileges for truncate statements
+    // and also do not allow truncates across tables with FK contstraints e.g. Oracle)
+    return PHPUnit_Extensions_Database_Operation_Factory::DELETE_ALL();
+  }
+
+  /**
+   * Overridden.
+   */
+  protected function getTearDownOperation() {
+    // NONE is default
+    return PHPUnit_Extensions_Database_Operation_Factory::NONE();
+  }
+
+  /**
+   * Sets up the fixture, e.g create a new entityManager for each test run
+   * This method is called before each test method is executed.
+   */
+  protected function setUp() {
+    parent::setUp();
+    $this->em = $this->createEntityManager();
+  }
+
+  /**
+   * @todo Still need to setup connection to different databases.
+   * @return EntityManager
+   */
+  private function createEntityManager() {
+    require dirname(__FILE__) . '/bootstrap_doctrine.php';
+    return $entityManager;
+  }
+
+  /**
+   * Called after setUp() and before each test. Used for common assertions
+   * across all tests.
+   */
+  protected function assertPreConditions() {
+    $con = $this->getConnection();
+    $fixture = dirname(__FILE__) . '/truncateDataTables.xml';
+    $tables = simplexml_load_file($fixture);
+
+    foreach ($tables as $tableName) {
+      $sql = "SELECT * FROM " . $tableName->getName();
+      $result = $con->createQueryTable('results_table', $sql);
+      if ($result->getRowCount() != 0)
+          throw new RuntimeException("Invalid fixture. Table has rows: " . $tableName->getName());
     }
+  }
 
-    /**
-     * Overridden. Returns the test database connection.
-     * @return PHPUnit_Extensions_Database_DB_IDatabaseConnection
-     */
-    protected function getConnection() {
-        require_once dirname(__FILE__) . '/bootstrap_pdo.php';
-        return getConnectionToTestDB();
-    }
+  /**
+   * Test the NGI service deleteNGI() method which recursively deletes child
+   * sites and services, roles etc.
+   */
+  public function testNgiService_deleteNgi() {
+    print __METHOD__ . "\n";
+    include __DIR__ . '/resources/sampleFixtureData1.php';
 
-    /**
-     * Overridden. Returns the test dataset.
-     * Defines how the initial state of the database should look before each test is executed.
-     * @return PHPUnit_Extensions_Database_DataSet_IDataSet
-     */
-    protected function getDataSet() {
-        return $this->createFlatXMLDataSet(dirname(__FILE__) . '/truncateDataTables.xml');
-        // Use below to return an empty data set if we don't want to truncate and seed
-        //return new PHPUnit_Extensions_Database_DataSet_DefaultDataSet();
-    }
+    // create an admin user (required to call the NGI service)
+    $adminUser = TestUtil::createSampleUser('some', 'admin', '/some/admin');
+    $adminUser->setAdmin(TRUE);
+    $this->em->persist($adminUser);
 
-    /**
-     * Overridden.
-     */
-    protected function getSetUpOperation() {
-        // CLEAN_INSERT is default
-        //return PHPUnit_Extensions_Database_Operation_Factory::CLEAN_INSERT();
-        //return PHPUnit_Extensions_Database_Operation_Factory::UPDATE();
-        //return PHPUnit_Extensions_Database_Operation_Factory::NONE();
-        //
-        // Issue a DELETE from <table> which is more portable than a
-        // TRUNCATE table <table> (some DBs require high privileges for truncate statements
-        // and also do not allow truncates across tables with FK contstraints e.g. Oracle)
-        return PHPUnit_Extensions_Database_Operation_Factory::DELETE_ALL();
-    }
-
-    /**
-     * Overridden.
-     */
-    protected function getTearDownOperation() {
-        // NONE is default
-        return PHPUnit_Extensions_Database_Operation_Factory::NONE();
-    }
-
-    /**
-     * Sets up the fixture, e.g create a new entityManager for each test run
-     * This method is called before each test method is executed.
-     */
-    protected function setUp() {
-        parent::setUp();
-        $this->em = $this->createEntityManager();
-    }
-
-    /**
-     * @todo Still need to setup connection to different databases.
-     * @return EntityManager
-     */
-    private function createEntityManager() {
-        require dirname(__FILE__) . '/bootstrap_doctrine.php';
-        return $entityManager;
-    }
-
-    /**
-     * Called after setUp() and before each test. Used for common assertions
-     * across all tests.
-     */
-    protected function assertPreConditions() {
-        $con = $this->getConnection();
-        $fixture = dirname(__FILE__) . '/truncateDataTables.xml';
-        $tables = simplexml_load_file($fixture);
-
-        foreach ($tables as $tableName) {
-            $sql = "SELECT * FROM " . $tableName->getName();
-            $result = $con->createQueryTable('results_table', $sql);
-            if ($result->getRowCount() != 0)
-                throw new RuntimeException("Invalid fixture. Table has rows: " . $tableName->getName());
-        }
-    }
-
-    /**
-     * Test the NGI service deleteNGI() method which recursively deletes child
-     * sites and services, roles etc.
-     */
-    public function testNgiService_deleteNgi() {
-        print __METHOD__ . "\n";
-        include __DIR__ . '/resources/sampleFixtureData1.php';
-
-        // create an admin user (required to call the NGI service)
-        $adminUser = TestUtil::createSampleUser('some', 'admin', '/some/admin');
-        $adminUser->setAdmin(TRUE);
-        $this->em->persist($adminUser);
-
-        // Now delete the ngi using the NGI service.
-        $ngiService = new org\gocdb\services\NGI();
-        $ngiService->setEntityManager($this->em);
-        $ngiService->deleteNgi($ngi, $adminUser, FALSE);
+    // Now delete the ngi using the NGI service.
+    $ngiService = new org\gocdb\services\NGI();
+    $ngiService->setEntityManager($this->em);
+    $ngiService->deleteNgi($ngi, $adminUser, FALSE);
 
 
-        // since we deleted the NGI, we expect an empty DB !
-        $result = $testConn->createQueryTable('results_table', "SELECT * FROM Roles");
-        $this->assertTrue($result->getRowCount() == 0);
+    // since we deleted the NGI, we expect an empty DB !
+    $result = $testConn->createQueryTable('results_table', "SELECT * FROM Roles");
+    $this->assertTrue($result->getRowCount() == 0);
 
-        $result = $testConn->createQueryTable('results_table', "SELECT * FROM NGIs");
-        $this->assertTrue($result->getRowCount() == 0);
+    $result = $testConn->createQueryTable('results_table', "SELECT * FROM NGIs");
+    $this->assertTrue($result->getRowCount() == 0);
 
-        $result = $testConn->createQueryTable('results_table', "SELECT * FROM Sites");
-        $this->assertTrue($result->getRowCount() == 0);
+    $result = $testConn->createQueryTable('results_table', "SELECT * FROM Sites");
+    $this->assertTrue($result->getRowCount() == 0);
 
-        $result = $testConn->createQueryTable('results_table', "SELECT * FROM Services");
-        $this->assertTrue($result->getRowCount() == 0);
+    $result = $testConn->createQueryTable('results_table', "SELECT * FROM Services");
+    $this->assertTrue($result->getRowCount() == 0);
 
-        $result = $testConn->createQueryTable('results_table', "SELECT * FROM Downtimes");
-        $this->assertTrue($result->getRowCount() == 0);
+    $result = $testConn->createQueryTable('results_table', "SELECT * FROM Downtimes");
+    $this->assertTrue($result->getRowCount() == 0);
 
-        $result = $testConn->createQueryTable('results_table', "SELECT * FROM EndpointLocations");
-        $this->assertTrue($result->getRowCount() == 0);
+    $result = $testConn->createQueryTable('results_table', "SELECT * FROM EndpointLocations");
+    $this->assertTrue($result->getRowCount() == 0);
 
-        $result = $testConn->createQueryTable('results_table', "SELECT * FROM CertificationStatusLogs");
-        $this->assertTrue($result->getRowCount() == 0);
-    }
+    $result = $testConn->createQueryTable('results_table', "SELECT * FROM CertificationStatusLogs");
+    $this->assertTrue($result->getRowCount() == 0);
+  }
 
 }
 ?>

--- a/tests/doctrine/NGIServiceTest.php
+++ b/tests/doctrine/NGIServiceTest.php
@@ -97,8 +97,9 @@ class NGIServiceTest extends PHPUnit_Extensions_Database_TestCase {
     foreach ($tables as $tableName) {
       $sql = "SELECT * FROM " . $tableName->getName();
       $result = $con->createQueryTable('results_table', $sql);
-      if ($result->getRowCount() != 0)
-          throw new RuntimeException("Invalid fixture. Table has rows: " . $tableName->getName());
+      if ($result->getRowCount() != 0) {
+        throw new RuntimeException("Invalid fixture. Table has rows: " . $tableName->getName());
+      }
     }
   }
 

--- a/tests/doctrine/RoleCascadeDeletionsTest.php
+++ b/tests/doctrine/RoleCascadeDeletionsTest.php
@@ -113,8 +113,9 @@ class RoleCascadeDeletionsTest extends PHPUnit_Extensions_Database_TestCase {
       $sql = "SELECT * FROM " . $tableName->getName();
       $result = $con->createQueryTable('results_table', $sql);
       //echo 'row count: '.$result->getRowCount() ;
-      if ($result->getRowCount() != 0)
+      if ($result->getRowCount() != 0) {
         throw new RuntimeException("Invalid fixture. Table has rows: " . $tableName->getName());
+      }
     }
   }
 

--- a/tests/doctrine/RoleCascadeDeletionsTest.php
+++ b/tests/doctrine/RoleCascadeDeletionsTest.php
@@ -29,10 +29,6 @@ class RoleCascadeDeletionsTest extends PHPUnit_Extensions_Database_TestCase {
 
     private $em;
 
-    //private $egiScope;
-    //private $localScope;
-    //private $eudatScope;
-
     /**
      * Overridden.
      */
@@ -99,7 +95,6 @@ class RoleCascadeDeletionsTest extends PHPUnit_Extensions_Database_TestCase {
      * @return EntityManager
      */
     private function createEntityManager() {
-        //require dirname(__FILE__).'/../lib/Doctrine/bootstrap.php';
         require dirname(__FILE__) . '/bootstrap_doctrine.php';
         return $entityManager;
     }

--- a/tests/doctrine/RoleCascadeDeletionsTest.php
+++ b/tests/doctrine/RoleCascadeDeletionsTest.php
@@ -27,260 +27,260 @@ require_once dirname(__FILE__) . '/bootstrap.php';
  */
 class RoleCascadeDeletionsTest extends PHPUnit_Extensions_Database_TestCase {
 
-    private $em;
+  private $em;
 
-    /**
-     * Overridden.
-     */
-    public static function setUpBeforeClass() {
-        parent::setUpBeforeClass();
-        echo "\n\n-------------------------------------------------\n";
-        echo "Executing RoleCascadeDeletionsTest. . .\n";
+  /**
+   * Overridden.
+   */
+  public static function setUpBeforeClass() {
+    parent::setUpBeforeClass();
+    echo "\n\n-------------------------------------------------\n";
+    echo "Executing RoleCascadeDeletionsTest. . .\n";
+  }
+
+  /**
+   * Overridden. Returns the test database connection.
+   * @return PHPUnit_Extensions_Database_DB_IDatabaseConnection
+   */
+  protected function getConnection() {
+    require_once dirname(__FILE__) . '/bootstrap_pdo.php';
+    return getConnectionToTestDB();
+  }
+
+  /**
+   * Overridden. Returns the test dataset.
+   * Defines how the initial state of the database should look before each test is executed.
+   * @return PHPUnit_Extensions_Database_DataSet_IDataSet
+   */
+  protected function getDataSet() {
+    return $this->createFlatXMLDataSet(dirname(__FILE__) . '/truncateDataTables.xml');
+    // Use below to return an empty data set if we don't want to truncate and seed
+    //return new PHPUnit_Extensions_Database_DataSet_DefaultDataSet();
+  }
+
+  /**
+   * Overridden.
+   */
+  protected function getSetUpOperation() {
+    // CLEAN_INSERT is default
+    //return PHPUnit_Extensions_Database_Operation_Factory::CLEAN_INSERT();
+    //return PHPUnit_Extensions_Database_Operation_Factory::UPDATE();
+    //return PHPUnit_Extensions_Database_Operation_Factory::NONE();
+    //
+    // Issue a DELETE from <table> which is more portable than a
+    // TRUNCATE table <table> (some DBs require high privileges for truncate statements
+    // and also do not allow truncates across tables with FK contstraints e.g. Oracle)
+    return PHPUnit_Extensions_Database_Operation_Factory::DELETE_ALL();
+  }
+
+  /**
+   * Overridden.
+   */
+  protected function getTearDownOperation() {
+    // NONE is default
+    return PHPUnit_Extensions_Database_Operation_Factory::NONE();
+  }
+
+  /**
+   * Sets up the fixture, e.g create a new entityManager for each test run
+   * This method is called before each test method is executed.
+   */
+  protected function setUp() {
+    parent::setUp();
+    $this->em = $this->createEntityManager();
+  }
+
+  /**
+   * @todo Still need to setup connection to different databases.
+   * @return EntityManager
+   */
+  private function createEntityManager() {
+    require dirname(__FILE__) . '/bootstrap_doctrine.php';
+    return $entityManager;
+  }
+
+  /**
+   * Called after setUp() and before each test. Used for common assertions
+   * across all tests.
+   */
+  protected function assertPreConditions() {
+    $con = $this->getConnection();
+    $fixture = dirname(__FILE__) . '/truncateDataTables.xml';
+    $tables = simplexml_load_file($fixture);
+
+    foreach ($tables as $tableName) {
+      //print $tableName->getName() . "\n";
+      $sql = "SELECT * FROM " . $tableName->getName();
+      $result = $con->createQueryTable('results_table', $sql);
+      //echo 'row count: '.$result->getRowCount() ;
+      if ($result->getRowCount() != 0)
+        throw new RuntimeException("Invalid fixture. Table has rows: " . $tableName->getName());
     }
+  }
 
-    /**
-     * Overridden. Returns the test database connection.
-     * @return PHPUnit_Extensions_Database_DB_IDatabaseConnection
-     */
-    protected function getConnection() {
-        require_once dirname(__FILE__) . '/bootstrap_pdo.php';
-        return getConnectionToTestDB();
-    }
+  /**
+   * Create a linked OwnedEntity graph with user with Roles over those OwnedEntities.
+   * Next, delete the User and assert that all the user's Roles were also deleted by the domain
+   * model's automatic onDelete=CASCADE defined on the Role's FK mapping to User.
+   */
+  public function testRolesCascadeDelete_OnUserDeletion() {
+    print __METHOD__ . "\n";
+    include __DIR__ . '/resources/sampleFixtureData1.php';
 
-    /**
-     * Overridden. Returns the test dataset.
-     * Defines how the initial state of the database should look before each test is executed.
-     * @return PHPUnit_Extensions_Database_DataSet_IDataSet
-     */
-    protected function getDataSet() {
-        return $this->createFlatXMLDataSet(dirname(__FILE__) . '/truncateDataTables.xml');
-        // Use below to return an empty data set if we don't want to truncate and seed
-        //return new PHPUnit_Extensions_Database_DataSet_DefaultDataSet();
-    }
+    // Delete the user. The onDelete=CASCADE defined in Role's user FK mapping
+    // will remove all the user's roles.
+    $this->em->remove($userWithRoles);
+    $this->em->flush();
 
-    /**
-     * Overridden.
-     */
-    protected function getSetUpOperation() {
-        // CLEAN_INSERT is default
-        //return PHPUnit_Extensions_Database_Operation_Factory::CLEAN_INSERT();
-        //return PHPUnit_Extensions_Database_Operation_Factory::UPDATE();
-        //return PHPUnit_Extensions_Database_Operation_Factory::NONE();
-        //
-        // Issue a DELETE from <table> which is more portable than a
-        // TRUNCATE table <table> (some DBs require high privileges for truncate statements
-        // and also do not allow truncates across tables with FK contstraints e.g. Oracle)
-        return PHPUnit_Extensions_Database_Operation_Factory::DELETE_ALL();
-    }
+    // Need to clear the identity map (all objects become detached) so that
+    // when we re-fetch the user, it will be looked from db not served by entity map
+    $this->em->clear();
 
-    /**
-     * Overridden.
-     */
-    protected function getTearDownOperation() {
-        // NONE is default
-        return PHPUnit_Extensions_Database_Operation_Factory::NONE();
-    }
+    $userWithRoles = $this->em->find("User", $userId);
+    $this->assertNull($userWithRoles);
 
-    /**
-     * Sets up the fixture, e.g create a new entityManager for each test run
-     * This method is called before each test method is executed.
-     */
-    protected function setUp() {
-        parent::setUp();
-        $this->em = $this->createEntityManager();
-    }
+    $testConn = $this->getConnection();
+    $result = $testConn->createQueryTable('results_table', "SELECT * FROM Users");
+    $this->assertTrue($result->getRowCount() == 0);
+    $result = $testConn->createQueryTable('results_table', "SELECT * FROM Roles");
+    $this->assertTrue($result->getRowCount() == 0);
+  }
 
-    /**
-     * @todo Still need to setup connection to different databases.
-     * @return EntityManager
-     */
-    private function createEntityManager() {
-        require dirname(__FILE__) . '/bootstrap_doctrine.php';
-        return $entityManager;
-    }
+  /**
+   * Create a linked OwnedEntity graph with user with Roles over those OwnedEntities.
+   * Next, delete selected OwnedEntities and assert that all the Roles that
+   * were linked to the deleted OwnedEntites were also deleted by the domain
+   * model's automatic onDelete=CASCADE defined on the Role's FK mapping to OwnedEntity.
+   *
+   * Delete all the OwnedEntities
+   */
+  public function testRolesCascadeDelete_OnOwnedEntityDeletion1() {
+    print __METHOD__ . "\n";
+    include __DIR__ . '/resources/sampleFixtureData1.php';
 
-    /**
-     * Called after setUp() and before each test. Used for common assertions
-     * across all tests.
-     */
-    protected function assertPreConditions() {
-        $con = $this->getConnection();
-        $fixture = dirname(__FILE__) . '/truncateDataTables.xml';
-        $tables = simplexml_load_file($fixture);
+    // Queue Deletion of ngi, site1 (and its services) and assert that the relevant
+    // user roles were also deleted as expected by the onDelete=cascades configured in the entity model.
+    // Note, we are not removing site2 as we want to keep this site and user's roles.
+    $siteDAO = new SiteDAO();
+    $serviceDAO = new ServiceDAO();
+    $ngiDAO = new NGIDAO();
+    $siteDAO->setEntityManager($this->em);
+    $serviceDAO->setEntityManager($this->em);
+    $ngiDAO->setEntityManager($this->em);
 
-        foreach ($tables as $tableName) {
-            //print $tableName->getName() . "\n";
-            $sql = "SELECT * FROM " . $tableName->getName();
-            $result = $con->createQueryTable('results_table', $sql);
-            //echo 'row count: '.$result->getRowCount() ;
-            if ($result->getRowCount() != 0)
-                throw new RuntimeException("Invalid fixture. Table has rows: " . $tableName->getName());
-        }
-    }
+    // ordering of removal is NOT significant here !
+    $ngiDAO->removeNGI($ngi);
+    $siteDAO->removeSite($site1);
+    $siteDAO->removeSite($site2);
+    $serviceDAO->removeService($service1);
+    $serviceDAO->removeService($service2);
 
-    /**
-     * Create a linked OwnedEntity graph with user with Roles over those OwnedEntities.
-     * Next, delete the User and assert that all the user's Roles were also deleted by the domain
-     * model's automatic onDelete=CASCADE defined on the Role's FK mapping to User.
-     */
-    public function testRolesCascadeDelete_OnUserDeletion() {
-        print __METHOD__ . "\n";
-        include __DIR__ . '/resources/sampleFixtureData1.php';
+    $this->em->flush();
 
-        // Delete the user. The onDelete=CASCADE defined in Role's user FK mapping
-        // will remove all the user's roles.
-        $this->em->remove($userWithRoles);
-        $this->em->flush();
+    // Need to clear the identity map (all objects become detached) so that
+    // when we re-fetch the user, it will be looked from db not served by entity map
+    $this->em->clear();
 
-        // Need to clear the identity map (all objects become detached) so that
-        // when we re-fetch the user, it will be looked from db not served by entity map
-        $this->em->clear();
+    // Need to re-fetch the user from the DB again, if don't, then user already
+    // has his eargerly fetched roles present in UserProxy object
+    $userWithRoles = $this->em->find("User", $userId);
+    $this->assertEquals(0, count($userWithRoles->getRoles()));
 
-        $userWithRoles = $this->em->find("User", $userId);
-        $this->assertNull($userWithRoles);
+    $testConn = $this->getConnection();
+    $result = $testConn->createQueryTable('results_table', "SELECT * FROM Roles");
+    $this->assertTrue($result->getRowCount() == 0);
+    $result = $testConn->createQueryTable('results_table', "SELECT * FROM Sites");
+    $this->assertTrue($result->getRowCount() == 0);
+    $result = $testConn->createQueryTable('results_table', "SELECT * FROM NGIs");
+    $this->assertTrue($result->getRowCount() == 0);
+    $result = $testConn->createQueryTable('results_table', "SELECT * FROM Services");
+    $this->assertTrue($result->getRowCount() == 0);
+  }
 
-        $testConn = $this->getConnection();
-        $result = $testConn->createQueryTable('results_table', "SELECT * FROM Users");
-        $this->assertTrue($result->getRowCount() == 0);
-        $result = $testConn->createQueryTable('results_table', "SELECT * FROM Roles");
-        $this->assertTrue($result->getRowCount() == 0);
-    }
+  /**
+   * Delete both Services but not the ngi
+   * @see testRolesCascadeDelete_OnOwnedEntityDeletion1
+   */
+  public function testRolesCascadeDelete_OnOwnedEntityDeletion2() {
+    print __METHOD__ . "\n";
+    include __DIR__ . '/resources/sampleFixtureData1.php';
 
-    /**
-     * Create a linked OwnedEntity graph with user with Roles over those OwnedEntities.
-     * Next, delete selected OwnedEntities and assert that all the Roles that
-     * were linked to the deleted OwnedEntites were also deleted by the domain
-     * model's automatic onDelete=CASCADE defined on the Role's FK mapping to OwnedEntity.
-     *
-     * Delete all the OwnedEntities
-     */
-    public function testRolesCascadeDelete_OnOwnedEntityDeletion1() {
-        print __METHOD__ . "\n";
-        include __DIR__ . '/resources/sampleFixtureData1.php';
+    $siteDAO = new SiteDAO();
+    $serviceDAO = new ServiceDAO();
+    $ngiDAO = new NGIDAO();
+    $siteDAO->setEntityManager($this->em);
+    $serviceDAO->setEntityManager($this->em);
+    $ngiDAO->setEntityManager($this->em);
 
-        // Queue Deletion of ngi, site1 (and its services) and assert that the relevant
-        // user roles were also deleted as expected by the onDelete=cascades configured in the entity model.
-        // Note, we are not removing site2 as we want to keep this site and user's roles.
-        $siteDAO = new SiteDAO();
-        $serviceDAO = new ServiceDAO();
-        $ngiDAO = new NGIDAO();
-        $siteDAO->setEntityManager($this->em);
-        $serviceDAO->setEntityManager($this->em);
-        $ngiDAO->setEntityManager($this->em);
+    // ordering of removal is NOT significant here !
+    $serviceDAO->removeService($service1);
+    $serviceDAO->removeService($service2);
+    $siteDAO->removeSite($site1);
+    $siteDAO->removeSite($site2);
+    //$ngiDAO->removeNGI($ngi); // don't remove NGI
 
-        // ordering of removal is NOT significant here !
-        $ngiDAO->removeNGI($ngi);
-        $siteDAO->removeSite($site1);
-        $siteDAO->removeSite($site2);
-        $serviceDAO->removeService($service1);
-        $serviceDAO->removeService($service2);
+    $this->em->flush();
 
-        $this->em->flush();
+    // Need to clear the identity map (all objects become detached) so that
+    // when we re-fetch the user, it will be looked from db not served by entity map
+    $this->em->clear();
 
-        // Need to clear the identity map (all objects become detached) so that
-        // when we re-fetch the user, it will be looked from db not served by entity map
-        $this->em->clear();
+    // Need to re-fetch the user from the DB again, if don't, then user already
+    // has his eargerly fetched roles present in UserProxy object
+    $userWithRoles = $this->em->find("User", $userId);
+    // user should have 2 remaining roles still from ngi
+    $this->assertEquals(2, count($userWithRoles->getRoles()));
 
-        // Need to re-fetch the user from the DB again, if don't, then user already
-        // has his eargerly fetched roles present in UserProxy object
-        $userWithRoles = $this->em->find("User", $userId);
-        $this->assertEquals(0, count($userWithRoles->getRoles()));
+    $testConn = $this->getConnection();
+    $result = $testConn->createQueryTable('results_table', "SELECT * FROM Roles");
+    $this->assertTrue($result->getRowCount() == 2);
+    $result = $testConn->createQueryTable('results_table', "SELECT * FROM NGIs");
+    $this->assertTrue($result->getRowCount() == 1);
+  }
 
-        $testConn = $this->getConnection();
-        $result = $testConn->createQueryTable('results_table', "SELECT * FROM Roles");
-        $this->assertTrue($result->getRowCount() == 0);
-        $result = $testConn->createQueryTable('results_table', "SELECT * FROM Sites");
-        $this->assertTrue($result->getRowCount() == 0);
-        $result = $testConn->createQueryTable('results_table', "SELECT * FROM NGIs");
-        $this->assertTrue($result->getRowCount() == 0);
-        $result = $testConn->createQueryTable('results_table', "SELECT * FROM Services");
-        $this->assertTrue($result->getRowCount() == 0);
-    }
+  /**
+   * Delete the ngi but not the sites
+   * @see testRolesCascadeDelete_OnOwnedEntityDeletion1
+   */
+  public function testRolesCascadeDelete_OnOwnedEntityDeletion3() {
+    print __METHOD__ . "\n";
+    include __DIR__ . '/resources/sampleFixtureData1.php';
 
-    /**
-     * Delete both Services but not the ngi
-     * @see testRolesCascadeDelete_OnOwnedEntityDeletion1
-     */
-    public function testRolesCascadeDelete_OnOwnedEntityDeletion2() {
-        print __METHOD__ . "\n";
-        include __DIR__ . '/resources/sampleFixtureData1.php';
+    // Queue Deletion of ngi and assert that the relevant
+    // ngi user roles were also deleted.
+    $ngiDAO = new NGIDAO();
+    $ngiDAO->setEntityManager($this->em);
 
-        $siteDAO = new SiteDAO();
-        $serviceDAO = new ServiceDAO();
-        $ngiDAO = new NGIDAO();
-        $siteDAO->setEntityManager($this->em);
-        $serviceDAO->setEntityManager($this->em);
-        $ngiDAO->setEntityManager($this->em);
+    // need to delete the relationships between ngi and sites before deleting
+    // the ngi - remember to unlink from both sides of the relationship
+    $ngi->getSites()->removeElement($site1);
+    $site1->setNgiDoJoin(null);
+    $ngi->getSites()->removeElement($site2);
+    $site2->setNgiDoJoin(null);
 
-        // ordering of removal is NOT significant here !
-        $serviceDAO->removeService($service1);
-        $serviceDAO->removeService($service2);
-        $siteDAO->removeSite($site1);
-        $siteDAO->removeSite($site2);
-        //$ngiDAO->removeNGI($ngi); // don't remove NGI
+    // Now delete the NGI
+    $ngiDAO->removeNGI($ngi);
 
-        $this->em->flush();
+    $this->em->flush();
 
-        // Need to clear the identity map (all objects become detached) so that
-        // when we re-fetch the user, it will be looked from db not served by entity map
-        $this->em->clear();
+    // Need to clear the identity map (all objects become detached) so that
+    // when we re-fetch the user, it will be looked from db not served by entity map
+    $this->em->clear();
 
-        // Need to re-fetch the user from the DB again, if don't, then user already
-        // has his eargerly fetched roles present in UserProxy object
-        $userWithRoles = $this->em->find("User", $userId);
-        // user should have 2 remaining roles still from ngi
-        $this->assertEquals(2, count($userWithRoles->getRoles()));
+    // Need to re-fetch the user from the DB again, if don't, then user already
+    // has his eargerly fetched roles present in UserProxy object
+    $userWithRoles = $this->em->find("User", $userId);
+    // user should have 4 remaining roles still from sites that exist in DB
+    $this->assertEquals(4, count($userWithRoles->getRoles()));
 
-        $testConn = $this->getConnection();
-        $result = $testConn->createQueryTable('results_table', "SELECT * FROM Roles");
-        $this->assertTrue($result->getRowCount() == 2);
-        $result = $testConn->createQueryTable('results_table', "SELECT * FROM NGIs");
-        $this->assertTrue($result->getRowCount() == 1);
-    }
-
-    /**
-     * Delete the ngi but not the sites
-     * @see testRolesCascadeDelete_OnOwnedEntityDeletion1
-     */
-    public function testRolesCascadeDelete_OnOwnedEntityDeletion3() {
-        print __METHOD__ . "\n";
-        include __DIR__ . '/resources/sampleFixtureData1.php';
-
-        // Queue Deletion of ngi and assert that the relevant
-        // ngi user roles were also deleted.
-        $ngiDAO = new NGIDAO();
-        $ngiDAO->setEntityManager($this->em);
-
-        // need to delete the relationships between ngi and sites before deleting
-        // the ngi - remember to unlink from both sides of the relationship
-        $ngi->getSites()->removeElement($site1);
-        $site1->setNgiDoJoin(null);
-        $ngi->getSites()->removeElement($site2);
-        $site2->setNgiDoJoin(null);
-
-        // Now delete the NGI
-        $ngiDAO->removeNGI($ngi);
-
-        $this->em->flush();
-
-        // Need to clear the identity map (all objects become detached) so that
-        // when we re-fetch the user, it will be looked from db not served by entity map
-        $this->em->clear();
-
-        // Need to re-fetch the user from the DB again, if don't, then user already
-        // has his eargerly fetched roles present in UserProxy object
-        $userWithRoles = $this->em->find("User", $userId);
-        // user should have 4 remaining roles still from sites that exist in DB
-        $this->assertEquals(4, count($userWithRoles->getRoles()));
-
-        $testConn = $this->getConnection();
-        $result = $testConn->createQueryTable('results_table', "SELECT * FROM Roles");
-        $this->assertTrue($result->getRowCount() == 4);
-        $result = $testConn->createQueryTable('results_table', "SELECT * FROM Sites");
-        $this->assertTrue($result->getRowCount() == 2);
-        $result = $testConn->createQueryTable('results_table', "SELECT * FROM NGIs");
-        $this->assertTrue($result->getRowCount() == 0);
-    }
+    $testConn = $this->getConnection();
+    $result = $testConn->createQueryTable('results_table', "SELECT * FROM Roles");
+    $this->assertTrue($result->getRowCount() == 4);
+    $result = $testConn->createQueryTable('results_table', "SELECT * FROM Sites");
+    $this->assertTrue($result->getRowCount() == 2);
+    $result = $testConn->createQueryTable('results_table', "SELECT * FROM NGIs");
+    $this->assertTrue($result->getRowCount() == 0);
+  }
 
 }
 

--- a/tests/doctrine/RoleServiceTest.php
+++ b/tests/doctrine/RoleServiceTest.php
@@ -1,8 +1,5 @@
 <?php
-//require_once 'PHPUnit/Extensions/Database/TestCase.php';
-//require_once 'PHPUnit/Extensions/Database/DataSet/DefaultDataSet.php';
 require_once dirname(__FILE__) . '/TestUtil.php';
-
 use Doctrine\ORM\EntityManager;
 require_once dirname(__FILE__) . '/bootstrap.php';
 require_once dirname(__FILE__). '/../../lib/Gocdb_Services/Role.php';
@@ -94,7 +91,6 @@ class RoleServiceTest extends PHPUnit_Extensions_Database_TestCase {
      * @return EntityManager
      */
     private function createEntityManager(){
-        //require dirname(__FILE__).'/../lib/Doctrine/bootstrap.php';
         require dirname(__FILE__).'/bootstrap_doctrine.php';
         return $entityManager;
     }
@@ -109,32 +105,12 @@ class RoleServiceTest extends PHPUnit_Extensions_Database_TestCase {
         $tables = simplexml_load_file($fixture);
 
         foreach($tables as $tableName) {
-            //print $tableName->getName() . "\n";
             $sql = "SELECT * FROM ".$tableName->getName();
             $result = $con->createQueryTable('results_table', $sql);
-            //echo 'row count: '.$result->getRowCount() ;
             if($result->getRowCount() != 0)
                 throw new RuntimeException("Invalid fixture. Table has rows: ".$tableName->getName());
         }
     }
-
-
-    /*public function testPersistGetSupportedRoleTypeNameClassPairs(){
-       print __METHOD__ . "\n";
-       $roleTypes = TestUtil::getSupportedRoleTypes();
-       if(count($roleTypes) == 0){
-           throw new LogicException('No roleTypes configured');
-       }
-       // Assert that we can persist all the configured role types.
-       // This is to test the unique constraint on the RoleType.name value
-       // and any other DB col constraints.
-       foreach($roleTypes as $rt){
-          $this->em->persist($rt);
-       }
-       $this->em->flush();
-    }*/
-
-
 
     public function test_getPendingRolesUserCanApprove(){
         print __METHOD__ . "\n";
@@ -630,62 +606,4 @@ class RoleServiceTest extends PHPUnit_Extensions_Database_TestCase {
 
     }
 
-
-
-
-
-
-    /*public function testRoleTypeValues(){
-        print __METHOD__ . "\n";
-        $roleService = new org\gocdb\services\Role();
-
-        $roleType = new RoleType(RoleTypeName::SITE_ADMIN, RoleTypeClass::SITE_USER);
-        $this->assertTrue($roleService->isValidRoleType($roleType));
-        $roleType = new RoleType(RoleTypeName::SITE_SECOFFICER, RoleTypeClass::SITE_MANAGER);
-        $this->assertTrue($roleService->isValidRoleType($roleType));
-        $roleType = new RoleType(RoleTypeName::SITE_SECOFFICER, \RoleTypeClass::SITE_USER);
-        $this->assertFalse($roleService->isValidRoleType($roleType));
-    }*/
-
-    /*public function testGetRoleTypeClassificationsByRoleTypeName(){
-        print __METHOD__ . "\n";
-        $roleService = new org\gocdb\services\Role();
-
-        $roleNames = $roleService->getRoleTypeNamesByClassification(RoleTypeClass::PROJECT);
-        $this->assertTrue(count($roleNames) == 4);
-        $this->assertTrue(in_array(RoleTypeName::COO, $roleNames));
-        $this->assertTrue(in_array(RoleTypeName::COD_ADMIN, $roleNames));
-        $this->assertTrue(in_array(RoleTypeName::COD_STAFF, $roleNames));
-        $this->assertTrue(in_array(RoleTypeName::EGI_CSIRT_OFFICER, $roleNames));
-
-        $roleNames = $roleService->getRoleTypeNamesByClassification(RoleTypeClass::REGIONAL_MANAGER);
-        $this->assertTrue(count($roleNames) == 3);
-        $this->assertTrue(in_array(RoleTypeName::NGI_SEC_OFFICER, $roleNames));
-        $this->assertTrue(in_array(RoleTypeName::NGI_OPS_DEP_MAN, $roleNames));
-        $this->assertTrue(in_array(RoleTypeName::NGI_OPS_MAN, $roleNames));
-
-        $roleNames = $roleService->getRoleTypeNamesByClassification(RoleTypeClass::REGIONAL_USER);
-        $this->assertTrue(count($roleNames) == 2);
-        $this->assertTrue(in_array(RoleTypeName::REG_STAFF_ROD, $roleNames));
-        $this->assertTrue(in_array(RoleTypeName::REG_FIRST_LINE_SUPPORT, $roleNames));
-
-        $roleNames = $roleService->getRoleTypeNamesByClassification(RoleTypeClass::SITE_MANAGER);
-        $this->assertTrue(count($roleNames) == 3);
-        $this->assertTrue(in_array(RoleTypeName::SITE_OPS_MAN, $roleNames));
-        $this->assertTrue(in_array(RoleTypeName::SITE_OPS_DEP_MAN, $roleNames));
-        $this->assertTrue(in_array(RoleTypeName::SITE_SECOFFICER, $roleNames));
-
-        $roleNames = $roleService->getRoleTypeNamesByClassification(RoleTypeClass::SITE_USER);
-        $this->assertTrue(count($roleNames) == 1);
-        $this->assertTrue(in_array(RoleTypeName::SITE_ADMIN, $roleNames));
-
-        $roleNames = $roleService->getRoleTypeNamesByClassification(RoleTypeClass::SERVICEGROUP_ADMIN);
-        $this->assertTrue(count($roleNames) == 1);
-        $this->assertTrue(in_array(RoleTypeName::SERVICEGROUP_ADMIN, $roleNames));
-    }*/
-
-
-
 }
-
-?>

--- a/tests/doctrine/RoleServiceTest.php
+++ b/tests/doctrine/RoleServiceTest.php
@@ -107,8 +107,9 @@ class RoleServiceTest extends PHPUnit_Extensions_Database_TestCase {
     foreach($tables as $tableName) {
       $sql = "SELECT * FROM ".$tableName->getName();
       $result = $con->createQueryTable('results_table', $sql);
-      if($result->getRowCount() != 0)
+      if($result->getRowCount() != 0) {
         throw new RuntimeException("Invalid fixture. Table has rows: ".$tableName->getName());
+      }
     }
   }
 

--- a/tests/doctrine/RoleServiceTest.php
+++ b/tests/doctrine/RoleServiceTest.php
@@ -19,591 +19,590 @@ require_once dirname(__FILE__). '/../../lib/Gocdb_Services/RoleActionAuthorisati
  * @author John Casson
  */
 class RoleServiceTest extends PHPUnit_Extensions_Database_TestCase {
-   private $em;
-   private $egiScope;
-   private $localScope;
-   private $eudatScope;
+  private $em;
+  private $egiScope;
+  private $localScope;
+  private $eudatScope;
 
 
-    /**
-     * Overridden.
+  /**
+   * Overridden.
+   */
+  public static function setUpBeforeClass() {
+    parent::setUpBeforeClass();
+    echo "\n\n-------------------------------------------------\n";
+    echo "Executing RoleServiceTest. . .\n";
+  }
+
+  /**
+   * Overridden. Returns the test database connection.
+   * @return PHPUnit_Extensions_Database_DB_IDatabaseConnection
+   */
+  protected function getConnection() {
+    require_once dirname(__FILE__) . '/bootstrap_pdo.php';
+    return getConnectionToTestDB();
+  }
+
+  /**
+   * Overridden. Returns the test dataset.
+   * Defines how the initial state of the database should look before each test is executed.
+   * @return PHPUnit_Extensions_Database_DataSet_IDataSet
+   */
+  protected function getDataSet() {
+    return $this->createFlatXMLDataSet(dirname(__FILE__) . '/truncateDataTables.xml');
+    // Use below to return an empty data set if we don't want to truncate and seed
+    //return new PHPUnit_Extensions_Database_DataSet_DefaultDataSet();
+  }
+
+  /**
+   * Overridden.
+   */
+  protected function getSetUpOperation() {
+    // CLEAN_INSERT is default
+    //return PHPUnit_Extensions_Database_Operation_Factory::CLEAN_INSERT();
+    //return PHPUnit_Extensions_Database_Operation_Factory::UPDATE();
+    //return PHPUnit_Extensions_Database_Operation_Factory::NONE();
+    //
+    // Issue a DELETE from <table> which is more portable than a
+    // TRUNCATE table <table> (some DBs require high privileges for truncate statements
+    // and also do not allow truncates across tables with FK contstraints e.g. Oracle)
+    return PHPUnit_Extensions_Database_Operation_Factory::DELETE_ALL();
+  }
+
+  /**
+   * Overridden.
+   */
+  protected function getTearDownOperation() {
+    // NONE is default
+    return PHPUnit_Extensions_Database_Operation_Factory::NONE();
+  }
+
+  /**
+   * Sets up the fixture, e.g create a new entityManager for each test run
+   * This method is called before each test method is executed.
+   */
+  protected function setUp() {
+    parent::setUp();
+    $this->em = $this->createEntityManager();
+  }
+
+  /**
+   * @todo Still need to setup connection to different databases.
+   * @return EntityManager
+   */
+  private function createEntityManager(){
+    require dirname(__FILE__).'/bootstrap_doctrine.php';
+    return $entityManager;
+  }
+
+  /**
+   * Called after setUp() and before each test. Used for common assertions
+   * across all tests.
+   */
+  protected function assertPreConditions() {
+    $con = $this->getConnection();
+    $fixture = dirname(__FILE__) . '/truncateDataTables.xml';
+    $tables = simplexml_load_file($fixture);
+
+    foreach($tables as $tableName) {
+      $sql = "SELECT * FROM ".$tableName->getName();
+      $result = $con->createQueryTable('results_table', $sql);
+      if($result->getRowCount() != 0)
+        throw new RuntimeException("Invalid fixture. Table has rows: ".$tableName->getName());
+    }
+  }
+
+  public function test_getPendingRolesUserCanApprove(){
+    print __METHOD__ . "\n";
+    // Create fixture data
+    // RoleTypes
+    $siteAdminRT = TestUtil::createSampleRoleType(RoleTypeName::SITE_ADMIN/*, RoleTypeClass::SITE_USER*/);
+    $siteManRT = TestUtil::createSampleRoleType(RoleTypeName::SITE_OPS_MAN/*, RoleTypeClass::SITE_MANAGER*/);
+    $regFLSupportRT = TestUtil::createSampleRoleType(RoleTypeName::REG_FIRST_LINE_SUPPORT/*, RoleTypeClass::REGIONAL_USER*/);
+
+    $this->em->persist($regFLSupportRT);
+    $this->em->persist($siteAdminRT);
+    $this->em->persist($siteManRT);
+
+    // User
+    $u = TestUtil::createSampleUser("Test", "Testing", "/c=test");
+    $this->em->persist($u);
+    // Site
+    $site1 = TestUtil::createSampleSite("SITENAME");
+    $this->em->persist($site1);
+    $n1 = TestUtil::createSampleNGI("NGI_UK");
+    $this->em->persist($n1);
+    $p1 = new \Project("EGI");
+    $this->em->persist($p1);
+
+    $n1->addSiteDoJoin($site1);
+    $p1->addNgi($n1);
+
+    // Create a SITE_OPS_MAN Role and link to the User, RoleType and site
+    $roleSite = TestUtil::createSampleRole($u, $siteManRT, $site1, RoleStatus::GRANTED);
+    $this->em->persist($roleSite);
+
+    // new user
+    $u2 = TestUtil::createSampleUser("Test2", "Testing2", "/c=test2");
+    $this->em->persist($u2);
+    // Create a pending SITE_ADMIN Role request for new user
+    $pendingSiteRole = TestUtil::createSampleRole($u2, $siteAdminRT, $site1, RoleStatus::PENDING);
+    $this->em->persist($pendingSiteRole);
+    $this->em->flush();
+
+    // ********NOTE******** Role Service uses a new connection for its transactional methods
+    $em2 = $this->createEntityManager();
+    $roleService = new org\gocdb\services\Role();
+    $roleService->setEntityManager($em2);
+    $roleActionMappingService = new org\gocdb\services\RoleActionMappingService();
+    $roleActionAuthorisationService = new org\gocdb\services\RoleActionAuthorisationService($roleActionMappingService);
+    $roleActionAuthorisationService->setEntityManager($em2);
+    $roleService->setRoleActionAuthorisationService($roleActionAuthorisationService);
+
+    $pendingGrantableRolesU1 = $roleService->getPendingRolesUserCanApprove($u);
+
+    // show that u1 has one pending role request
+    $this->assertTrue(count($pendingGrantableRolesU1) == 1);
+    $this->assertEquals($pendingSiteRole->getId(), $pendingGrantableRolesU1[0]->getId());
+    $this->assertEquals(RoleStatus::PENDING, $pendingGrantableRolesU1[0]->getStatus());
+    $this->assertEquals(RoleTypeName::SITE_ADMIN, $pendingGrantableRolesU1[0]->getRoleType()->getName());
+
+    // show that u2 has no pending role requests
+    $pendingGrantableRolesU2 = $roleService->getPendingRolesUserCanApprove($u2);
+    $this->assertTrue(count($pendingGrantableRolesU2) == 0);
+  }
+
+
+
+  public function test_getUserRoleNamesOverEntity(){
+    print __METHOD__ . "\n";
+    // Create fixture data
+    // RoleTypes
+    $siteAdminRT = TestUtil::createSampleRoleType(RoleTypeName::SITE_ADMIN/*, RoleTypeClass::SITE_USER*/);
+    $regFLSupportRT = TestUtil::createSampleRoleType(RoleTypeName::REG_FIRST_LINE_SUPPORT/*, RoleTypeClass::REGIONAL_USER*/);
+    $this->em->persist($regFLSupportRT);
+    $this->em->persist($siteAdminRT);
+    // User
+    $u = TestUtil::createSampleUser("Test", "Testing", "/c=test");
+    $this->em->persist($u);
+    // Site
+    $site1 = TestUtil::createSampleSite("SITENAME"/*, "PK01"*/);
+    $this->em->persist($site1);
+    // Create a Role and link to the User, ngiRoleType and site
+    $roleSite = TestUtil::createSampleRole($u, $siteAdminRT, $site1, RoleStatus::GRANTED);
+    $this->em->persist($roleSite);
+    $this->em->flush();
+
+    // ********NOTE******** Role Service uses a new connection for its transactional methods
+    $roleService = new org\gocdb\services\Role();
+    $roleService->setEntityManager($this->createEntityManager());
+
+    // Now test that method returns expected results
+    $roleNames = $roleService->getUserRoleNamesOverEntity($site1, $u, \RoleStatus::GRANTED);
+    $this->assertEquals(1, count($roleNames));
+    $this->assertContains(RoleTypeName::SITE_ADMIN, $roleNames);
+
+    // Create new NGI
+    $n = TestUtil::createSampleNGI("MYNGI");
+    $this->em->persist($n);
+
+    $roleNgi = TestUtil::createSampleRole($u, $regFLSupportRT, $n, RoleStatus::GRANTED);
+    $this->em->persist($roleNgi);
+    $this->em->flush();
+
+    // Now test that method returns expected results
+    $roleNames = $roleService->getUserRoleNamesOverEntity($n, $u);
+    $this->assertEquals(1, count($roleNames));
+    $this->assertContains(RoleTypeName::REG_FIRST_LINE_SUPPORT, $roleNames);
+  }
+
+
+  public function testGetUserRoles(){
+    print __METHOD__ . "\n";
+    // Create two roletypes
+    $ngiRoleType = TestUtil::createSampleRoleType("RT1_NAME"/*, RoleTypeClass::SITE_USER*/);
+    $siteRoleType = TestUtil::createSampleRoleType("RT2_NAME"/*, RoleTypeClass::REGIONAL_USER*/);
+    $this->em->persist($ngiRoleType);
+    $this->em->persist($siteRoleType);
+
+    // Create a user
+    $u = TestUtil::createSampleUser("Test", "Testing", "/c=test");
+    $this->em->persist($u);
+
+    // Create an NGI
+    $ngi = TestUtil::createSampleNGI("MYNGI");
+    $this->em->persist($ngi);
+
+    // Create a Role and link to the User, ngiRoleType and ngi
+    $roleNgi = TestUtil::createSampleRole($u, $ngiRoleType, $ngi, RoleStatus::GRANTED);
+    $this->em->persist($roleNgi);
+
+    // Create a site
+    $site1 = TestUtil::createSampleSite("SITENAME"/*, "PK01"*/);
+    $this->em->persist($site1);
+
+    // Create another role and link to the User, siteRoleType and site
+    $roleSite = TestUtil::createSampleRole($u, $siteRoleType, $site1, RoleStatus::GRANTED) ;
+    $this->em->persist($roleSite);
+
+    // Create a second and third sites and add to the NGI, but DO NOT add direct
+    // roles over those sites for the user. The user will still have role
+    // over the sites because they have a role over the NGI !
+    $site2 = TestUtil::createSampleSite("SITENAME2"/*, "PK01"*/);
+    $site3 = TestUtil::createSampleSite("SITENAME3"/*, "PK01"*/);
+    $this->em->persist($site2);
+    $this->em->persist($site3);
+    $ngi->addSiteDoJoin($site2);
+    $ngi->addSiteDoJoin($site3);
+
+    $this->em->flush();
+
+    // ********MUST******** start a new connection to test transactional
+    // isolation of RoleService methods.
+    $em = $this->createEntityManager();
+    $roleService = new org\gocdb\services\Role();
+    $roleService->setEntityManager($em);
+    // assert that user has expected roles
+    $roles = $roleService->getUserRoles($u, RoleStatus::GRANTED);
+    $this->assertEquals(2, sizeof($roles));
+    $this->assertTrue(count($roleService->getUserRoleNamesOverEntity($ngi, $u)) == 1);
+    $this->assertTrue(count($roleService->getUserRoleNamesOverEntity($site1, $u)) == 1);
+    $this->assertTrue(count($roleService->getUserRoleNamesOverEntity($site2, $u)) == 0);
+    $this->assertTrue(count($roleService->getUserRoleNamesOverEntity($site3, $u)) == 0);
+
+    // assert that the user has an expected site count with roles over those sites
+    $mySites = $roleService->getReachableSitesFromOwnedObjectRoles($u);
+    $this->assertEquals(3, sizeof($mySites));
+
+    // assert user don't have these pending/revoked roles
+    $roles = $roleService->getUserRoles($u, RoleStatus::PENDING);
+    $this->assertEmpty($roles);
+  }
+
+  /**
+   * @expectedException \LogicException
+   */
+  public function testInvalidRoleStatus(){
+    print __METHOD__ . "\n";
+    $roleService = new org\gocdb\services\Role();
+    $this->assertFalse($roleService->isValidRoleStatus("some invalid role"));
+    $u = TestUtil::createSampleUser("Test", "Testing", "/c=test");
+    $roleService->getUserRoles($u, "some invalid role");
+  }
+
+
+  public function test_getReachableProjectsFromOwnedEntity(){
+    print __METHOD__ . "\n";
+    include __DIR__ . '/resources/sampleFixtureData5.php';
+    $this->em->flush();
+
+
+    // ********MUST******** start a new connection to test transactional
+    // isolation of RoleService methods.
+    $em = $this->createEntityManager();
+    $roleService = new org\gocdb\services\Role();
+    $roleService->setEntityManager($em);
+
+
+    $projects = $roleService->getReachableProjectsFromOwnedEntity($p1);
+    $this->assertEquals($p1, $projects[0]);
+    $this->assertTrue(count($projects) == 1);
+    $projects = $roleService->getReachableProjectsFromOwnedEntity($n1);
+    $this->assertEquals($p1, $projects[0]);
+    $this->assertTrue(count($projects) == 1);
+    $projects = $roleService->getReachableProjectsFromOwnedEntity($s1);
+    $this->assertTrue(count($projects) == 1);
+    $this->assertEquals($p1, $projects[0]);
+
+
+    $projects = $roleService->getReachableProjectsFromOwnedEntity($p2);
+    $this->assertEquals($p2, $projects[0]);
+    $projects = $roleService->getReachableProjectsFromOwnedEntity($n2);
+    $this->assertTrue(count($projects) == 2);
+    $this->assertTrue(in_array($p2, $projects));
+    $this->assertTrue(in_array($p3, $projects));
+    $projects = $roleService->getReachableProjectsFromOwnedEntity($s2);
+    $this->assertTrue(count($projects) == 2);
+    $this->assertTrue(in_array($p2, $projects));
+    $this->assertTrue(in_array($p3, $projects));
+
+
+    $projects = $roleService->getReachableProjectsFromOwnedEntity($n3);
+    $this->assertTrue(count($projects) == 1);
+    $this->assertEquals($p3, $projects[0]);
+    $projects = $roleService->getReachableProjectsFromOwnedEntity($s3);
+    $this->assertTrue(count($projects) == 1);
+    $this->assertEquals($p3, $projects[0]);
+  }
+
+
+  public function test_getUserRolesByProject(){
+    print __METHOD__ . "\n";
+    include __DIR__ . '/resources/sampleFixtureData5.php';
+
+    // create a user
+    $u = TestUtil::createSampleUser("dave", "meredith", "idSTring");
+    $this->em->persist($u);
+
+    // add some roles to domain model
+    $ngiRoleType = TestUtil::createSampleRoleType("NGI_RT");
+    $siteRoleType = TestUtil::createSampleRoleType("SITE_RT");
+    $siteRoleType2 = TestUtil::createSampleRoleType("SITE_RT2");
+    $projRoleType = TestUtil::createSampleRoleType("PROJ_RT");
+    $this->em->persist($ngiRoleType);
+    $this->em->persist($siteRoleType);
+    $this->em->persist($siteRoleType2);
+    $this->em->persist($projRoleType);
+
+    $this->em->flush();
+
+    $roleService = new org\gocdb\services\Role();
+
+    // We could create/inject a new em connection into the roleService
+    // to test the transactional isolation of its methods (rather than injecting
+    // $this->em instance), e.g.:
+    //   $em = $this->createEntityManager();
+    //   $roleService->setEntityManager($em);
+    //
+    // However, this is problematic for this test which
+    // needs to use the in_array() method to assert that the tested methods return
+    // the expected roles - in_array() uses object-instance-equality to deterine
+    // if the role exists in the array, and using a different $em instance
+    // means the returned roles will be considered different
+    // instances. We could get round this by comparing the Ids, but this makes
+    // checking more of hassle as we need to extract all the Ids from the roles
+    // into another array to assert the ids are expected, as in:
+    //   $roleIds = array();
+    //   foreach($roles as $r){ $roleIds[] = $r->getId(); }
+    //   $this->assertTrue(in_array($r1->getId(), $roleIds));
+    //   $this->assertTrue(in_array($r2->getId(), $roleIds));
+    //
+    // For this test, we will therefore re-use $this->em to ensure
+    // object-equality:
+    $roleService->setEntityManager($this->em);
+
+    // confirm that function runs with no user roles over entity
+    $roles = $roleService->getUserRolesByProject($u, $p1);
+    $this->assertEmpty($roles);
+
+
+    // Create a Role and link to the User, ngiRoleType and ngi
+    /*
+     * p1     p2     p3
+     * |      |     /|
+     * n1     n2-r1  n3
+     * |      |      |
+     * s1     s2     s3
      */
-    public static function setUpBeforeClass() {
-        parent::setUpBeforeClass();
-        echo "\n\n-------------------------------------------------\n";
-        echo "Executing RoleServiceTest. . .\n";
-    }
+    $r1 = TestUtil::createSampleRole($u, $ngiRoleType, $n2, RoleStatus::GRANTED);
+    $this->em->persist($r1);
+    $this->em->flush();
 
-    /**
-     * Overridden. Returns the test database connection.
-     * @return PHPUnit_Extensions_Database_DB_IDatabaseConnection
+    $rolesDirect = $u->getRoles();
+    $this->assertEquals(1, count($rolesDirect));
+
+    $roles = $roleService->getUserRolesByProject($u, $p1);
+    $this->assertEmpty($roles);
+    $roles = $roleService->getUserRolesByProject($u, $p2);
+    $this->assertEquals(1, count($roles));
+    $this->assertEquals($r1->getId(), $roles[0]->getId());
+    $roles = $roleService->getUserRolesByProject($u, $p3);
+    $this->assertEquals(1, count($roles));
+    $this->assertEquals($r1->getId(), $roles[0]->getId());
+
+
+    /*
+     * p1     p2     p3
+     * |      |     /|
+     * n1     n2-r1  n3-r2
+     * |      |      |
+     * s1     s2     s3
      */
-    protected function getConnection() {
-        require_once dirname(__FILE__) . '/bootstrap_pdo.php';
-        return getConnectionToTestDB();
-    }
+    $r2 = TestUtil::createSampleRole($u, $ngiRoleType, $n3, RoleStatus::GRANTED);
+    $this->em->persist($r2);
+    $this->em->flush();
 
-    /**
-     * Overridden. Returns the test dataset.
-     * Defines how the initial state of the database should look before each test is executed.
-     * @return PHPUnit_Extensions_Database_DataSet_IDataSet
+    $roles = $roleService->getUserRolesByProject($u, $p1);
+    $this->assertEmpty($roles);
+    $roles = $roleService->getUserRolesByProject($u, $p2);
+    $this->assertEquals(1, count($roles));
+    $this->assertEquals($r1->getId(), $roles[0]->getId());
+
+    $roles = $roleService->getUserRolesByProject($u, $p3);
+    $this->assertEquals(2, count($roles));
+    $roleIds = array();
+    foreach($roles as $r){ $roleIds[] = $r->getId(); }
+    $this->assertTrue(in_array($r1->getId(), $roleIds));
+    $this->assertTrue(in_array($r2->getId(), $roleIds));
+
+    /*
+     * p1     p2     p3
+     * |      |     /|
+     * n1     n2-r1  n3-r2
+     * |      |      |
+     * s1     s2     s3-r3
      */
-    protected function getDataSet() {
-        return $this->createFlatXMLDataSet(dirname(__FILE__) . '/truncateDataTables.xml');
-        // Use below to return an empty data set if we don't want to truncate and seed
-        //return new PHPUnit_Extensions_Database_DataSet_DefaultDataSet();
-    }
+    $r3 = TestUtil::createSampleRole($u, $siteRoleType, $s3, RoleStatus::GRANTED);
+    $this->em->persist($r3);
+    $this->em->flush();
 
-    /**
-     * Overridden.
+    $roles = $roleService->getUserRolesByProject($u, $p1);
+    $this->assertEmpty($roles);
+    $roles = $roleService->getUserRolesByProject($u, $p2);
+    $this->assertEquals(1, count($roles));
+    $this->assertEquals($r1->getId(), $roles[0]->getId());
+
+    $roles = $roleService->getUserRolesByProject($u, $p3);
+    $this->assertEquals(3, count($roles));
+    $this->assertTrue(in_array($r1, $roles));
+    $this->assertTrue(in_array($r2, $roles));
+    $this->assertTrue(in_array($r3, $roles));
+
+    /*
+     * p1     p2     p3-r4
+     * |      |     /|
+     * n1     n2-r1  n3-r2
+     * |      |      |
+     * s1     s2     s3-r3
      */
-    protected function getSetUpOperation() {
-        // CLEAN_INSERT is default
-        //return PHPUnit_Extensions_Database_Operation_Factory::CLEAN_INSERT();
-        //return PHPUnit_Extensions_Database_Operation_Factory::UPDATE();
-        //return PHPUnit_Extensions_Database_Operation_Factory::NONE();
-        //
-        // Issue a DELETE from <table> which is more portable than a
-        // TRUNCATE table <table> (some DBs require high privileges for truncate statements
-        // and also do not allow truncates across tables with FK contstraints e.g. Oracle)
-        return PHPUnit_Extensions_Database_Operation_Factory::DELETE_ALL();
-    }
+    $r4 = TestUtil::createSampleRole($u, $projRoleType, $p3, RoleStatus::GRANTED);
+    $this->em->persist($r4);
+    $this->em->flush();
 
-    /**
-     * Overridden.
+    $rolesDirect = $u->getRoles();
+    $this->assertEquals(4, count($rolesDirect));
+
+    $roles = $roleService->getUserRolesByProject($u, $p1);
+    $this->assertEmpty($roles);
+    $roles = $roleService->getUserRolesByProject($u, $p2);
+    $this->assertEquals(1, count($roles));
+    $this->assertEquals($r1->getId(), $roles[0]->getId());
+    $roles = $roleService->getUserRolesByProject($u, $p3);
+    $this->assertEquals(4, count($roles));
+    $this->assertTrue(in_array($r1, $roles));
+    $this->assertTrue(in_array($r2, $roles));
+    $this->assertTrue(in_array($r3, $roles));
+    $this->assertTrue(in_array($r4, $roles));
+
+    /*
+     * p1     p2     p3-r4
+     * |      |     /|
+     * n1     n2-r1  n3-r2
+     * |      |      |
+     * s1     s2-r5  s3-r3
      */
-    protected function getTearDownOperation() {
-        // NONE is default
-        return PHPUnit_Extensions_Database_Operation_Factory::NONE();
-    }
+    $r5 = TestUtil::createSampleRole($u, $siteRoleType, $s2, RoleStatus::GRANTED);
+    $this->em->persist($r5);
+    $this->em->flush();
 
-    /**
-     * Sets up the fixture, e.g create a new entityManager for each test run
-     * This method is called before each test method is executed.
+    $rolesDirect = $u->getRoles();
+    $this->assertEquals(5, count($rolesDirect));
+
+    $roles = $roleService->getUserRolesByProject($u, $p1);
+    $this->assertEmpty($roles);
+    $roles = $roleService->getUserRolesByProject($u, $p2);
+    $this->assertEquals(2, count($roles));
+    $this->assertTrue(in_array($r1, $roles));
+    $this->assertTrue(in_array($r5, $roles));
+    $roles = $roleService->getUserRolesByProject($u, $p3);
+    $this->assertEquals(5, count($roles));
+    $this->assertTrue(in_array($r1, $roles));
+    $this->assertTrue(in_array($r2, $roles));
+    $this->assertTrue(in_array($r3, $roles));
+    $this->assertTrue(in_array($r4, $roles));
+    $this->assertTrue(in_array($r5, $roles));
+
+
+    /*
+     * p1     p2     p3-r4
+     * |      |     /|
+     * n1     n2-r1  n3-r2
+     * |      |      |
+     * s1-r6  s2-r5  s3-r3
      */
-    protected function setUp() {
-        parent::setUp();
-        $this->em = $this->createEntityManager();
-    }
+    $r6 = TestUtil::createSampleRole($u, $siteRoleType, $s1, RoleStatus::GRANTED);
+    $this->em->persist($r6);
+    $this->em->flush();
 
-    /**
-     * @todo Still need to setup connection to different databases.
-     * @return EntityManager
+    $rolesDirect = $u->getRoles();
+    $this->assertEquals(6, count($rolesDirect));
+
+    $roles = $roleService->getUserRolesByProject($u, $p1);
+    $this->assertEquals(1, count($roles));
+    $this->assertTrue(in_array($r6, $roles));
+    $roles = $roleService->getUserRolesByProject($u, $p2);
+    $this->assertEquals(2, count($roles));
+    $this->assertTrue(in_array($r1, $roles));
+    $this->assertTrue(in_array($r5, $roles));
+    $roles = $roleService->getUserRolesByProject($u, $p3);
+    $this->assertEquals(5, count($roles));
+    $this->assertTrue(in_array($r1, $roles));
+    $this->assertTrue(in_array($r2, $roles));
+    $this->assertTrue(in_array($r3, $roles));
+    $this->assertTrue(in_array($r4, $roles));
+    $this->assertTrue(in_array($r5, $roles));
+
+    /*
+     * p1     p2     p3-r4
+     * |      |     /|
+     * n1     n2-r1  n3-r2
+     * |      |      |
+     * s1-r6  s2-r5  s3-r3,r7
      */
-    private function createEntityManager(){
-        require dirname(__FILE__).'/bootstrap_doctrine.php';
-        return $entityManager;
-    }
+    $r7 = TestUtil::createSampleRole($u, $siteRoleType2, $s3, RoleStatus::GRANTED);
+    $this->em->persist($r7);
+    $this->em->flush();
 
-    /**
-     * Called after setUp() and before each test. Used for common assertions
-     * across all tests.
+    $rolesDirect = $u->getRoles();
+    $this->assertEquals(7, count($rolesDirect));
+
+    $roles = $roleService->getUserRolesByProject($u, $p1);
+    $this->assertEquals(1, count($roles));
+    $this->assertTrue(in_array($r6, $roles));
+    $roles = $roleService->getUserRolesByProject($u, $p2);
+    $this->assertEquals(2, count($roles));
+    $this->assertTrue(in_array($r1, $roles));
+    $this->assertTrue(in_array($r5, $roles));
+    $roles = $roleService->getUserRolesByProject($u, $p3);
+    $this->assertEquals(6, count($roles));
+    $this->assertTrue(in_array($r1, $roles));
+    $this->assertTrue(in_array($r2, $roles));
+    $this->assertTrue(in_array($r3, $roles));
+    $this->assertTrue(in_array($r4, $roles));
+    $this->assertTrue(in_array($r5, $roles));
+    $this->assertTrue(in_array($r7, $roles));
+
+
+    /*
+     * p1     p2-r8  p3-r4
+     * |      |     /|
+     * n1     n2-r1  n3-r2
+     * |      |      |
+     * s1-r6  s2-r5  s3-r3,r7
      */
-    protected function assertPreConditions() {
-        $con = $this->getConnection();
-        $fixture = dirname(__FILE__) . '/truncateDataTables.xml';
-        $tables = simplexml_load_file($fixture);
-
-        foreach($tables as $tableName) {
-            $sql = "SELECT * FROM ".$tableName->getName();
-            $result = $con->createQueryTable('results_table', $sql);
-            if($result->getRowCount() != 0)
-                throw new RuntimeException("Invalid fixture. Table has rows: ".$tableName->getName());
-        }
-    }
-
-    public function test_getPendingRolesUserCanApprove(){
-        print __METHOD__ . "\n";
-        // Create fixture data
-        // RoleTypes
-        $siteAdminRT = TestUtil::createSampleRoleType(RoleTypeName::SITE_ADMIN/*, RoleTypeClass::SITE_USER*/);
-        $siteManRT = TestUtil::createSampleRoleType(RoleTypeName::SITE_OPS_MAN/*, RoleTypeClass::SITE_MANAGER*/);
-        $regFLSupportRT = TestUtil::createSampleRoleType(RoleTypeName::REG_FIRST_LINE_SUPPORT/*, RoleTypeClass::REGIONAL_USER*/);
-
-        $this->em->persist($regFLSupportRT);
-        $this->em->persist($siteAdminRT);
-        $this->em->persist($siteManRT);
-
-        // User
-        $u = TestUtil::createSampleUser("Test", "Testing", "/c=test");
-        $this->em->persist($u);
-        // Site
-        $site1 = TestUtil::createSampleSite("SITENAME");
-        $this->em->persist($site1);
-        $n1 = TestUtil::createSampleNGI("NGI_UK");
-        $this->em->persist($n1);
-        $p1 = new \Project("EGI");
-        $this->em->persist($p1);
-
-        $n1->addSiteDoJoin($site1);
-        $p1->addNgi($n1);
-
-        // Create a SITE_OPS_MAN Role and link to the User, RoleType and site
-        $roleSite = TestUtil::createSampleRole($u, $siteManRT, $site1, RoleStatus::GRANTED);
-        $this->em->persist($roleSite);
-
-        // new user
-        $u2 = TestUtil::createSampleUser("Test2", "Testing2", "/c=test2");
-        $this->em->persist($u2);
-        // Create a pending SITE_ADMIN Role request for new user
-        $pendingSiteRole = TestUtil::createSampleRole($u2, $siteAdminRT, $site1, RoleStatus::PENDING);
-        $this->em->persist($pendingSiteRole);
-        $this->em->flush();
-
-        // ********NOTE******** Role Service uses a new connection for its transactional methods
-        $em2 = $this->createEntityManager();
-        $roleService = new org\gocdb\services\Role();
-        $roleService->setEntityManager($em2);
-        $roleActionMappingService = new org\gocdb\services\RoleActionMappingService();
-        $roleActionAuthorisationService = new org\gocdb\services\RoleActionAuthorisationService($roleActionMappingService);
-        $roleActionAuthorisationService->setEntityManager($em2);
-        $roleService->setRoleActionAuthorisationService($roleActionAuthorisationService);
-
-        $pendingGrantableRolesU1 = $roleService->getPendingRolesUserCanApprove($u);
-
-        // show that u1 has one pending role request
-        $this->assertTrue(count($pendingGrantableRolesU1) == 1);
-        $this->assertEquals($pendingSiteRole->getId(), $pendingGrantableRolesU1[0]->getId());
-        $this->assertEquals(RoleStatus::PENDING, $pendingGrantableRolesU1[0]->getStatus());
-        $this->assertEquals(RoleTypeName::SITE_ADMIN, $pendingGrantableRolesU1[0]->getRoleType()->getName());
-
-        // show that u2 has no pending role requests
-        $pendingGrantableRolesU2 = $roleService->getPendingRolesUserCanApprove($u2);
-        $this->assertTrue(count($pendingGrantableRolesU2) == 0);
-    }
-
-
-
-    public function test_getUserRoleNamesOverEntity(){
-        print __METHOD__ . "\n";
-        // Create fixture data
-        // RoleTypes
-        $siteAdminRT = TestUtil::createSampleRoleType(RoleTypeName::SITE_ADMIN/*, RoleTypeClass::SITE_USER*/);
-        $regFLSupportRT = TestUtil::createSampleRoleType(RoleTypeName::REG_FIRST_LINE_SUPPORT/*, RoleTypeClass::REGIONAL_USER*/);
-        $this->em->persist($regFLSupportRT);
-        $this->em->persist($siteAdminRT);
-        // User
-        $u = TestUtil::createSampleUser("Test", "Testing", "/c=test");
-        $this->em->persist($u);
-        // Site
-        $site1 = TestUtil::createSampleSite("SITENAME"/*, "PK01"*/);
-        $this->em->persist($site1);
-        // Create a Role and link to the User, ngiRoleType and site
-        $roleSite = TestUtil::createSampleRole($u, $siteAdminRT, $site1, RoleStatus::GRANTED);
-        $this->em->persist($roleSite);
-        $this->em->flush();
-
-        // ********NOTE******** Role Service uses a new connection for its transactional methods
-        $roleService = new org\gocdb\services\Role();
-        $roleService->setEntityManager($this->createEntityManager());
-
-        // Now test that method returns expected results
-        $roleNames = $roleService->getUserRoleNamesOverEntity($site1, $u, \RoleStatus::GRANTED);
-        $this->assertEquals(1, count($roleNames));
-        $this->assertContains(RoleTypeName::SITE_ADMIN, $roleNames);
-
-        // Create new NGI
-        $n = TestUtil::createSampleNGI("MYNGI");
-        $this->em->persist($n);
-
-        $roleNgi = TestUtil::createSampleRole($u, $regFLSupportRT, $n, RoleStatus::GRANTED);
-        $this->em->persist($roleNgi);
-        $this->em->flush();
-
-        // Now test that method returns expected results
-        $roleNames = $roleService->getUserRoleNamesOverEntity($n, $u);
-        $this->assertEquals(1, count($roleNames));
-        $this->assertContains(RoleTypeName::REG_FIRST_LINE_SUPPORT, $roleNames);
-    }
-
-
-    public function testGetUserRoles(){
-        print __METHOD__ . "\n";
-        // Create two roletypes
-        $ngiRoleType = TestUtil::createSampleRoleType("RT1_NAME"/*, RoleTypeClass::SITE_USER*/);
-        $siteRoleType = TestUtil::createSampleRoleType("RT2_NAME"/*, RoleTypeClass::REGIONAL_USER*/);
-        $this->em->persist($ngiRoleType);
-        $this->em->persist($siteRoleType);
-
-        // Create a user
-        $u = TestUtil::createSampleUser("Test", "Testing", "/c=test");
-        $this->em->persist($u);
-
-        // Create an NGI
-        $ngi = TestUtil::createSampleNGI("MYNGI");
-        $this->em->persist($ngi);
-
-        // Create a Role and link to the User, ngiRoleType and ngi
-        $roleNgi = TestUtil::createSampleRole($u, $ngiRoleType, $ngi, RoleStatus::GRANTED);
-        $this->em->persist($roleNgi);
-
-        // Create a site
-        $site1 = TestUtil::createSampleSite("SITENAME"/*, "PK01"*/);
-        $this->em->persist($site1);
-
-        // Create another role and link to the User, siteRoleType and site
-        $roleSite = TestUtil::createSampleRole($u, $siteRoleType, $site1, RoleStatus::GRANTED) ;
-        $this->em->persist($roleSite);
-
-        // Create a second and third sites and add to the NGI, but DO NOT add direct
-        // roles over those sites for the user. The user will still have role
-        // over the sites because they have a role over the NGI !
-        $site2 = TestUtil::createSampleSite("SITENAME2"/*, "PK01"*/);
-        $site3 = TestUtil::createSampleSite("SITENAME3"/*, "PK01"*/);
-        $this->em->persist($site2);
-        $this->em->persist($site3);
-        $ngi->addSiteDoJoin($site2);
-        $ngi->addSiteDoJoin($site3);
-
-        $this->em->flush();
-
-        // ********MUST******** start a new connection to test transactional
-        // isolation of RoleService methods.
-        $em = $this->createEntityManager();
-        $roleService = new org\gocdb\services\Role();
-        $roleService->setEntityManager($em);
-        // assert that user has expected roles
-        $roles = $roleService->getUserRoles($u, RoleStatus::GRANTED);
-        $this->assertEquals(2, sizeof($roles));
-        $this->assertTrue(count($roleService->getUserRoleNamesOverEntity($ngi, $u)) == 1);
-        $this->assertTrue(count($roleService->getUserRoleNamesOverEntity($site1, $u)) == 1);
-        $this->assertTrue(count($roleService->getUserRoleNamesOverEntity($site2, $u)) == 0);
-        $this->assertTrue(count($roleService->getUserRoleNamesOverEntity($site3, $u)) == 0);
-
-        // assert that the user has an expected site count with roles over those sites
-        $mySites = $roleService->getReachableSitesFromOwnedObjectRoles($u);
-        $this->assertEquals(3, sizeof($mySites));
-
-        // assert user don't have these pending/revoked roles
-        $roles = $roleService->getUserRoles($u, RoleStatus::PENDING);
-        $this->assertEmpty($roles);
-    }
-
-    /**
-     * @expectedException \LogicException
-     */
-    public function testInvalidRoleStatus(){
-        print __METHOD__ . "\n";
-       $roleService = new org\gocdb\services\Role();
-       $this->assertFalse($roleService->isValidRoleStatus("some invalid role"));
-       $u = TestUtil::createSampleUser("Test", "Testing", "/c=test");
-       $roleService->getUserRoles($u, "some invalid role");
-    }
-
-
-    public function test_getReachableProjectsFromOwnedEntity(){
-        print __METHOD__ . "\n";
-        include __DIR__ . '/resources/sampleFixtureData5.php';
-        $this->em->flush();
-
-
-        // ********MUST******** start a new connection to test transactional
-        // isolation of RoleService methods.
-        $em = $this->createEntityManager();
-        $roleService = new org\gocdb\services\Role();
-        $roleService->setEntityManager($em);
-
-
-        $projects = $roleService->getReachableProjectsFromOwnedEntity($p1);
-        $this->assertEquals($p1, $projects[0]);
-        $this->assertTrue(count($projects) == 1);
-        $projects = $roleService->getReachableProjectsFromOwnedEntity($n1);
-        $this->assertEquals($p1, $projects[0]);
-        $this->assertTrue(count($projects) == 1);
-        $projects = $roleService->getReachableProjectsFromOwnedEntity($s1);
-        $this->assertTrue(count($projects) == 1);
-        $this->assertEquals($p1, $projects[0]);
-
-
-        $projects = $roleService->getReachableProjectsFromOwnedEntity($p2);
-        $this->assertEquals($p2, $projects[0]);
-        $projects = $roleService->getReachableProjectsFromOwnedEntity($n2);
-        $this->assertTrue(count($projects) == 2);
-        $this->assertTrue(in_array($p2, $projects));
-        $this->assertTrue(in_array($p3, $projects));
-        $projects = $roleService->getReachableProjectsFromOwnedEntity($s2);
-        $this->assertTrue(count($projects) == 2);
-        $this->assertTrue(in_array($p2, $projects));
-        $this->assertTrue(in_array($p3, $projects));
-
-
-        $projects = $roleService->getReachableProjectsFromOwnedEntity($n3);
-        $this->assertTrue(count($projects) == 1);
-        $this->assertEquals($p3, $projects[0]);
-        $projects = $roleService->getReachableProjectsFromOwnedEntity($s3);
-        $this->assertTrue(count($projects) == 1);
-        $this->assertEquals($p3, $projects[0]);
-    }
-
-
-    public function test_getUserRolesByProject(){
-        print __METHOD__ . "\n";
-        include __DIR__ . '/resources/sampleFixtureData5.php';
-
-        // create a user
-        $u = TestUtil::createSampleUser("dave", "meredith", "idSTring");
-        $this->em->persist($u);
-
-        // add some roles to domain model
-        $ngiRoleType = TestUtil::createSampleRoleType("NGI_RT");
-        $siteRoleType = TestUtil::createSampleRoleType("SITE_RT");
-        $siteRoleType2 = TestUtil::createSampleRoleType("SITE_RT2");
-        $projRoleType = TestUtil::createSampleRoleType("PROJ_RT");
-        $this->em->persist($ngiRoleType);
-        $this->em->persist($siteRoleType);
-        $this->em->persist($siteRoleType2);
-        $this->em->persist($projRoleType);
-
-        $this->em->flush();
-
-        $roleService = new org\gocdb\services\Role();
-
-        // We could create/inject a new em connection into the roleService
-        // to test the transactional isolation of its methods (rather than injecting
-        // $this->em instance), e.g.:
-        //   $em = $this->createEntityManager();
-        //   $roleService->setEntityManager($em);
-        //
-        // However, this is problematic for this test which
-        // needs to use the in_array() method to assert that the tested methods return
-        // the expected roles - in_array() uses object-instance-equality to deterine
-        // if the role exists in the array, and using a different $em instance
-        // means the returned roles will be considered different
-        // instances. We could get round this by comparing the Ids, but this makes
-        // checking more of hassle as we need to extract all the Ids from the roles
-        // into another array to assert the ids are expected, as in:
-        //   $roleIds = array();
-        //   foreach($roles as $r){ $roleIds[] = $r->getId(); }
-        //   $this->assertTrue(in_array($r1->getId(), $roleIds));
-        //   $this->assertTrue(in_array($r2->getId(), $roleIds));
-        //
-        // For this test, we will therefore re-use $this->em to ensure
-        // object-equality:
-        $roleService->setEntityManager($this->em);
-
-        // confirm that function runs with no user roles over entity
-        $roles = $roleService->getUserRolesByProject($u, $p1);
-        $this->assertEmpty($roles);
-
-
-        // Create a Role and link to the User, ngiRoleType and ngi
-        /*
-         * p1     p2     p3
-         * |      |     /|
-         * n1     n2-r1  n3
-         * |      |      |
-         * s1     s2     s3
-         */
-        $r1 = TestUtil::createSampleRole($u, $ngiRoleType, $n2, RoleStatus::GRANTED);
-        $this->em->persist($r1);
-        $this->em->flush();
-
-        $rolesDirect = $u->getRoles();
-        $this->assertEquals(1, count($rolesDirect));
-
-        $roles = $roleService->getUserRolesByProject($u, $p1);
-        $this->assertEmpty($roles);
-        $roles = $roleService->getUserRolesByProject($u, $p2);
-        $this->assertEquals(1, count($roles));
-        $this->assertEquals($r1->getId(), $roles[0]->getId());
-        $roles = $roleService->getUserRolesByProject($u, $p3);
-        $this->assertEquals(1, count($roles));
-        $this->assertEquals($r1->getId(), $roles[0]->getId());
-
-
-        /*
-         * p1     p2     p3
-         * |      |     /|
-         * n1     n2-r1  n3-r2
-         * |      |      |
-         * s1     s2     s3
-         */
-        $r2 = TestUtil::createSampleRole($u, $ngiRoleType, $n3, RoleStatus::GRANTED);
-        $this->em->persist($r2);
-        $this->em->flush();
-
-        $roles = $roleService->getUserRolesByProject($u, $p1);
-        $this->assertEmpty($roles);
-        $roles = $roleService->getUserRolesByProject($u, $p2);
-        $this->assertEquals(1, count($roles));
-        $this->assertEquals($r1->getId(), $roles[0]->getId());
-
-        $roles = $roleService->getUserRolesByProject($u, $p3);
-        $this->assertEquals(2, count($roles));
-        $roleIds = array();
-        foreach($roles as $r){ $roleIds[] = $r->getId(); }
-        $this->assertTrue(in_array($r1->getId(), $roleIds));
-        $this->assertTrue(in_array($r2->getId(), $roleIds));
-
-        /*
-         * p1     p2     p3
-         * |      |     /|
-         * n1     n2-r1  n3-r2
-         * |      |      |
-         * s1     s2     s3-r3
-         */
-        $r3 = TestUtil::createSampleRole($u, $siteRoleType, $s3, RoleStatus::GRANTED);
-        $this->em->persist($r3);
-        $this->em->flush();
-
-        $roles = $roleService->getUserRolesByProject($u, $p1);
-        $this->assertEmpty($roles);
-        $roles = $roleService->getUserRolesByProject($u, $p2);
-        $this->assertEquals(1, count($roles));
-        $this->assertEquals($r1->getId(), $roles[0]->getId());
-
-        $roles = $roleService->getUserRolesByProject($u, $p3);
-        $this->assertEquals(3, count($roles));
-        $this->assertTrue(in_array($r1, $roles));
-        $this->assertTrue(in_array($r2, $roles));
-        $this->assertTrue(in_array($r3, $roles));
-
-        /*
-         * p1     p2     p3-r4
-         * |      |     /|
-         * n1     n2-r1  n3-r2
-         * |      |      |
-         * s1     s2     s3-r3
-         */
-        $r4 = TestUtil::createSampleRole($u, $projRoleType, $p3, RoleStatus::GRANTED);
-        $this->em->persist($r4);
-        $this->em->flush();
-
-        $rolesDirect = $u->getRoles();
-        $this->assertEquals(4, count($rolesDirect));
-
-        $roles = $roleService->getUserRolesByProject($u, $p1);
-        $this->assertEmpty($roles);
-        $roles = $roleService->getUserRolesByProject($u, $p2);
-        $this->assertEquals(1, count($roles));
-        $this->assertEquals($r1->getId(), $roles[0]->getId());
-        $roles = $roleService->getUserRolesByProject($u, $p3);
-        $this->assertEquals(4, count($roles));
-        $this->assertTrue(in_array($r1, $roles));
-        $this->assertTrue(in_array($r2, $roles));
-        $this->assertTrue(in_array($r3, $roles));
-        $this->assertTrue(in_array($r4, $roles));
-
-        /*
-         * p1     p2     p3-r4
-         * |      |     /|
-         * n1     n2-r1  n3-r2
-         * |      |      |
-         * s1     s2-r5  s3-r3
-         */
-        $r5 = TestUtil::createSampleRole($u, $siteRoleType, $s2, RoleStatus::GRANTED);
-        $this->em->persist($r5);
-        $this->em->flush();
-
-        $rolesDirect = $u->getRoles();
-        $this->assertEquals(5, count($rolesDirect));
-
-        $roles = $roleService->getUserRolesByProject($u, $p1);
-        $this->assertEmpty($roles);
-        $roles = $roleService->getUserRolesByProject($u, $p2);
-        $this->assertEquals(2, count($roles));
-        $this->assertTrue(in_array($r1, $roles));
-        $this->assertTrue(in_array($r5, $roles));
-        $roles = $roleService->getUserRolesByProject($u, $p3);
-        $this->assertEquals(5, count($roles));
-        $this->assertTrue(in_array($r1, $roles));
-        $this->assertTrue(in_array($r2, $roles));
-        $this->assertTrue(in_array($r3, $roles));
-        $this->assertTrue(in_array($r4, $roles));
-        $this->assertTrue(in_array($r5, $roles));
-
-
-        /*
-         * p1     p2     p3-r4
-         * |      |     /|
-         * n1     n2-r1  n3-r2
-         * |      |      |
-         * s1-r6  s2-r5  s3-r3
-         */
-        $r6 = TestUtil::createSampleRole($u, $siteRoleType, $s1, RoleStatus::GRANTED);
-        $this->em->persist($r6);
-        $this->em->flush();
-
-        $rolesDirect = $u->getRoles();
-        $this->assertEquals(6, count($rolesDirect));
-
-        $roles = $roleService->getUserRolesByProject($u, $p1);
-        $this->assertEquals(1, count($roles));
-        $this->assertTrue(in_array($r6, $roles));
-        $roles = $roleService->getUserRolesByProject($u, $p2);
-        $this->assertEquals(2, count($roles));
-        $this->assertTrue(in_array($r1, $roles));
-        $this->assertTrue(in_array($r5, $roles));
-        $roles = $roleService->getUserRolesByProject($u, $p3);
-        $this->assertEquals(5, count($roles));
-        $this->assertTrue(in_array($r1, $roles));
-        $this->assertTrue(in_array($r2, $roles));
-        $this->assertTrue(in_array($r3, $roles));
-        $this->assertTrue(in_array($r4, $roles));
-        $this->assertTrue(in_array($r5, $roles));
-
-        /*
-         * p1     p2     p3-r4
-         * |      |     /|
-         * n1     n2-r1  n3-r2
-         * |      |      |
-         * s1-r6  s2-r5  s3-r3,r7
-         */
-        $r7 = TestUtil::createSampleRole($u, $siteRoleType2, $s3, RoleStatus::GRANTED);
-        $this->em->persist($r7);
-        $this->em->flush();
-
-        $rolesDirect = $u->getRoles();
-        $this->assertEquals(7, count($rolesDirect));
-
-        $roles = $roleService->getUserRolesByProject($u, $p1);
-        $this->assertEquals(1, count($roles));
-        $this->assertTrue(in_array($r6, $roles));
-        $roles = $roleService->getUserRolesByProject($u, $p2);
-        $this->assertEquals(2, count($roles));
-        $this->assertTrue(in_array($r1, $roles));
-        $this->assertTrue(in_array($r5, $roles));
-        $roles = $roleService->getUserRolesByProject($u, $p3);
-        $this->assertEquals(6, count($roles));
-        $this->assertTrue(in_array($r1, $roles));
-        $this->assertTrue(in_array($r2, $roles));
-        $this->assertTrue(in_array($r3, $roles));
-        $this->assertTrue(in_array($r4, $roles));
-        $this->assertTrue(in_array($r5, $roles));
-        $this->assertTrue(in_array($r7, $roles));
-
-
-        /*
-         * p1     p2-r8  p3-r4
-         * |      |     /|
-         * n1     n2-r1  n3-r2
-         * |      |      |
-         * s1-r6  s2-r5  s3-r3,r7
-         */
-        $r8 = TestUtil::createSampleRole($u, $projRoleType, $p2, RoleStatus::GRANTED);
-        $this->em->persist($r8);
-        $this->em->flush();
-
-        $rolesDirect = $u->getRoles();
-        $this->assertEquals(8, count($rolesDirect));
-
-        $roles = $roleService->getUserRolesByProject($u, $p1);
-        $this->assertEquals(1, count($roles));
-        $this->assertTrue(in_array($r6, $roles));
-        $roles = $roleService->getUserRolesByProject($u, $p2);
-        $this->assertEquals(3, count($roles));
-        $this->assertTrue(in_array($r1, $roles));
-        $this->assertTrue(in_array($r5, $roles));
-        $this->assertTrue(in_array($r8, $roles));
-        $roles = $roleService->getUserRolesByProject($u, $p3);
-        $this->assertEquals(6, count($roles));
-        $this->assertTrue(in_array($r1, $roles));
-        $this->assertTrue(in_array($r2, $roles));
-        $this->assertTrue(in_array($r3, $roles));
-        $this->assertTrue(in_array($r4, $roles));
-        $this->assertTrue(in_array($r5, $roles));
-        $this->assertTrue(in_array($r7, $roles));
-
-    }
+    $r8 = TestUtil::createSampleRole($u, $projRoleType, $p2, RoleStatus::GRANTED);
+    $this->em->persist($r8);
+    $this->em->flush();
+
+    $rolesDirect = $u->getRoles();
+    $this->assertEquals(8, count($rolesDirect));
+
+    $roles = $roleService->getUserRolesByProject($u, $p1);
+    $this->assertEquals(1, count($roles));
+    $this->assertTrue(in_array($r6, $roles));
+    $roles = $roleService->getUserRolesByProject($u, $p2);
+    $this->assertEquals(3, count($roles));
+    $this->assertTrue(in_array($r1, $roles));
+    $this->assertTrue(in_array($r5, $roles));
+    $this->assertTrue(in_array($r8, $roles));
+    $roles = $roleService->getUserRolesByProject($u, $p3);
+    $this->assertEquals(6, count($roles));
+    $this->assertTrue(in_array($r1, $roles));
+    $this->assertTrue(in_array($r2, $roles));
+    $this->assertTrue(in_array($r3, $roles));
+    $this->assertTrue(in_array($r4, $roles));
+    $this->assertTrue(in_array($r5, $roles));
+    $this->assertTrue(in_array($r7, $roles));
+  }
 
 }

--- a/tests/doctrine/RolesTest.php
+++ b/tests/doctrine/RolesTest.php
@@ -106,8 +106,9 @@ class RolesTest extends PHPUnit_Extensions_Database_TestCase {
     foreach($tables as $tableName) {
       $sql = "SELECT * FROM ".$tableName->getName();
       $result = $con->createQueryTable('results_table', $sql);
-      if($result->getRowCount() != 0)
+      if($result->getRowCount() != 0) {
         throw new RuntimeException("Invalid fixture. Table has rows: ".$tableName->getName());
+      }
     }
   }
 

--- a/tests/doctrine/RolesTest.php
+++ b/tests/doctrine/RolesTest.php
@@ -1,6 +1,4 @@
 <?php
-//require_once 'PHPUnit/Extensions/Database/TestCase.php';
-//require_once 'PHPUnit/Extensions/Database/DataSet/DefaultDataSet.php';
 require_once dirname(__FILE__) . '/TestUtil.php';
 require_once dirname(__FILE__). '/../../lib/DAOs/ServiceDAO.php';
 require_once dirname(__FILE__). '/../../lib/DAOs/SiteDAO.php';
@@ -93,7 +91,6 @@ class RolesTest extends PHPUnit_Extensions_Database_TestCase {
      * @return EntityManager
      */
     private function createEntityManager(){
-        //require dirname(__FILE__).'/../lib/Doctrine/bootstrap.php';
         require dirname(__FILE__).'/bootstrap_doctrine.php';
         return $entityManager;
     }
@@ -108,10 +105,8 @@ class RolesTest extends PHPUnit_Extensions_Database_TestCase {
         $tables = simplexml_load_file($fixture);
 
         foreach($tables as $tableName) {
-            //print $tableName->getName() . "\n";
             $sql = "SELECT * FROM ".$tableName->getName();
             $result = $con->createQueryTable('results_table', $sql);
-            //echo 'row count: '.$result->getRowCount() ;
             if($result->getRowCount() != 0)
                 throw new RuntimeException("Invalid fixture. Table has rows: ".$tableName->getName());
         }
@@ -252,5 +247,4 @@ class RolesTest extends PHPUnit_Extensions_Database_TestCase {
 
 
 }
-
 ?>

--- a/tests/doctrine/RolesTest.php
+++ b/tests/doctrine/RolesTest.php
@@ -19,232 +19,227 @@ require_once dirname(__FILE__) . '/bootstrap.php';
  * @author John Casson
  */
 class RolesTest extends PHPUnit_Extensions_Database_TestCase {
-   private $em;
-   private $egiScope;
-   private $localScope;
-   private $eudatScope;
+  private $em;
+  private $egiScope;
+  private $localScope;
+  private $eudatScope;
 
+  /**
+   * Overridden.
+   */
+  public static function setUpBeforeClass() {
+    parent::setUpBeforeClass();
+    echo "\n\n-------------------------------------------------\n";
+    echo "Executing RolesTest. . .\n";
+  }
 
-    /**
-     * Overridden.
-     */
-    public static function setUpBeforeClass() {
-        parent::setUpBeforeClass();
-        echo "\n\n-------------------------------------------------\n";
-        echo "Executing RolesTest. . .\n";
+  /**
+   * Overridden. Returns the test database connection.
+   * @return PHPUnit_Extensions_Database_DB_IDatabaseConnection
+   */
+  protected function getConnection() {
+    require_once dirname(__FILE__) . '/bootstrap_pdo.php';
+    return getConnectionToTestDB();
+  }
+
+  /**
+   * Overridden. Returns the test dataset.
+   * Defines how the initial state of the database should look before each test is executed.
+   * @return PHPUnit_Extensions_Database_DataSet_IDataSet
+   */
+  protected function getDataSet() {
+    return $this->createFlatXMLDataSet(dirname(__FILE__) . '/truncateDataTables.xml');
+    // Use below to return an empty data set if we don't want to truncate and seed
+    //return new PHPUnit_Extensions_Database_DataSet_DefaultDataSet();
+  }
+
+  /**
+   * Overridden.
+   */
+  protected function getSetUpOperation() {
+    // CLEAN_INSERT is default
+    //return PHPUnit_Extensions_Database_Operation_Factory::CLEAN_INSERT();
+    //return PHPUnit_Extensions_Database_Operation_Factory::UPDATE();
+    //return PHPUnit_Extensions_Database_Operation_Factory::NONE();
+    //
+    // Issue a DELETE from <table> which is more portable than a
+    // TRUNCATE table <table> (some DBs require high privileges for truncate statements
+    // and also do not allow truncates across tables with FK contstraints e.g. Oracle)
+    return PHPUnit_Extensions_Database_Operation_Factory::DELETE_ALL();
+  }
+
+  /**
+   * Overridden.
+   */
+  protected function getTearDownOperation() {
+    // NONE is default
+    return PHPUnit_Extensions_Database_Operation_Factory::NONE();
+  }
+
+  /**
+   * Sets up the fixture, e.g create a new entityManager for each test run
+   * This method is called before each test method is executed.
+   */
+  protected function setUp() {
+    parent::setUp();
+    $this->em = $this->createEntityManager();
+  }
+
+  /**
+   * @todo Still need to setup connection to different databases.
+   * @return EntityManager
+   */
+  private function createEntityManager(){
+    require dirname(__FILE__).'/bootstrap_doctrine.php';
+    return $entityManager;
+  }
+
+  /**
+   * Called after setUp() and before each test. Used for common assertions
+   * across all tests.
+   */
+  protected function assertPreConditions() {
+    $con = $this->getConnection();
+    $fixture = dirname(__FILE__) . '/truncateDataTables.xml';
+    $tables = simplexml_load_file($fixture);
+
+    foreach($tables as $tableName) {
+      $sql = "SELECT * FROM ".$tableName->getName();
+      $result = $con->createQueryTable('results_table', $sql);
+      if($result->getRowCount() != 0)
+        throw new RuntimeException("Invalid fixture. Table has rows: ".$tableName->getName());
     }
+  }
 
-    /**
-     * Overridden. Returns the test database connection.
-     * @return PHPUnit_Extensions_Database_DB_IDatabaseConnection
-     */
-    protected function getConnection() {
-        require_once dirname(__FILE__) . '/bootstrap_pdo.php';
-        return getConnectionToTestDB();
+  /**
+   * Test Role's discriminator column
+   * Add a role type, user, site and a role linking
+   * them all together. Assert that $newRole->getOwnedEntity()
+   * returns an instanceof Site.
+   */
+  public function testRoleDiscriminatorSite() {
+    print __METHOD__ . "\n";
+    // Create a roletype
+    $rt = TestUtil::createSampleRoleType("ROLENAME");
+    $this->em->persist($rt);
+
+    // Create a user
+    $u = TestUtil::createSampleUser("Test", "Testing", "/c=test");
+    $this->em->persist($u);
+
+    // Create a site
+    $s = TestUtil::createSampleSite("SITENAME"/*, "PK01"*/);
+    $this->em->persist($s);
+
+    // Create a role and link to the user, role type and site
+    $r = TestUtil::createSampleRole($u, $rt, $s, RoleStatus::GRANTED);
+    $this->em->persist($r);
+
+    $this->em->flush();
+
+    // New reference to the freshly created role entity
+    $dbRole = $this->em->find("Role", $r->getId());
+    if(!$dbRole->getOwnedEntity() instanceof Site) {
+        $this->fail();
     }
+    // if we've reached this point without error the test
+    // has passed.
+  }
 
-    /**
-     * Overridden. Returns the test dataset.
-     * Defines how the initial state of the database should look before each test is executed.
-     * @return PHPUnit_Extensions_Database_DataSet_IDataSet
-     */
-    protected function getDataSet() {
-        return $this->createFlatXMLDataSet(dirname(__FILE__) . '/truncateDataTables.xml');
-        // Use below to return an empty data set if we don't want to truncate and seed
-        //return new PHPUnit_Extensions_Database_DataSet_DefaultDataSet();
+  /**
+  * Test Role's discriminator column
+  * Add a role type, user, NGI and a role linking
+  * them all together. Assert that $newRole->getOwnedEntity()
+  * returns an instance of NGI.
+  */
+  public function testRoleDiscriminatorNGI() {
+    print __METHOD__ . "\n";
+    // Create a roletype
+    $rt = TestUtil::createSampleRoleType("Name");
+    $this->em->persist($rt);
+
+    // Create a user
+    $u = TestUtil::createSampleUser("Test", "Testing", "/c=test");
+    $this->em->persist($u);
+
+    // Create an NGI
+    $n = TestUtil::createSampleNGI("MYNGI");
+    $this->em->persist($n);
+
+    // Create a role and link to the user, role type and site
+    $r = TestUtil::createSampleRole($u, $rt, $n, RoleStatus::GRANTED);
+
+    $this->em->persist($r);
+
+    $this->em->flush();
+
+    // New reference to the freshly created role entity
+    $dbRole = $this->em->find("Role", $r->getId());
+    if(!$dbRole->getOwnedEntity() instanceof NGI) {
+      $this->fail();
     }
+    // if we've reached this point without error the test
+    // has passed.
+  }
 
-    /**
-     * Overridden.
-     */
-    protected function getSetUpOperation() {
-        // CLEAN_INSERT is default
-        //return PHPUnit_Extensions_Database_Operation_Factory::CLEAN_INSERT();
-        //return PHPUnit_Extensions_Database_Operation_Factory::UPDATE();
-        //return PHPUnit_Extensions_Database_Operation_Factory::NONE();
-        //
-        // Issue a DELETE from <table> which is more portable than a
-        // TRUNCATE table <table> (some DBs require high privileges for truncate statements
-        // and also do not allow truncates across tables with FK contstraints e.g. Oracle)
-        return PHPUnit_Extensions_Database_Operation_Factory::DELETE_ALL();
-    }
+  /**
+   * Test Role's discriminator column
+   * Add a role type, user, NGI and a role linking
+   * them all together. Assert that $newRole->getOwnedEntity()
+   * returns an instance of NGI.
+   * @expectedException \Doctrine\DBAL\DBALException
+   */
+  public function testRoleTypeIntegrityConstraint() {
+    print __METHOD__ . "\n";
+    // Create a roletype
+    $rt = TestUtil::createSampleRoleType("NAME");
+    $this->em->persist($rt);
 
-    /**
-     * Overridden.
-     */
-    protected function getTearDownOperation() {
-        // NONE is default
-        return PHPUnit_Extensions_Database_Operation_Factory::NONE();
-    }
+    // Create a user
+    $u = TestUtil::createSampleUser("Test", "Testing", "/c=test");
+    $this->em->persist($u);
 
-    /**
-     * Sets up the fixture, e.g create a new entityManager for each test run
-     * This method is called before each test method is executed.
-     */
-    protected function setUp() {
-        parent::setUp();
-        $this->em = $this->createEntityManager();
-    }
+    // Create an NGI
+    $n = TestUtil::createSampleNGI("MYNGI");
+    $this->em->persist($n);
 
-    /**
-     * @todo Still need to setup connection to different databases.
-     * @return EntityManager
-     */
-    private function createEntityManager(){
-        require dirname(__FILE__).'/bootstrap_doctrine.php';
-        return $entityManager;
-    }
+    // Create a role and link to the user, role type and ngi
+    $r = TestUtil::createSampleRole($u, $rt, $n, RoleStatus::GRANTED);
+    $this->em->persist($r);
+    $this->em->flush();
 
-    /**
-     * Called after setUp() and before each test. Used for common assertions
-     * across all tests.
-     */
-    protected function assertPreConditions() {
-        $con = $this->getConnection();
-        $fixture = dirname(__FILE__) . '/truncateDataTables.xml';
-        $tables = simplexml_load_file($fixture);
+    // try to delete the role type before deleting
+    // the dependant role
+    $this->em->remove($rt);
+    $this->em->flush();
+  }
 
-        foreach($tables as $tableName) {
-            $sql = "SELECT * FROM ".$tableName->getName();
-            $result = $con->createQueryTable('results_table', $sql);
-            if($result->getRowCount() != 0)
-                throw new RuntimeException("Invalid fixture. Table has rows: ".$tableName->getName());
-        }
-    }
+  /**
+   * Ensure no duplicate role types are inserted
+   * @expectedException \Doctrine\DBAL\DBALException
+   */
+  public function testDuplicateRoleTypes() {
+    print __METHOD__ . "\n";
+    // Should throw an expected exception because the role type Name value
+    // must be unique
+    $rt1 = TestUtil::createSampleRoleType("RoleName"/*, RoleTypeClass::SITE_USER*/);
+    $rt2 = TestUtil::createSampleRoleType("RoleName"/*, RoleTypeClass::REGIONAL_USER*/);
+    $this->em->persist($rt1);
+    $this->em->persist($rt2);
+    $this->em->flush();
+  }
 
-    /**
-     * Test Role's discriminator column
-     * Add a role type, user, site and a role linking
-     * them all together. Assert that $newRole->getOwnedEntity()
-     * returns an instanceof Site.
-     */
-    public function testRoleDiscriminatorSite() {
-        print __METHOD__ . "\n";
-        // Create a roletype
-        $rt = TestUtil::createSampleRoleType("ROLENAME");
-        $this->em->persist($rt);
+  public function testRoleConstants(){
+    print __METHOD__ . "\n";
 
-        // Create a user
-        $u = TestUtil::createSampleUser("Test", "Testing", "/c=test");
-        $this->em->persist($u);
+    $roleNames = RoleTypeName::getAsArray();
+    $this->assertEquals(RoleTypeName::SITE_ADMIN, $roleNames['SITE_ADMIN'] );
+    $this->assertEquals(RoleTypeName::COD_ADMIN, $roleNames['COD_ADMIN'] );
 
-        // Create a site
-        $s = TestUtil::createSampleSite("SITENAME"/*, "PK01"*/);
-        $this->em->persist($s);
-
-        // Create a role and link to the user, role type and site
-        $r = TestUtil::createSampleRole($u, $rt, $s, RoleStatus::GRANTED);
-        $this->em->persist($r);
-
-        $this->em->flush();
-
-        // New reference to the freshly created role entity
-        $dbRole = $this->em->find("Role", $r->getId());
-        if(!$dbRole->getOwnedEntity() instanceof Site) {
-            $this->fail();
-        }
-        // if we've reached this point without error the test
-        // has passed.
-    }
-
-   /**
-    * Test Role's discriminator column
-    * Add a role type, user, NGI and a role linking
-    * them all together. Assert that $newRole->getOwnedEntity()
-    * returns an instance of NGI.
-    */
-    public function testRoleDiscriminatorNGI() {
-        print __METHOD__ . "\n";
-        // Create a roletype
-        $rt = TestUtil::createSampleRoleType("Name");
-        $this->em->persist($rt);
-
-        // Create a user
-        $u = TestUtil::createSampleUser("Test", "Testing", "/c=test");
-        $this->em->persist($u);
-
-        // Create an NGI
-        $n = TestUtil::createSampleNGI("MYNGI");
-        $this->em->persist($n);
-
-        // Create a role and link to the user, role type and site
-        $r = TestUtil::createSampleRole($u, $rt, $n, RoleStatus::GRANTED);
-
-        $this->em->persist($r);
-
-        $this->em->flush();
-
-        // New reference to the freshly created role entity
-        $dbRole = $this->em->find("Role", $r->getId());
-        if(!$dbRole->getOwnedEntity() instanceof NGI) {
-            $this->fail();
-        }
-        // if we've reached this point without error the test
-        // has passed.
-    }
-
-    /**
-     * Test Role's discriminator column
-     * Add a role type, user, NGI and a role linking
-     * them all together. Assert that $newRole->getOwnedEntity()
-     * returns an instance of NGI.
-     * @expectedException \Doctrine\DBAL\DBALException
-     */
-    public function testRoleTypeIntegrityConstraint() {
-        print __METHOD__ . "\n";
-        // Create a roletype
-        $rt = TestUtil::createSampleRoleType("NAME");
-        $this->em->persist($rt);
-
-        // Create a user
-        $u = TestUtil::createSampleUser("Test", "Testing", "/c=test");
-        $this->em->persist($u);
-
-        // Create an NGI
-        $n = TestUtil::createSampleNGI("MYNGI");
-        $this->em->persist($n);
-
-        // Create a role and link to the user, role type and ngi
-        $r = TestUtil::createSampleRole($u, $rt, $n, RoleStatus::GRANTED);
-        $this->em->persist($r);
-        $this->em->flush();
-
-        // try to delete the role type before deleting
-        // the dependant role
-        $this->em->remove($rt);
-        $this->em->flush();
-    }
-
-    /**
-     * Ensure no duplicate role types are inserted
-     * @expectedException \Doctrine\DBAL\DBALException
-     */
-    public function testDuplicateRoleTypes() {
-        print __METHOD__ . "\n";
-        // Should throw an expected exception because the role type Name value
-        // must be unique
-        $rt1 = TestUtil::createSampleRoleType("RoleName"/*, RoleTypeClass::SITE_USER*/);
-        $rt2 = TestUtil::createSampleRoleType("RoleName"/*, RoleTypeClass::REGIONAL_USER*/);
-        $this->em->persist($rt1);
-        $this->em->persist($rt2);
-        $this->em->flush();
-    }
-
-
-
-
-    public function testRoleConstants(){
-        print __METHOD__ . "\n";
-
-        $roleNames = RoleTypeName::getAsArray();
-        $this->assertEquals(RoleTypeName::SITE_ADMIN, $roleNames['SITE_ADMIN'] );
-        $this->assertEquals(RoleTypeName::COD_ADMIN, $roleNames['COD_ADMIN'] );
-
-        $roleStatusVals = RoleStatus::getAsArray();
-        $this->assertEquals(RoleStatus::GRANTED, $roleStatusVals['GRANTED']);
-        $this->assertEquals(RoleStatus::PENDING, $roleStatusVals['PENDING']);
-    }
-
+    $roleStatusVals = RoleStatus::getAsArray();
+    $this->assertEquals(RoleStatus::GRANTED, $roleStatusVals['GRANTED']);
+    $this->assertEquals(RoleStatus::PENDING, $roleStatusVals['PENDING']);
+  }
 
 }
 ?>

--- a/tests/doctrine/Scoped_IPIQuery_Test1.php
+++ b/tests/doctrine/Scoped_IPIQuery_Test1.php
@@ -105,8 +105,9 @@ class Scoped_IPIQuery_Test1 extends PHPUnit_Extensions_Database_TestCase {
       $sql = "SELECT * FROM " . $tableName->getName();
       $result = $con->createQueryTable('results_table', $sql);
       //echo 'row count: '.$result->getRowCount() ;
-      if ($result->getRowCount() != 0)
+      if ($result->getRowCount() != 0) {
         throw new RuntimeException("Invalid fixture. Table has rows: " . $tableName->getName());
+      }
     }
   }
 

--- a/tests/doctrine/Scoped_IPIQuery_Test1.php
+++ b/tests/doctrine/Scoped_IPIQuery_Test1.php
@@ -10,167 +10,167 @@ require_once dirname(__FILE__) . '/../../lib/Gocdb_Services/Factory.php';
 require_once dirname(__FILE__) . '/../../lib/Gocdb_Services/PI/QueryBuilders/ExtensionsParser.php';
 
 /**
- * Creates selected <code>IPIQuery</code> objects that perform scoped queries on
- * <code>IScopedEntity</code> objects, and assert that the query objects return
- * the expected number of scoped entities when querying against known fixture data.
- * <p>
- * Covers the following IPIQuery objects: GetNGI, GetSite, GetServiceEndpoint, GetServiceGroup
- *
- * @author David Meredith
- */
+* Creates selected <code>IPIQuery</code> objects that perform scoped queries on
+* <code>IScopedEntity</code> objects, and assert that the query objects return
+* the expected number of scoped entities when querying against known fixture data.
+* <p>
+* Covers the following IPIQuery objects: GetNGI, GetSite, GetServiceEndpoint, GetServiceGroup
+*
+* @author David Meredith
+*/
 class Scoped_IPIQuery_Test1 extends PHPUnit_Extensions_Database_TestCase {
 
-    private $em;
+  private $em;
 
-    /**
-     * Overridden.
-     */
-    public static function setUpBeforeClass() {
-        parent::setUpBeforeClass();
-        echo "\n\n-------------------------------------------------\n";
-        echo "Executing Scoped_IPIQuery_Test1. . .\n";
+  /**
+  * Overridden.
+  */
+  public static function setUpBeforeClass() {
+    parent::setUpBeforeClass();
+    echo "\n\n-------------------------------------------------\n";
+    echo "Executing Scoped_IPIQuery_Test1. . .\n";
+  }
+
+  /**
+  * Overridden. Returns the test database connection.
+  * @return PHPUnit_Extensions_Database_DB_IDatabaseConnection
+  */
+  protected function getConnection() {
+    require_once dirname(__FILE__) . '/bootstrap_pdo.php';
+    return getConnectionToTestDB();
+  }
+
+  /**
+  * Overridden. Returns the test dataset.
+  * Defines how the initial state of the database should look before each test is executed.
+  * @return PHPUnit_Extensions_Database_DataSet_IDataSet
+  */
+  protected function getDataSet() {
+    return $this->createFlatXMLDataSet(dirname(__FILE__) . '/truncateDataTables.xml');
+    // Use below to return an empty data set if we don't want to truncate and seed
+    //return new PHPUnit_Extensions_Database_DataSet_DefaultDataSet();
+  }
+
+  /**
+  * Overridden.
+  */
+  protected function getSetUpOperation() {
+    // CLEAN_INSERT is default
+    //return PHPUnit_Extensions_Database_Operation_Factory::CLEAN_INSERT();
+    //return PHPUnit_Extensions_Database_Operation_Factory::UPDATE();
+    //return PHPUnit_Extensions_Database_Operation_Factory::NONE();
+    //
+    // Issue a DELETE from <table> which is more portable than a
+    // TRUNCATE table <table> (some DBs require high privileges for truncate statements
+    // and also do not allow truncates across tables with FK contstraints e.g. Oracle)
+    return PHPUnit_Extensions_Database_Operation_Factory::DELETE_ALL();
+  }
+
+  /**
+  * Overridden.
+  */
+  protected function getTearDownOperation() {
+    // NONE is default
+    return PHPUnit_Extensions_Database_Operation_Factory::NONE();
+  }
+
+  /**
+  * Sets up the fixture, e.g create a new entityManager for each test run
+  * This method is called before each test method is executed.
+  */
+  protected function setUp() {
+    parent::setUp();
+    $this->em = $this->createEntityManager();
+  }
+
+  /**
+  * @return EntityManager
+  */
+  private function createEntityManager() {
+    require dirname(__FILE__) . '/bootstrap_doctrine.php';
+    return $entityManager;
+  }
+
+  /**
+  * Called after setUp() and before each test. Used for common assertions
+  * across all tests.
+  */
+  protected function assertPreConditions() {
+    $con = $this->getConnection();
+    $fixture = dirname(__FILE__) . '/truncateDataTables.xml';
+    $tables = simplexml_load_file($fixture);
+
+    foreach ($tables as $tableName) {
+      //print $tableName->getName() . "\n";
+      $sql = "SELECT * FROM " . $tableName->getName();
+      $result = $con->createQueryTable('results_table', $sql);
+      //echo 'row count: '.$result->getRowCount() ;
+      if ($result->getRowCount() != 0)
+        throw new RuntimeException("Invalid fixture. Table has rows: " . $tableName->getName());
     }
+  }
 
-    /**
-     * Overridden. Returns the test database connection.
-     * @return PHPUnit_Extensions_Database_DB_IDatabaseConnection
-     */
-    protected function getConnection() {
-        require_once dirname(__FILE__) . '/bootstrap_pdo.php';
-        return getConnectionToTestDB();
+  /**
+  * See class doc.
+  */
+  public function testGet_Scoped_IPIQuery() {
+    print __METHOD__ . "\n";
+    include __DIR__ . '/resources/sampleFixtureData2.php';
+
+    $query = new \org\gocdb\services\GetNGI($this->em);
+    $this->doScopedQueryCalls($query);
+
+    $query = new \org\gocdb\services\GetSite($this->em);
+    $this->doScopedQueryCalls($query);
+
+    $query = new \org\gocdb\services\GetService($this->em);
+    $this->doScopedQueryCalls($query);
+
+    $query = new \org\gocdb\services\GetServiceGroup($this->em);
+    $this->doScopedQueryCalls($query);
+
+    //$query = new \org\gocdb\services\GetDowntime($this->em);
+    //$this->doScopedQueryCalls($query);
+  }
+
+
+  private function doScopedQueryCalls(\org\gocdb\services\IPIQuery $query) {
+
+    // empty scope string is a wildcard for 'any' value (i.e. scope can be any value)
+    $this->queryForIScopedEntity($query, array('scope' => '', 'scope_match' => 'all'), 5);
+    $this->queryForIScopedEntity($query, array('scope' => '', 'scope_match' => 'any'), 5);
+    try {
+      $this->queryForIScopedEntity($query, null, 5);
+      $this->fail("Expected and InvalidArgumentException");
+    } catch(InvalidArgumentException $ex){
+      // ok, we expected this so continue on below
     }
+    // TODO - All Tests below involve missing/empty/null 'scope' and 'scope_match'
+    // values. This causes the IPIQuery object to invoke the Factory::getConfigService()
+    // to get the default 'scope' and 'scope_match' values.
+    // If we were being strict OO practitioners, then the IPIQuery
+    // objects shouldn't really depend on the Factory or ConfigService.
+    // Instead, these defaults could be injected from calling/client code
+    // (with an additional a hardwired fallback of 'scope_match = all' and
+    // 'no' default scope defined within the IPIQuery).
+    //
+    // 5 queries below use the default scope and default scope_match values
+    $this->queryForIScopedEntity($query, array('scope_match' => 'all'), 0); // no scope (uses default)
+    $this->queryForIScopedEntity($query, array('scope_match' => ''), 0); // no scope and empty scope_match
+    $this->queryForIScopedEntity($query, array(), 0); // no scope, no scope_match (uses defaults)
+    $this->queryForIScopedEntity($query, array('scope' => null, 'scope_match' => 'any'), 0); // no scope (uses default)
+    $this->queryForIScopedEntity($query, array('scope' => null, 'scope_match' => 'all'), 0);// no scope (uses default)
 
-    /**
-     * Overridden. Returns the test dataset.
-     * Defines how the initial state of the database should look before each test is executed.
-     * @return PHPUnit_Extensions_Database_DataSet_IDataSet
-     */
-    protected function getDataSet() {
-        return $this->createFlatXMLDataSet(dirname(__FILE__) . '/truncateDataTables.xml');
-        // Use below to return an empty data set if we don't want to truncate and seed
-        //return new PHPUnit_Extensions_Database_DataSet_DefaultDataSet();
-    }
-
-    /**
-     * Overridden.
-     */
-    protected function getSetUpOperation() {
-        // CLEAN_INSERT is default
-        //return PHPUnit_Extensions_Database_Operation_Factory::CLEAN_INSERT();
-        //return PHPUnit_Extensions_Database_Operation_Factory::UPDATE();
-        //return PHPUnit_Extensions_Database_Operation_Factory::NONE();
-        //
-        // Issue a DELETE from <table> which is more portable than a
-        // TRUNCATE table <table> (some DBs require high privileges for truncate statements
-        // and also do not allow truncates across tables with FK contstraints e.g. Oracle)
-        return PHPUnit_Extensions_Database_Operation_Factory::DELETE_ALL();
-    }
-
-    /**
-     * Overridden.
-     */
-    protected function getTearDownOperation() {
-        // NONE is default
-        return PHPUnit_Extensions_Database_Operation_Factory::NONE();
-    }
-
-    /**
-     * Sets up the fixture, e.g create a new entityManager for each test run
-     * This method is called before each test method is executed.
-     */
-    protected function setUp() {
-        parent::setUp();
-        $this->em = $this->createEntityManager();
-    }
-
-    /**
-     * @return EntityManager
-     */
-    private function createEntityManager() {
-        require dirname(__FILE__) . '/bootstrap_doctrine.php';
-        return $entityManager;
-    }
-
-    /**
-     * Called after setUp() and before each test. Used for common assertions
-     * across all tests.
-     */
-    protected function assertPreConditions() {
-        $con = $this->getConnection();
-        $fixture = dirname(__FILE__) . '/truncateDataTables.xml';
-        $tables = simplexml_load_file($fixture);
-
-        foreach ($tables as $tableName) {
-            //print $tableName->getName() . "\n";
-            $sql = "SELECT * FROM " . $tableName->getName();
-            $result = $con->createQueryTable('results_table', $sql);
-            //echo 'row count: '.$result->getRowCount() ;
-            if ($result->getRowCount() != 0)
-                throw new RuntimeException("Invalid fixture. Table has rows: " . $tableName->getName());
-        }
-    }
-
-   /**
-     * See class doc.
-     */
-    public function testGet_Scoped_IPIQuery() {
-        print __METHOD__ . "\n";
-        include __DIR__ . '/resources/sampleFixtureData2.php';
-
-        $query = new \org\gocdb\services\GetNGI($this->em);
-        $this->doScopedQueryCalls($query);
-
-        $query = new \org\gocdb\services\GetSite($this->em);
-        $this->doScopedQueryCalls($query);
-
-        $query = new \org\gocdb\services\GetService($this->em);
-        $this->doScopedQueryCalls($query);
-
-        $query = new \org\gocdb\services\GetServiceGroup($this->em);
-        $this->doScopedQueryCalls($query);
-
-        //$query = new \org\gocdb\services\GetDowntime($this->em);
-        //$this->doScopedQueryCalls($query);
-    }
-
-
-    private function doScopedQueryCalls(\org\gocdb\services\IPIQuery $query) {
-
-        // empty scope string is a wildcard for 'any' value (i.e. scope can be any value)
-        $this->queryForIScopedEntity($query, array('scope' => '', 'scope_match' => 'all'), 5);
-        $this->queryForIScopedEntity($query, array('scope' => '', 'scope_match' => 'any'), 5);
-        try {
-            $this->queryForIScopedEntity($query, null, 5);
-            $this->fail("Expected and InvalidArgumentException");
-        } catch(InvalidArgumentException $ex){
-            // ok, we expected this so continue on below
-        }
-        // TODO - All Tests below involve missing/empty/null 'scope' and 'scope_match'
-        // values. This causes the IPIQuery object to invoke the Factory::getConfigService()
-        // to get the default 'scope' and 'scope_match' values.
-        // If we were being strict OO practitioners, then the IPIQuery
-        // objects shouldn't really depend on the Factory or ConfigService.
-        // Instead, these defaults could be injected from calling/client code
-        // (with an additional a hardwired fallback of 'scope_match = all' and
-        // 'no' default scope defined within the IPIQuery).
-        //
-        // 5 queries below use the default scope and default scope_match values
-        $this->queryForIScopedEntity($query, array('scope_match' => 'all'), 0); // no scope (uses default)
-        $this->queryForIScopedEntity($query, array('scope_match' => ''), 0); // no scope and empty scope_match
-        $this->queryForIScopedEntity($query, array(), 0); // no scope, no scope_match (uses defaults)
-        $this->queryForIScopedEntity($query, array('scope' => null, 'scope_match' => 'any'), 0); // no scope (uses default)
-        $this->queryForIScopedEntity($query, array('scope' => null, 'scope_match' => 'all'), 0);// no scope (uses default)
-
-        // Test with scope_match = all
-        $this->queryForIScopedEntity($query, array('scope' => 'Scope0', 'scope_match' => 'all'), 4);
-        $this->queryForIScopedEntity($query, array('scope' => 'Scope0,Scope1', 'scope_match' => 'all'), 3);
-        $this->queryForIScopedEntity($query, array('scope' => 'Scope2', 'scope_match' => 'all'), 2);
-        $this->queryForIScopedEntity($query, array('scope' => 'Scope3,Scope4,Scope5', 'scope_match' => 'all'), 1);
-        $this->queryForIScopedEntity($query, array('scope' => 'Scope0,Scope1,ScopeX', 'scope_match' => 'all'), 0);
-        // Test with scope_match = any
-        $this->queryForIScopedEntity($query, array('scope' => 'Scope0', 'scope_match' => 'any'), 4);
-        $this->queryForIScopedEntity($query, array('scope' => 'Scope1', 'scope_match' => 'any'), 3);
-        $this->queryForIScopedEntity($query, array('scope' => 'ScopeX0,ScopeX1,ScopeX1', 'scope_match' => 'any'), 0);
+    // Test with scope_match = all
+    $this->queryForIScopedEntity($query, array('scope' => 'Scope0', 'scope_match' => 'all'), 4);
+    $this->queryForIScopedEntity($query, array('scope' => 'Scope0,Scope1', 'scope_match' => 'all'), 3);
+    $this->queryForIScopedEntity($query, array('scope' => 'Scope2', 'scope_match' => 'all'), 2);
+    $this->queryForIScopedEntity($query, array('scope' => 'Scope3,Scope4,Scope5', 'scope_match' => 'all'), 1);
+    $this->queryForIScopedEntity($query, array('scope' => 'Scope0,Scope1,ScopeX', 'scope_match' => 'all'), 0);
+    // Test with scope_match = any
+    $this->queryForIScopedEntity($query, array('scope' => 'Scope0', 'scope_match' => 'any'), 4);
+    $this->queryForIScopedEntity($query, array('scope' => 'Scope1', 'scope_match' => 'any'), 3);
+    $this->queryForIScopedEntity($query, array('scope' => 'ScopeX0,ScopeX1,ScopeX1', 'scope_match' => 'any'), 0);
 
 
     $this->queryForIScopedEntity($query, array('scope' => 'Scope0,Scope1,ScopeX', 'scope_match' => 'any'), 4);
@@ -178,16 +178,14 @@ class Scoped_IPIQuery_Test1 extends PHPUnit_Extensions_Database_TestCase {
     $this->queryForIScopedEntity($query, array('scope' => 'Scope1,Scope2', 'scope_match' => 'any'), 3);
     $this->queryForIScopedEntity($query, array('scope' => 'Scope2,Scope3,Scope4', 'scope_match' => 'any'), 2);
     $this->queryForIScopedEntity($query, array('scope' => 'Scope5,ScopeX,ScopeXX', 'scope_match' => 'any'), 1);
-    }
+  }
 
-    private function queryForIScopedEntity(\org\gocdb\services\IPIQuery $query, $params, $expectedCount) {
-        $query->validateParameters($params);
-        $query->createQuery();
-        $results = $query->executeQuery();
-        $this->assertTrue($expectedCount == count($results));
-        return $results;
-    }
-
+  private function queryForIScopedEntity(\org\gocdb\services\IPIQuery $query, $params, $expectedCount) {
+    $query->validateParameters($params);
+    $query->createQuery();
+    $results = $query->executeQuery();
+    $this->assertTrue($expectedCount == count($results));
+    return $results;
+  }
 }
-
 ?>

--- a/tests/doctrine/Scoped_IPIQuery_Test1.php
+++ b/tests/doctrine/Scoped_IPIQuery_Test1.php
@@ -1,22 +1,13 @@
 <?php
-
-//require_once 'PHPUnit/Extensions/Database/TestCase.php';
-//require_once 'PHPUnit/Extensions/Database/DataSet/DefaultDataSet.php';
 require_once dirname(__FILE__) . '/TestUtil.php';
-
 use Doctrine\ORM\EntityManager;
-
 require_once dirname(__FILE__) . '/bootstrap.php';
-//require_once dirname(__FILE__) . '/../../lib/Gocdb_Services/PI/QueryBuilders/ScopeQueryBuilder.php';
-//require_once dirname(__FILE__) . '/../../lib/Gocdb_Services/PI/QueryBuilders/Helpers.php';
 require_once dirname(__FILE__) . '/../../lib/Gocdb_Services/PI/GetNGI.php';
 require_once dirname(__FILE__) . '/../../lib/Gocdb_Services/PI/GetSite.php';
 require_once dirname(__FILE__) . '/../../lib/Gocdb_Services/PI/GetService.php';
 require_once dirname(__FILE__) . '/../../lib/Gocdb_Services/PI/GetServiceGroup.php';
-//
 require_once dirname(__FILE__) . '/../../lib/Gocdb_Services/Factory.php';
 require_once dirname(__FILE__) . '/../../lib/Gocdb_Services/PI/QueryBuilders/ExtensionsParser.php';
-
 
 /**
  * Creates selected <code>IPIQuery</code> objects that perform scoped queries on
@@ -181,11 +172,6 @@ class Scoped_IPIQuery_Test1 extends PHPUnit_Extensions_Database_TestCase {
         $this->queryForIScopedEntity($query, array('scope' => 'Scope1', 'scope_match' => 'any'), 3);
         $this->queryForIScopedEntity($query, array('scope' => 'ScopeX0,ScopeX1,ScopeX1', 'scope_match' => 'any'), 0);
 
-//	$query->validateParameters(array('scope' => 'Scope0,Scope1,ScopeX', 'scope_match' => 'any'));
-//	$query->createQuery();
-//      $results = $query->executeQuery();
-//	print_r(count($results));
-//      $this->assertTrue(4 == count($results));
 
     $this->queryForIScopedEntity($query, array('scope' => 'Scope0,Scope1,ScopeX', 'scope_match' => 'any'), 4);
     $this->queryForIScopedEntity($query, array('scope' => 'Scope1,ScopeX,ScopeXX', 'scope_match' => 'any'), 3);
@@ -204,5 +190,4 @@ class Scoped_IPIQuery_Test1 extends PHPUnit_Extensions_Database_TestCase {
 
 }
 
-//close class
 ?>

--- a/tests/doctrine/ServiceDAOTest.php
+++ b/tests/doctrine/ServiceDAOTest.php
@@ -1,11 +1,6 @@
 <?php
-
-//require_once 'PHPUnit/Extensions/Database/TestCase.php';
-//require_once 'PHPUnit/Extensions/Database/DataSet/DefaultDataSet.php';
 require_once dirname(__FILE__) . '/TestUtil.php';
-
 use Doctrine\ORM\EntityManager;
-
 require_once dirname(__FILE__) . '/bootstrap.php';
 require_once dirname(__FILE__) . '/../../lib/Gocdb_Services/Site.php';
 require_once dirname(__FILE__) . '/../../lib/Gocdb_Services/NGI.php';
@@ -19,11 +14,7 @@ require_once dirname(__FILE__) . '/../../lib/DAOs/ServiceDAO.php';
  * @author David Meredith
  */
 class ServiceDAOTest extends PHPUnit_Extensions_Database_TestCase {
-
     private $em;
-    //private $egiScope;
-    //private $localScope;
-    //private $eudatScope;
 
     /**
      * Overridden.
@@ -153,7 +144,6 @@ class ServiceDAOTest extends PHPUnit_Extensions_Database_TestCase {
         $this->assertTrue($result->getRowCount() == 0);
     }
 
-
      public function testNgiService_removeNgi() {
         print __METHOD__ . "\n";
         include __DIR__ . '/resources/sampleFixtureData1.php';
@@ -165,10 +155,7 @@ class ServiceDAOTest extends PHPUnit_Extensions_Database_TestCase {
         $ngiService = new org\gocdb\services\NGI();
         $ngiService->setEntityManager($this->em);
         $ngiService->deleteNgi($ngi, $adminUser, FALSE);
-
      }
-
 }
 
-//close class
 ?>

--- a/tests/doctrine/ServiceDAOTest.php
+++ b/tests/doctrine/ServiceDAOTest.php
@@ -101,8 +101,9 @@ class ServiceDAOTest extends PHPUnit_Extensions_Database_TestCase {
       $sql = "SELECT * FROM " . $tableName->getName();
       $result = $con->createQueryTable('results_table', $sql);
       //echo 'row count: '.$result->getRowCount() ;
-      if ($result->getRowCount() != 0)
+      if ($result->getRowCount() != 0){
         throw new RuntimeException("Invalid fixture. Table has rows: " . $tableName->getName());
+      }
     }
   }
 

--- a/tests/doctrine/ServiceDAOTest.php
+++ b/tests/doctrine/ServiceDAOTest.php
@@ -14,148 +14,148 @@ require_once dirname(__FILE__) . '/../../lib/DAOs/ServiceDAO.php';
  * @author David Meredith
  */
 class ServiceDAOTest extends PHPUnit_Extensions_Database_TestCase {
-    private $em;
+  private $em;
 
-    /**
-     * Overridden.
-     */
-    public static function setUpBeforeClass() {
-        parent::setUpBeforeClass();
-        echo "\n\n-------------------------------------------------\n";
-        echo "Executing ServiceDAOTest. . .\n";
+  /**
+  * Overridden.
+  */
+  public static function setUpBeforeClass() {
+    parent::setUpBeforeClass();
+    echo "\n\n-------------------------------------------------\n";
+    echo "Executing ServiceDAOTest. . .\n";
+  }
+
+  /**
+  * Overridden. Returns the test database connection.
+  * @return PHPUnit_Extensions_Database_DB_IDatabaseConnection
+  */
+  protected function getConnection() {
+    require_once dirname(__FILE__) . '/bootstrap_pdo.php';
+    return getConnectionToTestDB();
+  }
+
+  /**
+  * Overridden. Returns the test dataset.
+  * Defines how the initial state of the database should look before each test is executed.
+  * @return PHPUnit_Extensions_Database_DataSet_IDataSet
+  */
+  protected function getDataSet() {
+    return $this->createFlatXMLDataSet(dirname(__FILE__) . '/truncateDataTables.xml');
+    // Use below to return an empty data set if we don't want to truncate and seed
+    //return new PHPUnit_Extensions_Database_DataSet_DefaultDataSet();
+  }
+
+  /**
+  * Overridden.
+  */
+  protected function getSetUpOperation() {
+    // CLEAN_INSERT is default
+    //return PHPUnit_Extensions_Database_Operation_Factory::CLEAN_INSERT();
+    //return PHPUnit_Extensions_Database_Operation_Factory::UPDATE();
+    //return PHPUnit_Extensions_Database_Operation_Factory::NONE();
+    //
+    // Issue a DELETE from <table> which is more portable than a
+    // TRUNCATE table <table> (some DBs require high privileges for truncate statements
+    // and also do not allow truncates across tables with FK contstraints e.g. Oracle)
+    return PHPUnit_Extensions_Database_Operation_Factory::DELETE_ALL();
+  }
+
+  /**
+  * Overridden.
+  */
+  protected function getTearDownOperation() {
+    // NONE is default
+    return PHPUnit_Extensions_Database_Operation_Factory::NONE();
+  }
+
+  /**
+  * Sets up the fixture, e.g create a new entityManager for each test run
+  * This method is called before each test method is executed.
+  */
+  protected function setUp() {
+    parent::setUp();
+    $this->em = $this->createEntityManager();
+  }
+
+  /**
+  * @todo Still need to setup connection to different databases.
+  * @return EntityManager
+  */
+  private function createEntityManager() {
+    //require dirname(__FILE__).'/../lib/Doctrine/bootstrap.php';
+    require dirname(__FILE__) . '/bootstrap_doctrine.php';
+    return $entityManager;
+  }
+
+  /**
+  * Called after setUp() and before each test. Used for common assertions
+  * across all tests.
+  */
+  protected function assertPreConditions() {
+    $con = $this->getConnection();
+    $fixture = dirname(__FILE__) . '/truncateDataTables.xml';
+    $tables = simplexml_load_file($fixture);
+
+    foreach ($tables as $tableName) {
+      //print $tableName->getName() . "\n";
+      $sql = "SELECT * FROM " . $tableName->getName();
+      $result = $con->createQueryTable('results_table', $sql);
+      //echo 'row count: '.$result->getRowCount() ;
+      if ($result->getRowCount() != 0)
+        throw new RuntimeException("Invalid fixture. Table has rows: " . $tableName->getName());
     }
+  }
 
-    /**
-     * Overridden. Returns the test database connection.
-     * @return PHPUnit_Extensions_Database_DB_IDatabaseConnection
-     */
-    protected function getConnection() {
-        require_once dirname(__FILE__) . '/bootstrap_pdo.php';
-        return getConnectionToTestDB();
-    }
+  /**
+  * Test the ServiceDAO->removeService();
+  * Impt: A cascade=remove is configured between Service and EndpointLocation
+  * so that when a Service is removed, its associated ELs are also removed.
+  * <p>
+  * Note, no cascade remove behaviour is configured between EndpointLocation and
+  * Downtime because we need to have fine-grained programmatic control over
+  * which downtimes are deleted when a service EL is deleted (i.e. we only
+  * want to delete those DTs that exclusively link to one EL only and which
+  * would subsequently be orphaned). We do this managed deletion of DTs in ServiceDAO->removeService();
+  */
+  public function testServiceDAO_removeService() {
+    print __METHOD__ . "\n";
+    include __DIR__ . '/resources/sampleFixtureData1.php';
 
-    /**
-     * Overridden. Returns the test dataset.
-     * Defines how the initial state of the database should look before each test is executed.
-     * @return PHPUnit_Extensions_Database_DataSet_IDataSet
-     */
-    protected function getDataSet() {
-        return $this->createFlatXMLDataSet(dirname(__FILE__) . '/truncateDataTables.xml');
-        // Use below to return an empty data set if we don't want to truncate and seed
-        //return new PHPUnit_Extensions_Database_DataSet_DefaultDataSet();
-    }
+    // Impt: When deleting a service, we can't rely solely on the
+    // 'onDelete=cascade' defined on the 'EndpointLocation->service'
+    // to correctly cascade-delete the EL. This is because downtimes can also be linked
+    // to the EL.  Therefore, if we don't invoke an $em->remove() on the EL
+    // (either via cascade="remove" or manually invoking em->remove() on each EL),
+    // Doctrine will not have flagged the EL as removed and so will not automatically delete the
+    // relevant row(s) in 'DOWNTIMES_ENDPOINTLOCATIONS' join table.
+    // This would cause a FK integrity/violation constraint exception
+    // on the 'DOWNTIMES_ENDPOINTLOCATIONS.ENDPOINTLOCATION_ID' FK column.
+    // This is why we need to do a managed delete using the ServiceDAO
+    $serviceDao = new ServiceDAO();
+    $serviceDao->setEntityManager($this->em);
+    $serviceDao->removeService($service1);
+    $this->em->flush();
 
-    /**
-     * Overridden.
-     */
-    protected function getSetUpOperation() {
-        // CLEAN_INSERT is default
-        //return PHPUnit_Extensions_Database_Operation_Factory::CLEAN_INSERT();
-        //return PHPUnit_Extensions_Database_Operation_Factory::UPDATE();
-        //return PHPUnit_Extensions_Database_Operation_Factory::NONE();
-        //
-        // Issue a DELETE from <table> which is more portable than a
-        // TRUNCATE table <table> (some DBs require high privileges for truncate statements
-        // and also do not allow truncates across tables with FK contstraints e.g. Oracle)
-        return PHPUnit_Extensions_Database_Operation_Factory::DELETE_ALL();
-    }
+    // use DB connection to check data has been deleted
+    $con = $this->getConnection();
+    $result = $con->createQueryTable('results_table', "SELECT * FROM EndpointLocations");
+    $this->assertTrue($result->getRowCount() == 0);
+    $result = $con->createQueryTable('results_table', "SELECT * FROM Downtimes");
+    $this->assertTrue($result->getRowCount() == 0);
+  }
 
-    /**
-     * Overridden.
-     */
-    protected function getTearDownOperation() {
-        // NONE is default
-        return PHPUnit_Extensions_Database_Operation_Factory::NONE();
-    }
+  public function testNgiService_removeNgi() {
+    print __METHOD__ . "\n";
+    include __DIR__ . '/resources/sampleFixtureData1.php';
 
-    /**
-     * Sets up the fixture, e.g create a new entityManager for each test run
-     * This method is called before each test method is executed.
-     */
-    protected function setUp() {
-        parent::setUp();
-        $this->em = $this->createEntityManager();
-    }
+    $adminUser = TestUtil::createSampleUser('some', 'admin', '/some/admin');
+    $adminUser->setAdmin(TRUE);
+    $this->em->persist($adminUser);
 
-    /**
-     * @todo Still need to setup connection to different databases.
-     * @return EntityManager
-     */
-    private function createEntityManager() {
-        //require dirname(__FILE__).'/../lib/Doctrine/bootstrap.php';
-        require dirname(__FILE__) . '/bootstrap_doctrine.php';
-        return $entityManager;
-    }
-
-    /**
-     * Called after setUp() and before each test. Used for common assertions
-     * across all tests.
-     */
-    protected function assertPreConditions() {
-        $con = $this->getConnection();
-        $fixture = dirname(__FILE__) . '/truncateDataTables.xml';
-        $tables = simplexml_load_file($fixture);
-
-        foreach ($tables as $tableName) {
-            //print $tableName->getName() . "\n";
-            $sql = "SELECT * FROM " . $tableName->getName();
-            $result = $con->createQueryTable('results_table', $sql);
-            //echo 'row count: '.$result->getRowCount() ;
-            if ($result->getRowCount() != 0)
-                throw new RuntimeException("Invalid fixture. Table has rows: " . $tableName->getName());
-        }
-    }
-
-    /**
-     * Test the ServiceDAO->removeService();
-     * Impt: A cascade=remove is configured between Service and EndpointLocation
-     * so that when a Service is removed, its associated ELs are also removed.
-     * <p>
-     * Note, no cascade remove behaviour is configured between EndpointLocation and
-     * Downtime because we need to have fine-grained programmatic control over
-     * which downtimes are deleted when a service EL is deleted (i.e. we only
-     * want to delete those DTs that exclusively link to one EL only and which
-     * would subsequently be orphaned). We do this managed deletion of DTs in ServiceDAO->removeService();
-     */
-    public function testServiceDAO_removeService() {
-        print __METHOD__ . "\n";
-        include __DIR__ . '/resources/sampleFixtureData1.php';
-
-        // Impt: When deleting a service, we can't rely solely on the
-        // 'onDelete=cascade' defined on the 'EndpointLocation->service'
-        // to correctly cascade-delete the EL. This is because downtimes can also be linked
-        // to the EL.  Therefore, if we don't invoke an $em->remove() on the EL
-        // (either via cascade="remove" or manually invoking em->remove() on each EL),
-        // Doctrine will not have flagged the EL as removed and so will not automatically delete the
-        // relevant row(s) in 'DOWNTIMES_ENDPOINTLOCATIONS' join table.
-        // This would cause a FK integrity/violation constraint exception
-        // on the 'DOWNTIMES_ENDPOINTLOCATIONS.ENDPOINTLOCATION_ID' FK column.
-        // This is why we need to do a managed delete using the ServiceDAO
-        $serviceDao = new ServiceDAO();
-        $serviceDao->setEntityManager($this->em);
-        $serviceDao->removeService($service1);
-        $this->em->flush();
-
-        // use DB connection to check data has been deleted
-        $con = $this->getConnection();
-        $result = $con->createQueryTable('results_table', "SELECT * FROM EndpointLocations");
-        $this->assertTrue($result->getRowCount() == 0);
-        $result = $con->createQueryTable('results_table', "SELECT * FROM Downtimes");
-        $this->assertTrue($result->getRowCount() == 0);
-    }
-
-     public function testNgiService_removeNgi() {
-        print __METHOD__ . "\n";
-        include __DIR__ . '/resources/sampleFixtureData1.php';
-
-        $adminUser = TestUtil::createSampleUser('some', 'admin', '/some/admin');
-        $adminUser->setAdmin(TRUE);
-        $this->em->persist($adminUser);
-
-        $ngiService = new org\gocdb\services\NGI();
-        $ngiService->setEntityManager($this->em);
-        $ngiService->deleteNgi($ngi, $adminUser, FALSE);
-     }
+    $ngiService = new org\gocdb\services\NGI();
+    $ngiService->setEntityManager($this->em);
+    $ngiService->deleteNgi($ngi, $adminUser, FALSE);
+  }
 }
 
 ?>

--- a/tests/doctrine/ServiceMoveTest.php
+++ b/tests/doctrine/ServiceMoveTest.php
@@ -102,8 +102,9 @@ class ServiceMoveTest extends PHPUnit_Extensions_Database_TestCase {
     foreach($tables as $tableName) {
       $sql = "SELECT * FROM ".$tableName->getName();
       $result = $con->createQueryTable('results_table', $sql);
-      if($result->getRowCount() != 0)
+      if($result->getRowCount() != 0) {
         throw new RuntimeException("Invalid fixture. Table has rows: ".$tableName->getName());
+      }
     }
   }
 

--- a/tests/doctrine/ServiceMoveTest.php
+++ b/tests/doctrine/ServiceMoveTest.php
@@ -6,249 +6,242 @@ require_once dirname(__FILE__). '/../../lib/Gocdb_Services/Site.php';
 require_once dirname(__FILE__). '/../../lib/Gocdb_Services/ServiceService.php';
 
 /**
- *
- *Test site ownership transfer between NGIs
- *
- * @author George Ryall
- * @author David Meredith
- * @author John Casson
- */
+*
+*Test site ownership transfer between NGIs
+*
+* @author George Ryall
+* @author David Meredith
+* @author John Casson
+*/
 class ServiceMoveTest extends PHPUnit_Extensions_Database_TestCase {
-   private $em;
-   private $egiScope;
-   private $localScope;
-   private $eudatScope;
+  private $em;
+  private $egiScope;
+  private $localScope;
+  private $eudatScope;
 
 
-    /**
-     * Overridden.
-     */
-    public static function setUpBeforeClass() {
-        parent::setUpBeforeClass();
-        echo "\n\n-------------------------------------------------\n";
-        echo "Executing ServiceMoveTest. . .\n";
+  /**
+  * Overridden.
+  */
+  public static function setUpBeforeClass() {
+    parent::setUpBeforeClass();
+    echo "\n\n-------------------------------------------------\n";
+    echo "Executing ServiceMoveTest. . .\n";
+  }
+
+  /**
+  * Overridden. Returns the test database connection.
+  * @return PHPUnit_Extensions_Database_DB_IDatabaseConnection
+  */
+  protected function getConnection() {
+    require_once dirname(__FILE__) . '/bootstrap_pdo.php';
+    return getConnectionToTestDB();
+  }
+
+  /**
+  * Overridden. Returns the test dataset.
+  * Defines how the initial state of the database should look before each test is executed.
+  * @return PHPUnit_Extensions_Database_DataSet_IDataSet
+  */
+  protected function getDataSet() {
+    return $this->createFlatXMLDataSet(dirname(__FILE__) . '/truncateDataTables.xml');
+    // Use below to return an empty data set if we don't want to truncate and seed
+    //return new PHPUnit_Extensions_Database_DataSet_DefaultDataSet();
+  }
+
+  /**
+  * Overridden.
+  */
+  protected function getSetUpOperation() {
+    // CLEAN_INSERT is default
+    //return PHPUnit_Extensions_Database_Operation_Factory::CLEAN_INSERT();
+    //return PHPUnit_Extensions_Database_Operation_Factory::UPDATE();
+    //return PHPUnit_Extensions_Database_Operation_Factory::NONE();
+    //
+    // Issue a DELETE from <table> which is more portable than a
+    // TRUNCATE table <table> (some DBs require high privileges for truncate statements
+    // and also do not allow truncates across tables with FK contstraints e.g. Oracle)
+    return PHPUnit_Extensions_Database_Operation_Factory::DELETE_ALL();
+  }
+
+  /**
+  * Overridden.
+  */
+  protected function getTearDownOperation() {
+    // NONE is default
+    return PHPUnit_Extensions_Database_Operation_Factory::NONE();
+  }
+
+  /**
+  * Sets up the fixture, e.g create a new entityManager for each test run
+  * This method is called before each test method is executed.
+  */
+  protected function setUp() {
+    parent::setUp();
+    $this->em = $this->createEntityManager();
+  }
+
+  /**
+  * @todo Still need to setup connection to different databases.
+  * @return EntityManager
+  */
+  private function createEntityManager(){
+    require dirname(__FILE__).'/bootstrap_doctrine.php';
+    return $entityManager;
+  }
+
+  /**
+  * Called after setUp() and before each test. Used for common assertions
+  * across all tests.
+  */
+  protected function assertPreConditions() {
+    $con = $this->getConnection();
+    $fixture = dirname(__FILE__) . '/truncateDataTables.xml';
+    $tables = simplexml_load_file($fixture);
+
+    foreach($tables as $tableName) {
+      $sql = "SELECT * FROM ".$tableName->getName();
+      $result = $con->createQueryTable('results_table', $sql);
+      if($result->getRowCount() != 0)
+        throw new RuntimeException("Invalid fixture. Table has rows: ".$tableName->getName());
     }
+  }
 
-    /**
-     * Overridden. Returns the test database connection.
-     * @return PHPUnit_Extensions_Database_DB_IDatabaseConnection
-     */
-    protected function getConnection() {
-        require_once dirname(__FILE__) . '/bootstrap_pdo.php';
-        return getConnectionToTestDB();
-    }
+  /*
+  * Inserts Two NGIs, three sites, and a service endpoint.
+  * Checks the inserted data is there.
+  *  Moves two of the sites between NGIs.
+  *  Checks the sites are under the right NGIs.
+  */
+  public function testServiceMoves() {
+    print __METHOD__ . "\n";
 
-    /**
-     * Overridden. Returns the test dataset.
-     * Defines how the initial state of the database should look before each test is executed.
-     * @return PHPUnit_Extensions_Database_DataSet_IDataSet
-     */
-    protected function getDataSet() {
-        return $this->createFlatXMLDataSet(dirname(__FILE__) . '/truncateDataTables.xml');
-        // Use below to return an empty data set if we don't want to truncate and seed
-        //return new PHPUnit_Extensions_Database_DataSet_DefaultDataSet();
-    }
+    //Insert initial data
+    $S1 = TestUtil::createSamplesite("Site1");
+    $S2 = TestUtil::createSamplesite("Site2");
+    $SE1 = TestUtil::createSampleService("SEP1");
+    $SE2 = TestUtil::createSampleService("SEP2");
+    $SE3 = TestUtil::createSampleService("SEP3");
+    $dummy_user = TestUtil::createSampleUser('Test', 'User', '/Some/string');
 
-    /**
-     * Overridden.
-     */
-    protected function getSetUpOperation() {
-        // CLEAN_INSERT is default
-        //return PHPUnit_Extensions_Database_Operation_Factory::CLEAN_INSERT();
-        //return PHPUnit_Extensions_Database_Operation_Factory::UPDATE();
-        //return PHPUnit_Extensions_Database_Operation_Factory::NONE();
-        //
-        // Issue a DELETE from <table> which is more portable than a
-        // TRUNCATE table <table> (some DBs require high privileges for truncate statements
-        // and also do not allow truncates across tables with FK contstraints e.g. Oracle)
-        return PHPUnit_Extensions_Database_Operation_Factory::DELETE_ALL();
-    }
+    //Make dummy user a GOCDB admin so it can perfirm site moves etc.
+    $dummy_user->setAdmin(true);
 
-    /**
-     * Overridden.
-     */
-    protected function getTearDownOperation() {
-        // NONE is default
-        return PHPUnit_Extensions_Database_Operation_Factory::NONE();
-    }
+    // Assign the service end points to the sites
+    $S1->addServiceDoJoin($SE1);
+    $S2->addServiceDoJoin($SE2);
+    $S2->addServiceDoJoin($SE3);
 
-    /**
-     * Sets up the fixture, e.g create a new entityManager for each test run
-     * This method is called before each test method is executed.
-     */
-    protected function setUp() {
-        parent::setUp();
-        $this->em = $this->createEntityManager();
-    }
+    //Persist initial data
+    $this->em->persist($S1);
+    $this->em->persist($S2);
+    $this->em->persist($SE1);
+    $this->em->persist($SE2);
+    $this->em->persist($SE3);
+    $this->em->persist($dummy_user);
+    $this->em->flush();
 
-    /**
-     * @todo Still need to setup connection to different databases.
-     * @return EntityManager
-     */
-    private function createEntityManager(){
-        require dirname(__FILE__).'/bootstrap_doctrine.php';
-        return $entityManager;
-    }
-
-    /**
-     * Called after setUp() and before each test. Used for common assertions
-     * across all tests.
-     */
-    protected function assertPreConditions() {
-        $con = $this->getConnection();
-        $fixture = dirname(__FILE__) . '/truncateDataTables.xml';
-        $tables = simplexml_load_file($fixture);
-
-        foreach($tables as $tableName) {
-            $sql = "SELECT * FROM ".$tableName->getName();
-            $result = $con->createQueryTable('results_table', $sql);
-            if($result->getRowCount() != 0)
-                throw new RuntimeException("Invalid fixture. Table has rows: ".$tableName->getName());
-        }
-    }
+    //Use DB connection to check data
+    $con = $this->getConnection();
 
     /*
-     * Inserts Two NGIs, three sites, and a service endpoint.
-     * Checks the inserted data is there.
-     *  Moves two of the sites between NGIs.
-     *  Checks the sites are under the right NGIs.
-     */
-    public function testServiceMoves() {
+    * Check both that each Site is present and that the ID matches the doctrine one
+    */
+    $S1_ID = $S1->getId();
+    $sql = "SELECT 1 FROM Sites WHERE shortname = 'Site1' AND ID = '$S1_ID'";
+    $result = $con->createQueryTable('', $sql);
+    $this->assertEquals(1, $result->getRowCount());
 
-        print __METHOD__ . "\n";
+    $S2_ID = $S2->getId();
+    $sql = "SELECT 1 FROM Sites WHERE shortname = 'Site2' AND ID = '$S2_ID'";
+    $result = $con->createQueryTable('', $sql);
+    $this->assertEquals(1, $result->getRowCount());
 
-        //Insert initial data
-        $S1 = TestUtil::createSamplesite("Site1");
-        $S2 = TestUtil::createSamplesite("Site2");
-        $SE1 = TestUtil::createSampleService("SEP1");
-        $SE2 = TestUtil::createSampleService("SEP2");
-        $SE3 = TestUtil::createSampleService("SEP3");
-        $dummy_user = TestUtil::createSampleUser('Test', 'User', '/Some/string');
+    /*
+    * Check each service endpoint is: present, has the right ID & parent Site
+    */
+    $SE1_id= $SE1->getId();
+    $sql = "SELECT 1 FROM Services WHERE hostname = 'SEP1' AND ID = '$SE1_id' AND PARENTSITE_ID = '$S1_ID'";
+    $result = $con->createQueryTable('', $sql);
+    $this->assertEquals(1, $result->getRowCount());
 
-        //Make dummy user a GOCDB admin so it can perfirm site moves etc.
-        $dummy_user->setAdmin(true);
+    $SE2_id= $SE2->getId();
+    $sql = "SELECT 1 FROM Services WHERE hostname = 'SEP2' AND ID = '$SE2_id' AND PARENTSITE_ID = '$S2_ID'";
+    $result = $con->createQueryTable('', $sql);
+    $this->assertEquals(1, $result->getRowCount());
 
-        // Assign the service end points to the sites
-        $S1->addServiceDoJoin($SE1);
-        $S2->addServiceDoJoin($SE2);
-        $S2->addServiceDoJoin($SE3);
+    $SE3_id= $SE3->getId();
+    $sql = "SELECT 1 FROM Services WHERE hostname = 'SEP3' AND ID = '$SE3_id' AND PARENTSITE_ID = '$S2_ID'";
+    $result = $con->createQueryTable('', $sql);
+    $this->assertEquals(1, $result->getRowCount());
 
-        //Persist initial data
-        $this->em->persist($S1);
-        $this->em->persist($S2);
-        $this->em->persist($SE1);
-        $this->em->persist($SE2);
-        $this->em->persist($SE3);
-        $this->em->persist($dummy_user);
-        $this->em->flush();
+    //Move service endpoints
+    $serv = new org\gocdb\services\ServiceService;
+    $serv->setEntityManager($this->em);
+    $serv->moveService($SE1, $S2, $dummy_user);
+    $serv->moveService($SE2, $S1, $dummy_user);
+    $serv->moveService($SE3, $S2, $dummy_user); //No change
 
-        //Use DB connection to check data
-        $con = $this->getConnection();
+    //flush movement
+    $this->em->flush();
 
-            /*
-             * Check both that each Site is present and that the ID matches the doctrine one
-             */
-            $S1_ID = $S1->getId();
-            $sql = "SELECT 1 FROM Sites WHERE shortname = 'Site1' AND ID = '$S1_ID'";
-            $result = $con->createQueryTable('', $sql);
-            $this->assertEquals(1, $result->getRowCount());
+    //Use doctrine to check movement
+    //Check correct Site for each service endpoint
+    $this->assertEquals($S2, $SE1->getParentSite());
+    $this->assertEquals($S1, $SE2->getParentSite());
+    $this->assertEquals($S2, $SE3->getParentSite());
 
-            $S2_ID = $S2->getId();
-            $sql = "SELECT 1 FROM Sites WHERE shortname = 'Site2' AND ID = '$S2_ID'";
-            $result = $con->createQueryTable('', $sql);
-            $this->assertEquals(1, $result->getRowCount());
-
-            /*
-             * Check each service endpoint is: present, has the right ID & parent Site
-             */
-            $SE1_id= $SE1->getId();
-            $sql = "SELECT 1 FROM Services WHERE hostname = 'SEP1' AND ID = '$SE1_id' AND PARENTSITE_ID = '$S1_ID'";
-            $result = $con->createQueryTable('', $sql);
-            $this->assertEquals(1, $result->getRowCount());
-
-            $SE2_id= $SE2->getId();
-            $sql = "SELECT 1 FROM Services WHERE hostname = 'SEP2' AND ID = '$SE2_id' AND PARENTSITE_ID = '$S2_ID'";
-            $result = $con->createQueryTable('', $sql);
-            $this->assertEquals(1, $result->getRowCount());
-
-            $SE3_id= $SE3->getId();
-            $sql = "SELECT 1 FROM Services WHERE hostname = 'SEP3' AND ID = '$SE3_id' AND PARENTSITE_ID = '$S2_ID'";
-            $result = $con->createQueryTable('', $sql);
-            $this->assertEquals(1, $result->getRowCount());
-
-
-        //Move service endpoints
-        $serv = new org\gocdb\services\ServiceService;
-        $serv->setEntityManager($this->em);
-        $serv->moveService($SE1, $S2, $dummy_user);
-        $serv->moveService($SE2, $S1, $dummy_user);
-        $serv->moveService($SE3, $S2, $dummy_user); //No change
-
-
-        //flush movement
-        $this->em->flush();
-
-        //Use doctrine to check movement
-            //Check correct Site for each service endpoint
-            $this->assertEquals($S2, $SE1->getParentSite());
-            $this->assertEquals($S1, $SE2->getParentSite());
-            $this->assertEquals($S2, $SE3->getParentSite());
-
-
-            //Check correct service endpoints for each Site
-                //Site1
-                $SiteSEPs = $S1->getServices();
-                foreach ($SiteSEPs as $SEP){
-                    $this->assertEquals($SE2, $SEP);
-                }
-                //Site2
-                $SiteSEPs = $S2->getServices();
-                foreach ($SiteSEPs as $SEP){
-                    $this->assertTrue(($SEP==$SE1) or ($SEP==$SE3));
-                }
-
-
-        //Use database connection to check movememrnt
-            $con = $this->getConnection();
-
-            //Check Sites are still present and their ID is unchanged
-            $sql = "SELECT 1 FROM Sites WHERE shortname = 'Site1' AND ID = '$S1_ID'";
-            $result = $con->createQueryTable('', $sql);
-            $this->assertEquals(1, $result->getRowCount());
-
-            $sql = "SELECT 1 FROM Sites WHERE shortname = 'Site2' AND ID = '$S2_ID'";
-            $result = $con->createQueryTable('', $sql);
-            $this->assertEquals(1, $result->getRowCount());
-
-
-            //Check each Site has the correct number of service endpoints
-                //Site 1
-                $sql = "SELECT 1 FROM Services WHERE parentsite_id = '$S1_ID'";
-                $result = $con->createQueryTable('', $sql);
-                $this->assertEquals(1, $result->getRowCount());
-
-                //Site 2
-                $sql = "SELECT 1 FROM Services WHERE parentsite_id = '$S2_ID'";
-                $result = $con->createQueryTable('', $sql);
-                $this->assertEquals(2, $result->getRowCount());
-
-            //check Site IDs are unchanged and they are assigned to the correct NGI
-                //Site 1
-                $sql = "SELECT 1 FROM Services WHERE hostname = 'SEP1' AND id = '$SE1_id' AND parentsite_id = '$S2_ID'";
-                $result = $con->createQueryTable('', $sql);
-                $this->assertEquals(1, $result->getRowCount());
-
-                //Site 2
-                $sql = "SELECT 1 FROM Services WHERE hostname = 'SEP2' AND id = '$SE2_id' AND parentsite_id = '$S1_ID'";
-                $result = $con->createQueryTable('', $sql);
-                $this->assertEquals(1, $result->getRowCount());
-
-                //Site 3
-                $sql = "SELECT 1 FROM Services WHERE hostname = 'SEP3' AND id = '$SE3_id' AND parentsite_id = '$S2_ID'";
-                $result = $con->createQueryTable('', $sql);
-                $this->assertEquals(1, $result->getRowCount());
-
+    //Check correct service endpoints for each Site
+    //Site1
+    $SiteSEPs = $S1->getServices();
+    foreach ($SiteSEPs as $SEP){
+      $this->assertEquals($SE2, $SEP);
     }
-}
+    //Site2
+    $SiteSEPs = $S2->getServices();
+    foreach ($SiteSEPs as $SEP){
+      $this->assertTrue(($SEP==$SE1) or ($SEP==$SE3));
+    }
 
+    //Use database connection to check movememrnt
+    $con = $this->getConnection();
+
+    //Check Sites are still present and their ID is unchanged
+    $sql = "SELECT 1 FROM Sites WHERE shortname = 'Site1' AND ID = '$S1_ID'";
+    $result = $con->createQueryTable('', $sql);
+    $this->assertEquals(1, $result->getRowCount());
+
+    $sql = "SELECT 1 FROM Sites WHERE shortname = 'Site2' AND ID = '$S2_ID'";
+    $result = $con->createQueryTable('', $sql);
+    $this->assertEquals(1, $result->getRowCount());
+
+    //Check each Site has the correct number of service endpoints
+    //Site 1
+    $sql = "SELECT 1 FROM Services WHERE parentsite_id = '$S1_ID'";
+    $result = $con->createQueryTable('', $sql);
+    $this->assertEquals(1, $result->getRowCount());
+
+    //Site 2
+    $sql = "SELECT 1 FROM Services WHERE parentsite_id = '$S2_ID'";
+    $result = $con->createQueryTable('', $sql);
+    $this->assertEquals(2, $result->getRowCount());
+
+    //check Site IDs are unchanged and they are assigned to the correct NGI
+    //Site 1
+    $sql = "SELECT 1 FROM Services WHERE hostname = 'SEP1' AND id = '$SE1_id' AND parentsite_id = '$S2_ID'";
+    $result = $con->createQueryTable('', $sql);
+    $this->assertEquals(1, $result->getRowCount());
+
+    //Site 2
+    $sql = "SELECT 1 FROM Services WHERE hostname = 'SEP2' AND id = '$SE2_id' AND parentsite_id = '$S1_ID'";
+    $result = $con->createQueryTable('', $sql);
+    $this->assertEquals(1, $result->getRowCount());
+
+    //Site 3
+    $sql = "SELECT 1 FROM Services WHERE hostname = 'SEP3' AND id = '$SE3_id' AND parentsite_id = '$S2_ID'";
+    $result = $con->createQueryTable('', $sql);
+    $this->assertEquals(1, $result->getRowCount());
+  }
+
+}
 ?>

--- a/tests/doctrine/ServiceMoveTest.php
+++ b/tests/doctrine/ServiceMoveTest.php
@@ -1,10 +1,5 @@
 <?php
-//use org\gocdb\services\Site;
-//use org\gocdb\services\ServiceService;
-//require_once 'PHPUnit/Extensions/Database/TestCase.php';
-//require_once 'PHPUnit/Extensions/Database/DataSet/DefaultDataSet.php';
 require_once dirname(__FILE__) . '/TestUtil.php';
-
 use Doctrine\ORM\EntityManager;
 require_once dirname(__FILE__) . '/bootstrap.php';
 require_once dirname(__FILE__). '/../../lib/Gocdb_Services/Site.php';
@@ -91,7 +86,6 @@ class ServiceMoveTest extends PHPUnit_Extensions_Database_TestCase {
      * @return EntityManager
      */
     private function createEntityManager(){
-        //require dirname(__FILE__).'/../lib/Doctrine/bootstrap.php';
         require dirname(__FILE__).'/bootstrap_doctrine.php';
         return $entityManager;
     }
@@ -106,10 +100,8 @@ class ServiceMoveTest extends PHPUnit_Extensions_Database_TestCase {
         $tables = simplexml_load_file($fixture);
 
         foreach($tables as $tableName) {
-            //print $tableName->getName() . "\n";
             $sql = "SELECT * FROM ".$tableName->getName();
             $result = $con->createQueryTable('results_table', $sql);
-            //echo 'row count: '.$result->getRowCount() ;
             if($result->getRowCount() != 0)
                 throw new RuntimeException("Invalid fixture. Table has rows: ".$tableName->getName());
         }
@@ -256,7 +248,7 @@ class ServiceMoveTest extends PHPUnit_Extensions_Database_TestCase {
                 $result = $con->createQueryTable('', $sql);
                 $this->assertEquals(1, $result->getRowCount());
 
-    }//close function
-}//close class
+    }
+}
 
 ?>

--- a/tests/doctrine/resources/sampleFixtureData1.php
+++ b/tests/doctrine/resources/sampleFixtureData1.php
@@ -1,112 +1,112 @@
 <?php
 
 /*
- * Include this file in your tests in order to persist a set of known fixuture data
- * for subsequent use in testing.
- *
- * The Fixture data consists of NGI, Sites, Services, User and Roles etc.
- * If you update this fixture data, make sure you update the tests that
- * include this file as the tests assume a known fixture data structure.
- *
- * See the corresponding fixtureDataERD.svg file for an ERD of this fixture data
- *
- * @author David Meredith
- */
+* Include this file in your tests in order to persist a set of known fixuture data
+* for subsequent use in testing.
+*
+* The Fixture data consists of NGI, Sites, Services, User and Roles etc.
+* If you update this fixture data, make sure you update the tests that
+* include this file as the tests assume a known fixture data structure.
+*
+* See the corresponding fixtureDataERD.svg file for an ERD of this fixture data
+*
+* @author David Meredith
+*/
 
-        $roleType1 = TestUtil::createSampleRoleType("NAME");
-        $roleType2 = TestUtil::createSampleRoleType("NAME2");
-        $this->em->persist($roleType1);
-        $this->em->persist($roleType2);
+$roleType1 = TestUtil::createSampleRoleType("NAME");
+$roleType2 = TestUtil::createSampleRoleType("NAME2");
+$this->em->persist($roleType1);
+$this->em->persist($roleType2);
 
-        // Create a user
-        $userWithRoles = TestUtil::createSampleUser("Test", "Testing", "/c=test");
-        $this->em->persist($userWithRoles);
+// Create a user
+$userWithRoles = TestUtil::createSampleUser("Test", "Testing", "/c=test");
+$this->em->persist($userWithRoles);
 
-        // Create an NGI, site and services
-        $ngi = TestUtil::createSampleNGI("MYNGI");
-        $site1 = TestUtil::createSampleSite('site1');
-        $site2 = TestUtil::createSampleSite('site2');
-        $service1 = TestUtil::createSampleService('site1_service1');
-        $service2 = TestUtil::createSampleService('site1_service2');
+// Create an NGI, site and services
+$ngi = TestUtil::createSampleNGI("MYNGI");
+$site1 = TestUtil::createSampleSite('site1');
+$site2 = TestUtil::createSampleSite('site2');
+$service1 = TestUtil::createSampleService('site1_service1');
+$service2 = TestUtil::createSampleService('site1_service2');
 
-        $endpoint1 = TestUtil::createSampleEndpointLocation();
-        $downtime1 = TestUtil::createSampleDowntime();
-        $downtime2 = TestUtil::createSampleDowntime();
-        $service1->addEndpointLocationDoJoin($endpoint1);
-        $downtime1->addEndpointLocation($endpoint1);
-        $downtime2->addEndpointLocation($endpoint1);
+$endpoint1 = TestUtil::createSampleEndpointLocation();
+$downtime1 = TestUtil::createSampleDowntime();
+$downtime2 = TestUtil::createSampleDowntime();
+$service1->addEndpointLocationDoJoin($endpoint1);
+$downtime1->addEndpointLocation($endpoint1);
+$downtime2->addEndpointLocation($endpoint1);
 
-        $site1->addServiceDoJoin($service1);
-        $site1->addServiceDoJoin($service2);
+$site1->addServiceDoJoin($service1);
+$site1->addServiceDoJoin($service2);
 
-        $ngi->addSiteDoJoin($site1);
-        $ngi->addSiteDoJoin($site2);
-
-
-        $certStatusLog1 = TestUtil::createSampleCertStatusLog();
-        $certStatusLog2 = TestUtil::createSampleCertStatusLog();
-        $site2->addCertificationStatusLog($certStatusLog1);
-        $site2->addCertificationStatusLog($certStatusLog2);
+$ngi->addSiteDoJoin($site1);
+$ngi->addSiteDoJoin($site2);
 
 
-        $this->em->persist($ngi);
-        $this->em->persist($site1);
-        $this->em->persist($site2);
-        $this->em->persist($service1);
-        $this->em->persist($service2);
-        $this->em->persist($certStatusLog1);
-        $this->em->persist($certStatusLog2);
-        $this->em->persist($endpoint1);
-        $this->em->persist($downtime1);
-        $this->em->persist($downtime2);
-
-        // Create some roles and link to the user, role type and ngi
-        // roles on ngi
-        $ngiRole1 = TestUtil::createSampleRole($userWithRoles, $roleType1, $ngi, RoleStatus::GRANTED);
-        $ngiRole2 = TestUtil::createSampleRole($userWithRoles, $roleType2, $ngi, RoleStatus::GRANTED);
-        // roles on site1
-        $site1Role1 = TestUtil::createSampleRole($userWithRoles, $roleType1, $site1, RoleStatus::GRANTED);
-        $site1Role2 = TestUtil::createSampleRole($userWithRoles, $roleType2, $site1, RoleStatus::GRANTED);
-        // roles on site2
-        $site2Role1= TestUtil::createSampleRole($userWithRoles, $roleType1, $site2, RoleStatus::GRANTED);
-        $site2Role2= TestUtil::createSampleRole($userWithRoles, $roleType2, $site2, RoleStatus::GRANTED);
-
-        $this->em->persist($ngiRole1);
-        $this->em->persist($ngiRole2);
-        $this->em->persist($site1Role1);
-        $this->em->persist($site1Role2);
-        $this->em->persist($site2Role1);
-        $this->em->persist($site2Role2);
-        $this->em->flush();
-
-        // The userWithRolesmust be flushed before we can gaurentee that the ID is available
-        $userId = $userWithRoles->getId();
+$certStatusLog1 = TestUtil::createSampleCertStatusLog();
+$certStatusLog2 = TestUtil::createSampleCertStatusLog();
+$site2->addCertificationStatusLog($certStatusLog1);
+$site2->addCertificationStatusLog($certStatusLog2);
 
 
-        // Assert fixture data is setup correctly in the DB.
-        $testConn = $this->getConnection();
+$this->em->persist($ngi);
+$this->em->persist($site1);
+$this->em->persist($site2);
+$this->em->persist($service1);
+$this->em->persist($service2);
+$this->em->persist($certStatusLog1);
+$this->em->persist($certStatusLog2);
+$this->em->persist($endpoint1);
+$this->em->persist($downtime1);
+$this->em->persist($downtime2);
 
-        $result = $testConn->createQueryTable('results_table', "SELECT * FROM Users");
-        $this->assertTrue($result->getRowCount() == 1);
+// Create some roles and link to the user, role type and ngi
+// roles on ngi
+$ngiRole1 = TestUtil::createSampleRole($userWithRoles, $roleType1, $ngi, RoleStatus::GRANTED);
+$ngiRole2 = TestUtil::createSampleRole($userWithRoles, $roleType2, $ngi, RoleStatus::GRANTED);
+// roles on site1
+$site1Role1 = TestUtil::createSampleRole($userWithRoles, $roleType1, $site1, RoleStatus::GRANTED);
+$site1Role2 = TestUtil::createSampleRole($userWithRoles, $roleType2, $site1, RoleStatus::GRANTED);
+// roles on site2
+$site2Role1= TestUtil::createSampleRole($userWithRoles, $roleType1, $site2, RoleStatus::GRANTED);
+$site2Role2= TestUtil::createSampleRole($userWithRoles, $roleType2, $site2, RoleStatus::GRANTED);
 
-        $result = $testConn->createQueryTable('results_table', "SELECT * FROM Roles");
-        $this->assertTrue($result->getRowCount() == 6);
+$this->em->persist($ngiRole1);
+$this->em->persist($ngiRole2);
+$this->em->persist($site1Role1);
+$this->em->persist($site1Role2);
+$this->em->persist($site2Role1);
+$this->em->persist($site2Role2);
+$this->em->flush();
 
-        $result = $testConn->createQueryTable('results_table', "SELECT * FROM NGIs");
-        $this->assertTrue($result->getRowCount() == 1);
+// The userWithRolesmust be flushed before we can gaurentee that the ID is available
+$userId = $userWithRoles->getId();
 
-        $result = $testConn->createQueryTable('results_table', "SELECT * FROM Sites");
-        $this->assertTrue($result->getRowCount() == 2);
 
-        $result = $testConn->createQueryTable('results_table', "SELECT * FROM Services");
-        $this->assertTrue($result->getRowCount() == 2);
+// Assert fixture data is setup correctly in the DB.
+$testConn = $this->getConnection();
 
-        $result = $testConn->createQueryTable('results_table', "SELECT * FROM Downtimes");
-        $this->assertTrue($result->getRowCount() == 2);
+$result = $testConn->createQueryTable('results_table', "SELECT * FROM Users");
+$this->assertTrue($result->getRowCount() == 1);
 
-        $result = $testConn->createQueryTable('results_table', "SELECT * FROM EndpointLocations");
-        $this->assertTrue($result->getRowCount() == 1);
+$result = $testConn->createQueryTable('results_table', "SELECT * FROM Roles");
+$this->assertTrue($result->getRowCount() == 6);
 
-        $result = $testConn->createQueryTable('results_table', "SELECT * FROM CertificationStatusLogs");
-        $this->assertTrue($result->getRowCount() == 2);
+$result = $testConn->createQueryTable('results_table', "SELECT * FROM NGIs");
+$this->assertTrue($result->getRowCount() == 1);
+
+$result = $testConn->createQueryTable('results_table', "SELECT * FROM Sites");
+$this->assertTrue($result->getRowCount() == 2);
+
+$result = $testConn->createQueryTable('results_table', "SELECT * FROM Services");
+$this->assertTrue($result->getRowCount() == 2);
+
+$result = $testConn->createQueryTable('results_table', "SELECT * FROM Downtimes");
+$this->assertTrue($result->getRowCount() == 2);
+
+$result = $testConn->createQueryTable('results_table', "SELECT * FROM EndpointLocations");
+$this->assertTrue($result->getRowCount() == 1);
+
+$result = $testConn->createQueryTable('results_table', "SELECT * FROM CertificationStatusLogs");
+$this->assertTrue($result->getRowCount() == 2);
 ?>

--- a/tests/doctrine/resources/sampleFixtureData2.php
+++ b/tests/doctrine/resources/sampleFixtureData2.php
@@ -32,167 +32,168 @@
  *  - Scope4
  *  - Scope5
  */
-        $scopeCount = 6;
-        $scopes = array();
-        // create scopes and persist
-        for($i=0; $i<$scopeCount; $i++){
-            $scopes[] = TestUtil::createSampleScope("Proj scope ".$i, "Scope".$i);
-            $this->em->persist($scopes[$i]);
-        }
+$scopeCount = 6;
+$scopes = array();
+// create scopes and persist
+for($i=0; $i<$scopeCount; $i++){
+  $scopes[] = TestUtil::createSampleScope("Proj scope ".$i, "Scope".$i);
+  $this->em->persist($scopes[$i]);
+}
 
-        // NGIs ****************************
-        // create ngis and persist
-        $ngi0 = TestUtil::createSampleNGI("MYNGI0");
-        $ngi1 = TestUtil::createSampleNGI("MYNGI1");
-        $ngi2 = TestUtil::createSampleNGI("MYNGI2");
-        $ngi3 = TestUtil::createSampleNGI("MYNGI3");
-        $ngi4 = TestUtil::createSampleNGI("MYNGI4");
-        $this->em->persist($ngi0);
-        $this->em->persist($ngi1);
-        $this->em->persist($ngi2);
-        $this->em->persist($ngi3);
-        $this->em->persist($ngi4);
-        // Add different scopes to selected ngis:
-        // ngi0 has no scope
-        // ngi1 has one scope
-        $ngi1->addScope($scopes[0]);
-        // ngi2 has 2 scopes
-        $ngi2->addScope($scopes[0]);
-        $ngi2->addScope($scopes[1]);
-        // ngi3 has 3 scopes
-        $ngi3->addScope($scopes[0]);
-        $ngi3->addScope($scopes[1]);
-        $ngi3->addScope($scopes[2]);
-        //  ngi4 has all scopes
-        for($i=0; $i<$scopeCount; $i++){
-            $ngi4->addScope($scopes[$i]);
-        }
-        // NGIs ****************************
-
-
-        // At least one certStatus is needed for the tests
-        $certStatus = new CertificationStatus();
-        $certStatus->setName('Certified');
-        $this->em->persist($certStatus);
-
-        // Sites: all have same 'Certified' cert status
-        // ****************************
-        $site0 = TestUtil::createSampleSite("Site0");
-        $site0->setCertificationStatus($certStatus);
-        $site1 = TestUtil::createSampleSite("Site1");
-        $site1->setCertificationStatus($certStatus);
-        $site2 = TestUtil::createSampleSite("Site2");
-        $site2->setCertificationStatus($certStatus);
-        $site3 = TestUtil::createSampleSite("Site3");
-        $site3->setCertificationStatus($certStatus);
-        $site4 = TestUtil::createSampleSite("Site4");
-        $site4->setCertificationStatus($certStatus);
+// NGIs ****************************
+// create ngis and persist
+$ngi0 = TestUtil::createSampleNGI("MYNGI0");
+$ngi1 = TestUtil::createSampleNGI("MYNGI1");
+$ngi2 = TestUtil::createSampleNGI("MYNGI2");
+$ngi3 = TestUtil::createSampleNGI("MYNGI3");
+$ngi4 = TestUtil::createSampleNGI("MYNGI4");
+$this->em->persist($ngi0);
+$this->em->persist($ngi1);
+$this->em->persist($ngi2);
+$this->em->persist($ngi3);
+$this->em->persist($ngi4);
+// Add different scopes to selected ngis:
+// ngi0 has no scope
+// ngi1 has one scope
+$ngi1->addScope($scopes[0]);
+// ngi2 has 2 scopes
+$ngi2->addScope($scopes[0]);
+$ngi2->addScope($scopes[1]);
+// ngi3 has 3 scopes
+$ngi3->addScope($scopes[0]);
+$ngi3->addScope($scopes[1]);
+$ngi3->addScope($scopes[2]);
+//  ngi4 has all scopes
+for($i=0; $i<$scopeCount; $i++){
+  $ngi4->addScope($scopes[$i]);
+}
+// NGIs ****************************
 
 
-        $this->em->persist($site0);
-        $this->em->persist($site1);
-        $this->em->persist($site2);
-        $this->em->persist($site3);
-        $this->em->persist($site4);
-        // Add different scopes to selected sites:
-        // site0 has no scope
-        // site1 has one scope
-        $site1->addScope($scopes[0]);
-        // site2 has two scopes
-        $site2->addScope($scopes[0]);
-        $site2->addScope($scopes[1]);
-        // site3 has three scopes
-        $site3->addScope($scopes[0]);
-        $site3->addScope($scopes[1]);
-        $site3->addScope($scopes[2]);
-        //  site4 has all scopes
-        for($i=0; $i<$scopeCount; $i++){
-            $site4->addScope($scopes[$i]);
-        }
-        // Sites ****************************
+// At least one certStatus is needed for the tests
+$certStatus = new CertificationStatus();
+$certStatus->setName('Certified');
+$this->em->persist($certStatus);
+
+// Sites: all have same 'Certified' cert status
+// ****************************
+$site0 = TestUtil::createSampleSite("Site0");
+$site0->setCertificationStatus($certStatus);
+$site1 = TestUtil::createSampleSite("Site1");
+$site1->setCertificationStatus($certStatus);
+$site2 = TestUtil::createSampleSite("Site2");
+$site2->setCertificationStatus($certStatus);
+$site3 = TestUtil::createSampleSite("Site3");
+$site3->setCertificationStatus($certStatus);
+$site4 = TestUtil::createSampleSite("Site4");
+$site4->setCertificationStatus($certStatus);
 
 
-        // Services: all services are added to $site0
-        // ****************************
-        $service0 = TestUtil::createSampleService("Service0");
-        $site0->addServiceDoJoin($service0);
-        $service1 = TestUtil::createSampleService("Service1");
-        $site0->addServiceDoJoin($service1);
-        $service2 = TestUtil::createSampleService("Service2");
-        $site0->addServiceDoJoin($service2);
-        $service3 = TestUtil::createSampleService("Service3");
-        $site0->addServiceDoJoin($service3);
-        $service4 = TestUtil::createSampleService("Service4");
-        $site0->addServiceDoJoin($service4);
-        $this->em->persist($service0);
-        $this->em->persist($service1);
-        $this->em->persist($service2);
-        $this->em->persist($service3);
-        $this->em->persist($service4);
-        // Add different scopes to selected services:
-        // service0 has no scope
-        // service1 has one scope
-        $service0->addScope($scopes[0]);
-        // service2 has two scopes
-        $service2->addScope($scopes[0]);
-        $service2->addScope($scopes[1]);
-        // service3 has three scopes
-        $service3->addScope($scopes[0]);
-        $service3->addScope($scopes[1]);
-        $service3->addScope($scopes[2]);
-        //  service4 has all scopes
-        for($i=0; $i<$scopeCount; $i++){
-            $service4->addScope($scopes[$i]);
-        }
-        // Services ****************************
+$this->em->persist($site0);
+$this->em->persist($site1);
+$this->em->persist($site2);
+$this->em->persist($site3);
+$this->em->persist($site4);
+// Add different scopes to selected sites:
+// site0 has no scope
+// site1 has one scope
+$site1->addScope($scopes[0]);
+// site2 has two scopes
+$site2->addScope($scopes[0]);
+$site2->addScope($scopes[1]);
+// site3 has three scopes
+$site3->addScope($scopes[0]);
+$site3->addScope($scopes[1]);
+$site3->addScope($scopes[2]);
+//  site4 has all scopes
+for($i=0; $i<$scopeCount; $i++){
+  $site4->addScope($scopes[$i]);
+}
+// Sites ****************************
 
 
-        // ServiceGroups ****************************
-        $sg0 = TestUtil::createSampleServiceGroup("SG0");
-        $sg1 = TestUtil::createSampleServiceGroup("SG1");
-        $sg2 = TestUtil::createSampleServiceGroup("SG2");
-        $sg3 = TestUtil::createSampleServiceGroup("SG3");
-        $sg4 = TestUtil::createSampleServiceGroup("SG4");
-        $this->em->persist($sg0);
-        $this->em->persist($sg1);
-        $this->em->persist($sg2);
-        $this->em->persist($sg3);
-        $this->em->persist($sg4);
-        // Add different scopes to selected sgs:
-        // sg0 has no scope
-        // sg1 has one scope
-        $sg1->addScope($scopes[0]);
-        // sg2 has two scopes
-        $sg2->addScope($scopes[0]);
-        $sg2->addScope($scopes[1]);
-        // sg3 has three scopes
-        $sg3->addScope($scopes[0]);
-        $sg3->addScope($scopes[1]);
-        $sg3->addScope($scopes[2]);
-        //  sg4 has all scopes
-        for($i=0; $i<$scopeCount; $i++){
-            $sg4->addScope($scopes[$i]);
-        }
-        // ServiceGroups ****************************
+// Services: all services are added to $site0
+// ****************************
+$service0 = TestUtil::createSampleService("Service0");
+$site0->addServiceDoJoin($service0);
+$service1 = TestUtil::createSampleService("Service1");
+$site0->addServiceDoJoin($service1);
+$service2 = TestUtil::createSampleService("Service2");
+$site0->addServiceDoJoin($service2);
+$service3 = TestUtil::createSampleService("Service3");
+$site0->addServiceDoJoin($service3);
+$service4 = TestUtil::createSampleService("Service4");
+$site0->addServiceDoJoin($service4);
+$this->em->persist($service0);
+$this->em->persist($service1);
+$this->em->persist($service2);
+$this->em->persist($service3);
+$this->em->persist($service4);
+// Add different scopes to selected services:
+// service0 has no scope
+// service1 has one scope
+$service0->addScope($scopes[0]);
+// service2 has two scopes
+$service2->addScope($scopes[0]);
+$service2->addScope($scopes[1]);
+// service3 has three scopes
+$service3->addScope($scopes[0]);
+$service3->addScope($scopes[1]);
+$service3->addScope($scopes[2]);
+//  service4 has all scopes
+for($i=0; $i<$scopeCount; $i++){
+  $service4->addScope($scopes[$i]);
+}
+// Services ****************************
 
-        // commit
-        $this->em->flush();
 
-        // Assert fixture data is setup correctly in the DB.
-        $testConn = $this->getConnection();
+// ServiceGroups ****************************
+$sg0 = TestUtil::createSampleServiceGroup("SG0");
+$sg1 = TestUtil::createSampleServiceGroup("SG1");
+$sg2 = TestUtil::createSampleServiceGroup("SG2");
+$sg3 = TestUtil::createSampleServiceGroup("SG3");
+$sg4 = TestUtil::createSampleServiceGroup("SG4");
+$this->em->persist($sg0);
+$this->em->persist($sg1);
+$this->em->persist($sg2);
+$this->em->persist($sg3);
+$this->em->persist($sg4);
+// Add different scopes to selected sgs:
+// sg0 has no scope
+// sg1 has one scope
+$sg1->addScope($scopes[0]);
+// sg2 has two scopes
+$sg2->addScope($scopes[0]);
+$sg2->addScope($scopes[1]);
+// sg3 has three scopes
+$sg3->addScope($scopes[0]);
+$sg3->addScope($scopes[1]);
+$sg3->addScope($scopes[2]);
+//  sg4 has all scopes
+for($i=0; $i<$scopeCount; $i++){
+  $sg4->addScope($scopes[$i]);
+}
+// ServiceGroups ****************************
 
-        $result = $testConn->createQueryTable('results_table', "SELECT * FROM Scopes");
-        $this->assertTrue($result->getRowCount() == $scopeCount);
+// commit
+$this->em->flush();
 
-        $result = $testConn->createQueryTable('results_table', "SELECT * FROM NGIs");
-        $this->assertTrue($result->getRowCount() == 5);
+// Assert fixture data is setup correctly in the DB.
+$testConn = $this->getConnection();
 
-        $result = $testConn->createQueryTable('results_table', "SELECT * FROM Sites");
-        $this->assertTrue($result->getRowCount() == 5);
+$result = $testConn->createQueryTable('results_table', "SELECT * FROM Scopes");
+$this->assertTrue($result->getRowCount() == $scopeCount);
 
-        $result = $testConn->createQueryTable('results_table', "SELECT * FROM Services");
-        $this->assertTrue($result->getRowCount() == 5);
+$result = $testConn->createQueryTable('results_table', "SELECT * FROM NGIs");
+$this->assertTrue($result->getRowCount() == 5);
 
-        $result = $testConn->createQueryTable('results_table', "SELECT * FROM ServiceGroups");
-        $this->assertTrue($result->getRowCount() == 5);
+$result = $testConn->createQueryTable('results_table', "SELECT * FROM Sites");
+$this->assertTrue($result->getRowCount() == 5);
+
+$result = $testConn->createQueryTable('results_table', "SELECT * FROM Services");
+$this->assertTrue($result->getRowCount() == 5);
+
+$result = $testConn->createQueryTable('results_table', "SELECT * FROM ServiceGroups");
+$this->assertTrue($result->getRowCount() == 5);
+
 ?>

--- a/tests/doctrine/resources/sampleFixtureData3.php
+++ b/tests/doctrine/resources/sampleFixtureData3.php
@@ -7,79 +7,79 @@
  */
 
 
-        // Sites ****************************
-        $site0 = TestUtil::createSampleSite("Site0");
-        $site1 = TestUtil::createSampleSite("Site1");
-        $site2 = TestUtil::createSampleSite("Site2");
-        $site3 = TestUtil::createSampleSite("Site3");
-        $site4 = TestUtil::createSampleSite("Site4");
-        $this->em->persist($site0);
-        $this->em->persist($site1);
-        $this->em->persist($site2);
-        $this->em->persist($site3);
-        $this->em->persist($site4);
-        // Sites ****************************
+// Sites ****************************
+$site0 = TestUtil::createSampleSite("Site0");
+$site1 = TestUtil::createSampleSite("Site1");
+$site2 = TestUtil::createSampleSite("Site2");
+$site3 = TestUtil::createSampleSite("Site3");
+$site4 = TestUtil::createSampleSite("Site4");
+$this->em->persist($site0);
+$this->em->persist($site1);
+$this->em->persist($site2);
+$this->em->persist($site3);
+$this->em->persist($site4);
+// Sites ****************************
 
 
-        // site1 has 1 prop
-        $s1p1 = TestUtil::createSampleSiteProperty("s1p1", "v1");
-        $site1->addSitePropertyDoJoin($s1p1);
-        $this->em->persist($s1p1);
+// site1 has 1 prop
+$s1p1 = TestUtil::createSampleSiteProperty("s1p1", "v1");
+$site1->addSitePropertyDoJoin($s1p1);
+$this->em->persist($s1p1);
 
-        // site2 has 2 props
-        $s2p1 = TestUtil::createSampleSiteProperty("s2p1", "v1");
-        $s2p2 = TestUtil::createSampleSiteProperty("s2p2", "v2");
-        $this->em->persist($s2p1);
-        $this->em->persist($s2p2);
-        $site2->addSitePropertyDoJoin($s2p1);
-        $site2->addSitePropertyDoJoin($s2p2);
+// site2 has 2 props
+$s2p1 = TestUtil::createSampleSiteProperty("s2p1", "v1");
+$s2p2 = TestUtil::createSampleSiteProperty("s2p2", "v2");
+$this->em->persist($s2p1);
+$this->em->persist($s2p2);
+$site2->addSitePropertyDoJoin($s2p1);
+$site2->addSitePropertyDoJoin($s2p2);
 
-        // site3
-        $s3p1 = TestUtil::createSampleSiteProperty("s3p1", "v1");
-        $s3p2 = TestUtil::createSampleSiteProperty("s3p2", "v2");
-        $s3p3 = TestUtil::createSampleSiteProperty("VO", "foo");
-        $s3p4 = TestUtil::createSampleSiteProperty("VO2", "bar");
-        $this->em->persist($s3p1);
-        $this->em->persist($s3p2);
-        $this->em->persist($s3p3);
-        $this->em->persist($s3p4);
-        $site3->addSitePropertyDoJoin($s3p1);
-        $site3->addSitePropertyDoJoin($s3p2);
-        $site3->addSitePropertyDoJoin($s3p3);
-        $site3->addSitePropertyDoJoin($s3p4);
+// site3
+$s3p1 = TestUtil::createSampleSiteProperty("s3p1", "v1");
+$s3p2 = TestUtil::createSampleSiteProperty("s3p2", "v2");
+$s3p3 = TestUtil::createSampleSiteProperty("VO", "foo");
+$s3p4 = TestUtil::createSampleSiteProperty("VO2", "bar");
+$this->em->persist($s3p1);
+$this->em->persist($s3p2);
+$this->em->persist($s3p3);
+$this->em->persist($s3p4);
+$site3->addSitePropertyDoJoin($s3p1);
+$site3->addSitePropertyDoJoin($s3p2);
+$site3->addSitePropertyDoJoin($s3p3);
+$site3->addSitePropertyDoJoin($s3p4);
 
-        // site4
-        $s4p1 = TestUtil::createSampleSiteProperty("s4p1", "v1");
-        $s4p2 = TestUtil::createSampleSiteProperty("s4p2", "v2");
-        $s4p3 = TestUtil::createSampleSiteProperty("VO", "foo");
-        $s4p4 = TestUtil::createSampleSiteProperty("VO", "bar");
-        $s4p5 = TestUtil::createSampleSiteProperty("VO2", "baz");
-        $s4p6 = TestUtil::createSampleSiteProperty("VO2", "bing");
-        $this->em->persist($s4p1);
-        $this->em->persist($s4p2);
-        $this->em->persist($s4p3);
-        $this->em->persist($s4p4);
-        $this->em->persist($s4p5);
-        $this->em->persist($s4p6);
-        $site4->addSitePropertyDoJoin($s4p1);
-        $site4->addSitePropertyDoJoin($s4p2);
-        $site4->addSitePropertyDoJoin($s4p3);
-        $site4->addSitePropertyDoJoin($s4p4);
-        $site4->addSitePropertyDoJoin($s4p5);
-        $site4->addSitePropertyDoJoin($s4p6);
-
-
-        // commit
-        $this->em->flush();
-
-        // Assert fixture data is setup correctly in the DB.
-        $testConn = $this->getConnection();
+// site4
+$s4p1 = TestUtil::createSampleSiteProperty("s4p1", "v1");
+$s4p2 = TestUtil::createSampleSiteProperty("s4p2", "v2");
+$s4p3 = TestUtil::createSampleSiteProperty("VO", "foo");
+$s4p4 = TestUtil::createSampleSiteProperty("VO", "bar");
+$s4p5 = TestUtil::createSampleSiteProperty("VO2", "baz");
+$s4p6 = TestUtil::createSampleSiteProperty("VO2", "bing");
+$this->em->persist($s4p1);
+$this->em->persist($s4p2);
+$this->em->persist($s4p3);
+$this->em->persist($s4p4);
+$this->em->persist($s4p5);
+$this->em->persist($s4p6);
+$site4->addSitePropertyDoJoin($s4p1);
+$site4->addSitePropertyDoJoin($s4p2);
+$site4->addSitePropertyDoJoin($s4p3);
+$site4->addSitePropertyDoJoin($s4p4);
+$site4->addSitePropertyDoJoin($s4p5);
+$site4->addSitePropertyDoJoin($s4p6);
 
 
-        $result = $testConn->createQueryTable('results_table', "SELECT * FROM Sites");
-        $this->assertTrue($result->getRowCount() == 5);
+// commit
+$this->em->flush();
 
-        $result = $testConn->createQueryTable('results_table', "SELECT * FROM Site_Properties");
-        $this->assertTrue($result->getRowCount() == 13);
+// Assert fixture data is setup correctly in the DB.
+$testConn = $this->getConnection();
+
+
+$result = $testConn->createQueryTable('results_table', "SELECT * FROM Sites");
+$this->assertTrue($result->getRowCount() == 5);
+
+$result = $testConn->createQueryTable('results_table', "SELECT * FROM Site_Properties");
+$this->assertTrue($result->getRowCount() == 13);
 
 ?>

--- a/tests/doctrine/resources/sampleFixtureData3.php
+++ b/tests/doctrine/resources/sampleFixtureData3.php
@@ -6,10 +6,6 @@
  * @author David Meredith
  */
 
-/*
-
- */
-
 
         // Sites ****************************
         $site0 = TestUtil::createSampleSite("Site0");
@@ -23,8 +19,6 @@
         $this->em->persist($site3);
         $this->em->persist($site4);
         // Sites ****************************
-
-
 
 
         // site1 has 1 prop

--- a/tests/doctrine/resources/sampleFixtureData4.php
+++ b/tests/doctrine/resources/sampleFixtureData4.php
@@ -13,152 +13,152 @@
  * @author David Meredith
  */
 
-        $roleType1 = TestUtil::createSampleRoleType("NAME");
-        $roleType2 = TestUtil::createSampleRoleType("NAME2");
-        $this->em->persist($roleType1);
-        $this->em->persist($roleType2);
+$roleType1 = TestUtil::createSampleRoleType("NAME");
+$roleType2 = TestUtil::createSampleRoleType("NAME2");
+$this->em->persist($roleType1);
+$this->em->persist($roleType2);
 
-        // Create a user
-        $userWithRoles = TestUtil::createSampleUser("Test", "Testing", "/c=test");
-        $this->em->persist($userWithRoles);
-        $userId = $userWithRoles->getId();
+// Create a user
+$userWithRoles = TestUtil::createSampleUser("Test", "Testing", "/c=test");
+$this->em->persist($userWithRoles);
+$userId = $userWithRoles->getId();
 
-        // Create an NGI, site and services
-        $ngi = TestUtil::createSampleNGI("MYNGI");
-        $site1 = TestUtil::createSampleSite('site1');
-        $site2 = TestUtil::createSampleSite('site2');
+// Create an NGI, site and services
+$ngi = TestUtil::createSampleNGI("MYNGI");
+$site1 = TestUtil::createSampleSite('site1');
+$site2 = TestUtil::createSampleSite('site2');
 
-        $service1 = TestUtil::createSampleService('site1_service1');
-        $endpoint1 = TestUtil::createSampleEndpointLocation();
-        $endpoint2 = TestUtil::createSampleEndpointLocation();
-        $service1->addEndpointLocationDoJoin($endpoint1);
-        $service1->addEndpointLocationDoJoin($endpoint2);
-
-
-        $service2 = TestUtil::createSampleService('site1_service2');
-        $endpoint2_1 = TestUtil::createSampleEndpointLocation();
-        $endpoint2_2 = TestUtil::createSampleEndpointLocation();
-        $service2->addEndpointLocationDoJoin($endpoint2_1);
-        $service2->addEndpointLocationDoJoin($endpoint2_2);
+$service1 = TestUtil::createSampleService('site1_service1');
+$endpoint1 = TestUtil::createSampleEndpointLocation();
+$endpoint2 = TestUtil::createSampleEndpointLocation();
+$service1->addEndpointLocationDoJoin($endpoint1);
+$service1->addEndpointLocationDoJoin($endpoint2);
 
 
-
-        // create downtimes
-        $downtime1 = TestUtil::createSampleDowntime();
-        $downtime2 = TestUtil::createSampleDowntime();
-        $downtime3 = TestUtil::createSampleDowntime();
-        $downtime4 = TestUtil::createSampleDowntime();
-        $downtime5 = TestUtil::createSampleDowntime();
-        $downtime6 = TestUtil::createSampleDowntime();
-        $downtime7 = TestUtil::createSampleDowntime();
-        $downtimeOrphan = TestUtil::createSampleDowntime();
-        $downtimeOrphan->setDescription("orphan");
-
-        // link downtimes to services and service-endpoints
-        $downtime1->addEndpointLocation($endpoint1);
-        $downtime1->addService($service1);
-        $downtime2->addEndpointLocation($endpoint1);
-        $downtime2->addService($service1);
-        $downtime3->addEndpointLocation($endpoint2);
-        $downtime3->addService($service1);
-        $downtime4->addEndpointLocation($endpoint2);
-        //$downtime4->addService($service1); // downtime4 is not linked to service !!!
-        //$downtime5->addEndpointLocation($endpoint2); // downtime5 is not linked to endpoint
-        $downtime5->addService($service1);
-        $downtime6->addService($service1);
-
-
-        //$downtime4->addEndpointLocation($endpoint2_1); // downtiem4 is not linked to endpoint !
-        $downtime4->addService($service2);// downtime4 is directly linked to service2
-        $downtime6->addEndpointLocation($endpoint2_1); //downtime6 is linked to service2 via its endpoint
-        //$downtime6->addService($service2);  // downtime6 is not linked to endpoint !
-        $downtime7->addService($service2);
-        $downtime7->addEndpointLocation($endpoint2_2);
+$service2 = TestUtil::createSampleService('site1_service2');
+$endpoint2_1 = TestUtil::createSampleEndpointLocation();
+$endpoint2_2 = TestUtil::createSampleEndpointLocation();
+$service2->addEndpointLocationDoJoin($endpoint2_1);
+$service2->addEndpointLocationDoJoin($endpoint2_2);
 
 
 
-        $site1->addServiceDoJoin($service1);
-        $site1->addServiceDoJoin($service2);
-        $ngi->addSiteDoJoin($site1);
-        $ngi->addSiteDoJoin($site2);
+// create downtimes
+$downtime1 = TestUtil::createSampleDowntime();
+$downtime2 = TestUtil::createSampleDowntime();
+$downtime3 = TestUtil::createSampleDowntime();
+$downtime4 = TestUtil::createSampleDowntime();
+$downtime5 = TestUtil::createSampleDowntime();
+$downtime6 = TestUtil::createSampleDowntime();
+$downtime7 = TestUtil::createSampleDowntime();
+$downtimeOrphan = TestUtil::createSampleDowntime();
+$downtimeOrphan->setDescription("orphan");
+
+// link downtimes to services and service-endpoints
+$downtime1->addEndpointLocation($endpoint1);
+$downtime1->addService($service1);
+$downtime2->addEndpointLocation($endpoint1);
+$downtime2->addService($service1);
+$downtime3->addEndpointLocation($endpoint2);
+$downtime3->addService($service1);
+$downtime4->addEndpointLocation($endpoint2);
+//$downtime4->addService($service1); // downtime4 is not linked to service !!!
+//$downtime5->addEndpointLocation($endpoint2); // downtime5 is not linked to endpoint
+$downtime5->addService($service1);
+$downtime6->addService($service1);
 
 
-        $certStatusLog1 = TestUtil::createSampleCertStatusLog();
-        $certStatusLog2 = TestUtil::createSampleCertStatusLog();
-        $site2->addCertificationStatusLog($certStatusLog1);
-        $site2->addCertificationStatusLog($certStatusLog2);
-
-        // ngi, site, service
-        $this->em->persist($ngi);
-        $this->em->persist($site1);
-        $this->em->persist($site2);
-        $this->em->persist($service1);
-        $this->em->persist($service2);
-        // endpoints
-        $this->em->persist($endpoint1);
-        $this->em->persist($endpoint2);
-        $this->em->persist($endpoint2_1);
-        $this->em->persist($endpoint2_2);
-        // downtimes
-        $this->em->persist($downtime1);
-        $this->em->persist($downtime2);
-        $this->em->persist($downtime3);
-        $this->em->persist($downtime4);
-        $this->em->persist($downtime5);
-        $this->em->persist($downtime6);
-        $this->em->persist($downtime7);
-        $this->em->persist($downtimeOrphan);
-        // cert status logs
-        $this->em->persist($certStatusLog1);
-        $this->em->persist($certStatusLog2);
-
-
-        // Create some roles and link to the user, role type and ngi
-        // roles on ngi
-        $ngiRole1 = TestUtil::createSampleRole($userWithRoles, $roleType1, $ngi, RoleStatus::GRANTED);
-        $ngiRole2 = TestUtil::createSampleRole($userWithRoles, $roleType2, $ngi, RoleStatus::GRANTED);
-        // roles on site1
-        $site1Role1 = TestUtil::createSampleRole($userWithRoles, $roleType1, $site1, RoleStatus::GRANTED);
-        $site1Role2 = TestUtil::createSampleRole($userWithRoles, $roleType2, $site1, RoleStatus::GRANTED);
-        // roles on site2
-        $site2Role1= TestUtil::createSampleRole($userWithRoles, $roleType1, $site2, RoleStatus::GRANTED);
-        $site2Role2= TestUtil::createSampleRole($userWithRoles, $roleType2, $site2, RoleStatus::GRANTED);
-
-        $this->em->persist($ngiRole1);
-        $this->em->persist($ngiRole2);
-        $this->em->persist($site1Role1);
-        $this->em->persist($site1Role2);
-        $this->em->persist($site2Role1);
-        $this->em->persist($site2Role2);
+//$downtime4->addEndpointLocation($endpoint2_1); // downtiem4 is not linked to endpoint !
+$downtime4->addService($service2);// downtime4 is directly linked to service2
+$downtime6->addEndpointLocation($endpoint2_1); //downtime6 is linked to service2 via its endpoint
+//$downtime6->addService($service2);  // downtime6 is not linked to endpoint !
+$downtime7->addService($service2);
+$downtime7->addEndpointLocation($endpoint2_2);
 
 
 
-        $this->em->flush();
+$site1->addServiceDoJoin($service1);
+$site1->addServiceDoJoin($service2);
+$ngi->addSiteDoJoin($site1);
+$ngi->addSiteDoJoin($site2);
+
+
+$certStatusLog1 = TestUtil::createSampleCertStatusLog();
+$certStatusLog2 = TestUtil::createSampleCertStatusLog();
+$site2->addCertificationStatusLog($certStatusLog1);
+$site2->addCertificationStatusLog($certStatusLog2);
+
+// ngi, site, service
+$this->em->persist($ngi);
+$this->em->persist($site1);
+$this->em->persist($site2);
+$this->em->persist($service1);
+$this->em->persist($service2);
+// endpoints
+$this->em->persist($endpoint1);
+$this->em->persist($endpoint2);
+$this->em->persist($endpoint2_1);
+$this->em->persist($endpoint2_2);
+// downtimes
+$this->em->persist($downtime1);
+$this->em->persist($downtime2);
+$this->em->persist($downtime3);
+$this->em->persist($downtime4);
+$this->em->persist($downtime5);
+$this->em->persist($downtime6);
+$this->em->persist($downtime7);
+$this->em->persist($downtimeOrphan);
+// cert status logs
+$this->em->persist($certStatusLog1);
+$this->em->persist($certStatusLog2);
+
+
+// Create some roles and link to the user, role type and ngi
+// roles on ngi
+$ngiRole1 = TestUtil::createSampleRole($userWithRoles, $roleType1, $ngi, RoleStatus::GRANTED);
+$ngiRole2 = TestUtil::createSampleRole($userWithRoles, $roleType2, $ngi, RoleStatus::GRANTED);
+// roles on site1
+$site1Role1 = TestUtil::createSampleRole($userWithRoles, $roleType1, $site1, RoleStatus::GRANTED);
+$site1Role2 = TestUtil::createSampleRole($userWithRoles, $roleType2, $site1, RoleStatus::GRANTED);
+// roles on site2
+$site2Role1= TestUtil::createSampleRole($userWithRoles, $roleType1, $site2, RoleStatus::GRANTED);
+$site2Role2= TestUtil::createSampleRole($userWithRoles, $roleType2, $site2, RoleStatus::GRANTED);
+
+$this->em->persist($ngiRole1);
+$this->em->persist($ngiRole2);
+$this->em->persist($site1Role1);
+$this->em->persist($site1Role2);
+$this->em->persist($site2Role1);
+$this->em->persist($site2Role2);
 
 
 
-        // Assert fixture data is setup correctly in the DB.
-        $testConn = $this->getConnection();
+$this->em->flush();
 
-        $result = $testConn->createQueryTable('results_table', "SELECT * FROM Users");
-        $this->assertTrue($result->getRowCount() == 1);
 
-        $result = $testConn->createQueryTable('results_table', "SELECT * FROM Roles");
-        $this->assertTrue($result->getRowCount() == 6);
 
-        $result = $testConn->createQueryTable('results_table', "SELECT * FROM NGIs");
-        $this->assertTrue($result->getRowCount() == 1);
+// Assert fixture data is setup correctly in the DB.
+$testConn = $this->getConnection();
 
-        $result = $testConn->createQueryTable('results_table', "SELECT * FROM Sites");
-        $this->assertTrue($result->getRowCount() == 2);
+$result = $testConn->createQueryTable('results_table', "SELECT * FROM Users");
+$this->assertTrue($result->getRowCount() == 1);
 
-        $result = $testConn->createQueryTable('results_table', "SELECT * FROM Services");
-        $this->assertTrue($result->getRowCount() == 2);
+$result = $testConn->createQueryTable('results_table', "SELECT * FROM Roles");
+$this->assertTrue($result->getRowCount() == 6);
 
-        $result = $testConn->createQueryTable('results_table', "SELECT * FROM Downtimes");
-        $this->assertTrue($result->getRowCount() == 8);
+$result = $testConn->createQueryTable('results_table', "SELECT * FROM NGIs");
+$this->assertTrue($result->getRowCount() == 1);
 
-        $result = $testConn->createQueryTable('results_table', "SELECT * FROM EndpointLocations");
-        $this->assertTrue($result->getRowCount() == 4);
+$result = $testConn->createQueryTable('results_table', "SELECT * FROM Sites");
+$this->assertTrue($result->getRowCount() == 2);
+
+$result = $testConn->createQueryTable('results_table', "SELECT * FROM Services");
+$this->assertTrue($result->getRowCount() == 2);
+
+$result = $testConn->createQueryTable('results_table', "SELECT * FROM Downtimes");
+$this->assertTrue($result->getRowCount() == 8);
+
+$result = $testConn->createQueryTable('results_table', "SELECT * FROM EndpointLocations");
+$this->assertTrue($result->getRowCount() == 4);
 
 ?>

--- a/tests/doctrine/resources/sampleFixtureData4.php
+++ b/tests/doctrine/resources/sampleFixtureData4.php
@@ -68,7 +68,7 @@ $downtime5->addService($service1);
 $downtime6->addService($service1);
 
 
-//$downtime4->addEndpointLocation($endpoint2_1); // downtiem4 is not linked to endpoint !
+//$downtime4->addEndpointLocation($endpoint2_1); // downtime4 is not linked to endpoint !
 $downtime4->addService($service2);// downtime4 is directly linked to service2
 $downtime6->addEndpointLocation($endpoint2_1); //downtime6 is linked to service2 via its endpoint
 //$downtime6->addService($service2);  // downtime6 is not linked to endpoint !

--- a/tests/doctrine/resources/sampleFixtureData5.php
+++ b/tests/doctrine/resources/sampleFixtureData5.php
@@ -14,40 +14,39 @@
  */
 
 
-        /*
-         * Create test data with the following structure (note p3 has two ngis)
-         *
-         * p1  p2  p3
-         * |   |  /|
-         * n1  n2  n3
-         * |   |   |
-         * s1  s2  s3
-         */
-        $p1 = new \Project("p1");
-        $n1 = TestUtil::createSampleNGI("n1");
-        $s1 = TestUtil::createSampleSite("s1");
-        $this->em->persist($p1);
-        $this->em->persist($n1);
-        $this->em->persist($s1);
-        $n1->addSiteDoJoin($s1);
-        $p1->addNgi($n1);
+/*
+ * Create test data with the following structure (note p3 has two ngis)
+ *
+ * p1  p2  p3
+ * |   |  /|
+ * n1  n2  n3
+ * |   |   |
+ * s1  s2  s3
+ */
+$p1 = new \Project("p1");
+$n1 = TestUtil::createSampleNGI("n1");
+$s1 = TestUtil::createSampleSite("s1");
+$this->em->persist($p1);
+$this->em->persist($n1);
+$this->em->persist($s1);
+$n1->addSiteDoJoin($s1);
+$p1->addNgi($n1);
 
-        $p2 = new \Project("p2");
-        $n2 = TestUtil::createSampleNGI("n2");
-        $s2 = TestUtil::createSampleSite("s2");
-        $this->em->persist($p2);
-        $this->em->persist($n2);
-        $this->em->persist($s2);
-        $n2->addSiteDoJoin($s2);
-        $p2->addNgi($n2);
+$p2 = new \Project("p2");
+$n2 = TestUtil::createSampleNGI("n2");
+$s2 = TestUtil::createSampleSite("s2");
+$this->em->persist($p2);
+$this->em->persist($n2);
+$this->em->persist($s2);
+$n2->addSiteDoJoin($s2);
+$p2->addNgi($n2);
 
-        $p3 = new \Project("p3");
-        $n3 = TestUtil::createSampleNGI("n3");
-        $s3 = TestUtil::createSampleSite("s3");
-        $this->em->persist($p3);
-        $this->em->persist($n3);
-        $this->em->persist($s3);
-        $n3->addSiteDoJoin($s3);
-        $p3->addNgi($n3);
-        $p3->addNgi($n2);     // note the p3 is parent to n2 + n3
-
+$p3 = new \Project("p3");
+$n3 = TestUtil::createSampleNGI("n3");
+$s3 = TestUtil::createSampleSite("s3");
+$this->em->persist($p3);
+$this->em->persist($n3);
+$this->em->persist($s3);
+$n3->addSiteDoJoin($s3);
+$p3->addNgi($n3);
+$p3->addNgi($n2);     // note the p3 is parent to n2 + n3

--- a/tests/unit/lib/Gocdb_Services/RoleActionAuthorisationServiceTest.php
+++ b/tests/unit/lib/Gocdb_Services/RoleActionAuthorisationServiceTest.php
@@ -16,10 +16,8 @@ require_once __DIR__ . '/../../../doctrine/TestUtil.php';
 require_once __DIR__ . '/../../../../lib/Gocdb_Services/Role.php';
 require_once __DIR__ . '/../../../../lib/Gocdb_Services/RoleActionMappingService.php';
 require_once __DIR__ . '/../../../../lib/Gocdb_Services/RoleActionAuthorisationService.php';
-
 use Doctrine\ORM\EntityManager;
 require_once __DIR__ . '/../../../doctrine/bootstrap.php';
-
 
 /**
  * Description of RoleActionAuthorisationServiceTest
@@ -159,7 +157,7 @@ class RoleActionAuthorisationServiceTest  extends PHPUnit_Extensions_Database_Te
 
     // Create RoleActionAuthorisationService with dependencies
         $roleAuthServ = new org\gocdb\services\RoleActionAuthorisationService
-                ($roleActionMappingService/*, $roleService*/);
+                ($roleActionMappingService);
         $roleAuthServ->setEntityManager($em2);
 
         // Create role and link user and owned entities (user link not shown)
@@ -175,7 +173,6 @@ class RoleActionAuthorisationServiceTest  extends PHPUnit_Extensions_Database_Te
     // Assert user has no authorising roles over n1 BECAUSE p1 is not
     // mapped in XML file and there is no default mapping!
         $enablingRoles = $roleAuthServ->authoriseAction(\Action::REVOKE_ROLE, $n1, $u)->getGrantingRoles();
-    //print_r("dave: ".$enablingRoles[0]->getRoleType()->getName());
         $this->assertEquals(0, count($enablingRoles));
     }
 
@@ -220,10 +217,6 @@ class RoleActionAuthorisationServiceTest  extends PHPUnit_Extensions_Database_Te
         $roleActionMappingService = new org\gocdb\services\RoleActionMappingService();
         $roleActionMappingService->setRoleActionMappingsXmlPath(
                 __DIR__."/../../resources/roleActionMappingSamples/TestRoleActionMappings6.xml");
-
-        //Create Role Service
-        //$roleService = new org\gocdb\services\Role();
-        //$roleService->setEntityManager($em2);
 
         // Create RoleActionAuthorisationService with dependencies
         $roleAuthServ = new org\gocdb\services\RoleActionAuthorisationService
@@ -499,11 +492,7 @@ class RoleActionAuthorisationServiceTest  extends PHPUnit_Extensions_Database_Te
         $this->assertEquals(1, count($enablingRoles));
         $this->assertTrue(in_array($r6, $enablingRoles));
 
-
-
-
     }
-
 
 
     public function test_getUserRolesOnAndAboveEntity(){
@@ -904,19 +893,6 @@ class RoleActionAuthorisationServiceTest  extends PHPUnit_Extensions_Database_Te
         $this->assertEquals(0, count($enablingRoles));
     }
 
-
-
-
-
-
-
-    /*private function getRoleTypeNames($enablingRoles) {
-        $enablingRoleNames = array();
-        foreach ($enablingRoles as $role) {
-            $enablingRoleNames[] = $role->getRoleType()->getName();
-        }
-        return $enablingRoleNames;
-    }*/
 
 }
 

--- a/tests/unit/lib/Gocdb_Services/RoleActionAuthorisationServiceTest.php
+++ b/tests/unit/lib/Gocdb_Services/RoleActionAuthorisationServiceTest.php
@@ -20,125 +20,122 @@ use Doctrine\ORM\EntityManager;
 require_once __DIR__ . '/../../../doctrine/bootstrap.php';
 
 /**
- * Description of RoleActionAuthorisationServiceTest
- *
- * @author djm76
- */
+* Description of RoleActionAuthorisationServiceTest
+*
+* @author djm76
+*/
 class RoleActionAuthorisationServiceTest  extends PHPUnit_Extensions_Database_TestCase{
-    private $em;
+  private $em;
 
+  /**
+   * Overridden.
+   */
+  public static function setUpBeforeClass() {
+    parent::setUpBeforeClass();
+    echo "\n\n-------------------------------------------------\n";
+    echo "Executing RoleServiceTest. . .\n";
+  }
 
+  /**
+  * Overridden. Returns the test database connection.
+  * @return PHPUnit_Extensions_Database_DB_IDatabaseConnection
+  */
+  protected function getConnection() {
+    require_once __DIR__ . '/../../../doctrine/bootstrap_pdo.php';
+    return getConnectionToTestDB();
+  }
 
-    /**
-     * Overridden.
-     */
-    public static function setUpBeforeClass() {
-        parent::setUpBeforeClass();
-        echo "\n\n-------------------------------------------------\n";
-        echo "Executing RoleServiceTest. . .\n";
+  /**
+  * Overridden. Returns the test dataset.
+  * Defines how the initial state of the database should look before each test is executed.
+  * @return PHPUnit_Extensions_Database_DataSet_IDataSet
+  */
+  protected function getDataSet() {
+    return $this->createFlatXMLDataSet(__DIR__ . '/../../../doctrine/truncateDataTables.xml');
+    // Use below to return an empty data set if we don't want to truncate and seed
+    //return new PHPUnit_Extensions_Database_DataSet_DefaultDataSet();
+  }
+
+  /**
+  * Overridden.
+  */
+  protected function getSetUpOperation() {
+    // CLEAN_INSERT is default
+    //return PHPUnit_Extensions_Database_Operation_Factory::CLEAN_INSERT();
+    //return PHPUnit_Extensions_Database_Operation_Factory::UPDATE();
+    //return PHPUnit_Extensions_Database_Operation_Factory::NONE();
+    //
+    // Issue a DELETE from <table> which is more portable than a
+    // TRUNCATE table <table> (some DBs require high privileges for truncate statements
+    // and also do not allow truncates across tables with FK contstraints e.g. Oracle)
+    return PHPUnit_Extensions_Database_Operation_Factory::DELETE_ALL();
+  }
+
+  /**
+  * Overridden.
+  */
+  protected function getTearDownOperation() {
+    // NONE is default
+    return PHPUnit_Extensions_Database_Operation_Factory::NONE();
+  }
+
+  /**
+  * Sets up the fixture, e.g create a new entityManager for each test run
+  * This method is called before each test method is executed.
+  */
+  protected function setUp() {
+    parent::setUp();
+    $this->em = $this->createEntityManager();
+  }
+
+  /**
+  * @todo Still need to setup connection to different databases.
+  * @return EntityManager
+  */
+  private function createEntityManager(){
+    require __DIR__ . '/../../../doctrine/bootstrap_doctrine.php';
+    return $entityManager;
+  }
+
+  /**
+  * Called after setUp() and before each test. Used for common assertions
+  * across all tests.
+  */
+  protected function assertPreConditions() {
+    $con = $this->getConnection();
+    $fixture = __DIR__ . '/../../../doctrine/truncateDataTables.xml';
+    $tables = simplexml_load_file($fixture);
+
+    foreach($tables as $tableName) {
+      //print $tableName->getName() . "\n";
+      $sql = "SELECT * FROM ".$tableName->getName();
+      $result = $con->createQueryTable('results_table', $sql);
+      //echo 'row count: '.$result->getRowCount() ;
+      if($result->getRowCount() != 0){
+        throw new RuntimeException("Invalid fixture. Table has rows: ".$tableName->getName());
+      }
     }
+  }
 
-    /**
-     * Overridden. Returns the test database connection.
-     * @return PHPUnit_Extensions_Database_DB_IDatabaseConnection
-     */
-    protected function getConnection() {
-        require_once __DIR__ . '/../../../doctrine/bootstrap_pdo.php';
-        return getConnectionToTestDB();
-    }
-
-    /**
-     * Overridden. Returns the test dataset.
-     * Defines how the initial state of the database should look before each test is executed.
-     * @return PHPUnit_Extensions_Database_DataSet_IDataSet
-     */
-    protected function getDataSet() {
-        return $this->createFlatXMLDataSet(__DIR__ . '/../../../doctrine/truncateDataTables.xml');
-        // Use below to return an empty data set if we don't want to truncate and seed
-        //return new PHPUnit_Extensions_Database_DataSet_DefaultDataSet();
-    }
-
-    /**
-     * Overridden.
-     */
-    protected function getSetUpOperation() {
-        // CLEAN_INSERT is default
-        //return PHPUnit_Extensions_Database_Operation_Factory::CLEAN_INSERT();
-        //return PHPUnit_Extensions_Database_Operation_Factory::UPDATE();
-        //return PHPUnit_Extensions_Database_Operation_Factory::NONE();
-        //
-        // Issue a DELETE from <table> which is more portable than a
-        // TRUNCATE table <table> (some DBs require high privileges for truncate statements
-        // and also do not allow truncates across tables with FK contstraints e.g. Oracle)
-        return PHPUnit_Extensions_Database_Operation_Factory::DELETE_ALL();
-    }
-
-    /**
-     * Overridden.
-     */
-    protected function getTearDownOperation() {
-        // NONE is default
-        return PHPUnit_Extensions_Database_Operation_Factory::NONE();
-    }
-
-    /**
-     * Sets up the fixture, e.g create a new entityManager for each test run
-     * This method is called before each test method is executed.
-     */
-    protected function setUp() {
-        parent::setUp();
-        $this->em = $this->createEntityManager();
-    }
-
-    /**
-     * @todo Still need to setup connection to different databases.
-     * @return EntityManager
-     */
-    private function createEntityManager(){
-        require __DIR__ . '/../../../doctrine/bootstrap_doctrine.php';
-        return $entityManager;
-    }
-
-    /**
-     * Called after setUp() and before each test. Used for common assertions
-     * across all tests.
-     */
-    protected function assertPreConditions() {
-        $con = $this->getConnection();
-        $fixture = __DIR__ . '/../../../doctrine/truncateDataTables.xml';
-        $tables = simplexml_load_file($fixture);
-
-        foreach($tables as $tableName) {
-            //print $tableName->getName() . "\n";
-            $sql = "SELECT * FROM ".$tableName->getName();
-            $result = $con->createQueryTable('results_table', $sql);
-            //echo 'row count: '.$result->getRowCount() ;
-            if($result->getRowCount() != 0){
-                throw new RuntimeException("Invalid fixture. Table has rows: ".$tableName->getName());
-            }
-        }
-    }
-
-
-    public function NOT_RUN_test_authoriseActionBug(){
-        print __METHOD__ . "\n";
+  public function NOT_RUN_test_authoriseActionBug(){
+    print __METHOD__ . "\n";
     $codRT = TestUtil::createSampleRoleType(TestRoleTypeName::COD_ADMIN);
     $this->em->persist($codRT);  // edit all sites cert status only
 
     // Create a user
-        $u = TestUtil::createSampleUser("Test", "Testing", "/c=test");
-        $this->em->persist($u);
+    $u = TestUtil::createSampleUser("Test", "Testing", "/c=test");
+    $this->em->persist($u);
 
     /*
-         * Create test data with the following structure
-         *
-         *   p1  EGI
-         *    \  /
-         *     n1
-         */
-        $p1 = new \Project("p1");
+     * Create test data with the following structure
+     *
+     *   p1  EGI
+     *    \  /
+     *     n1
+     */
+    $p1 = new \Project("p1");
     $p2 = new \Project("EGI");
-        $n1 = TestUtil::createSampleNGI("n1");
+    $n1 = TestUtil::createSampleNGI("n1");
     $this->em->persist($p1);
     $this->em->persist($p2);
     $this->em->persist($n1);
@@ -146,803 +143,784 @@ class RoleActionAuthorisationServiceTest  extends PHPUnit_Extensions_Database_Te
     $p2->addNgi($n1);
 
     // Build dependencies and inject business objects:
-        // start a new connection to test transactional isolation of RoleService methods.
-        //$em2 = $this->createEntityManager();
-        $em2 = $this->em;
+    // start a new connection to test transactional isolation of RoleService methods.
+    //$em2 = $this->createEntityManager();
+    $em2 = $this->em;
 
-        // Create RoleActionMappingService with non-default roleActionMappings file
-        $roleActionMappingService = new org\gocdb\services\RoleActionMappingService();
-        $roleActionMappingService->setRoleActionMappingsXmlPath(
-                __DIR__."/../../resources/roleActionMappingSamples/TestRoleActionMappings7.xml");
+    // Create RoleActionMappingService with non-default roleActionMappings file
+    $roleActionMappingService = new org\gocdb\services\RoleActionMappingService();
+    $roleActionMappingService->setRoleActionMappingsXmlPath(
+      __DIR__."/../../resources/roleActionMappingSamples/TestRoleActionMappings7.xml"
+    );
 
     // Create RoleActionAuthorisationService with dependencies
-        $roleAuthServ = new org\gocdb\services\RoleActionAuthorisationService
-                ($roleActionMappingService);
-        $roleAuthServ->setEntityManager($em2);
+    $roleAuthServ = new org\gocdb\services\RoleActionAuthorisationService($roleActionMappingService);
+    $roleAuthServ->setEntityManager($em2);
 
-        // Create role and link user and owned entities (user link not shown)
+    // Create role and link user and owned entities (user link not shown)
     /*
-         * r1->p1  EGI
-         *      \  /
-         *       n1
-         */
+     * r1->p1  EGI
+     *      \  /
+     *       n1
+     */
     $r1 = TestUtil::createSampleRole($u, $codRT, $p1, RoleStatus::GRANTED);
-        $this->em->persist($r1);
-        $this->em->flush();
+    $this->em->persist($r1);
+    $this->em->flush();
 
     // Assert user has no authorising roles over n1 BECAUSE p1 is not
     // mapped in XML file and there is no default mapping!
-        $enablingRoles = $roleAuthServ->authoriseAction(\Action::REVOKE_ROLE, $n1, $u)->getGrantingRoles();
-        $this->assertEquals(0, count($enablingRoles));
-    }
-
-    public function test_authoriseAction(){
-        print __METHOD__ . "\n";
-        // Create roletypes
-        $siteAdminRT = TestUtil::createSampleRoleType(TestRoleTypeName::SITE_ADMIN);
-        $siteDepManAdminRT = TestUtil::createSampleRoleType(TestRoleTypeName::SITE_OPS_DEP_MAN);
-        $ngiManRT = TestUtil::createSampleRoleType(TestRoleTypeName::NGI_OPS_MAN);
-        $rodRT = TestUtil::createSampleRoleType(TestRoleTypeName::REG_STAFF_ROD);
-        $codRT = TestUtil::createSampleRoleType(TestRoleTypeName::COD_ADMIN);
-        $cooRT = TestUtil::createSampleRoleType(TestRoleTypeName::COO);
-        $this->em->persist($siteAdminRT); // edit site1 (but not cert status)
-        $this->em->persist($ngiManRT); // edit owned site1/site2 and cert status
-        $this->em->persist($rodRT);  // edit owned sites 1and2 (but not cert status)
-        $this->em->persist($codRT);  // edit all sites cert status only
-        $this->em->persist($cooRT);  // edit all sites cert status only
-        $this->em->persist($siteDepManAdminRT);  // edit all sites cert status only
-
-
-        // Create a user
-        $u = TestUtil::createSampleUser("Test", "Testing", "/c=test");
-        $this->em->persist($u);
-
-        /*
-         * Create test data with the following structure (note p3 has two ngis)
-         *
-         * p1  p2  p3
-         * |   |  /|
-         * n1  n2  n3
-         * |   |   |
-         * s1  s2  s3
-         */
-        include __DIR__ . '/../../resources/sampleFixtureData6.php';
-
-        // Build dependencies and inject business objects:
-        // start a new connection to test transactional isolation of RoleService methods.
-        //$em2 = $this->createEntityManager();
-        $em2 = $this->em;
-
-        // Create RoleActionMappingService with non-default roleActionMappings file
-        $roleActionMappingService = new org\gocdb\services\RoleActionMappingService();
-        $roleActionMappingService->setRoleActionMappingsXmlPath(
-                __DIR__."/../../resources/roleActionMappingSamples/TestRoleActionMappings6.xml");
-
-        // Create RoleActionAuthorisationService with dependencies
-        $roleAuthServ = new org\gocdb\services\RoleActionAuthorisationService
-                ($roleActionMappingService/*, $roleService*/);
-        $roleAuthServ->setEntityManager($em2);
-
-
-        // Create role and link user and owned entities (user link not shown)
-        /*
-         *    p1  p2  p3
-         *    |    |  /|
-         * r1-n1  n2  n3
-         *    |   |   |
-         *    s1  s2  s3
-         */
-        $r1 = TestUtil::createSampleRole($u, $ngiManRT, $n1, RoleStatus::GRANTED);
-        $this->em->persist($r1);
-        $this->em->flush();
-
-        // Assert user can edit s1 using r1
-        $enablingRoles = $roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $s1, $u)->getGrantingRoles();
-        $this->assertEquals(1, count($enablingRoles));
-        $this->assertTrue(in_array($r1, $enablingRoles));
-        $this->assertEquals(TestRoleTypeName::NGI_OPS_MAN, $enablingRoles[0]->getRoleType()->getName());
-
-        // Assert user can edit n1 using r1
-        $enablingRoles = $roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $n1, $u)->getGrantingRoles();
-        $this->assertEquals(1, count($enablingRoles));
-        $this->assertTrue(in_array($r1, $enablingRoles));
-        $this->assertEquals(TestRoleTypeName::NGI_OPS_MAN, $enablingRoles[0]->getRoleType()->getName());
-
-        // Assert user can change s1 cert status with r1
-        $this->assertTrue(in_array($r1, $roleAuthServ->authoriseAction(\Action::SITE_EDIT_CERT_STATUS, $s1, $u)->getGrantingRoles()) );
-
-        // Assert user can't edit other sites/ngis/projects
-        $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $s2, $u)->getGrantingRoles()));
-        $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $s3, $u)->getGrantingRoles()));
-        $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $n2, $u)->getGrantingRoles()));
-        $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $n3, $u)->getGrantingRoles()));
-        $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $p1, $u)->getGrantingRoles()));
-        $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $p2, $u)->getGrantingRoles()));
-        $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $p3, $u)->getGrantingRoles()));
-
-         /*
-         *    p1  p2  p3
-         *    |    |  /|
-         * r1-n1  n2  n3
-         *    |   |   |
-         * r2-s1  s2  s3
-         */
-        $r2 = TestUtil::createSampleRole($u, $siteAdminRT, $s1, RoleStatus::GRANTED) ;
-        $this->em->persist($r2);
-        $this->em->flush();
-
-        // Assert user can edit s1 using r1 + r2
-        $enablingRoles = $roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $s1, $u)->getGrantingRoles();
-        $this->assertEquals(2, count($enablingRoles));
-        $this->assertTrue(in_array($r1, $enablingRoles));
-        $this->assertTrue(in_array($r2, $enablingRoles));
-        //$enablingRoleNames = $this->getRoleTypeNames($enablingRoles);
-        //$this->assertTrue(in_array(TestRoleTypeName::NGI_OPS_MAN, $enablingRoleNames));
-        //$this->assertTrue(in_array(TestRoleTypeName::SITE_ADMIN, $enablingRoleNames));
-
-        // Assert user can change site cert status with r1
-        $enablingRoles = $roleAuthServ->authoriseAction(\Action::SITE_EDIT_CERT_STATUS, $s1, $u)->getGrantingRoles();
-        $this->assertEquals(1, count($enablingRoles));
-        $this->assertTrue(in_array($r1, $enablingRoles));
-
-        // Assert user can't edit other sites/ngis/projects
-        $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $s2, $u)->getGrantingRoles()));
-        $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $s3, $u)->getGrantingRoles()));
-        $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $n2, $u)->getGrantingRoles()));
-        $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $n3, $u)->getGrantingRoles()));
-        $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $p1, $u)->getGrantingRoles()));
-        $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $p2, $u)->getGrantingRoles()));
-        $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $p3, $u)->getGrantingRoles()));
-
-        /*
-         *    p1     p2  p3
-         *    |      |  /|
-         * r1-n1     n2  n3
-         *    |      |   |
-         * r2-s1  r3-s2  s3
-         */
-        $r3 = TestUtil::createSampleRole($u, $siteAdminRT, $s2, RoleStatus::GRANTED) ;
-        $this->em->persist($r3);
-        $this->em->flush();
-
-        // Assert user can edit s1 via r1 + r2
-        $enablingRoles = $roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $s1, $u)->getGrantingRoles();
-        $this->assertEquals(2, count($enablingRoles));
-        $this->assertTrue(in_array($r1, $enablingRoles));
-        $this->assertTrue(in_array($r2, $enablingRoles));
-
-        // Assert user can edit s2 via r3
-        $enablingRoles = $roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $s2, $u)->getGrantingRoles();
-        $this->assertEquals(1, count($enablingRoles));
-        $this->assertTrue(in_array($r3, $enablingRoles));
-
-        // Assert user can change s1 cert status via r1
-        $enablingRoles = $roleAuthServ->authoriseAction(\Action::SITE_EDIT_CERT_STATUS, $s1, $u)->getGrantingRoles();
-        $this->assertEquals(1, count($enablingRoles));
-        $this->assertTrue(in_array($r1, $enablingRoles));
-
-        // Assert user cant change s2 cert status
-        $enablingRoles = $roleAuthServ->authoriseAction(\Action::SITE_EDIT_CERT_STATUS, $s2, $u)->getGrantingRoles();
-        $this->assertEquals(0, count($enablingRoles));
-
-        // Assert user can't edit other sites/ngis/projects
-        $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $s3, $u)->getGrantingRoles()));
-        $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $n2, $u)->getGrantingRoles()));
-        $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $n3, $u)->getGrantingRoles()));
-        $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $p1, $u)->getGrantingRoles()));
-        $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $p2, $u)->getGrantingRoles()));
-        $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $p3, $u)->getGrantingRoles()));
-
-
-        /*
-         *    p1  r4-p2  p3
-         *    |      |  /|
-         * r1-n1     n2  n3
-         *    |      |   |
-         * r2-s1  r3-s2  s3
-         */
-        $r4 = TestUtil::createSampleRole($u, $cooRT, $p2, RoleStatus::GRANTED);
-        $this->em->persist($r4);
-        $this->em->flush();
-
-        // Assert user can edit p2 via r4
-        $enablingRoles = $roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $p2, $u)->getGrantingRoles();
-        $this->assertEquals(1, count($enablingRoles));
-        $this->assertTrue(in_array($r4, $enablingRoles));
-
-        // Assert user can grantRole on p2 via r4
-        $enablingRoles = $roleAuthServ->authoriseAction(\Action::GRANT_ROLE, $p2, $u)->getGrantingRoles();
-        $this->assertEquals(1, count($enablingRoles));
-        $this->assertTrue(in_array($r4, $enablingRoles));
-
-        // Assert user can grantRole on n2 via r4
-        $enablingRoles = $roleAuthServ->authoriseAction(\Action::GRANT_ROLE, $n2, $u)->getGrantingRoles();
-        $this->assertEquals(1, count($enablingRoles));
-        $this->assertTrue(in_array($r4, $enablingRoles));
-
-        // Assert user can't edit other sites/ngis/projects
-        $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $n2, $u)->getGrantingRoles()));
-        $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $s3, $u)->getGrantingRoles()));
-        $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $n3, $u)->getGrantingRoles()));
-        $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $p3, $u)->getGrantingRoles()));
-
-        /*
-         *    p1  r4-p2  p3-r5
-         *    |      |  /|
-         * r1-n1     n2  n3
-         *    |      |   |
-         * r2-s1  r3-s2  s3
-         */
-        $r5 = TestUtil::createSampleRole($u, $codRT, $p3, RoleStatus::GRANTED);
-        $this->em->persist($r5);
-        $this->em->flush();
-
-        // Assert user can edit p3 with r5
-        $enablingRoles = $roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $p3, $u)->getGrantingRoles();
-        $this->assertEquals(1, count($enablingRoles));
-        $this->assertTrue(in_array($r5, $enablingRoles));
-
-        // Assert user can grant role on n2 + n3 via r5
-        $enablingRoles = $roleAuthServ->authoriseAction(\Action::GRANT_ROLE, $n2, $u)->getGrantingRoles();
-        $this->assertEquals(2, count($enablingRoles));
-        $this->assertTrue(in_array($r5, $enablingRoles));
-        $this->assertTrue(in_array($r4, $enablingRoles));
-
-        // Assert user can't edit other sites/ngis/projects
-        $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $n2, $u)->getGrantingRoles()));
-        $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $s3, $u)->getGrantingRoles()));
-        $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $n3, $u)->getGrantingRoles()));
-
-
-
-        /*
-         *    p1  r4-p2  p3-r5
-         *    |      |  /|
-         * r1-n1     n2  n3-r6
-         *    |      |   |
-         * r2-s1  r3-s2  s3
-         */
-        $r6 = TestUtil::createSampleRole($u, $ngiManRT, $n3, RoleStatus::GRANTED);
-        $this->em->persist($r6);
-        $this->em->flush();
-
-        /*
-         *    p1  r4-p2  p3-r5
-         *    |      |  /|
-         * r1-n1     n2  n3-r6
-         *    |      |   |
-         * r2-s1  r3-s2  s3-r7
-         */
-        $r7 = TestUtil::createSampleRole($u, $siteAdminRT, $s3, RoleStatus::GRANTED);
-        $this->em->persist($r7);
-        $this->em->flush();
-
-        // Assert user can edit s3 with r6 + r7
-        $enablingRoles = $roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $s3, $u)->getGrantingRoles();
-        $this->assertEquals(2, count($enablingRoles));
-        $this->assertTrue(in_array($r7, $enablingRoles));
-        $this->assertTrue(in_array($r6, $enablingRoles));
-
-
-        /*
-         *    p1  r4-p2  p3-r5
-         *    |      |  /|
-         * r1-n1  r8-n2  n3-r6
-         *    |      |   |
-         * r2-s1  r3-s2  s3-r7
-         */
-        $r8 = TestUtil::createSampleRole($u, $ngiManRT, $n2, RoleStatus::GRANTED);
-        $this->em->persist($r8);
-        $this->em->flush();
-
-        $enablingRoles = $roleAuthServ->authoriseAction(\Action::SITE_EDIT_CERT_STATUS, $s2, $u)->getGrantingRoles();
-        $this->assertEquals(3, count($enablingRoles));
-        $this->assertTrue(in_array($r8, $enablingRoles));
-        $this->assertTrue(in_array($r4, $enablingRoles));
-        $this->assertTrue(in_array($r5, $enablingRoles));
-
-        $enablingRoles = $roleAuthServ->authoriseAction(\Action::SITE_EDIT_CERT_STATUS, $s3, $u)->getGrantingRoles();
-        $this->assertEquals(2, count($enablingRoles));
-        $this->assertTrue(in_array($r6, $enablingRoles));
-        $this->assertTrue(in_array($r5, $enablingRoles));
-
-        /*
-         *    p1  r4-p2  p3-r5
-         *    |      |  /|
-         * r1-n1  r8-n2  n3-r6
-         *    |      |   |
-         * r2-s1  r3-s2  s3-r7,r9
-         */
-        $r9 = TestUtil::createSampleRole($u, $siteDepManAdminRT, $s3, RoleStatus::GRANTED);
-        $this->em->persist($r9);
-        $this->em->flush();
-
-        // Assert user can edit s3 with r7, r9, r6
-        $enablingRoles = $roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $s3, $u)->getGrantingRoles();
-        $this->assertEquals(3, count($enablingRoles));
-        $this->assertTrue(in_array($r7, $enablingRoles));
-        $this->assertTrue(in_array($r9, $enablingRoles));
-        $this->assertTrue(in_array($r6, $enablingRoles));
-
-        // Assert user can change s3 cert status with r6 + r5
-        $enablingRoles = $roleAuthServ->authoriseAction(\Action::SITE_EDIT_CERT_STATUS, $s3, $u)->getGrantingRoles();
-        $this->assertEquals(2, count($enablingRoles));
-        $this->assertTrue(in_array($r6, $enablingRoles));
-        $this->assertTrue(in_array($r5, $enablingRoles));
-
-        /*
-         *    p1  r4-p2  p3-r5
-         *    |      |  /|
-         * r1-n1  r8-n2  n3-r6,r10
-         *    |      |   |
-         * r2-s1  r3-s2  s3-r7,r9
-         */
-        $r10 = TestUtil::createSampleRole($u, $rodRT, $n3, RoleStatus::GRANTED);
-        $this->em->persist($r10);
-        $this->em->flush();
-
-        $enablingRoles = $roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $s3, $u)->getGrantingRoles();
-        $this->assertEquals(4, count($enablingRoles));
-        $this->assertTrue(in_array($r6, $enablingRoles));
-        $this->assertTrue(in_array($r10, $enablingRoles));
-        $this->assertTrue(in_array($r7, $enablingRoles));
-        $this->assertTrue(in_array($r9, $enablingRoles));
-
-        $enablingRoles = $roleAuthServ->authoriseAction(\Action::NGI_ADD_SITE, $n3, $u)->getGrantingRoles();
-        $this->assertEquals(1, count($enablingRoles));
-        $this->assertTrue(in_array($r6, $enablingRoles));
-
-    }
-
-
-    public function test_getUserRolesOnAndAboveEntity(){
-        print __METHOD__ . "\n";
-        include __DIR__ . '/../../resources/sampleFixtureData5.php';
-
-        // create a user
-        $u = TestUtil::createSampleUser("dave", "meredith", "idSTring");
-        $this->em->persist($u);
-
-        // add some roles to domain model
-        $ngiRoleType = TestUtil::createSampleRoleType("NGI_RT");
-        $siteRoleType = TestUtil::createSampleRoleType("SITE_RT");
-        $siteRoleType2 = TestUtil::createSampleRoleType("SITE_RT2");
-        $projRoleType = TestUtil::createSampleRoleType("PROJ_RT");
-        $this->em->persist($ngiRoleType);
-        $this->em->persist($siteRoleType);
-        $this->em->persist($siteRoleType2);
-        $this->em->persist($projRoleType);
-
-        $this->em->flush();
-
-
-        $roleActionMappingService = new org\gocdb\services\RoleActionMappingService();
-        // Create RoleActionAuthorisationService with dependencies
-        $roleAuthServ = new org\gocdb\services\RoleActionAuthorisationService
-                ($roleActionMappingService/*, $roleService*/);
-
-
-        // We could create/inject a new em connection into the roleService
-        // to test the transactional isolation of its methods (rather than injecting
-        // $this->em instance), e.g.:
-        //   $em = $this->createEntityManager();
-        //   $roleService->setEntityManager($em);
-        //
-        // However, this is problematic for this test which
-        // needs to use the in_array() method to assert that the tested methods return
-        // the expected roles - in_array() uses object-instance-equality to deterine
-        // if the role exists in the array, and using a different $em instance
-        // means the returned roles will be considered different
-        // instances. We could get round this by comparing the Ids, but this makes
-        // checking more of hassle as we need to extract all the Ids from the roles
-        // into another array to assert the ids are expected, as in:
-        //   $roleIds = array();
-        //   foreach($roles as $r){ $roleIds[] = $r->getId(); }
-        //   $this->assertTrue(in_array($r1->getId(), $roleIds));
-        //   $this->assertTrue(in_array($r2->getId(), $roleIds));
-        //
-        // For this test, we will therefore re-use $this->em to ensure
-        // object-equality:
-        $roleAuthServ->setEntityManager($this->em);
-
-        $roles = $roleAuthServ->getUserRolesReachableFromEntityASC($u, $p1);
-        $this->assertEmpty($roles);
-
-
-        // Create a Role and link to the User, ngiRoleType and ngi
-        /*
-         * p1     p2     p3
-         * |      |     /|
-         * n1     n2-r1  n3
-         * |      |      |
-         * s1     s2     s3
-         */
-        $r1 = TestUtil::createSampleRole($u, $ngiRoleType, $n2, RoleStatus::GRANTED);
-        $this->em->persist($r1);
-        $this->em->flush();
-
-        $rolesDirect = $u->getRoles();
-        $this->assertEquals(1, count($rolesDirect));
-
-        $roles = $roleAuthServ->getUserRolesReachableFromEntityASC($u, $s1);
-        $this->assertEmpty($roles);
-
-        $roles = $roleAuthServ->getUserRolesReachableFromEntityASC($u, $s2);
-        $this->assertEquals(1, count($roles));
-        $this->assertTrue(in_array($r1, $roles));
-
-        /*
-         * p1     p2     p3
-         * |      |     /|
-         * n1     n2-r1  n3-r2
-         * |      |      |
-         * s1     s2     s3
-         */
-        $r2 = TestUtil::createSampleRole($u, $ngiRoleType, $n3, RoleStatus::GRANTED);
-        $this->em->persist($r2);
-        $this->em->flush();
-
-        $roles = $roleAuthServ->getUserRolesReachableFromEntityASC($u, $s2);
-        $this->assertEquals(1, count($roles));
-        $this->assertTrue(in_array($r1, $roles));
-
-        $roles = $roleAuthServ->getUserRolesReachableFromEntityASC($u, $s3);
-        $this->assertEquals(1, count($roles));
-        $this->assertTrue(in_array($r2, $roles));
-
-         /*
-         * p1     p2     p3
-         * |      |     /|
-         * n1     n2-r1  n3-r2
-         * |      |      |
-         * s1     s2     s3-r3
-         */
-        $r3 = TestUtil::createSampleRole($u, $siteRoleType, $s3, RoleStatus::GRANTED);
-        $this->em->persist($r3);
-        $this->em->flush();
-
-        $roles = $roleAuthServ->getUserRolesReachableFromEntityASC($u, $s3);
-        $this->assertEquals(2, count($roles));
-        $this->assertTrue(in_array($r2, $roles));
-        $this->assertTrue(in_array($r3, $roles));
-
-        /*
-         * p1     p2     p3-r4
-         * |      |     /|
-         * n1     n2-r1  n3-r2
-         * |      |      |
-         * s1     s2     s3-r3
-         */
-        $r4 = TestUtil::createSampleRole($u, $projRoleType, $p3, RoleStatus::GRANTED);
-        $this->em->persist($r4);
-        $this->em->flush();
-
-         /*
-         * p1     p2     p3-r4
-         * |      |     /|
-         * n1     n2-r1  n3-r2
-         * |      |      |
-         * s1     s2-r5  s3-r3
-         */
-        $r5 = TestUtil::createSampleRole($u, $siteRoleType, $s2, RoleStatus::GRANTED);
-        $this->em->persist($r5);
-        $this->em->flush();
-
-        /*
-         * p1     p2     p3-r4
-         * |      |     /|
-         * n1     n2-r1  n3-r2
-         * |      |      |
-         * s1-r6  s2-r5  s3-r3
-         */
-        $r6 = TestUtil::createSampleRole($u, $siteRoleType, $s1, RoleStatus::GRANTED);
-        $this->em->persist($r6);
-        $this->em->flush();
-
-        /*
-         * p1     p2     p3-r4
-         * |      |     /|
-         * n1     n2-r1  n3-r2
-         * |      |      |
-         * s1-r6  s2-r5  s3-r3,r7
-         */
-        $r7 = TestUtil::createSampleRole($u, $siteRoleType2, $s3, RoleStatus::GRANTED);
-        $this->em->persist($r7);
-        $this->em->flush();
-
-        /*
-         * p1     p2-r8  p3-r4
-         * |      |     /|
-         * n1     n2-r1  n3-r2
-         * |      |      |
-         * s1-r6  s2-r5  s3-r3,r7
-         */
-        $r8 = TestUtil::createSampleRole($u, $projRoleType, $p2, RoleStatus::GRANTED);
-        $this->em->persist($r8);
-        $this->em->flush();
-
-        $roles = $roleAuthServ->getUserRolesReachableFromEntityASC($u, $s1);
-        $this->assertEquals(1, count($roles));
-        $this->assertTrue(in_array($r6, $roles));
-
-        $roles = $roleAuthServ->getUserRolesReachableFromEntityASC($u, $s2);
-        $this->assertEquals(4, count($roles));
-        $this->assertTrue(in_array($r5, $roles));
-        $this->assertTrue(in_array($r1, $roles));
-        $this->assertTrue(in_array($r8, $roles));
-        $this->assertTrue(in_array($r4, $roles));
-
-        $roles = $roleAuthServ->getUserRolesReachableFromEntityASC($u, $s3);
-        $this->assertEquals(4, count($roles));
-        $this->assertTrue(in_array($r2, $roles));
-        $this->assertTrue(in_array($r3, $roles));
-        $this->assertTrue(in_array($r4, $roles));
-        $this->assertTrue(in_array($r7, $roles));
-
-    }
-
-
-
-    /**
-     * Persist some seed data - roletypes, user, Project, NGI, sites and SEs and
-     * assert that the user has the expected number of roles that grant specific
-     * actions over the owned objects. For example, assert that the user has 'n'
-     * number of roles that allow a particular site to be edited, or 'n' number
-     * of roles that allow an NGI certification status change.
+    $enablingRoles = $roleAuthServ->authoriseAction(\Action::REVOKE_ROLE, $n1, $u)->getGrantingRoles();
+    $this->assertEquals(0, count($enablingRoles));
+  }
+
+  public function test_authoriseAction(){
+    print __METHOD__ . "\n";
+    // Create roletypes
+    $siteAdminRT = TestUtil::createSampleRoleType(TestRoleTypeName::SITE_ADMIN);
+    $siteDepManAdminRT = TestUtil::createSampleRoleType(TestRoleTypeName::SITE_OPS_DEP_MAN);
+    $ngiManRT = TestUtil::createSampleRoleType(TestRoleTypeName::NGI_OPS_MAN);
+    $rodRT = TestUtil::createSampleRoleType(TestRoleTypeName::REG_STAFF_ROD);
+    $codRT = TestUtil::createSampleRoleType(TestRoleTypeName::COD_ADMIN);
+    $cooRT = TestUtil::createSampleRoleType(TestRoleTypeName::COO);
+    $this->em->persist($siteAdminRT); // edit site1 (but not cert status)
+    $this->em->persist($ngiManRT); // edit owned site1/site2 and cert status
+    $this->em->persist($rodRT);  // edit owned sites 1and2 (but not cert status)
+    $this->em->persist($codRT);  // edit all sites cert status only
+    $this->em->persist($cooRT);  // edit all sites cert status only
+    $this->em->persist($siteDepManAdminRT);  // edit all sites cert status only
+
+    // Create a user
+    $u = TestUtil::createSampleUser("Test", "Testing", "/c=test");
+    $this->em->persist($u);
+
+    /*
+     * Create test data with the following structure (note p3 has two ngis)
+     *
+     * p1  p2  p3
+     * |   |  /|
+     * n1  n2  n3
+     * |   |   |
+     * s1  s2  s3
      */
-    public function testAuthoriseAction2(){
-        print __METHOD__ . "\n";
-        // Create roletypes
-        $siteAdminRT = TestUtil::createSampleRoleType(RoleTypeName::SITE_ADMIN/*, RoleTypeClass::SITE_USER*/);
-        $ngiManRT = TestUtil::createSampleRoleType(RoleTypeName::NGI_OPS_MAN/*, RoleTypeClass::REGIONAL_MANAGER*/);
-        $rodRT = TestUtil::createSampleRoleType(RoleTypeName::REG_STAFF_ROD/*, RoleTypeClass::REGIONAL_USER*/);
-        $codRT = TestUtil::createSampleRoleType(RoleTypeName::COD_ADMIN/*, RoleTypeClass::PROJECT*/);
-        $this->em->persist($siteAdminRT); // edit site1 (but not cert status)
-        $this->em->persist($ngiManRT); // edit owned site1/site2 and cert status
-        $this->em->persist($rodRT);  // edit owned sites 1and2 (but not cert status)
-        $this->em->persist($codRT);  // edit all sites cert status only
+    include __DIR__ . '/../../resources/sampleFixtureData6.php';
 
-        // Create a user
-        $u = TestUtil::createSampleUser("Test", "Testing", "/c=test");
-        $this->em->persist($u);
+    // Build dependencies and inject business objects:
+    // start a new connection to test transactional isolation of RoleService methods.
+    //$em2 = $this->createEntityManager();
+    $em2 = $this->em;
 
-        // Create a linked object graph
-/*
-                                 p1
-                                 |
-                                 ngi      <- ngiManRT, rodRT,
-                                 |    \
-             siteAdminRT  ->   site1   site2
-                                 |
-                                 se1
+    // Create RoleActionMappingService with non-default roleActionMappings file
+    $roleActionMappingService = new org\gocdb\services\RoleActionMappingService();
+    $roleActionMappingService->setRoleActionMappingsXmlPath(
+      __DIR__."/../../resources/roleActionMappingSamples/TestRoleActionMappings6.xml"
+    );
 
- */
+    // Create RoleActionAuthorisationService with dependencies
+    $roleAuthServ = new org\gocdb\services\RoleActionAuthorisationService($roleActionMappingService);
+    $roleAuthServ->setEntityManager($em2);
 
-        $ngi = TestUtil::createSampleNGI("MYNGI");
-        $this->em->persist($ngi);
-        $site1 = TestUtil::createSampleSite("SITENAME"/*, "PK01"*/);
-        //$site1->setNgiDoJoin($ngi);
-        $ngi->addSiteDoJoin($site1);
-        $this->em->persist($site1);
-        $se1 = TestUtil::createSampleService('somelabel');
-        $site1->addServiceDoJoin($se1);
-        $this->em->persist($se1);
-        $site2_userHasNoDirectRole = TestUtil::createSampleSite("SITENAME_2"/*, "PK01"*/);
-        $ngi->addSiteDoJoin($site2_userHasNoDirectRole);
-        //$site2_userHasNoDirectRole->setNgiDoJoin($ngi);
-        $this->em->persist($site2_userHasNoDirectRole);
+    // Create role and link user and owned entities (user link not shown)
+    /*
+     *    p1  p2  p3
+     *    |    |  /|
+     * r1-n1  n2  n3
+     *    |   |   |
+     *    s1  s2  s3
+     */
+    $r1 = TestUtil::createSampleRole($u, $ngiManRT, $n1, RoleStatus::GRANTED);
+    $this->em->persist($r1);
+    $this->em->flush();
 
-        $p1 = new \Project("EGI");
-        $this->em->persist($p1);
-        $p1->addNgi($ngi);
+    // Assert user can edit s1 using r1
+    $enablingRoles = $roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $s1, $u)->getGrantingRoles();
+    $this->assertEquals(1, count($enablingRoles));
+    $this->assertTrue(in_array($r1, $enablingRoles));
+    $this->assertEquals(TestRoleTypeName::NGI_OPS_MAN, $enablingRoles[0]->getRoleType()->getName());
+
+    // Assert user can edit n1 using r1
+    $enablingRoles = $roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $n1, $u)->getGrantingRoles();
+    $this->assertEquals(1, count($enablingRoles));
+    $this->assertTrue(in_array($r1, $enablingRoles));
+    $this->assertEquals(TestRoleTypeName::NGI_OPS_MAN, $enablingRoles[0]->getRoleType()->getName());
+
+    // Assert user can change s1 cert status with r1
+    $this->assertTrue(in_array($r1, $roleAuthServ->authoriseAction(\Action::SITE_EDIT_CERT_STATUS, $s1, $u)->getGrantingRoles()) );
+
+    // Assert user can't edit other sites/ngis/projects
+    $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $s2, $u)->getGrantingRoles()));
+    $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $s3, $u)->getGrantingRoles()));
+    $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $n2, $u)->getGrantingRoles()));
+    $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $n3, $u)->getGrantingRoles()));
+    $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $p1, $u)->getGrantingRoles()));
+    $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $p2, $u)->getGrantingRoles()));
+    $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $p3, $u)->getGrantingRoles()));
+
+     /*
+     *    p1  p2  p3
+     *    |    |  /|
+     * r1-n1  n2  n3
+     *    |   |   |
+     * r2-s1  s2  s3
+     */
+    $r2 = TestUtil::createSampleRole($u, $siteAdminRT, $s1, RoleStatus::GRANTED) ;
+    $this->em->persist($r2);
+    $this->em->flush();
+
+    // Assert user can edit s1 using r1 + r2
+    $enablingRoles = $roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $s1, $u)->getGrantingRoles();
+    $this->assertEquals(2, count($enablingRoles));
+    $this->assertTrue(in_array($r1, $enablingRoles));
+    $this->assertTrue(in_array($r2, $enablingRoles));
+    //$enablingRoleNames = $this->getRoleTypeNames($enablingRoles);
+    //$this->assertTrue(in_array(TestRoleTypeName::NGI_OPS_MAN, $enablingRoleNames));
+    //$this->assertTrue(in_array(TestRoleTypeName::SITE_ADMIN, $enablingRoleNames));
+
+    // Assert user can change site cert status with r1
+    $enablingRoles = $roleAuthServ->authoriseAction(\Action::SITE_EDIT_CERT_STATUS, $s1, $u)->getGrantingRoles();
+    $this->assertEquals(1, count($enablingRoles));
+    $this->assertTrue(in_array($r1, $enablingRoles));
+
+    // Assert user can't edit other sites/ngis/projects
+    $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $s2, $u)->getGrantingRoles()));
+    $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $s3, $u)->getGrantingRoles()));
+    $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $n2, $u)->getGrantingRoles()));
+    $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $n3, $u)->getGrantingRoles()));
+    $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $p1, $u)->getGrantingRoles()));
+    $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $p2, $u)->getGrantingRoles()));
+    $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $p3, $u)->getGrantingRoles()));
+
+    /*
+     *    p1     p2  p3
+     *    |      |  /|
+     * r1-n1     n2  n3
+     *    |      |   |
+     * r2-s1  r3-s2  s3
+     */
+    $r3 = TestUtil::createSampleRole($u, $siteAdminRT, $s2, RoleStatus::GRANTED) ;
+    $this->em->persist($r3);
+    $this->em->flush();
+
+    // Assert user can edit s1 via r1 + r2
+    $enablingRoles = $roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $s1, $u)->getGrantingRoles();
+    $this->assertEquals(2, count($enablingRoles));
+    $this->assertTrue(in_array($r1, $enablingRoles));
+    $this->assertTrue(in_array($r2, $enablingRoles));
+
+    // Assert user can edit s2 via r3
+    $enablingRoles = $roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $s2, $u)->getGrantingRoles();
+    $this->assertEquals(1, count($enablingRoles));
+    $this->assertTrue(in_array($r3, $enablingRoles));
+
+    // Assert user can change s1 cert status via r1
+    $enablingRoles = $roleAuthServ->authoriseAction(\Action::SITE_EDIT_CERT_STATUS, $s1, $u)->getGrantingRoles();
+    $this->assertEquals(1, count($enablingRoles));
+    $this->assertTrue(in_array($r1, $enablingRoles));
+
+    // Assert user cant change s2 cert status
+    $enablingRoles = $roleAuthServ->authoriseAction(\Action::SITE_EDIT_CERT_STATUS, $s2, $u)->getGrantingRoles();
+    $this->assertEquals(0, count($enablingRoles));
+
+    // Assert user can't edit other sites/ngis/projects
+    $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $s3, $u)->getGrantingRoles()));
+    $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $n2, $u)->getGrantingRoles()));
+    $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $n3, $u)->getGrantingRoles()));
+    $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $p1, $u)->getGrantingRoles()));
+    $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $p2, $u)->getGrantingRoles()));
+    $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $p3, $u)->getGrantingRoles()));
 
 
+    /*
+     *    p1  r4-p2  p3
+     *    |      |  /|
+     * r1-n1     n2  n3
+     *    |      |   |
+     * r2-s1  r3-s2  s3
+     */
+    $r4 = TestUtil::createSampleRole($u, $cooRT, $p2, RoleStatus::GRANTED);
+    $this->em->persist($r4);
+    $this->em->flush();
 
-        // Create ngiManagerRole, ngiUserRole, siteAdminRole and link user and owned entities
-        $ngiManagerRole = TestUtil::createSampleRole($u, $ngiManRT, $ngi, RoleStatus::GRANTED);
-        $this->em->persist($ngiManagerRole);
-        $rodUserRole = TestUtil::createSampleRole($u, $rodRT, $ngi, RoleStatus::GRANTED);
-        $this->em->persist($rodUserRole);
-        $siteAdminRole = TestUtil::createSampleRole($u, $siteAdminRT, $site1, RoleStatus::GRANTED) ;
-        $this->em->persist($siteAdminRole);
+    // Assert user can edit p2 via r4
+    $enablingRoles = $roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $p2, $u)->getGrantingRoles();
+    $this->assertEquals(1, count($enablingRoles));
+    $this->assertTrue(in_array($r4, $enablingRoles));
 
-        $this->em->flush();
+    // Assert user can grantRole on p2 via r4
+    $enablingRoles = $roleAuthServ->authoriseAction(\Action::GRANT_ROLE, $p2, $u)->getGrantingRoles();
+    $this->assertEquals(1, count($enablingRoles));
+    $this->assertTrue(in_array($r4, $enablingRoles));
 
-        // ********MUST******** start a new connection to test transactional
-        // isolation of RoleService methods.
-        //$em = $this->createEntityManager();
-        //$siteService = new org\gocdb\services\Site();
-        //$siteService->setEntityManager($em);
-        $roleActionMappingService = new org\gocdb\services\RoleActionMappingService();
-        $roleActionAuthService = new org\gocdb\services\RoleActionAuthorisationService($roleActionMappingService);
-        $roleActionAuthService->setEntityManager($this->em);
+    // Assert user can grantRole on n2 via r4
+    $enablingRoles = $roleAuthServ->authoriseAction(\Action::GRANT_ROLE, $n2, $u)->getGrantingRoles();
+    $this->assertEquals(1, count($enablingRoles));
+    $this->assertTrue(in_array($r4, $enablingRoles));
 
+    // Assert user can't edit other sites/ngis/projects
+    $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $n2, $u)->getGrantingRoles()));
+    $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $s3, $u)->getGrantingRoles()));
+    $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $n3, $u)->getGrantingRoles()));
+    $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $p3, $u)->getGrantingRoles()));
 
-        // Assert user can edit site using 3 enabling roles
-        $enablingRoles = $roleActionAuthService->authoriseAction(\Action::EDIT_OBJECT, $site1, $u)->getGrantingRoles();
-        $this->assertEquals(3, count($enablingRoles));
-        $this->assertTrue(in_array($siteAdminRole, $enablingRoles));
-        $this->assertTrue(in_array($rodUserRole, $enablingRoles));
-        $this->assertTrue(in_array($ngiManagerRole, $enablingRoles));
+    /*
+     *    p1  r4-p2  p3-r5
+     *    |      |  /|
+     * r1-n1     n2  n3
+     *    |      |   |
+     * r2-s1  r3-s2  s3
+     */
+    $r5 = TestUtil::createSampleRole($u, $codRT, $p3, RoleStatus::GRANTED);
+    $this->em->persist($r5);
+    $this->em->flush();
 
+    // Assert user can edit p3 with r5
+    $enablingRoles = $roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $p3, $u)->getGrantingRoles();
+    $this->assertEquals(1, count($enablingRoles));
+    $this->assertTrue(in_array($r5, $enablingRoles));
 
-        // Assert user can only edit cert status through his NGI_OPS_MAN role
-        $enablingRoles = $roleActionAuthService->authoriseAction(\Action::SITE_EDIT_CERT_STATUS, $site1, $u)->getGrantingRoles();
-        $this->assertEquals(1, count($enablingRoles));
-        $this->assertTrue(in_array($ngiManagerRole, $enablingRoles));
-//
-//        // Add a new project role and link ngi and give user COD_ADMIN Project role (use $this->em to isolate)
-        $codRole = TestUtil::createSampleRole($u, $codRT, $p1, RoleStatus::GRANTED);
-        $this->em->persist($codRole);
-        $this->em->flush();
+    // Assert user can grant role on n2 + n3 via r5
+    $enablingRoles = $roleAuthServ->authoriseAction(\Action::GRANT_ROLE, $n2, $u)->getGrantingRoles();
+    $this->assertEquals(2, count($enablingRoles));
+    $this->assertTrue(in_array($r5, $enablingRoles));
+    $this->assertTrue(in_array($r4, $enablingRoles));
 
-/*
-                                 p1      <- codRT
-                                 |
-                                 ngi      <- ngiManRT, rodRT,
-                                 |    \
-             siteAdminRT  ->   site1   site2
-                                 |
-                                 se1
+    // Assert user can't edit other sites/ngis/projects
+    $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $n2, $u)->getGrantingRoles()));
+    $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $s3, $u)->getGrantingRoles()));
+    $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $n3, $u)->getGrantingRoles()));
 
-*/
+    /*
+     *    p1  r4-p2  p3-r5
+     *    |      |  /|
+     * r1-n1     n2  n3-r6
+     *    |      |   |
+     * r2-s1  r3-s2  s3
+     */
+    $r6 = TestUtil::createSampleRole($u, $ngiManRT, $n3, RoleStatus::GRANTED);
+    $this->em->persist($r6);
+    $this->em->flush();
 
-        // Assert user now has 2 roles that enable SITE_EDIT_CERT_STATUS change action
-        $enablingRoles = $roleActionAuthService->authoriseAction(\Action::SITE_EDIT_CERT_STATUS, $site1, $u)->getGrantingRoles();
-        $this->assertEquals(2, count($enablingRoles));
-        $this->assertTrue(in_array($ngiManagerRole, $enablingRoles));
-        $this->assertTrue(in_array($codRole, $enablingRoles));
+    /*
+     *    p1  r4-p2  p3-r5
+     *    |      |  /|
+     * r1-n1     n2  n3-r6
+     *    |      |   |
+     * r2-s1  r3-s2  s3-r7
+     */
+    $r7 = TestUtil::createSampleRole($u, $siteAdminRT, $s3, RoleStatus::GRANTED);
+    $this->em->persist($r7);
+    $this->em->flush();
 
-        // Assert user can edit SE using SITE_ADMIN, NGI_OPS_MAN, REG_STAFF_ROD roles (but not COD role)
-        $enablingRoles = $roleActionAuthService->authoriseAction(\Action::EDIT_OBJECT, $se1->getParentSite(), $u)->getGrantingRoles();
-        $this->assertEquals(3, count($enablingRoles));
-        $this->assertTrue(in_array($siteAdminRole, $enablingRoles));
-        $this->assertTrue(in_array($ngiManagerRole, $enablingRoles));
-        $this->assertTrue(in_array($rodUserRole, $enablingRoles));
+    // Assert user can edit s3 with r6 + r7
+    $enablingRoles = $roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $s3, $u)->getGrantingRoles();
+    $this->assertEquals(2, count($enablingRoles));
+    $this->assertTrue(in_array($r7, $enablingRoles));
+    $this->assertTrue(in_array($r6, $enablingRoles));
 
-        // Assert User can only edit Site2 through his 2 indirect ngi roles
-        // (user don't have any direct site level roles on this site and COD don't give edit perm)
-        $enablingRoles = $roleActionAuthService->authoriseAction(\Action::EDIT_OBJECT, $site2_userHasNoDirectRole, $u)->getGrantingRoles();
-        $this->assertEquals(2, count($enablingRoles));
-        $this->assertTrue(in_array($ngiManagerRole, $enablingRoles));
-        $this->assertTrue(in_array($rodUserRole, $enablingRoles));
+    /*
+     *    p1  r4-p2  p3-r5
+     *    |      |  /|
+     * r1-n1  r8-n2  n3-r6
+     *    |      |   |
+     * r2-s1  r3-s2  s3-r7
+     */
+    $r8 = TestUtil::createSampleRole($u, $ngiManRT, $n2, RoleStatus::GRANTED);
+    $this->em->persist($r8);
+    $this->em->flush();
 
-        // Delete the user's Project COD role
-        $this->em->remove($codRole);
-        $this->em->flush();
-/*
-                                 p1
-                                 |
-                                 ngi      <- ngiManRT, rodRT,
-                                 |    \
-             siteAdminRT  ->   site1   site2
-                                 |
-                                 se1
+    $enablingRoles = $roleAuthServ->authoriseAction(\Action::SITE_EDIT_CERT_STATUS, $s2, $u)->getGrantingRoles();
+    $this->assertEquals(3, count($enablingRoles));
+    $this->assertTrue(in_array($r8, $enablingRoles));
+    $this->assertTrue(in_array($r4, $enablingRoles));
+    $this->assertTrue(in_array($r5, $enablingRoles));
 
-*/
+    $enablingRoles = $roleAuthServ->authoriseAction(\Action::SITE_EDIT_CERT_STATUS, $s3, $u)->getGrantingRoles();
+    $this->assertEquals(2, count($enablingRoles));
+    $this->assertTrue(in_array($r6, $enablingRoles));
+    $this->assertTrue(in_array($r5, $enablingRoles));
 
-        // Assert user can only SITE_EDIT_CERT_STATUS through 1 role for both sites
-        $enablingRoles =  $roleActionAuthService->authoriseAction(\Action::SITE_EDIT_CERT_STATUS, $site2_userHasNoDirectRole, $u)->getGrantingRoles();
-        $this->assertEquals(1, count($enablingRoles));
-        $this->assertTrue(in_array($ngiManagerRole, $enablingRoles));
-        $enablingRoles =  $roleActionAuthService->authoriseAction(\Action::SITE_EDIT_CERT_STATUS, $site1, $u)->getGrantingRoles();
-        $this->assertEquals(1, count($enablingRoles));
-        $this->assertTrue(in_array($ngiManagerRole, $enablingRoles));
+    /*
+     *    p1  r4-p2  p3-r5
+     *    |      |  /|
+     * r1-n1  r8-n2  n3-r6
+     *    |      |   |
+     * r2-s1  r3-s2  s3-r7,r9
+     */
+    $r9 = TestUtil::createSampleRole($u, $siteDepManAdminRT, $s3, RoleStatus::GRANTED);
+    $this->em->persist($r9);
+    $this->em->flush();
 
-        // Delete the user's NGI manager role
-        $this->em->remove($ngiManagerRole);
-        $this->em->flush();
-/*
-                                 p1
-                                 |
-                                 ngi      <- rodRT,
-                                 |    \
-             siteAdminRT  ->   site1   site2
-                                 |
-                                 se1
+    // Assert user can edit s3 with r7, r9, r6
+    $enablingRoles = $roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $s3, $u)->getGrantingRoles();
+    $this->assertEquals(3, count($enablingRoles));
+    $this->assertTrue(in_array($r7, $enablingRoles));
+    $this->assertTrue(in_array($r9, $enablingRoles));
+    $this->assertTrue(in_array($r6, $enablingRoles));
 
-*/
+    // Assert user can change s3 cert status with r6 + r5
+    $enablingRoles = $roleAuthServ->authoriseAction(\Action::SITE_EDIT_CERT_STATUS, $s3, $u)->getGrantingRoles();
+    $this->assertEquals(2, count($enablingRoles));
+    $this->assertTrue(in_array($r6, $enablingRoles));
+    $this->assertTrue(in_array($r5, $enablingRoles));
 
-        // Assert user can't edit site2 cert status
-        $enablingRoles = $roleActionAuthService->authoriseAction(\Action::SITE_EDIT_CERT_STATUS, $site2_userHasNoDirectRole, $u)->getGrantingRoles();
-        $this->assertEquals(0, count($enablingRoles));
-        // Assert user can still edit site via his ROD role
-        $enablingRoles = $roleActionAuthService->authoriseAction(\Action::EDIT_OBJECT, $site2_userHasNoDirectRole, $u)->getGrantingRoles();
-        $this->assertEquals(1, count($enablingRoles));
-        $this->assertTrue(in_array($rodUserRole, $enablingRoles));
+    /*
+     *    p1  r4-p2  p3-r5
+     *    |      |  /|
+     * r1-n1  r8-n2  n3-r6,r10
+     *    |      |   |
+     * r2-s1  r3-s2  s3-r7,r9
+     */
+    $r10 = TestUtil::createSampleRole($u, $rodRT, $n3, RoleStatus::GRANTED);
+    $this->em->persist($r10);
+    $this->em->flush();
 
-        // Delete the user's NGI ROD role
-        $this->em->remove($rodUserRole);
-        $this->em->flush();
+    $enablingRoles = $roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $s3, $u)->getGrantingRoles();
+    $this->assertEquals(4, count($enablingRoles));
+    $this->assertTrue(in_array($r6, $enablingRoles));
+    $this->assertTrue(in_array($r10, $enablingRoles));
+    $this->assertTrue(in_array($r7, $enablingRoles));
+    $this->assertTrue(in_array($r9, $enablingRoles));
 
-/*
-                                 p1
-                                 |
-                                 ngi
-                                 |    \
-             siteAdminRT  ->   site1   site2
-                                 |
-                                 se1
+    $enablingRoles = $roleAuthServ->authoriseAction(\Action::NGI_ADD_SITE, $n3, $u)->getGrantingRoles();
+    $this->assertEquals(1, count($enablingRoles));
+    $this->assertTrue(in_array($r6, $enablingRoles));
+  }
 
-*/
+  public function test_getUserRolesOnAndAboveEntity(){
+    print __METHOD__ . "\n";
+    include __DIR__ . '/../../resources/sampleFixtureData5.php';
 
-        // User can't edit site2
-        $enablingRoles = $roleActionAuthService->authoriseAction(\Action::EDIT_OBJECT, $site2_userHasNoDirectRole, $u)->getGrantingRoles();
-        $this->assertEquals(0, count($enablingRoles));
+    // create a user
+    $u = TestUtil::createSampleUser("dave", "meredith", "idSTring");
+    $this->em->persist($u);
 
-        // Assert user can still edit SITE1 through his direct site level role (this role has not been deleted)
-        $enablingRoles = $roleActionAuthService->authoriseAction(\Action::EDIT_OBJECT, $site1, $u)->getGrantingRoles();
-        $this->assertEquals(1, count($enablingRoles));
-        $this->assertTrue(in_array($siteAdminRole, $enablingRoles));
+    // add some roles to domain model
+    $ngiRoleType = TestUtil::createSampleRoleType("NGI_RT");
+    $siteRoleType = TestUtil::createSampleRoleType("SITE_RT");
+    $siteRoleType2 = TestUtil::createSampleRoleType("SITE_RT2");
+    $projRoleType = TestUtil::createSampleRoleType("PROJ_RT");
+    $this->em->persist($ngiRoleType);
+    $this->em->persist($siteRoleType);
+    $this->em->persist($siteRoleType2);
+    $this->em->persist($projRoleType);
 
-        // Delete user's remaining Site role
-        $this->em->remove($siteAdminRole);
-        $this->em->flush();
-/*
-                                 p1
-                                 |
-                                 ngi
-                                 |    \
-                               site1   site2
-                                 |
-                                 se1
+    $this->em->flush();
 
-*/
-        // User can't edit site1
-        $enablingRoles = $roleActionAuthService->authoriseAction(\Action::EDIT_OBJECT, $site1, $u)->getGrantingRoles();
-        $this->assertEquals(0, count($enablingRoles));
-    }
+    $roleActionMappingService = new org\gocdb\services\RoleActionMappingService();
+    // Create RoleActionAuthorisationService with dependencies
+    $roleAuthServ = new org\gocdb\services\RoleActionAuthorisationService($roleActionMappingService);
 
+    // We could create/inject a new em connection into the roleService
+    // to test the transactional isolation of its methods (rather than injecting
+    // $this->em instance), e.g.:
+    //   $em = $this->createEntityManager();
+    //   $roleService->setEntityManager($em);
+    //
+    // However, this is problematic for this test which
+    // needs to use the in_array() method to assert that the tested methods return
+    // the expected roles - in_array() uses object-instance-equality to deterine
+    // if the role exists in the array, and using a different $em instance
+    // means the returned roles will be considered different
+    // instances. We could get round this by comparing the Ids, but this makes
+    // checking more of hassle as we need to extract all the Ids from the roles
+    // into another array to assert the ids are expected, as in:
+    //   $roleIds = array();
+    //   foreach($roles as $r){ $roleIds[] = $r->getId(); }
+    //   $this->assertTrue(in_array($r1->getId(), $roleIds));
+    //   $this->assertTrue(in_array($r2->getId(), $roleIds));
+    //
+    // For this test, we will therefore re-use $this->em to ensure
+    // object-equality:
+    $roleAuthServ->setEntityManager($this->em);
+
+    $roles = $roleAuthServ->getUserRolesReachableFromEntityASC($u, $p1);
+    $this->assertEmpty($roles);
+
+    // Create a Role and link to the User, ngiRoleType and ngi
+    /*
+     * p1     p2     p3
+     * |      |     /|
+     * n1     n2-r1  n3
+     * |      |      |
+     * s1     s2     s3
+     */
+    $r1 = TestUtil::createSampleRole($u, $ngiRoleType, $n2, RoleStatus::GRANTED);
+    $this->em->persist($r1);
+    $this->em->flush();
+
+    $rolesDirect = $u->getRoles();
+    $this->assertEquals(1, count($rolesDirect));
+
+    $roles = $roleAuthServ->getUserRolesReachableFromEntityASC($u, $s1);
+    $this->assertEmpty($roles);
+
+    $roles = $roleAuthServ->getUserRolesReachableFromEntityASC($u, $s2);
+    $this->assertEquals(1, count($roles));
+    $this->assertTrue(in_array($r1, $roles));
+
+    /*
+     * p1     p2     p3
+     * |      |     /|
+     * n1     n2-r1  n3-r2
+     * |      |      |
+     * s1     s2     s3
+     */
+    $r2 = TestUtil::createSampleRole($u, $ngiRoleType, $n3, RoleStatus::GRANTED);
+    $this->em->persist($r2);
+    $this->em->flush();
+
+    $roles = $roleAuthServ->getUserRolesReachableFromEntityASC($u, $s2);
+    $this->assertEquals(1, count($roles));
+    $this->assertTrue(in_array($r1, $roles));
+
+    $roles = $roleAuthServ->getUserRolesReachableFromEntityASC($u, $s3);
+    $this->assertEquals(1, count($roles));
+    $this->assertTrue(in_array($r2, $roles));
+
+     /*
+     * p1     p2     p3
+     * |      |     /|
+     * n1     n2-r1  n3-r2
+     * |      |      |
+     * s1     s2     s3-r3
+     */
+    $r3 = TestUtil::createSampleRole($u, $siteRoleType, $s3, RoleStatus::GRANTED);
+    $this->em->persist($r3);
+    $this->em->flush();
+
+    $roles = $roleAuthServ->getUserRolesReachableFromEntityASC($u, $s3);
+    $this->assertEquals(2, count($roles));
+    $this->assertTrue(in_array($r2, $roles));
+    $this->assertTrue(in_array($r3, $roles));
+
+    /*
+     * p1     p2     p3-r4
+     * |      |     /|
+     * n1     n2-r1  n3-r2
+     * |      |      |
+     * s1     s2     s3-r3
+     */
+    $r4 = TestUtil::createSampleRole($u, $projRoleType, $p3, RoleStatus::GRANTED);
+    $this->em->persist($r4);
+    $this->em->flush();
+
+     /*
+     * p1     p2     p3-r4
+     * |      |     /|
+     * n1     n2-r1  n3-r2
+     * |      |      |
+     * s1     s2-r5  s3-r3
+     */
+    $r5 = TestUtil::createSampleRole($u, $siteRoleType, $s2, RoleStatus::GRANTED);
+    $this->em->persist($r5);
+    $this->em->flush();
+
+    /*
+     * p1     p2     p3-r4
+     * |      |     /|
+     * n1     n2-r1  n3-r2
+     * |      |      |
+     * s1-r6  s2-r5  s3-r3
+     */
+    $r6 = TestUtil::createSampleRole($u, $siteRoleType, $s1, RoleStatus::GRANTED);
+    $this->em->persist($r6);
+    $this->em->flush();
+
+    /*
+     * p1     p2     p3-r4
+     * |      |     /|
+     * n1     n2-r1  n3-r2
+     * |      |      |
+     * s1-r6  s2-r5  s3-r3,r7
+     */
+    $r7 = TestUtil::createSampleRole($u, $siteRoleType2, $s3, RoleStatus::GRANTED);
+    $this->em->persist($r7);
+    $this->em->flush();
+
+    /*
+     * p1     p2-r8  p3-r4
+     * |      |     /|
+     * n1     n2-r1  n3-r2
+     * |      |      |
+     * s1-r6  s2-r5  s3-r3,r7
+     */
+    $r8 = TestUtil::createSampleRole($u, $projRoleType, $p2, RoleStatus::GRANTED);
+    $this->em->persist($r8);
+    $this->em->flush();
+
+    $roles = $roleAuthServ->getUserRolesReachableFromEntityASC($u, $s1);
+    $this->assertEquals(1, count($roles));
+    $this->assertTrue(in_array($r6, $roles));
+
+    $roles = $roleAuthServ->getUserRolesReachableFromEntityASC($u, $s2);
+    $this->assertEquals(4, count($roles));
+    $this->assertTrue(in_array($r5, $roles));
+    $this->assertTrue(in_array($r1, $roles));
+    $this->assertTrue(in_array($r8, $roles));
+    $this->assertTrue(in_array($r4, $roles));
+
+    $roles = $roleAuthServ->getUserRolesReachableFromEntityASC($u, $s3);
+    $this->assertEquals(4, count($roles));
+    $this->assertTrue(in_array($r2, $roles));
+    $this->assertTrue(in_array($r3, $roles));
+    $this->assertTrue(in_array($r4, $roles));
+    $this->assertTrue(in_array($r7, $roles));
+
+  }
+
+  /**
+   * Persist some seed data - roletypes, user, Project, NGI, sites and SEs and
+   * assert that the user has the expected number of roles that grant specific
+   * actions over the owned objects. For example, assert that the user has 'n'
+   * number of roles that allow a particular site to be edited, or 'n' number
+   * of roles that allow an NGI certification status change.
+   */
+  public function testAuthoriseAction2(){
+    print __METHOD__ . "\n";
+    // Create roletypes
+    $siteAdminRT = TestUtil::createSampleRoleType(RoleTypeName::SITE_ADMIN/*, RoleTypeClass::SITE_USER*/);
+    $ngiManRT = TestUtil::createSampleRoleType(RoleTypeName::NGI_OPS_MAN/*, RoleTypeClass::REGIONAL_MANAGER*/);
+    $rodRT = TestUtil::createSampleRoleType(RoleTypeName::REG_STAFF_ROD/*, RoleTypeClass::REGIONAL_USER*/);
+    $codRT = TestUtil::createSampleRoleType(RoleTypeName::COD_ADMIN/*, RoleTypeClass::PROJECT*/);
+    $this->em->persist($siteAdminRT); // edit site1 (but not cert status)
+    $this->em->persist($ngiManRT); // edit owned site1/site2 and cert status
+    $this->em->persist($rodRT);  // edit owned sites 1and2 (but not cert status)
+    $this->em->persist($codRT);  // edit all sites cert status only
+
+    // Create a user
+    $u = TestUtil::createSampleUser("Test", "Testing", "/c=test");
+    $this->em->persist($u);
+
+    /*
+    * Create a linked object graph
+    *
+    *                         p1
+    *                         |
+    *                        ngi      <- ngiManRT, rodRT,
+    *                      |    \
+    * siteAdminRT  ->   site1   site2
+    *                     |
+    *                   se1
+    *
+    */
+    $ngi = TestUtil::createSampleNGI("MYNGI");
+    $this->em->persist($ngi);
+    $site1 = TestUtil::createSampleSite("SITENAME"/*, "PK01"*/);
+    //$site1->setNgiDoJoin($ngi);
+    $ngi->addSiteDoJoin($site1);
+    $this->em->persist($site1);
+    $se1 = TestUtil::createSampleService('somelabel');
+    $site1->addServiceDoJoin($se1);
+    $this->em->persist($se1);
+    $site2_userHasNoDirectRole = TestUtil::createSampleSite("SITENAME_2"/*, "PK01"*/);
+    $ngi->addSiteDoJoin($site2_userHasNoDirectRole);
+    //$site2_userHasNoDirectRole->setNgiDoJoin($ngi);
+    $this->em->persist($site2_userHasNoDirectRole);
+
+    $p1 = new \Project("EGI");
+    $this->em->persist($p1);
+    $p1->addNgi($ngi);
+
+    // Create ngiManagerRole, ngiUserRole, siteAdminRole and link user and owned entities
+    $ngiManagerRole = TestUtil::createSampleRole($u, $ngiManRT, $ngi, RoleStatus::GRANTED);
+    $this->em->persist($ngiManagerRole);
+    $rodUserRole = TestUtil::createSampleRole($u, $rodRT, $ngi, RoleStatus::GRANTED);
+    $this->em->persist($rodUserRole);
+    $siteAdminRole = TestUtil::createSampleRole($u, $siteAdminRT, $site1, RoleStatus::GRANTED) ;
+    $this->em->persist($siteAdminRole);
+    $this->em->flush();
+
+    // ********MUST******** start a new connection to test transactional
+    // isolation of RoleService methods.
+    //$em = $this->createEntityManager();
+    //$siteService = new org\gocdb\services\Site();
+    //$siteService->setEntityManager($em);
+    $roleActionMappingService = new org\gocdb\services\RoleActionMappingService();
+    $roleActionAuthService = new org\gocdb\services\RoleActionAuthorisationService($roleActionMappingService);
+    $roleActionAuthService->setEntityManager($this->em);
+
+    // Assert user can edit site using 3 enabling roles
+    $enablingRoles = $roleActionAuthService->authoriseAction(\Action::EDIT_OBJECT, $site1, $u)->getGrantingRoles();
+    $this->assertEquals(3, count($enablingRoles));
+    $this->assertTrue(in_array($siteAdminRole, $enablingRoles));
+    $this->assertTrue(in_array($rodUserRole, $enablingRoles));
+    $this->assertTrue(in_array($ngiManagerRole, $enablingRoles));
+
+    // Assert user can only edit cert status through his NGI_OPS_MAN role
+    $enablingRoles = $roleActionAuthService->authoriseAction(\Action::SITE_EDIT_CERT_STATUS, $site1, $u)->getGrantingRoles();
+    $this->assertEquals(1, count($enablingRoles));
+    $this->assertTrue(in_array($ngiManagerRole, $enablingRoles));
+
+    // Add a new project role and link ngi and give user COD_ADMIN Project role (use $this->em to isolate)
+    $codRole = TestUtil::createSampleRole($u, $codRT, $p1, RoleStatus::GRANTED);
+    $this->em->persist($codRole);
+    $this->em->flush();
+
+    /*
+    *                                 p1      <- codRT
+    *                                |
+    *                               ngi      <- ngiManRT, rodRT,
+    *                             |    \
+    *         siteAdminRT  ->   site1   site2
+    *                            |
+    *                           se1
+    *
+    */
+
+    // Assert user now has 2 roles that enable SITE_EDIT_CERT_STATUS change action
+    $enablingRoles = $roleActionAuthService->authoriseAction(\Action::SITE_EDIT_CERT_STATUS, $site1, $u)->getGrantingRoles();
+    $this->assertEquals(2, count($enablingRoles));
+    $this->assertTrue(in_array($ngiManagerRole, $enablingRoles));
+    $this->assertTrue(in_array($codRole, $enablingRoles));
+
+    // Assert user can edit SE using SITE_ADMIN, NGI_OPS_MAN, REG_STAFF_ROD roles (but not COD role)
+    $enablingRoles = $roleActionAuthService->authoriseAction(\Action::EDIT_OBJECT, $se1->getParentSite(), $u)->getGrantingRoles();
+    $this->assertEquals(3, count($enablingRoles));
+    $this->assertTrue(in_array($siteAdminRole, $enablingRoles));
+    $this->assertTrue(in_array($ngiManagerRole, $enablingRoles));
+    $this->assertTrue(in_array($rodUserRole, $enablingRoles));
+
+    // Assert User can only edit Site2 through his 2 indirect ngi roles
+    // (user don't have any direct site level roles on this site and COD don't give edit perm)
+    $enablingRoles = $roleActionAuthService->authoriseAction(\Action::EDIT_OBJECT, $site2_userHasNoDirectRole, $u)->getGrantingRoles();
+    $this->assertEquals(2, count($enablingRoles));
+    $this->assertTrue(in_array($ngiManagerRole, $enablingRoles));
+    $this->assertTrue(in_array($rodUserRole, $enablingRoles));
+
+    // Delete the user's Project COD role
+    $this->em->remove($codRole);
+    $this->em->flush();
+    /*
+    *                               p1
+    *                                |
+      *                             ngi      <- ngiManRT, rodRT,
+    *                             |    \
+    *         siteAdminRT  ->   site1   site2
+    *                             |
+    *                            se1
+    *
+    */
+
+    // Assert user can only SITE_EDIT_CERT_STATUS through 1 role for both sites
+    $enablingRoles =  $roleActionAuthService->authoriseAction(\Action::SITE_EDIT_CERT_STATUS, $site2_userHasNoDirectRole, $u)->getGrantingRoles();
+    $this->assertEquals(1, count($enablingRoles));
+    $this->assertTrue(in_array($ngiManagerRole, $enablingRoles));
+    $enablingRoles =  $roleActionAuthService->authoriseAction(\Action::SITE_EDIT_CERT_STATUS, $site1, $u)->getGrantingRoles();
+    $this->assertEquals(1, count($enablingRoles));
+    $this->assertTrue(in_array($ngiManagerRole, $enablingRoles));
+
+    // Delete the user's NGI manager role
+    $this->em->remove($ngiManagerRole);
+    $this->em->flush();
+
+    /*
+    *                         p1
+    *                         |
+    *                        ngi      <- rodRT,
+    *                      |    \
+    *  siteAdminRT  ->   site1   site2
+    *                     |
+    *                    se1
+    */
+
+    // Assert user can't edit site2 cert status
+    $enablingRoles = $roleActionAuthService->authoriseAction(\Action::SITE_EDIT_CERT_STATUS, $site2_userHasNoDirectRole, $u)->getGrantingRoles();
+    $this->assertEquals(0, count($enablingRoles));
+    // Assert user can still edit site via his ROD role
+    $enablingRoles = $roleActionAuthService->authoriseAction(\Action::EDIT_OBJECT, $site2_userHasNoDirectRole, $u)->getGrantingRoles();
+    $this->assertEquals(1, count($enablingRoles));
+    $this->assertTrue(in_array($rodUserRole, $enablingRoles));
+
+    // Delete the user's NGI ROD role
+    $this->em->remove($rodUserRole);
+    $this->em->flush();
+
+    /*
+    *                         p1
+    *                         |
+    *                         ngi
+    *                       |    \
+    *  siteAdminRT  ->   site1   site2
+    *                      |
+    *                     se1
+    */
+
+    // User can't edit site2
+    $enablingRoles = $roleActionAuthService->authoriseAction(\Action::EDIT_OBJECT, $site2_userHasNoDirectRole, $u)->getGrantingRoles();
+    $this->assertEquals(0, count($enablingRoles));
+
+    // Assert user can still edit SITE1 through his direct site level role (this role has not been deleted)
+    $enablingRoles = $roleActionAuthService->authoriseAction(\Action::EDIT_OBJECT, $site1, $u)->getGrantingRoles();
+    $this->assertEquals(1, count($enablingRoles));
+    $this->assertTrue(in_array($siteAdminRole, $enablingRoles));
+
+    // Delete user's remaining Site role
+    $this->em->remove($siteAdminRole);
+    $this->em->flush();
+
+    /*
+    *                         p1
+    *                         |
+    *                         ngi
+    *                       |    \
+    *                     site1   site2
+    *                      |
+    *                     se1
+    */
+
+    // User can't edit site1
+    $enablingRoles = $roleActionAuthService->authoriseAction(\Action::EDIT_OBJECT, $site1, $u)->getGrantingRoles();
+    $this->assertEquals(0, count($enablingRoles));
+  }
 
 }
 
 class TestRoleTypeName {
 
-    const GOCDB_ADMIN = 'GOCDB_ADMIN';
+  const GOCDB_ADMIN = 'GOCDB_ADMIN';
 
-    // Roles for Sites
-    const SITE_ADMIN = 'Site Administrator'; // C
+  // Roles for Sites
+  const SITE_ADMIN = 'Site Administrator'; // C
 
-    const SITE_SECOFFICER = 'Site Security Officer'; // C'
-    const SITE_OPS_DEP_MAN = 'Site Operations Deputy Manager'; // C'
-    const SITE_OPS_MAN = 'Site Operations Manager'; // C'
+  const SITE_SECOFFICER = 'Site Security Officer'; // C'
+  const SITE_OPS_DEP_MAN = 'Site Operations Deputy Manager'; // C'
+  const SITE_OPS_MAN = 'Site Operations Manager'; // C'
 
-    // Roles for NGIs
-    const REG_FIRST_LINE_SUPPORT = 'Regional First Line Support'; // D
-    const REG_STAFF_ROD = 'Regional Staff (ROD)'; // D
+  // Roles for NGIs
+  const REG_FIRST_LINE_SUPPORT = 'Regional First Line Support'; // D
+  const REG_STAFF_ROD = 'Regional Staff (ROD)'; // D
 
-    const NGI_SEC_OFFICER = 'NGI Security Officer'; // D'
-    const NGI_OPS_DEP_MAN = 'NGI Operations Deputy Manager'; // D'
-    const NGI_OPS_MAN = 'NGI Operations Manager'; // D'
+  const NGI_SEC_OFFICER = 'NGI Security Officer'; // D'
+  const NGI_OPS_DEP_MAN = 'NGI Operations Deputy Manager'; // D'
+  const NGI_OPS_MAN = 'NGI Operations Manager'; // D'
 
-    // Roles for Projects
-    const COD_STAFF = 'COD Staff'; // E
-    const COD_ADMIN = 'COD Administrator'; // E
-    const EGI_CSIRT_OFFICER = 'EGI CSIRT Officer'; // E
-    const COO = 'Chief Operations Officer'; // E
+  // Roles for Projects
+  const COD_STAFF = 'COD Staff'; // E
+  const COD_ADMIN = 'COD Administrator'; // E
+  const EGI_CSIRT_OFFICER = 'EGI CSIRT Officer'; // E
+  const COO = 'Chief Operations Officer'; // E
 
-    // Roles for ServiceGroups
-    const SERVICEGROUP_ADMIN = 'Service Group Administrator'; // ServiceGroupC'
+  // Roles for ServiceGroups
+  const SERVICEGROUP_ADMIN = 'Service Group Administrator'; // ServiceGroupC'
 
-    // "Other" roles that have slipped by us (see AddRoleTypes.php)
-    const CIC_STAFF = 'CIC Staff'; // Pretty sure this role is not required anymore: https://rt.egi.eu/rt/Ticket/Display.html?id=931
-    const REG_STAFF = 'Regional Staff';
+  // "Other" roles that have slipped by us (see AddRoleTypes.php)
+  const CIC_STAFF = 'CIC Staff'; // Pretty sure this role is not required anymore: https://rt.egi.eu/rt/Ticket/Display.html?id=931
+  const REG_STAFF = 'Regional Staff';
 
-    /**
-     * private constructor to limit instantiation
-     */
-    private function __construct() {
-    }
+  /**
+  * private constructor to limit instantiation
+  */
+  private function __construct() {
+  }
 
-    /**
-     * Get an associative array of the class constants. Array keys are the constant
-     * names, array values are the constant values.
-     * @return array
-     */
-    public static function getAsArray() {
-        $tmp = new ReflectionClass(get_called_class());
-        $a = $tmp->getConstants();        //$b = array_flip($a)
-        return $a;
-    }
+  /**
+  * Get an associative array of the class constants. Array keys are the constant
+  * names, array values are the constant values.
+  * @return array
+  */
+  public static function getAsArray() {
+    $tmp = new ReflectionClass(get_called_class());
+    $a = $tmp->getConstants();        //$b = array_flip($a)
+    return $a;
+  }
 
 }

--- a/tests/unit/lib/Gocdb_Services/RoleActionAuthorisationServiceTest.php
+++ b/tests/unit/lib/Gocdb_Services/RoleActionAuthorisationServiceTest.php
@@ -792,7 +792,7 @@ class RoleActionAuthorisationServiceTest  extends PHPUnit_Extensions_Database_Te
     /*
     *                               p1
     *                                |
-      *                             ngi      <- ngiManRT, rodRT,
+    *                             ngi      <- ngiManRT, rodRT,
     *                             |    \
     *         siteAdminRT  ->   site1   site2
     *                             |

--- a/tests/unit/lib/Gocdb_Services/RoleActionMappingServiceTest.php
+++ b/tests/unit/lib/Gocdb_Services/RoleActionMappingServiceTest.php
@@ -27,7 +27,6 @@ class RoleActionMappingServiceTest extends PHPUnit_Framework_TestCase {
      * Called once, before any of the tests are executed.
      */
     public static function setUpBeforeClass() {
-        //print __METHOD__ . "\n";
     }
 
     /**
@@ -42,11 +41,9 @@ class RoleActionMappingServiceTest extends PHPUnit_Framework_TestCase {
      * assert any pre-conditions required by tests.
      */
     protected function assertPreConditions() {
-        //print __METHOD__ . "\n";
     }
 
     protected function assertPostConditions() {
-        //print __METHOD__ . "\n";
     }
 
     /**
@@ -54,14 +51,12 @@ class RoleActionMappingServiceTest extends PHPUnit_Framework_TestCase {
      * This method is called after a test is executed.
      */
     protected function tearDown() {
-        //print __METHOD__ . "\n";
     }
 
     /**
      * executed only once, after all the testing methods
      */
     public static function tearDownAfterClass() {
-        //print __METHOD__ . "\n";
     }
 
     protected function onNotSuccessfulTest(Exception $e) {
@@ -75,15 +70,6 @@ class RoleActionMappingServiceTest extends PHPUnit_Framework_TestCase {
         $roleActionService = new org\gocdb\services\RoleActionMappingService();
         $errors = $roleActionService->validateRoleActionMappingFileAgainstXsd();
         $this->assertEmpty($errors);
-        /*$xml = new \DOMDocument();
-        $xml->load(__DIR__."/../../../../config/RoleActionMappings.xml");
-        if (!$xml->schemaValidate(__DIR__."/../../../../config/RoleActionMappingsSchema.xsd")) {
-            $this->fail('could not validate instance doc');
-            $errors = libxml_get_errors();
-            foreach ($errors as $error) {
-                print libxml_display_error($error);
-            }
-        }*/
     }
 
     public function testGetRoleNamesForProject(){
@@ -93,21 +79,8 @@ class RoleActionMappingServiceTest extends PHPUnit_Framework_TestCase {
 
         $rolenamesOver = $roleActionService->getRoleTypeNamesForProject('EGI');
         $this->assertEquals(14, count($rolenamesOver));
-        //print_r($rolenamesOver);
     $rolenamesOver = $roleActionService->getRoleTypeNamesForProject(null);
         $this->assertEquals(14, count($rolenamesOver));
-
-//        $rolenamesOver = $roleActionService->getRoleTypeNamesForProject('WLCG');
-//        $this->assertEquals(4, count($rolenamesOver));
-//        //print_r($rolenamesOver);
-//
-//        $rolenamesOver = $roleActionService->getRoleTypeNamesForProject('EUDAT');
-//        $this->assertEquals(5, count($rolenamesOver));
-//        //print_r($rolenamesOver);
-//
-//        $rolenamesOver = $roleActionService->getRoleTypeNamesForProject(NULL);
-//        $this->assertEquals(1, count($rolenamesOver));
-        //print_r($rolenamesOver);
     }
 
 
@@ -199,17 +172,6 @@ class RoleActionMappingServiceTest extends PHPUnit_Framework_TestCase {
         $roleActionService = new org\gocdb\services\RoleActionMappingService();
         $roleActionService->setRoleActionMappingsXmlPath(__DIR__."/../../resources/roleActionMappingSamples/TestRoleActionMappings4.xml");
 
-//        // EGI project
-//        $expected = array('RoleH' => 'Project');
-//        $enablingRoleTypeNames = $roleActionService->getRoleTypeNamesThatEnableActionOnTargetObjectType("AZ", 'project', 'egi');
-//        $this->assertArraySubset($expected, $enablingRoleTypeNames);
-//        //print_r($enablingRoleNames);
-//
-//        $expected = array();
-//        $enablingRoleTypeNames = $roleActionService->getRoleTypeNamesThatEnableActionOnTargetObjectType("AZ", 'site', 'egi');
-//        $this->assertArraySubset($expected, $enablingRoleTypeNames);
-
-        // EGI2 project
         // to do action 'AX' on a 'site' requires roles:
         $expected = array('RoleA','RoleB','RoleC','RoleD','RoleE');
         $enablingRoleTypeNames = $roleActionService->getRoleTypeNamesThatEnableActionOnTargetObjectType("AX", 'site', 'egi2');
@@ -248,30 +210,6 @@ class RoleActionMappingServiceTest extends PHPUnit_Framework_TestCase {
 
     }
 
-    /*
-     * @expectedException \LogicException
-     * @expectedExceptionCode 22
-     */
-//    public function testInvalidDocMultipleDefaultElements(){
-//        print __METHOD__ . "\n";
-//        $roleActionService = new org\gocdb\services\RoleActionMappingService();
-//        $roleActionService->setRoleActionMappingsXmlPath(__DIR__."/../../resources/roleActionMappingSamples/TestRoleActionMappings1.xml");
-//        $roleActionService->getRoleTypeNamesThatEnableActionOnTargetObjectType("action", "hello", "world");
-//    }
-
-//    public function testInvalidDocMultipleRoleActionMappingsForProject(){
-//        print __METHOD__ . "\n";
-//        $roleActionService = new org\gocdb\services\RoleActionMappingService();
-//        $roleActionService->setRoleActionMappingsXmlPath(__DIR__."/../../resources/roleActionMappingSamples/TestInvalidRoleActionMappings2.xml");
-//        try {
-//            $roleActionService->getRoleTypeNamesThatEnableActionOnTargetObjectType("action", "hello", "EGI");
-//            $this->fail("shouldn't have got here");
-//        } catch (\Exception $ex){
-//            //print_r($ex->getMessage()) ;
-//            //$errors = libxml_get_errors();
-//            //var_dump($errors);
-//        }
-//    }
 
     public function testGetEnabledActionsForRoleType1() {
     print __METHOD__ . "\n";
@@ -280,9 +218,7 @@ class RoleActionMappingServiceTest extends PHPUnit_Framework_TestCase {
 
     $enabledActionsOnTargets = $roleActionService->getEnabledActionsForRoleType('RoleA');
 
-//	foreach($enabledActionsOnTargets as $enabledActionOnTarget){
-//	    print_r($enabledActionOnTarget[0].' '.$enabledActionOnTarget[1]."\n");
-//	}
+
     $expectedActionsOnTargets = array();
         $expectedActionsOnTargets[] = array('A1', 'site');
         $expectedActionsOnTargets[] = array('A1', 'service');
@@ -317,9 +253,7 @@ class RoleActionMappingServiceTest extends PHPUnit_Framework_TestCase {
     $roleActionService->setRoleActionMappingsXmlPath(__DIR__ . "/../../resources/roleActionMappingSamples/TestRoleActionMappings5.xml");
 
     $enabledActionsOnTargets = $roleActionService->getEnabledActionsForRoleType('NGI Operations Manager');
-//	foreach($enabledActionsOnTargets as $enabledActionOnTarget){
-//	    print_r($enabledActionOnTarget[0].' '.$enabledActionOnTarget[1]."\n");
-//	}
+
 
     $expectedActionsOnTargets = array();
         $expectedActionsOnTargets[] = array('ACTION_EDIT_OBJECT', 'Ngi');

--- a/tests/unit/lib/Gocdb_Services/RoleActionMappingServiceTest.php
+++ b/tests/unit/lib/Gocdb_Services/RoleActionMappingServiceTest.php
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
- require_once __DIR__.'/../../../../lib/Gocdb_Services/RoleActionMappingService.php';
+require_once __DIR__.'/../../../../lib/Gocdb_Services/RoleActionMappingService.php';
 
 /**
  * Test case for the {@see \org\gocdb\services\RoleActionMappingService} service class.
@@ -22,196 +22,196 @@
  * @author David Meredith
  */
 class RoleActionMappingServiceTest extends PHPUnit_Framework_TestCase {
+  /**
+  * Called once, before any of the tests are executed.
+  */
+  public static function setUpBeforeClass() {
+  }
 
-    /**
-     * Called once, before any of the tests are executed.
-     */
-    public static function setUpBeforeClass() {
-    }
+  /**
+  * Sets up the fixture, for example, opens a network connection.
+  * This method is called before each test method is executed.
+  */
+  protected function setUp() {
+  }
 
-    /**
-     * Sets up the fixture, for example, opens a network connection.
-     * This method is called before each test method is executed.
-     */
-    protected function setUp() {
-    }
+  /**
+  * Like setUp(), this is called before each test method to
+  * assert any pre-conditions required by tests.
+  */
+  protected function assertPreConditions() {
+  }
 
-    /**
-     * Like setUp(), this is called before each test method to
-     * assert any pre-conditions required by tests.
-     */
-    protected function assertPreConditions() {
-    }
+  protected function assertPostConditions() {
+  }
 
-    protected function assertPostConditions() {
-    }
+  /**
+  * Tears down the fixture, for example, closes a network connection.
+  * This method is called after a test is executed.
+  */
+  protected function tearDown() {
+  }
 
-    /**
-     * Tears down the fixture, for example, closes a network connection.
-     * This method is called after a test is executed.
-     */
-    protected function tearDown() {
-    }
+  /**
+  * executed only once, after all the testing methods
+  */
+  public static function tearDownAfterClass() {
+  }
 
-    /**
-     * executed only once, after all the testing methods
-     */
-    public static function tearDownAfterClass() {
-    }
-
-    protected function onNotSuccessfulTest(Exception $e) {
-        print __METHOD__ . "\n";
-        throw $e;
-    }
+  protected function onNotSuccessfulTest(Exception $e) {
+    print __METHOD__ . "\n";
+    throw $e;
+  }
 
 
-    public function testValidateRoleActionMappingsAgainstSchema() {
-        print __METHOD__ . "\n";
-        $roleActionService = new org\gocdb\services\RoleActionMappingService();
-        $errors = $roleActionService->validateRoleActionMappingFileAgainstXsd();
-        $this->assertEmpty($errors);
-    }
+  public function testValidateRoleActionMappingsAgainstSchema() {
+    print __METHOD__ . "\n";
+    $roleActionService = new org\gocdb\services\RoleActionMappingService();
+    $errors = $roleActionService->validateRoleActionMappingFileAgainstXsd();
+    $this->assertEmpty($errors);
+  }
 
-    public function testGetRoleNamesForProject(){
-        print __METHOD__ . "\n";
-        $roleActionService = new org\gocdb\services\RoleActionMappingService();
-        $roleActionService->setRoleActionMappingsXmlPath(__DIR__."/../../resources/roleActionMappingSamples/TestRoleActionMappings5.xml");
+  public function testGetRoleNamesForProject(){
+    print __METHOD__ . "\n";
+    $roleActionService = new org\gocdb\services\RoleActionMappingService();
+    $roleActionService->setRoleActionMappingsXmlPath(__DIR__."/../../resources/roleActionMappingSamples/TestRoleActionMappings5.xml");
 
-        $rolenamesOver = $roleActionService->getRoleTypeNamesForProject('EGI');
-        $this->assertEquals(14, count($rolenamesOver));
+    $rolenamesOver = $roleActionService->getRoleTypeNamesForProject('EGI');
+    $this->assertEquals(14, count($rolenamesOver));
     $rolenamesOver = $roleActionService->getRoleTypeNamesForProject(null);
-        $this->assertEquals(14, count($rolenamesOver));
-    }
+    $this->assertEquals(14, count($rolenamesOver));
+  }
 
 
-    public function testGetEnablingRolesForTargetedAction1(){
-        print __METHOD__ . "\n";
-        $roleActionService = new org\gocdb\services\RoleActionMappingService();
-        $roleActionService->setRoleActionMappingsXmlPath(__DIR__."/../../resources/roleActionMappingSamples/TestRoleActionMappings5.xml");
+  public function testGetEnablingRolesForTargetedAction1(){
+    print __METHOD__ . "\n";
+    $roleActionService = new org\gocdb\services\RoleActionMappingService();
+    $roleActionService->setRoleActionMappingsXmlPath(__DIR__."/../../resources/roleActionMappingSamples/TestRoleActionMappings5.xml");
 
-        $expected = array('COD Staff', 'COD Administrator', 'EGI CSIRT Officer', 'Chief Operations Officer');
-        $enablingRoleTypeNames = $roleActionService->getRoleTypeNamesThatEnableActionOnTargetObjectType("ACTION_EDIT_OBJECT", 'PRoJect', 'EGI');
-        $this->assertArraySubset($expected, array_keys($enablingRoleTypeNames));
-        $this->assertEquals(count($expected), count($enablingRoleTypeNames));
+    $expected = array('COD Staff', 'COD Administrator', 'EGI CSIRT Officer', 'Chief Operations Officer');
+    $enablingRoleTypeNames = $roleActionService->getRoleTypeNamesThatEnableActionOnTargetObjectType("ACTION_EDIT_OBJECT", 'PRoJect', 'EGI');
+    $this->assertArraySubset($expected, array_keys($enablingRoleTypeNames));
+    $this->assertEquals(count($expected), count($enablingRoleTypeNames));
 
-        $expected = array('COD Staff', 'COD Administrator', 'EGI CSIRT Officer', 'Chief Operations Officer', 'NGI Operations Manager', 'NGI Operations Deputy Manager', 'NGI Security Officer');
-        $enablingRoleTypeNames = $roleActionService->getRoleTypeNamesThatEnableActionOnTargetObjectType("ACTION_GRANT_ROLE", 'ngi', 'EGI');
-        $this->assertArraySubset($expected, array_keys($enablingRoleTypeNames));
-        $this->assertEquals(count($expected), count($enablingRoleTypeNames));
+    $expected = array('COD Staff', 'COD Administrator', 'EGI CSIRT Officer', 'Chief Operations Officer', 'NGI Operations Manager', 'NGI Operations Deputy Manager', 'NGI Security Officer');
+    $enablingRoleTypeNames = $roleActionService->getRoleTypeNamesThatEnableActionOnTargetObjectType("ACTION_GRANT_ROLE", 'ngi', 'EGI');
+    $this->assertArraySubset($expected, array_keys($enablingRoleTypeNames));
+    $this->assertEquals(count($expected), count($enablingRoleTypeNames));
 
-        $expected = array('Service Group Administrator');
-        $enablingRoleTypeNames = $roleActionService->getRoleTypeNamesThatEnableActionOnTargetObjectType("ACTION_EDIT_OBJECT", 'SErviceGroup', 'EGI');
-        $this->assertArraySubset($expected, array_keys($enablingRoleTypeNames));
-        $this->assertEquals(count($expected), count($enablingRoleTypeNames));
+    $expected = array('Service Group Administrator');
+    $enablingRoleTypeNames = $roleActionService->getRoleTypeNamesThatEnableActionOnTargetObjectType("ACTION_EDIT_OBJECT", 'SErviceGroup', 'EGI');
+    $this->assertArraySubset($expected, array_keys($enablingRoleTypeNames));
+    $this->assertEquals(count($expected), count($enablingRoleTypeNames));
 
-        $expected = array(
-            'NGI Operations Manager' => 'Ngi',
-            'NGI Operations Deputy Manager' => 'Ngi',
-            'NGI Security Officer' => 'Ngi',
-            'Regional Staff (ROD)' => 'Ngi',
-            'Regional First Line Support' => 'Ngi');
-        $enablingRoleTypeNames = $roleActionService->getRoleTypeNamesThatEnableActionOnTargetObjectType("ACTION_EDIT_OBJECT", 'ngi', 'egi');
-        $this->assertArraySubset($expected, ($enablingRoleTypeNames));
-        $this->assertEquals(count($expected), count($enablingRoleTypeNames));
+    $expected = array(
+      'NGI Operations Manager' => 'Ngi',
+      'NGI Operations Deputy Manager' => 'Ngi',
+      'NGI Security Officer' => 'Ngi',
+      'Regional Staff (ROD)' => 'Ngi',
+      'Regional First Line Support' => 'Ngi'
+    );
+    $enablingRoleTypeNames = $roleActionService->getRoleTypeNamesThatEnableActionOnTargetObjectType("ACTION_EDIT_OBJECT", 'ngi', 'egi');
+    $this->assertArraySubset($expected, ($enablingRoleTypeNames));
+    $this->assertEquals(count($expected), count($enablingRoleTypeNames));
 
-        // the action don't exist in the XML doc, so expect an empty array
-        $expected = array();
-        $enablingRoleTypeNames = $roleActionService->getRoleTypeNamesThatEnableActionOnTargetObjectType("ACTION_dont_exist", 'ngi', 'egi');
-        $this->assertArraySubset($expected, array_keys($enablingRoleTypeNames));
-        $this->assertEquals(count($expected), count($enablingRoleTypeNames));
+    // the action don't exist in the XML doc, so expect an empty array
+    $expected = array();
+    $enablingRoleTypeNames = $roleActionService->getRoleTypeNamesThatEnableActionOnTargetObjectType("ACTION_dont_exist", 'ngi', 'egi');
+    $this->assertArraySubset($expected, array_keys($enablingRoleTypeNames));
+    $this->assertEquals(count($expected), count($enablingRoleTypeNames));
 
-        // the Target entityType don't exist in the XML doc, so expect an empty array
-        $expected = array();
-        $enablingRoleTypeNames = $roleActionService->getRoleTypeNamesThatEnableActionOnTargetObjectType("ACTION_EDIT_OBJECT", 'ngix_dont_exist', 'egi');
-        $this->assertArraySubset($expected, array_keys($enablingRoleTypeNames));
-        $this->assertEquals(count($expected), count($enablingRoleTypeNames));
-
-
-        $expected = array(
-            'NGI Operations Deputy Manager' => 'Ngi',
-            'NGI Operations Manager' => 'Ngi',
-            'NGI Security Officer' => 'Ngi',
-            'Site Security Officer' => 'Site',
-            'Site Operations Deputy Manager' => 'Site',
-            'Site Operations Manager' => 'Site',
-            );
-        $enablingRoleTypeNames = $roleActionService->getRoleTypeNamesThatEnableActionOnTargetObjectType("ACTION_GRANT_ROLE", 'site', 'egi');
-        $this->assertArraySubset($expected, $enablingRoleTypeNames);
-        $this->assertEquals(count($expected), count($enablingRoleTypeNames));
-        $enablingRoleTypeNames = $roleActionService->getRoleTypeNamesThatEnableActionOnTargetObjectType("ACTION_REJECT_ROLE", 'site', 'egi');
-        $this->assertArraySubset($expected, $enablingRoleTypeNames);
-        $this->assertEquals(count($expected), count($enablingRoleTypeNames));
-        $enablingRoleTypeNames = $roleActionService->getRoleTypeNamesThatEnableActionOnTargetObjectType("ACTION_REVOKE_ROLE", 'site', 'egi');
-        $this->assertArraySubset($expected, $enablingRoleTypeNames);
-        $this->assertEquals(count($expected), count($enablingRoleTypeNames));
-
-        $expected = array(
-            'NGI Operations Deputy Manager' => 'Ngi',
-            'NGI Operations Manager' => 'Ngi',
-            'NGI Security Officer' => 'Ngi',
-            'COD Staff' => 'Project',
-            'COD Administrator' => 'Project',
-            'EGI CSIRT Officer' => 'Project',
-            'Chief Operations Officer' => 'Project'
-            );
-        $enablingRoleTypeNames = $roleActionService->getRoleTypeNamesThatEnableActionOnTargetObjectType("ACTION_SITE_EDIT_CERT_STATUS", 'site', 'egi');
-        $this->assertArraySubset($expected, $enablingRoleTypeNames);
-        $this->assertEquals(count($expected), count($enablingRoleTypeNames));
-
-        $expected = array(
-            'Service Group Administrator' => 'ServiceGroup',
-            );
-        $enablingRoleTypeNames = $roleActionService->getRoleTypeNamesThatEnableActionOnTargetObjectType("ACTION_EDIT_OBJECT", 'serviceGroup', NULL);
-        $this->assertArraySubset($expected, $enablingRoleTypeNames);
-        $this->assertEquals(count($expected), count($enablingRoleTypeNames));
-    }
+    // the Target entityType don't exist in the XML doc, so expect an empty array
+    $expected = array();
+    $enablingRoleTypeNames = $roleActionService->getRoleTypeNamesThatEnableActionOnTargetObjectType("ACTION_EDIT_OBJECT", 'ngix_dont_exist', 'egi');
+    $this->assertArraySubset($expected, array_keys($enablingRoleTypeNames));
+    $this->assertEquals(count($expected), count($enablingRoleTypeNames));
 
 
-    public function testGetEnablingRolesForTargetedAction2(){
-        print __METHOD__ . "\n";
-        $roleActionService = new org\gocdb\services\RoleActionMappingService();
-        $roleActionService->setRoleActionMappingsXmlPath(__DIR__."/../../resources/roleActionMappingSamples/TestRoleActionMappings4.xml");
+    $expected = array(
+      'NGI Operations Deputy Manager' => 'Ngi',
+      'NGI Operations Manager' => 'Ngi',
+      'NGI Security Officer' => 'Ngi',
+      'Site Security Officer' => 'Site',
+      'Site Operations Deputy Manager' => 'Site',
+      'Site Operations Manager' => 'Site',
+    );
+    $enablingRoleTypeNames = $roleActionService->getRoleTypeNamesThatEnableActionOnTargetObjectType("ACTION_GRANT_ROLE", 'site', 'egi');
+    $this->assertArraySubset($expected, $enablingRoleTypeNames);
+    $this->assertEquals(count($expected), count($enablingRoleTypeNames));
+    $enablingRoleTypeNames = $roleActionService->getRoleTypeNamesThatEnableActionOnTargetObjectType("ACTION_REJECT_ROLE", 'site', 'egi');
+    $this->assertArraySubset($expected, $enablingRoleTypeNames);
+    $this->assertEquals(count($expected), count($enablingRoleTypeNames));
+    $enablingRoleTypeNames = $roleActionService->getRoleTypeNamesThatEnableActionOnTargetObjectType("ACTION_REVOKE_ROLE", 'site', 'egi');
+    $this->assertArraySubset($expected, $enablingRoleTypeNames);
+    $this->assertEquals(count($expected), count($enablingRoleTypeNames));
 
-        // to do action 'AX' on a 'site' requires roles:
-        $expected = array('RoleA','RoleB','RoleC','RoleD','RoleE');
-        $enablingRoleTypeNames = $roleActionService->getRoleTypeNamesThatEnableActionOnTargetObjectType("AX", 'site', 'egi2');
-        $this->assertArraySubset($expected, array_keys($enablingRoleTypeNames));
-        //print_r($enablingRoleNames);
+    $expected = array(
+      'NGI Operations Deputy Manager' => 'Ngi',
+      'NGI Operations Manager' => 'Ngi',
+      'NGI Security Officer' => 'Ngi',
+      'COD Staff' => 'Project',
+      'COD Administrator' => 'Project',
+      'EGI CSIRT Officer' => 'Project',
+      'Chief Operations Officer' => 'Project'
+    );
+    $enablingRoleTypeNames = $roleActionService->getRoleTypeNamesThatEnableActionOnTargetObjectType("ACTION_SITE_EDIT_CERT_STATUS", 'site', 'egi');
+    $this->assertArraySubset($expected, $enablingRoleTypeNames);
+    $this->assertEquals(count($expected), count($enablingRoleTypeNames));
 
-        // to do action 'AX' on a 'service' requires roles:
-        $expected = array('RoleA','RoleB','RoleC','RoleD','RoleE');
-        $enablingRoleTypeNames = $roleActionService->getRoleTypeNamesThatEnableActionOnTargetObjectType("AX", 'service', 'egi2');
-        $this->assertArraySubset($expected, array_keys($enablingRoleTypeNames));
-
-        // to do action 'AX' on a 'project' requires roles:
-        $expected = array('RoleD','RoleE');
-        $enablingRoleTypeNames = $roleActionService->getRoleTypeNamesThatEnableActionOnTargetObjectType("AX", 'project', 'egi2');
-        $this->assertArraySubset($expected, array_keys($enablingRoleTypeNames));
-
-        // to do action 'A1' on a 'site' requires roles:
-        $expected = array('RoleA','RoleB','RoleC');
-        $enablingRoleTypeNames = $roleActionService->getRoleTypeNamesThatEnableActionOnTargetObjectType("A1", 'site', 'egi2');
-        $this->assertArraySubset($expected, array_keys($enablingRoleTypeNames));
-
-        // to do action 'A5' on a 'site' requires roles:
-        $expected = array('RoleD','RoleE');
-        $enablingRoleTypeNames = $roleActionService->getRoleTypeNamesThatEnableActionOnTargetObjectType("A5", 'site', 'egi2');
-        $this->assertArraySubset($expected, array_keys($enablingRoleTypeNames));
-
-        // to do action 'A1' on a 'service' requires roles:
-        $expected = array('RoleA','RoleB','RoleC');
-        $enablingRoleTypeNames = $roleActionService->getRoleTypeNamesThatEnableActionOnTargetObjectType("A1", 'service', 'egi2');
-        $this->assertArraySubset($expected, array_keys($enablingRoleTypeNames));
-
-        // to do action 'AY' on a 'project' requires roles:
-        $expected = array('RoleF');
-        $enablingRoleTypeNames = $roleActionService->getRoleTypeNamesThatEnableActionOnTargetObjectType("AY", 'project', 'egi2');
-        $this->assertArraySubset($expected, array_keys($enablingRoleTypeNames));
-
-    }
+    $expected = array(
+      'Service Group Administrator' => 'ServiceGroup',
+    );
+    $enablingRoleTypeNames = $roleActionService->getRoleTypeNamesThatEnableActionOnTargetObjectType("ACTION_EDIT_OBJECT", 'serviceGroup', NULL);
+    $this->assertArraySubset($expected, $enablingRoleTypeNames);
+    $this->assertEquals(count($expected), count($enablingRoleTypeNames));
+  }
 
 
-    public function testGetEnabledActionsForRoleType1() {
+  public function testGetEnablingRolesForTargetedAction2(){
+    print __METHOD__ . "\n";
+    $roleActionService = new org\gocdb\services\RoleActionMappingService();
+    $roleActionService->setRoleActionMappingsXmlPath(__DIR__."/../../resources/roleActionMappingSamples/TestRoleActionMappings4.xml");
+
+    // to do action 'AX' on a 'site' requires roles:
+    $expected = array('RoleA','RoleB','RoleC','RoleD','RoleE');
+    $enablingRoleTypeNames = $roleActionService->getRoleTypeNamesThatEnableActionOnTargetObjectType("AX", 'site', 'egi2');
+    $this->assertArraySubset($expected, array_keys($enablingRoleTypeNames));
+    //print_r($enablingRoleNames);
+
+    // to do action 'AX' on a 'service' requires roles:
+    $expected = array('RoleA','RoleB','RoleC','RoleD','RoleE');
+    $enablingRoleTypeNames = $roleActionService->getRoleTypeNamesThatEnableActionOnTargetObjectType("AX", 'service', 'egi2');
+    $this->assertArraySubset($expected, array_keys($enablingRoleTypeNames));
+
+    // to do action 'AX' on a 'project' requires roles:
+    $expected = array('RoleD','RoleE');
+    $enablingRoleTypeNames = $roleActionService->getRoleTypeNamesThatEnableActionOnTargetObjectType("AX", 'project', 'egi2');
+    $this->assertArraySubset($expected, array_keys($enablingRoleTypeNames));
+
+    // to do action 'A1' on a 'site' requires roles:
+    $expected = array('RoleA','RoleB','RoleC');
+    $enablingRoleTypeNames = $roleActionService->getRoleTypeNamesThatEnableActionOnTargetObjectType("A1", 'site', 'egi2');
+    $this->assertArraySubset($expected, array_keys($enablingRoleTypeNames));
+
+    // to do action 'A5' on a 'site' requires roles:
+    $expected = array('RoleD','RoleE');
+    $enablingRoleTypeNames = $roleActionService->getRoleTypeNamesThatEnableActionOnTargetObjectType("A5", 'site', 'egi2');
+    $this->assertArraySubset($expected, array_keys($enablingRoleTypeNames));
+
+    // to do action 'A1' on a 'service' requires roles:
+    $expected = array('RoleA','RoleB','RoleC');
+    $enablingRoleTypeNames = $roleActionService->getRoleTypeNamesThatEnableActionOnTargetObjectType("A1", 'service', 'egi2');
+    $this->assertArraySubset($expected, array_keys($enablingRoleTypeNames));
+
+    // to do action 'AY' on a 'project' requires roles:
+    $expected = array('RoleF');
+    $enablingRoleTypeNames = $roleActionService->getRoleTypeNamesThatEnableActionOnTargetObjectType("AY", 'project', 'egi2');
+    $this->assertArraySubset($expected, array_keys($enablingRoleTypeNames));
+
+  }
+
+
+  public function testGetEnabledActionsForRoleType1() {
     print __METHOD__ . "\n";
     $roleActionService = new org\gocdb\services\RoleActionMappingService();
     $roleActionService->setRoleActionMappingsXmlPath(__DIR__ . "/../../resources/roleActionMappingSamples/TestRoleActionMappings4.xml");
@@ -220,34 +220,34 @@ class RoleActionMappingServiceTest extends PHPUnit_Framework_TestCase {
 
 
     $expectedActionsOnTargets = array();
-        $expectedActionsOnTargets[] = array('A1', 'site');
-        $expectedActionsOnTargets[] = array('A1', 'service');
-        $expectedActionsOnTargets[] = array('A2', 'site');
-        $expectedActionsOnTargets[] = array('A2', 'service');
-        $expectedActionsOnTargets[] = array('A3', 'site');
-        $expectedActionsOnTargets[] = array('A3', 'service');
-        $expectedActionsOnTargets[] = array('AX', 'site');
-        $expectedActionsOnTargets[] = array('AX', 'service');
-        // assert
+    $expectedActionsOnTargets[] = array('A1', 'site');
+    $expectedActionsOnTargets[] = array('A1', 'service');
+    $expectedActionsOnTargets[] = array('A2', 'site');
+    $expectedActionsOnTargets[] = array('A2', 'service');
+    $expectedActionsOnTargets[] = array('A3', 'site');
+    $expectedActionsOnTargets[] = array('A3', 'service');
+    $expectedActionsOnTargets[] = array('AX', 'site');
+    $expectedActionsOnTargets[] = array('AX', 'service');
+    // assert
     $this->assertEquals($expectedActionsOnTargets, $enabledActionsOnTargets);
 
     $enabledActionsOnTargets = $roleActionService->getEnabledActionsForRoleType('RoleD');
     $expectedActionsOnTargets = array();
-        $expectedActionsOnTargets[] = array('A4', 'site');
-        $expectedActionsOnTargets[] = array('A4', 'service');
-        $expectedActionsOnTargets[] = array('A4', 'project');
-        $expectedActionsOnTargets[] = array('A5', 'site');
-        $expectedActionsOnTargets[] = array('A5', 'service');
-        $expectedActionsOnTargets[] = array('A5', 'project');
-        $expectedActionsOnTargets[] = array('AX', 'site');
-        $expectedActionsOnTargets[] = array('AX', 'service');
-        $expectedActionsOnTargets[] = array('AX', 'project');
+    $expectedActionsOnTargets[] = array('A4', 'site');
+    $expectedActionsOnTargets[] = array('A4', 'service');
+    $expectedActionsOnTargets[] = array('A4', 'project');
+    $expectedActionsOnTargets[] = array('A5', 'site');
+    $expectedActionsOnTargets[] = array('A5', 'service');
+    $expectedActionsOnTargets[] = array('A5', 'project');
+    $expectedActionsOnTargets[] = array('AX', 'site');
+    $expectedActionsOnTargets[] = array('AX', 'service');
+    $expectedActionsOnTargets[] = array('AX', 'project');
     // assert
     $this->assertEquals($expectedActionsOnTargets, $enabledActionsOnTargets);
 
-    }
+  }
 
-    public function testGetEnabledActionsForRoleType2() {
+  public function testGetEnabledActionsForRoleType2() {
     print __METHOD__ . "\n";
     $roleActionService = new org\gocdb\services\RoleActionMappingService();
     $roleActionService->setRoleActionMappingsXmlPath(__DIR__ . "/../../resources/roleActionMappingSamples/TestRoleActionMappings5.xml");
@@ -256,36 +256,34 @@ class RoleActionMappingServiceTest extends PHPUnit_Framework_TestCase {
 
 
     $expectedActionsOnTargets = array();
-        $expectedActionsOnTargets[] = array('ACTION_EDIT_OBJECT', 'Ngi');
-        $expectedActionsOnTargets[] = array('ACTION_NGI_ADD_SITE', 'Ngi');
-        $expectedActionsOnTargets[] = array('ACTION_GRANT_ROLE', 'Ngi');
-        $expectedActionsOnTargets[] = array('ACTION_REJECT_ROLE', 'Ngi');
-        $expectedActionsOnTargets[] = array('ACTION_REVOKE_ROLE', 'Ngi');
-        $expectedActionsOnTargets[] = array('ACTION_EDIT_OBJECT', 'Site');
-        $expectedActionsOnTargets[] = array('ACTION_SITE_ADD_SERVICE', 'Site');
-        $expectedActionsOnTargets[] = array('ACTION_SITE_DELETE_SERVICE', 'Site');
-        $expectedActionsOnTargets[] = array('ACTION_GRANT_ROLE', 'Site');
-        $expectedActionsOnTargets[] = array(' ACTION_REJECT_ROLE', 'Site');
-        $expectedActionsOnTargets[] = array(' ACTION_REVOKE_ROLE', 'Site');
-        $expectedActionsOnTargets[] = array('ACTION_SITE_EDIT_CERT_STATUS', 'Site');
+    $expectedActionsOnTargets[] = array('ACTION_EDIT_OBJECT', 'Ngi');
+    $expectedActionsOnTargets[] = array('ACTION_NGI_ADD_SITE', 'Ngi');
+    $expectedActionsOnTargets[] = array('ACTION_GRANT_ROLE', 'Ngi');
+    $expectedActionsOnTargets[] = array('ACTION_REJECT_ROLE', 'Ngi');
+    $expectedActionsOnTargets[] = array('ACTION_REVOKE_ROLE', 'Ngi');
+    $expectedActionsOnTargets[] = array('ACTION_EDIT_OBJECT', 'Site');
+    $expectedActionsOnTargets[] = array('ACTION_SITE_ADD_SERVICE', 'Site');
+    $expectedActionsOnTargets[] = array('ACTION_SITE_DELETE_SERVICE', 'Site');
+    $expectedActionsOnTargets[] = array('ACTION_GRANT_ROLE', 'Site');
+    $expectedActionsOnTargets[] = array(' ACTION_REJECT_ROLE', 'Site');
+    $expectedActionsOnTargets[] = array(' ACTION_REVOKE_ROLE', 'Site');
+    $expectedActionsOnTargets[] = array('ACTION_SITE_EDIT_CERT_STATUS', 'Site');
     // assert
     $this->assertEquals($expectedActionsOnTargets, $enabledActionsOnTargets);
 
 
     $enabledActionsOnTargets = $roleActionService->getEnabledActionsForRoleType('COD Staff');
     $expectedActionsOnTargets = array();
-        $expectedActionsOnTargets[] = array('ACTION_EDIT_OBJECT', 'Project');
-        $expectedActionsOnTargets[] = array('ACTION_GRANT_ROLE', 'Project');
-        $expectedActionsOnTargets[] = array('ACTION_REJECT_ROLE', 'Project');
-        $expectedActionsOnTargets[] = array('ACTION_REVOKE_ROLE', 'Project');
-        $expectedActionsOnTargets[] = array('ACTION_GRANT_ROLE', 'Ngi');
-        $expectedActionsOnTargets[] = array('ACTION_REJECT_ROLE', 'Ngi');
-        $expectedActionsOnTargets[] = array('ACTION_REVOKE_ROLE', 'Ngi');
-        $expectedActionsOnTargets[] = array('ACTION_SITE_EDIT_CERT_STATUS', 'Site');
+    $expectedActionsOnTargets[] = array('ACTION_EDIT_OBJECT', 'Project');
+    $expectedActionsOnTargets[] = array('ACTION_GRANT_ROLE', 'Project');
+    $expectedActionsOnTargets[] = array('ACTION_REJECT_ROLE', 'Project');
+    $expectedActionsOnTargets[] = array('ACTION_REVOKE_ROLE', 'Project');
+    $expectedActionsOnTargets[] = array('ACTION_GRANT_ROLE', 'Ngi');
+    $expectedActionsOnTargets[] = array('ACTION_REJECT_ROLE', 'Ngi');
+    $expectedActionsOnTargets[] = array('ACTION_REVOKE_ROLE', 'Ngi');
+    $expectedActionsOnTargets[] = array('ACTION_SITE_EDIT_CERT_STATUS', 'Site');
     // assert
     $this->assertEquals($expectedActionsOnTargets, $enabledActionsOnTargets);
-
-
-    }
+  }
 
 }

--- a/tests/unit/lib/Gocdb_Services/ScopeServiceTest.php
+++ b/tests/unit/lib/Gocdb_Services/ScopeServiceTest.php
@@ -108,10 +108,8 @@ class ScopeServiceTest extends PHPUnit_Extensions_Database_TestCase{
         $tables = simplexml_load_file($fixture);
 
         foreach($tables as $tableName) {
-            //print $tableName->getName() . "\n";
             $sql = "SELECT * FROM ".$tableName->getName();
             $result = $con->createQueryTable('results_table', $sql);
-            //echo 'row count: '.$result->getRowCount() ;
             if($result->getRowCount() != 0){
                 throw new RuntimeException("Invalid fixture. Table has rows: ".$tableName->getName());
             }
@@ -145,10 +143,6 @@ class ScopeServiceTest extends PHPUnit_Extensions_Database_TestCase{
         }
         $scopes = $scopeService->getScopes($scopeIds);
         $this->assertEquals(10, count($scopes));
-//        foreach($scopes as $scope){
-//            echo $scope->getId().' '.$scope->getName()."\n";
-//        }
-
     }
 
     public function testGetScopesFilterByParams1() {
@@ -167,7 +161,6 @@ class ScopeServiceTest extends PHPUnit_Extensions_Database_TestCase{
         $excludedScopeNames = $configService->getReservedScopeList();//'Scope0', 'Scope1', 'Scope2', 'Scope3'
         $filteredScopes = $scopeService->getScopesFilterByParams($filterParams, null);
         foreach($filteredScopes as $scope){
-            //echo $scope->getName()."\n";
             if(in_array($scope->getName(), $excludedScopeNames)){
                $this->fail("Reserved scope returned");
             }
@@ -198,7 +191,6 @@ class ScopeServiceTest extends PHPUnit_Extensions_Database_TestCase{
         $excludedScopeNames = array('Scope4', 'Scope5', 'Scope6', 'Scope7', 'Scope8', 'Scope9');
         $filteredScopes = $scopeService->getScopesFilterByParams($filterParams, null);
         foreach($filteredScopes as $scope){
-            //echo $scope->getName()."\n";
             if(in_array($scope->getName(), $excludedScopeNames)){
                $this->fail("Normal/Non-Reserved scope returned");
             }
@@ -257,7 +249,6 @@ class ScopeServiceTest extends PHPUnit_Extensions_Database_TestCase{
         $excludedScopeNames = array('Scope1','Scope2','Scope3','Scope4','Scope5','Scope6','Scope7','Scope8','Scope9');
         $filteredScopes = $scopeService->getScopesFilterByParams($filterParams, null);
         foreach($filteredScopes as $scope){
-            //echo $scope->getName()."\n";
             if(in_array($scope->getName(), $excludedScopeNames)){
                $this->fail("Default scope returned");
             }

--- a/tests/unit/lib/Gocdb_Services/ScopeServiceTest.php
+++ b/tests/unit/lib/Gocdb_Services/ScopeServiceTest.php
@@ -14,7 +14,6 @@
 require_once __DIR__ . '/../../../doctrine/TestUtil.php';
 require_once __DIR__ . '/../../../../lib/Gocdb_Services/Scope.php';
 require_once __DIR__ . '/../../../../lib/Gocdb_Services/Config.php';
-
 use Doctrine\ORM\EntityManager;
 require_once __DIR__ . '/../../../doctrine/bootstrap.php';
 
@@ -24,281 +23,278 @@ require_once __DIR__ . '/../../../doctrine/bootstrap.php';
  * @author David Meredith
  */
 class ScopeServiceTest extends PHPUnit_Extensions_Database_TestCase{
-     private $em;
+  private $em;
 
+  /**
+  * Overridden.
+  */
+  public static function setUpBeforeClass() {
+    parent::setUpBeforeClass();
+    echo "\n\n-------------------------------------------------\n";
+    echo "Executing ScopeServiceTest. . .\n";
+  }
 
+  /**
+  * Overridden. Returns the test database connection.
+  * @return PHPUnit_Extensions_Database_DB_IDatabaseConnection
+  */
+  protected function getConnection() {
+    require_once __DIR__ . '/../../../doctrine/bootstrap_pdo.php';
+    return getConnectionToTestDB();
+  }
 
-    /**
-     * Overridden.
-     */
-    public static function setUpBeforeClass() {
-        parent::setUpBeforeClass();
-        echo "\n\n-------------------------------------------------\n";
-        echo "Executing ScopeServiceTest. . .\n";
+  /**
+  * Overridden. Returns the test dataset.
+  * Defines how the initial state of the database should look before each test is executed.
+  * @return PHPUnit_Extensions_Database_DataSet_IDataSet
+  */
+  protected function getDataSet() {
+    return $this->createFlatXMLDataSet(__DIR__ . '/../../../doctrine/truncateDataTables.xml');
+    // Use below to return an empty data set if we don't want to truncate and seed
+    //return new PHPUnit_Extensions_Database_DataSet_DefaultDataSet();
+  }
+
+  /**
+  * Overridden.
+  */
+  protected function getSetUpOperation() {
+    // CLEAN_INSERT is default
+    //return PHPUnit_Extensions_Database_Operation_Factory::CLEAN_INSERT();
+    //return PHPUnit_Extensions_Database_Operation_Factory::UPDATE();
+    //return PHPUnit_Extensions_Database_Operation_Factory::NONE();
+    //
+    // Issue a DELETE from <table> which is more portable than a
+    // TRUNCATE table <table> (some DBs require high privileges for truncate statements
+    // and also do not allow truncates across tables with FK contstraints e.g. Oracle)
+    return PHPUnit_Extensions_Database_Operation_Factory::DELETE_ALL();
+  }
+
+  /**
+  * Overridden.
+  */
+  protected function getTearDownOperation() {
+    // NONE is default
+    return PHPUnit_Extensions_Database_Operation_Factory::NONE();
+  }
+
+  /**
+  * Sets up the fixture, e.g create a new entityManager for each test run
+  * This method is called before each test method is executed.
+  */
+  protected function setUp() {
+    parent::setUp();
+    $this->em = $this->createEntityManager();
+  }
+
+  /**
+  * @todo Still need to setup connection to different databases.
+  * @return EntityManager
+  */
+  private function createEntityManager(){
+    require __DIR__ . '/../../../doctrine/bootstrap_doctrine.php';
+    return $entityManager;
+  }
+
+  /**
+  * Called after setUp() and before each test. Used for common assertions
+  * across all tests.
+  */
+  protected function assertPreConditions() {
+    $con = $this->getConnection();
+    $fixture = __DIR__ . '/../../../doctrine/truncateDataTables.xml';
+    $tables = simplexml_load_file($fixture);
+
+    foreach($tables as $tableName) {
+      $sql = "SELECT * FROM ".$tableName->getName();
+      $result = $con->createQueryTable('results_table', $sql);
+      if($result->getRowCount() != 0){
+        throw new RuntimeException("Invalid fixture. Table has rows: ".$tableName->getName());
+      }
     }
+  }
 
-    /**
-     * Overridden. Returns the test database connection.
-     * @return PHPUnit_Extensions_Database_DB_IDatabaseConnection
-     */
-    protected function getConnection() {
-        require_once __DIR__ . '/../../../doctrine/bootstrap_pdo.php';
-        return getConnectionToTestDB();
+  private function insertTestScopes(){
+    $scopeCount = 10;
+    $scopes = array();
+    // create scopes and persist
+    for($i=0; $i<$scopeCount; $i++){
+      $scopes[] = TestUtil::createSampleScope("scope ".$i, "Scope".$i);
+      $this->em->persist($scopes[$i]);
     }
+  }
 
-    /**
-     * Overridden. Returns the test dataset.
-     * Defines how the initial state of the database should look before each test is executed.
-     * @return PHPUnit_Extensions_Database_DataSet_IDataSet
-     */
-    protected function getDataSet() {
-        return $this->createFlatXMLDataSet(__DIR__ . '/../../../doctrine/truncateDataTables.xml');
-        // Use below to return an empty data set if we don't want to truncate and seed
-        //return new PHPUnit_Extensions_Database_DataSet_DefaultDataSet();
+  public function testGetScopes(){
+    print __METHOD__ . "\n";
+    $this->insertTestScopes();
+    $this->em->flush();
+
+    $scopeService = new \org\gocdb\services\Scope();
+    $scopeService->setEntityManager($this->em);
+
+    $scopes = $scopeService->getScopes();
+    $this->assertEquals(10, count($scopes));
+    $scopeIds = array();
+    foreach($scopes as $scope){
+      $scopeIds[] = $scope->getId();
     }
+    $scopes = $scopeService->getScopes($scopeIds);
+    $this->assertEquals(10, count($scopes));
+  }
 
-    /**
-     * Overridden.
-     */
-    protected function getSetUpOperation() {
-        // CLEAN_INSERT is default
-        //return PHPUnit_Extensions_Database_Operation_Factory::CLEAN_INSERT();
-        //return PHPUnit_Extensions_Database_Operation_Factory::UPDATE();
-        //return PHPUnit_Extensions_Database_Operation_Factory::NONE();
-        //
-        // Issue a DELETE from <table> which is more portable than a
-        // TRUNCATE table <table> (some DBs require high privileges for truncate statements
-        // and also do not allow truncates across tables with FK contstraints e.g. Oracle)
-        return PHPUnit_Extensions_Database_Operation_Factory::DELETE_ALL();
+  public function testGetScopesFilterByParams1() {
+    print __METHOD__ . "\n";
+    $this->insertTestScopes();
+    $this->em->flush();
+
+    $scopeService = new \org\gocdb\services\Scope();
+    $scopeService->setEntityManager($this->em);
+    $configService = new \org\gocdb\services\Config();
+    $configService->setLocalInfoFileLocation(__DIR__ . '/../../resources/sample_local_info1.xml');
+    $scopeService->setConfigService($configService);
+
+    // exclude all the 'Reserved' scopes
+    $filterParams = array('excludeReserved' => true);
+    $excludedScopeNames = $configService->getReservedScopeList();//'Scope0', 'Scope1', 'Scope2', 'Scope3'
+    $filteredScopes = $scopeService->getScopesFilterByParams($filterParams, null);
+    foreach($filteredScopes as $scope){
+      if(in_array($scope->getName(), $excludedScopeNames)){
+       $this->fail("Reserved scope returned");
+      }
     }
+    $this->assertEquals(6, count($filteredScopes));
 
-    /**
-     * Overridden.
-     */
-    protected function getTearDownOperation() {
-        // NONE is default
-        return PHPUnit_Extensions_Database_Operation_Factory::NONE();
+    // excluding all the 'Normal/Non-Reserved' scopes should leave 0
+    $filterParams = array('excludeNonReserved' => true);
+    $filteredScopes = $scopeService->getScopesFilterByParams($filterParams, $filteredScopes);
+    $this->assertEquals(0, count($filteredScopes));
+  }
+
+
+
+  public function testGetScopesFilterByParams2() {
+    print __METHOD__ . "\n";
+    $this->insertTestScopes();
+    $this->em->flush();
+
+    $scopeService = new \org\gocdb\services\Scope();
+    $scopeService->setEntityManager($this->em);
+    $configService = new \org\gocdb\services\Config();
+    $configService->setLocalInfoFileLocation(__DIR__ . '/../../resources/sample_local_info1.xml');
+    $scopeService->setConfigService($configService);
+
+    // exclude all the 'Normal/Non-Reserved' scopes:
+    $filterParams = array('excludeNonReserved' => true);
+    $excludedScopeNames = array('Scope4', 'Scope5', 'Scope6', 'Scope7', 'Scope8', 'Scope9');
+    $filteredScopes = $scopeService->getScopesFilterByParams($filterParams, null);
+    foreach($filteredScopes as $scope){
+      if(in_array($scope->getName(), $excludedScopeNames)){
+       $this->fail("Normal/Non-Reserved scope returned");
+      }
     }
+    $this->assertEquals(4, count($filteredScopes));
 
-    /**
-     * Sets up the fixture, e.g create a new entityManager for each test run
-     * This method is called before each test method is executed.
-     */
-    protected function setUp() {
-        parent::setUp();
-        $this->em = $this->createEntityManager();
+    // excluding all the 'Reserved' scopes should leave 0
+    $filterParams = array('excludeReserved' => true);
+    $filteredScopes = $scopeService->getScopesFilterByParams($filterParams, $filteredScopes);
+    $this->assertEquals(0, count($filteredScopes));
+  }
+
+
+  public function testGetScopesFilterByParams3() {
+    print __METHOD__ . "\n";
+    $this->insertTestScopes();
+    $this->em->flush();
+
+    $scopeService = new \org\gocdb\services\Scope();
+    $scopeService->setEntityManager($this->em);
+    $configService = new \org\gocdb\services\Config();
+    $configService->setLocalInfoFileLocation(__DIR__ . '/../../resources/sample_local_info1.xml');
+    $scopeService->setConfigService($configService);
+
+    // exclude all the 'Default' scopes:
+    $filterParams = array('excludeDefault' => true);
+    $excludedScopeNames = array('Scope0');
+    $filteredScopes = $scopeService->getScopesFilterByParams($filterParams, null);
+    foreach($filteredScopes as $scope){
+      //echo $scope->getName()."\n";
+      if(in_array($scope->getName(), $excludedScopeNames)){
+        $this->fail("Default scope returned");
+      }
     }
+    $this->assertEquals(9, count($filteredScopes));
 
-    /**
-     * @todo Still need to setup connection to different databases.
-     * @return EntityManager
-     */
-    private function createEntityManager(){
-        require __DIR__ . '/../../../doctrine/bootstrap_doctrine.php';
-        return $entityManager;
+    // excluding all the 'Non Default' scopes should leave 0
+    $filterParams = array('excludeNonDefault' => true);
+    $filteredScopes = $scopeService->getScopesFilterByParams($filterParams, $filteredScopes);
+    $this->assertEquals(0, count($filteredScopes));
+  }
+
+  public function testGetScopesFilterByParams4() {
+    print __METHOD__ . "\n";
+    $this->insertTestScopes();
+    $this->em->flush();
+
+    $scopeService = new \org\gocdb\services\Scope();
+    $scopeService->setEntityManager($this->em);
+    $configService = new \org\gocdb\services\Config();
+    $configService->setLocalInfoFileLocation(__DIR__ . '/../../resources/sample_local_info1.xml');
+    $scopeService->setConfigService($configService);
+
+    // exclude all the 'Non Default' scopes:
+    $filterParams = array('excludeNonDefault' => true);
+    $excludedScopeNames = array('Scope1','Scope2','Scope3','Scope4','Scope5','Scope6','Scope7','Scope8','Scope9');
+    $filteredScopes = $scopeService->getScopesFilterByParams($filterParams, null);
+    foreach($filteredScopes as $scope){
+      if(in_array($scope->getName(), $excludedScopeNames)){
+        $this->fail("Default scope returned");
+      }
     }
+    $this->assertEquals(1, count($filteredScopes));
 
-    /**
-     * Called after setUp() and before each test. Used for common assertions
-     * across all tests.
-     */
-    protected function assertPreConditions() {
-        $con = $this->getConnection();
-        $fixture = __DIR__ . '/../../../doctrine/truncateDataTables.xml';
-        $tables = simplexml_load_file($fixture);
+    // excluding all the 'Default' scopes should leave 0
+    $filterParams = array('excludeDefault' => true);
+    $filteredScopes = $scopeService->getScopesFilterByParams($filterParams, $filteredScopes);
+    $this->assertEquals(0, count($filteredScopes));
+  }
 
-        foreach($tables as $tableName) {
-            $sql = "SELECT * FROM ".$tableName->getName();
-            $result = $con->createQueryTable('results_table', $sql);
-            if($result->getRowCount() != 0){
-                throw new RuntimeException("Invalid fixture. Table has rows: ".$tableName->getName());
-            }
-        }
+  public function testGetScopesFilterByParams5() {
+    print __METHOD__ . "\n";
+    $this->insertTestScopes();
+    $this->em->flush();
+
+    $scopeService = new \org\gocdb\services\Scope();
+    $scopeService->setEntityManager($this->em);
+    $configService = new \org\gocdb\services\Config();
+    $configService->setLocalInfoFileLocation(__DIR__ . '/../../resources/sample_local_info1.xml');
+    $scopeService->setConfigService($configService);
+
+    $filterParams = array('excludeDefault' => true, 'excludeNonReserved' => true);
+    $excludedScopeNames = array('Scope0', 'Scope4','Scope5','Scope6','Scope7','Scope8','Scope9');
+    // $expectedScopeNames=array('Scope1','Scope2','Scope3');
+    $filteredScopes = $scopeService->getScopesFilterByParams($filterParams, null);
+    foreach($filteredScopes as $scope){
+      //echo $scope->getName()."\n";
+      if(in_array($scope->getName(), $excludedScopeNames)){
+        $this->fail("Default scope returned");
+      }
     }
-
-    private function insertTestScopes(){
-        $scopeCount = 10;
-        $scopes = array();
-        // create scopes and persist
-        for($i=0; $i<$scopeCount; $i++){
-            $scopes[] = TestUtil::createSampleScope("scope ".$i, "Scope".$i);
-            $this->em->persist($scopes[$i]);
-        }
-    }
+    $this->assertEquals(3, count($filteredScopes));
+  }
 
 
-    public function testGetScopes(){
-        print __METHOD__ . "\n";
-        $this->insertTestScopes();
-        $this->em->flush();
+  /**
+  * @expectedException InvalidArgumentException
+  */
+  public function testGetScopesFilterByParamsUnsupportedParam() {
+    print __METHOD__ . "\n";
+    $scopeService = new \org\gocdb\services\Scope();
+    $scopeService->setEntityManager($this->em);
+    $configService = new \org\gocdb\services\Config();
+    $configService->setLocalInfoFileLocation(__DIR__ . '/../../resources/sample_local_info1.xml');
+    $scopeService->setConfigService($configService);
 
-        $scopeService = new \org\gocdb\services\Scope();
-        $scopeService->setEntityManager($this->em);
-
-        $scopes = $scopeService->getScopes();
-        $this->assertEquals(10, count($scopes));
-        $scopeIds = array();
-        foreach($scopes as $scope){
-            $scopeIds[] = $scope->getId();
-        }
-        $scopes = $scopeService->getScopes($scopeIds);
-        $this->assertEquals(10, count($scopes));
-    }
-
-    public function testGetScopesFilterByParams1() {
-        print __METHOD__ . "\n";
-        $this->insertTestScopes();
-        $this->em->flush();
-
-        $scopeService = new \org\gocdb\services\Scope();
-        $scopeService->setEntityManager($this->em);
-        $configService = new \org\gocdb\services\Config();
-        $configService->setLocalInfoFileLocation(__DIR__ . '/../../resources/sample_local_info1.xml');
-        $scopeService->setConfigService($configService);
-
-        // exclude all the 'Reserved' scopes
-        $filterParams = array('excludeReserved' => true);
-        $excludedScopeNames = $configService->getReservedScopeList();//'Scope0', 'Scope1', 'Scope2', 'Scope3'
-        $filteredScopes = $scopeService->getScopesFilterByParams($filterParams, null);
-        foreach($filteredScopes as $scope){
-            if(in_array($scope->getName(), $excludedScopeNames)){
-               $this->fail("Reserved scope returned");
-            }
-        }
-        $this->assertEquals(6, count($filteredScopes));
-
-        // excluding all the 'Normal/Non-Reserved' scopes should leave 0
-        $filterParams = array('excludeNonReserved' => true);
-        $filteredScopes = $scopeService->getScopesFilterByParams($filterParams, $filteredScopes);
-        $this->assertEquals(0, count($filteredScopes));
-    }
-
-
-
-    public function testGetScopesFilterByParams2() {
-        print __METHOD__ . "\n";
-        $this->insertTestScopes();
-        $this->em->flush();
-
-        $scopeService = new \org\gocdb\services\Scope();
-        $scopeService->setEntityManager($this->em);
-        $configService = new \org\gocdb\services\Config();
-        $configService->setLocalInfoFileLocation(__DIR__ . '/../../resources/sample_local_info1.xml');
-        $scopeService->setConfigService($configService);
-
-        // exclude all the 'Normal/Non-Reserved' scopes:
-        $filterParams = array('excludeNonReserved' => true);
-        $excludedScopeNames = array('Scope4', 'Scope5', 'Scope6', 'Scope7', 'Scope8', 'Scope9');
-        $filteredScopes = $scopeService->getScopesFilterByParams($filterParams, null);
-        foreach($filteredScopes as $scope){
-            if(in_array($scope->getName(), $excludedScopeNames)){
-               $this->fail("Normal/Non-Reserved scope returned");
-            }
-        }
-        $this->assertEquals(4, count($filteredScopes));
-
-        // excluding all the 'Reserved' scopes should leave 0
-        $filterParams = array('excludeReserved' => true);
-        $filteredScopes = $scopeService->getScopesFilterByParams($filterParams, $filteredScopes);
-        $this->assertEquals(0, count($filteredScopes));
-    }
-
-
-    public function testGetScopesFilterByParams3() {
-        print __METHOD__ . "\n";
-        $this->insertTestScopes();
-        $this->em->flush();
-
-        $scopeService = new \org\gocdb\services\Scope();
-        $scopeService->setEntityManager($this->em);
-        $configService = new \org\gocdb\services\Config();
-        $configService->setLocalInfoFileLocation(__DIR__ . '/../../resources/sample_local_info1.xml');
-        $scopeService->setConfigService($configService);
-
-        // exclude all the 'Default' scopes:
-        $filterParams = array('excludeDefault' => true);
-        $excludedScopeNames = array('Scope0');
-        $filteredScopes = $scopeService->getScopesFilterByParams($filterParams, null);
-        foreach($filteredScopes as $scope){
-            //echo $scope->getName()."\n";
-            if(in_array($scope->getName(), $excludedScopeNames)){
-               $this->fail("Default scope returned");
-            }
-        }
-        $this->assertEquals(9, count($filteredScopes));
-
-        // excluding all the 'Non Default' scopes should leave 0
-        $filterParams = array('excludeNonDefault' => true);
-        $filteredScopes = $scopeService->getScopesFilterByParams($filterParams, $filteredScopes);
-        $this->assertEquals(0, count($filteredScopes));
-    }
-
-    public function testGetScopesFilterByParams4() {
-        print __METHOD__ . "\n";
-        $this->insertTestScopes();
-        $this->em->flush();
-
-        $scopeService = new \org\gocdb\services\Scope();
-        $scopeService->setEntityManager($this->em);
-        $configService = new \org\gocdb\services\Config();
-        $configService->setLocalInfoFileLocation(__DIR__ . '/../../resources/sample_local_info1.xml');
-        $scopeService->setConfigService($configService);
-
-        // exclude all the 'Non Default' scopes:
-        $filterParams = array('excludeNonDefault' => true);
-        $excludedScopeNames = array('Scope1','Scope2','Scope3','Scope4','Scope5','Scope6','Scope7','Scope8','Scope9');
-        $filteredScopes = $scopeService->getScopesFilterByParams($filterParams, null);
-        foreach($filteredScopes as $scope){
-            if(in_array($scope->getName(), $excludedScopeNames)){
-               $this->fail("Default scope returned");
-            }
-        }
-        $this->assertEquals(1, count($filteredScopes));
-
-        // excluding all the 'Default' scopes should leave 0
-        $filterParams = array('excludeDefault' => true);
-        $filteredScopes = $scopeService->getScopesFilterByParams($filterParams, $filteredScopes);
-        $this->assertEquals(0, count($filteredScopes));
-    }
-
-    public function testGetScopesFilterByParams5() {
-        print __METHOD__ . "\n";
-        $this->insertTestScopes();
-        $this->em->flush();
-
-        $scopeService = new \org\gocdb\services\Scope();
-        $scopeService->setEntityManager($this->em);
-        $configService = new \org\gocdb\services\Config();
-        $configService->setLocalInfoFileLocation(__DIR__ . '/../../resources/sample_local_info1.xml');
-        $scopeService->setConfigService($configService);
-
-        $filterParams = array('excludeDefault' => true, 'excludeNonReserved' => true);
-        $excludedScopeNames = array('Scope0', 'Scope4','Scope5','Scope6','Scope7','Scope8','Scope9');
-        // $expectedScopeNames=array('Scope1','Scope2','Scope3');
-        $filteredScopes = $scopeService->getScopesFilterByParams($filterParams, null);
-        foreach($filteredScopes as $scope){
-            //echo $scope->getName()."\n";
-            if(in_array($scope->getName(), $excludedScopeNames)){
-               $this->fail("Default scope returned");
-            }
-        }
-        $this->assertEquals(3, count($filteredScopes));
-    }
-
-
-    /**
-     * @expectedException InvalidArgumentException
-     */
-    public function testGetScopesFilterByParamsUnsupportedParam() {
-        print __METHOD__ . "\n";
-        $scopeService = new \org\gocdb\services\Scope();
-        $scopeService->setEntityManager($this->em);
-        $configService = new \org\gocdb\services\Config();
-        $configService->setLocalInfoFileLocation(__DIR__ . '/../../resources/sample_local_info1.xml');
-        $scopeService->setConfigService($configService);
-
-        $filterParams = array('_excludeNonDefault' => true);
-        $filteredScopes = $scopeService->getScopesFilterByParams($filterParams, null);
-    }
+    $filterParams = array('_excludeNonDefault' => true);
+    $filteredScopes = $scopeService->getScopesFilterByParams($filterParams, null);
+  }
 
 }

--- a/tests/unit/resources/sampleFixtureData5.php
+++ b/tests/unit/resources/sampleFixtureData5.php
@@ -14,40 +14,39 @@
  */
 
 
-        /*
-         * Create test data with the following structure (note p3 has two ngis)
-         *
-         * p1  p2  p3
-         * |   |  /|
-         * n1  n2  n3
-         * |   |   |
-         * s1  s2  s3
-         */
-        $p1 = new \Project("p1");
-        $n1 = TestUtil::createSampleNGI("n1");
-        $s1 = TestUtil::createSampleSite("s1");
-        $this->em->persist($p1);
-        $this->em->persist($n1);
-        $this->em->persist($s1);
-        $n1->addSiteDoJoin($s1);
-        $p1->addNgi($n1);
+/*
+ * Create test data with the following structure (note p3 has two ngis)
+ *
+ * p1  p2  p3
+ * |   |  /|
+ * n1  n2  n3
+ * |   |   |
+ * s1  s2  s3
+ */
+$p1 = new \Project("p1");
+$n1 = TestUtil::createSampleNGI("n1");
+$s1 = TestUtil::createSampleSite("s1");
+$this->em->persist($p1);
+$this->em->persist($n1);
+$this->em->persist($s1);
+$n1->addSiteDoJoin($s1);
+$p1->addNgi($n1);
 
-        $p2 = new \Project("p2");
-        $n2 = TestUtil::createSampleNGI("n2");
-        $s2 = TestUtil::createSampleSite("s2");
-        $this->em->persist($p2);
-        $this->em->persist($n2);
-        $this->em->persist($s2);
-        $n2->addSiteDoJoin($s2);
-        $p2->addNgi($n2);
+$p2 = new \Project("p2");
+$n2 = TestUtil::createSampleNGI("n2");
+$s2 = TestUtil::createSampleSite("s2");
+$this->em->persist($p2);
+$this->em->persist($n2);
+$this->em->persist($s2);
+$n2->addSiteDoJoin($s2);
+$p2->addNgi($n2);
 
-        $p3 = new \Project("p3");
-        $n3 = TestUtil::createSampleNGI("n3");
-        $s3 = TestUtil::createSampleSite("s3");
-        $this->em->persist($p3);
-        $this->em->persist($n3);
-        $this->em->persist($s3);
-        $n3->addSiteDoJoin($s3);
-        $p3->addNgi($n3);
-        $p3->addNgi($n2);     // note the p3 is parent to n2 + n3
-
+$p3 = new \Project("p3");
+$n3 = TestUtil::createSampleNGI("n3");
+$s3 = TestUtil::createSampleSite("s3");
+$this->em->persist($p3);
+$this->em->persist($n3);
+$this->em->persist($s3);
+$n3->addSiteDoJoin($s3);
+$p3->addNgi($n3);
+$p3->addNgi($n2);     // note the p3 is parent to n2 + n3

--- a/tests/unit/resources/sampleFixtureData6.php
+++ b/tests/unit/resources/sampleFixtureData6.php
@@ -14,40 +14,39 @@
  */
 
 
-        /*
-         * Create test data with the following structure (note p3 has two ngis)
-         *
-         * p1  p2  p3
-         * |   |  /|
-         * n1  n2  n3
-         * |   |   |
-         * s1  s2  s3
-         */
-        $p1 = new \Project("p1");
-        $n1 = TestUtil::createSampleNGI("n1");
-        $s1 = TestUtil::createSampleSite("s1");
-        $this->em->persist($p1);
-        $this->em->persist($n1);
-        $this->em->persist($s1);
-        $n1->addSiteDoJoin($s1);
-        $p1->addNgi($n1);
+/*
+ * Create test data with the following structure (note p3 has two ngis)
+ *
+ * p1  p2  p3
+ * |   |  /|
+ * n1  n2  n3
+ * |   |   |
+ * s1  s2  s3
+ */
+$p1 = new \Project("p1");
+$n1 = TestUtil::createSampleNGI("n1");
+$s1 = TestUtil::createSampleSite("s1");
+$this->em->persist($p1);
+$this->em->persist($n1);
+$this->em->persist($s1);
+$n1->addSiteDoJoin($s1);
+$p1->addNgi($n1);
 
-        $p2 = new \Project("p2");
-        $n2 = TestUtil::createSampleNGI("n2");
-        $s2 = TestUtil::createSampleSite("s2");
-        $this->em->persist($p2);
-        $this->em->persist($n2);
-        $this->em->persist($s2);
-        $n2->addSiteDoJoin($s2);
-        $p2->addNgi($n2);
+$p2 = new \Project("p2");
+$n2 = TestUtil::createSampleNGI("n2");
+$s2 = TestUtil::createSampleSite("s2");
+$this->em->persist($p2);
+$this->em->persist($n2);
+$this->em->persist($s2);
+$n2->addSiteDoJoin($s2);
+$p2->addNgi($n2);
 
-        $p3 = new \Project("p3");
-        $n3 = TestUtil::createSampleNGI("n3");
-        $s3 = TestUtil::createSampleSite("s3");
-        $this->em->persist($p3);
-        $this->em->persist($n3);
-        $this->em->persist($s3);
-        $n3->addSiteDoJoin($s3);
-        $p3->addNgi($n3);
-        $p3->addNgi($n2);     // note the p3 is parent to n2 + n3
-
+$p3 = new \Project("p3");
+$n3 = TestUtil::createSampleNGI("n3");
+$s3 = TestUtil::createSampleSite("s3");
+$this->em->persist($p3);
+$this->em->persist($n3);
+$this->em->persist($s3);
+$n3->addSiteDoJoin($s3);
+$p3->addNgi($n3);
+$p3->addNgi($n2);     // note the p3 is parent to n2 + n3


### PR DESCRIPTION
Generally tidy up the test suite a bit:
* Removes a quantity of commented out redundant code from across the test
suite
* Ensure uniform indenting across code within the test suite
* Tidy up some comments
* Change the way some functions are spread across lines
* Remove some empty lines
* Add some curly braces to some if statements (the code works without them, but this improves readability)
* Fix a typo in a comment in one of the unit tests