### PR TITLE
Align body of STFC logo and clean css for sponsor logos.

### DIFF
--- a/htdocs/landing/home.css
+++ b/htdocs/landing/home.css
@@ -88,8 +88,8 @@ a {
 div.Copyright_Text {
     font-size: 0.8em;
     text-align: center;
-    margin-top: 1em;
-    margin-bottom: 1em;
+    margin: 1em auto;
+    width: 80%;
 }
 
 a.docLink {

--- a/htdocs/landing/home.css
+++ b/htdocs/landing/home.css
@@ -44,11 +44,11 @@ h1,h2,h3 {
 /* h2-4 are only used in the Privacy and AUP policy notices */
 
 h2 {
-    font-size: 2.0em;	
+    font-size: 2.0em;
 }
 
 h3 {
-    font-size: 1.5em;	
+    font-size: 1.5em;
     line-height: 1;
 }
 
@@ -63,7 +63,7 @@ a {
     margin-bottom: 0em;
 }
 
-.page_container,.wide_page_container { 
+.page_container,.wide_page_container {
     position: relative;
     margin-left: auto;
     margin-right: auto;
@@ -100,9 +100,20 @@ a:hover {
     text-decoration: underline;
 }
 
-img.Sponsor_Logo {
-  max-height: 100%;
-  border: none; /* for IE(11) */
+a.Sponsor_Link img.Sponsor_Logo {
+    display:inline-block;
+    vertical-align: bottom;
+    height: 100%;
+}
+
+a.Sponsor_Link:hover {
+    text-decoration: none;
+}
+
+/* Put a small gap between the clickable area of the sponsor logos */
+a.Sponsor_Link {
+    margin-left: 3px;
+    margin-right: 3px;
 }
 
 h1.Landing_Welcome {
@@ -112,8 +123,8 @@ h1.Landing_Welcome {
 /* The GOCDB cloverleaf */
 
 img.Landing_Logo {
-  display: inline-block; 
-  vertical-align:top; 
+  display: inline-block;
+  vertical-align:top;
   margin-right: 1em;
 }
 

--- a/htdocs/landing/index.html
+++ b/htdocs/landing/index.html
@@ -45,7 +45,13 @@
               </a>
           </div>
           <div class="Copyright_Text">
-            <p>The GOCDB service is provided by <a href="https://stfc.ukri.org/">STFC</a>, part of UK Research and Innovation, for <a href="https://egi.eu">EGI</a>, co-funded by <a href="https://egi.eu">EGI.eu</a> and <a href="https://eosc-hub.eu">EOSC-hub</a>. Licensed under the <a href="https://www.apache.org/licenses/LICENSE-2.0">Apache 2 License</a>.</p>
+            <p>The GOCDB service is provided by <a class="docLink" href="https://stfc.ukri.org/">STFC</a>,
+              part of <a class="docLink" href="https://www.ukri.org">UK Research and Innovation</a>,
+              for <a class="docLink" href="https://egi.eu">EGI</a>,
+              co-funded by <a class="docLink" href="https://egi.eu">EGI.eu</a> and
+              <a class="docLink hover" href="https://eosc-hub.eu">EOSC-hub</a>.
+              Licensed under the <a class="docLink" href="https://www.apache.org/licenses/LICENSE-2.0">Apache 2 License</a>.
+            </p>
           </div>
         </div>
       </div>

--- a/htdocs/landing/index.html
+++ b/htdocs/landing/index.html
@@ -24,14 +24,28 @@
             <a href="/portal/" class="button">Access GOCDB</a>
             <p>Browse the <a href="https://wiki.egi.eu/wiki/GOCDB" class="docLink hover">GOCDB documentation index</a> on the EGI wiki.</p>
           </div>
-          <div style="height: 30px">
-            <a href="https://stfc.ukri.org" target="_blank"> <img class="Sponsor_Logo" src="UKRI_STF_Council-Logo_Horiz-RGB.png" alt="The logo of the Science and Technology Facilities Council" /> </a>
-            <a href="https://europa.eu/european-union/index_en" target="_blank"> <img class="Sponsor_Logo" src="eu_flag_yellow_low_150.png" alt="The logo of the European Union" /> </a>
-            <a href="https://www.egi.eu" target="_blank"> <img class="Sponsor_Logo" src="egi_logo_no_background_150.png" alt="The logo of the E G I Foundation" /> </a>
-            <a href="https://eosc-hub.eu/" target="_blank"> <img class="Sponsor_Logo" src="eosc-hub-v-web_150.png" alt="The logo of the EOSC-hub Horizon 20 20 project" /> </a>
+
+          <div style="height:34px;">
+              <a href="https://stfc.ukri.org" class="Sponsor_Link" target="_blank">
+                <!-- Allow for STFC council symbol extending above the upper bound of the UKRI symbol -->
+                <img  style="height: 112%; margin-top: -12%;" class="Sponsor_Logo"
+                src="UKRI_STF_Council-Logo_Horiz-RGB.png"
+                alt="The logo of the Science and Technology Facilities Council" /></a>
+              <a href="https://europa.eu/european-union/index_en" class="Sponsor_Link" target="_blank">
+                <img class="Sponsor_Logo" src="eu_flag_yellow_low_150.png"
+                alt="The logo of the European Union" />
+              </a>
+              <a href="https://www.egi.eu" class="Sponsor_Link" target="_blank">
+                <img class="Sponsor_Logo" src="egi_logo_no_background_150.png"
+                alt="The logo of the E G I Foundation" />
+              </a>
+              <a href="https://eosc-hub.eu/" class="Sponsor_Link" target="_blank">
+                <img class="Sponsor_Logo" src="eosc-hub-v-web_150.png"
+                alt="The logo of the EOSC-hub Horizon 20 20 project" />
+              </a>
           </div>
           <div class="Copyright_Text">
-            <p>The GOCDB service is provided by <a href="https://stfc.ukri.org/">STFC</a> for <a href="https://egi.eu">EGI</a>, co-funded by <a href="https://egi.eu">EGI.eu</a> and <a href="https://eosc-hub.eu">EOSC-hub</a>. Licensed under the <a href="https://www.apache.org/licenses/LICENSE-2.0">Apache 2 License</a>.</p>
+            <p>The GOCDB service is provided by <a href="https://stfc.ukri.org/">STFC</a>, part of UK Research and Innovation, for <a href="https://egi.eu">EGI</a>, co-funded by <a href="https://egi.eu">EGI.eu</a> and <a href="https://eosc-hub.eu">EOSC-hub</a>. Licensed under the <a href="https://www.apache.org/licenses/LICENSE-2.0">Apache 2 License</a>.</p>
           </div>
         </div>
       </div>

--- a/htdocs/web_portal/components/Draw_Components/draw_page_components.php
+++ b/htdocs/web_portal/components/Draw_Components/draw_page_components.php
@@ -123,10 +123,32 @@
         $HTML = "";
         $HTML .= '<div class="Left_Logo_Box left_box_menu">';
         $HTML .= '<div class="Left_Logo_Row">';
-        $HTML .= '<a href="https://stfc.ukri.org/" target="_blank"><img class="Left_Logo_Image" style="margin: 0px 5px 0px 0px;" src="'.\GocContextPath::getPath().'img/UKRI_STF_Council-Logo_Horiz-RGB_crop.png" alt="The logo of the Science and Technology Facilities Council" /></a>';
-        $HTML .= '<a href="https://europa.eu/european-union/index_en" target="_blank"><img class="Left_Logo_Image" src="'.\GocContextPath::getPath().'img/eu_flag_yellow_low_150.png" alt="The logo of the European Union" /></a>&nbsp;&nbsp;';
-        $HTML .= '<a href="https://www.egi.eu" target="_blank"><img class="Left_Logo_Image" src="'.\GocContextPath::getPath().'img/egi_logo_no_background_150.png" alt="The logo of the E G I Foundation" /></a>';
-        $HTML .= '<a href="https://www.eosc-hub.eu/" target="_blank"><img class="Left_Logo_Image" style="margin: 0px 0px 0px 5px" src="'.\GocContextPath::getPath().'img/eosc-hub-v-web_150.png" alt="The logo of the EOSC-hub Horizon 20 20 project" /></a>';
+
+        $HTML .= '<a href="https://stfc.ukri.org/" class="Sponsor_Link" target="_blank">'.
+                    /* Allow for STFC council symbol extending above the upper bound of the UKRI symbol */
+                    '<img style="height: 112%; margin-top: -12%" class="Sponsor_Logo" '.
+                    'src="'.\GocContextPath::getPath().'img/UKRI_STF_Council-Logo_Horiz-RGB_crop.png" '.
+                    'alt="The logo of the Science and Technology Facilities Council" />'.
+                    '</a>';
+
+        $HTML .= '<a href="https://europa.eu/european-union/index_en" class="Sponsor_Link" target="_blank">'.
+                    '<img class="Sponsor_Logo" '.
+                    'src="'.\GocContextPath::getPath().'img/eu_flag_yellow_low_150.png" '.
+                    'alt="The logo of the European Union" />'.
+                    '.</a>';
+
+        $HTML .= '<a href="https://www.egi.eu" class="Sponsor_Link" target="_blank">'.
+                    '<img class="Sponsor_Logo" '.
+                    'src="'.\GocContextPath::getPath().'img/egi_logo_no_background_150.png" '.
+                    'alt="The logo of the E G I Foundation" />
+                    </a>';
+
+        $HTML .= '<a href="https://www.eosc-hub.eu/" class="Sponsor_Link" target="_blank">'.
+                    '<img class="Sponsor_Logo" '.
+                    'src="'.\GocContextPath::getPath().'img/eosc-hub-v-web_150.png" '.
+                    'alt="The logo of the EOSC-hub Horizon 20 20 project" />'.
+                    '</a>';
+
         $HTML .= '</div>';
         $HTML .= 'GOCDB is provided by <a href="https://stfc.ukri.org/">STFC</a> for <a href="https://egi.eu">EGI</a>, co-funded by <a href="https://egi.eu">EGI.eu</a> and <a href="https://www.eosc-hub.eu/">EOSC-hub.</a>';
 	      $HTML .= '<br>- ';

--- a/htdocs/web_portal/css/web_portal.css
+++ b/htdocs/web_portal/css/web_portal.css
@@ -37,7 +37,7 @@ table.tablesorter thead tr .headerSortDown, table.tablesorter thead tr .headerSo
 
 
 
-body {  
+body {
     background: linear-gradient(to bottom left,#F7F9FE, #DEE9FB, #D0DFF9);
     color: #272A4B;
     font-family: 'PT Sans', sans-serif;
@@ -105,14 +105,14 @@ h1 {
 }
 
 
- 
+
 /*
     *	Containing DIV's
 	*	Page Container is the whole page
 	*	Left Box is the menu
 	*	Right Box is the smaller page contents
 	*/
-.page_container { 
+.page_container {
     position: relative;
     margin-left: auto;
     margin-right: auto;
@@ -166,8 +166,14 @@ div.Left_Logo_Row {
     margin-bottom: 5px;
 }
 
-img.Left_Logo_Image {
-    max-height: 100%;
+a.Sponsor_Link img.Sponsor_Logo {
+    display:inline-block;
+    vertical-align: bottom;
+    height: 100%;
+}
+
+a.Sponsor_Link:hover {
+    text-decoration: none;
 }
 
 div.Indented {
@@ -186,7 +192,7 @@ div.Indented {
 
 .Logo_Text {
     display: inline;
-} 
+}
 
 .logo_image {
     display: inline;
@@ -512,8 +518,8 @@ img.decoration {
 
 img.titleIcon{
     height:25px;
-    float: right; 
-    margin:2% 1% 1% 0%; 
+    float: right;
+    margin:2% 1% 1% 0%;
 }
 
 input.vSiteSearch {
@@ -576,7 +582,7 @@ img.centered {
 
 span.topMargin {
     margin-top: 1em;
-}	
+}
 
 span.block {
     display: block;
@@ -647,7 +653,7 @@ div.rightPageContainer {
     border: 1px solid #B4B4B4;
     padding: 1em;
     border-radius: 0.4em;
-    
+
 }
 
 div.tableContainer {
@@ -673,8 +679,8 @@ div.tableContainer {
 
 .smallLabelText{
     margin-left:8px;
-    font-size:11px; 
-    font-weight: normal; 
+    font-size:11px;
+    font-weight: normal;
     font-style:italic;
     display:inline-block;
 }
@@ -688,7 +694,7 @@ label.error {
 }
 
 .selectService{
-    background-color: #D5D5D5;	
+    background-color: #D5D5D5;
 }
 
 .selectEndpoint{


### PR DESCRIPTION
Aligns the top of the UKRI logo with the top of the other sponsor logos on the landing and in the left menu, allowing the STFC council symbol to project above the upper line, to better balance the visual weight of the logos. Is stable with IE11 so long as compatibility mode is not enabled. Also increases the size of the logos on the landing page slightly to avoid tiny-font syndrome. Some cleaning of the CSS classes and associated code. Added "part of UK Research and Innovation" to landing page acknowledgement.

Before -
![image](https://user-images.githubusercontent.com/20706670/86373276-28d0e700-bc7b-11ea-8928-580866f7b048.png)
![image](https://user-images.githubusercontent.com/20706670/86373599-7baa9e80-bc7b-11ea-8324-51da47efc8b7.png)

After -
![image](https://user-images.githubusercontent.com/20706670/86373829-c2989400-bc7b-11ea-91e3-0879f8694d67.png)
![image](https://user-images.githubusercontent.com/20706670/86373700-97ae4000-bc7b-11ea-98eb-297dd0d70345.png)


