### PR TITLE
Add base directory .htaccess to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 
-# Generic 
+# Generic
 =====================
 *~
 
@@ -16,6 +16,7 @@ composer.bat
 composer
 gocdb.log
 tests/coverageReports/
+/.htaccess
 
 # Eclipse: https://github.com/github/gitignore/blob/master/Global/Eclipse.gitignore
 # =====================
@@ -71,7 +72,7 @@ local.properties
 
 
 
-# Netbeans: https://github.com/github/gitignore/blob/master/Global/NetBeans.gitignore 
+# Netbeans: https://github.com/github/gitignore/blob/master/Global/NetBeans.gitignore
 # =====================
 nbproject/
 nbproject/private/


### PR DESCRIPTION
When testing on a active web-serving instance, this prevents .htaccess showing up as untracked in git.