### PR TITLE
Increase size of new window icons

### DIFF
--- a/htdocs/web_portal/css/web_portal.css
+++ b/htdocs/web_portal/css/web_portal.css
@@ -693,9 +693,10 @@ label.error {
 
 .selectEndpoint{
 }
-/* Registration page */
+
+/* Registration and User pages */
 img.new_window{
-  height: 0.75em;
+  height: 1em;
 }
 
 img.person{


### PR DESCRIPTION
Resolves #166.

This PR increases the size of new window icons from 0.75em to 1em to make them clearer which addresses my original issue with the new icon.

Example from a user page before:
![image](https://user-images.githubusercontent.com/4836233/80359249-75f89d00-8875-11ea-91af-46b7d4b18e32.png)

And after:
![image](https://user-images.githubusercontent.com/4836233/80359343-9de80080-8875-11ea-8d52-076499f86ba5.png)
