### PR TITLE
Unregistered user protected messages fix

### DIFF
--- a/htdocs/web_portal/views/ngi/view_ngi.php
+++ b/htdocs/web_portal/views/ngi/view_ngi.php
@@ -54,7 +54,7 @@
                             <a href="mailto:<?php xecho($params['ngi']->getEmail()) ?>">
                                 <?php xecho($params['ngi']->getEmail()) ?>
                             </a>
-                            <?php } else {echo('PROTECTED - Auth Required');} ?>
+                            <?php } else {echo('PROTECTED - Registration required');} ?>
                         </td>
                     </tr>
                     <tr class="site_table_row_2">
@@ -63,7 +63,7 @@
                             <a href="mailto:<?php xecho($params['ngi']->getRodEmail()) ?>">
                             <?php xecho($params['ngi']->getRodEmail()) ?>
                             </a>
-                            <?php } else {echo('PROTECTED - Auth Required');} ?>
+                            <?php } else {echo('PROTECTED - Registration required');} ?>
                         </td>
                     </tr>
                     <tr class="site_table_row_1">
@@ -72,7 +72,7 @@
                             <a href="mailto:<?php xecho($params['ngi']->getHelpdeskEmail()) ;?>">
                             <?php xecho($params['ngi']->getHelpdeskEmail()) ?>
                             </a>
-                            <?php } else {echo('PROTECTED - Auth Required');} ?>
+                            <?php } else {echo('PROTECTED - Registration required');} ?>
                         </td>
                     </tr>
                     <tr class="site_table_row_2">
@@ -81,14 +81,14 @@
                             <a href="mailto:<?php echo $params['ngi']->getSecurityEmail() ?>">
                             <?php xecho($params['ngi']->getSecurityEmail()) ?>
                             </a>
-                            <?php } else {echo('PROTECTED - Auth Required');} ?>
+                            <?php } else {echo('PROTECTED - Registration required');} ?>
                         </td>
                     </tr>
                     <tr class="site_table_row_1">
                         <td class="site_table" style="width: 30%">GGUS Support Unit</td><td class="site_table">
                             <?php if($params['authenticated']) { ?>
                             <?php xecho($params['ngi']->getGgus_Su()) ?>
-                            <?php } else {echo('PROTECTED - Auth Required');} ?>
+                            <?php } else {echo('PROTECTED - Registration required');} ?>
                         </td>
                     </tr>
                 </table>

--- a/htdocs/web_portal/views/search_results.php
+++ b/htdocs/web_portal/views/search_results.php
@@ -167,7 +167,7 @@
                                         if ($params['authenticated']) {
                                             xecho($user->getEmail());
                                         } else {
-                                            echo 'PROTECTED - Authentication required';
+                                            echo 'PROTECTED - Registration required';
                                         }
                                     ?>
                                 </td>

--- a/htdocs/web_portal/views/service/view_service.php
+++ b/htdocs/web_portal/views/service/view_service.php
@@ -60,14 +60,14 @@ $configService = \Factory::getConfigService();
                     <td class="site_table">IP Address</td><td class="site_table">
                         <?php if ($params['authenticated']) {
                           xecho($se->getIpAddress());
-                        }else echo('PROTECED - Auth required');  ?>
+                        }else echo('PROTECTED - Auth required');  ?>
                     </td>
                 </tr>
                 <tr class="site_table_row_1">
                     <td class="site_table">IP v6 Address</td><td class="site_table">
                         <?php if ($params['authenticated']) {
                             xecho($se->getIpV6Address());
-                        } else echo('PROTECED - Auth required'); ?>
+                        } else echo('PROTECTED - Auth required'); ?>
                     </td>
                 </tr>
                 <tr class="site_table_row_2">

--- a/htdocs/web_portal/views/service/view_service.php
+++ b/htdocs/web_portal/views/service/view_service.php
@@ -86,12 +86,9 @@ $configService = \Factory::getConfigService();
                 </tr>
                 <tr class="site_table_row_2">
                     <td class="site_table">Contact E-Mail</td><td class="site_table">
-                    <?php if (!$params['authenticated']) : ?>
-                            PROTECTED - Registration required
-                    <?php endif; ?>
-                    <?php if ($params['authenticated']) : ?>
-                            <?php xecho($se->getEmail()) ?>
-                    <?php endif; ?>
+                        <?php if ($params['authenticated']) {
+                            xecho($se->getEmail());
+                        } else echo('PROTECTED - Registration required'); ?>
                     </td>
                 </tr>
                 <tr class="site_table_row_1">

--- a/htdocs/web_portal/views/service/view_service.php
+++ b/htdocs/web_portal/views/service/view_service.php
@@ -53,41 +53,41 @@ $configService = \Factory::getConfigService();
                     <td class="site_table">Host name</td><td class="site_table">
                         <?php if ($params['authenticated']) {
                             xecho($se->getHostName());
-                        } else echo('PROTECTED - Auth required'); ?>
+                        } else echo('PROTECTED - Registration required'); ?>
                     </td>
                 </tr>
                 <tr class="site_table_row_2">
                     <td class="site_table">IP Address</td><td class="site_table">
                         <?php if ($params['authenticated']) {
                           xecho($se->getIpAddress());
-                        }else echo('PROTECTED - Auth required');  ?>
+                        }else echo('PROTECTED - Registration required');  ?>
                     </td>
                 </tr>
                 <tr class="site_table_row_1">
                     <td class="site_table">IP v6 Address</td><td class="site_table">
                         <?php if ($params['authenticated']) {
                             xecho($se->getIpV6Address());
-                        } else echo('PROTECTED - Auth required'); ?>
+                        } else echo('PROTECTED - Registration required'); ?>
                     </td>
                 </tr>
                 <tr class="site_table_row_2">
                     <td class="site_table">Operating System</td><td class="site_table">
                         <?php if ($params['authenticated']) {
                             xecho($se->getOperatingSystem());
-                        } else echo('PROTECTED - Auth required'); ?>
+                        } else echo('PROTECTED - Registration required'); ?>
                     </td>
                 </tr>
                 <tr class="site_table_row_1">
                     <td class="site_table">Architecture</td><td class="site_table">
                         <?php if ($params['authenticated']) {
                             xecho($se->getArchitecture());
-                        } else echo('PROTECTED - Auth required'); ?>
+                        } else echo('PROTECTED - Registration required'); ?>
                     </td>
                 </tr>
                 <tr class="site_table_row_2">
                     <td class="site_table">Contact E-Mail</td><td class="site_table">
                     <?php if (!$params['authenticated']) : ?>
-                            PROTECTED - Auth required
+                            PROTECTED - Registration required
                     <?php endif; ?>
                     <?php if ($params['authenticated']) : ?>
                             <?php xecho($se->getEmail()) ?>
@@ -119,7 +119,7 @@ $configService = \Factory::getConfigService();
                         <div style="word-wrap: break-word;">
                                 <?php if ($params['authenticated']) {
                                     xecho($se->getDn()) ;
-                                } else echo('PROTECTED - Auth required'); ?>
+                                } else echo('PROTECTED - Registration required'); ?>
                         </div>
                     </td>
                 </tr>

--- a/htdocs/web_portal/views/service_group/view_sgroup.php
+++ b/htdocs/web_portal/views/service_group/view_sgroup.php
@@ -85,7 +85,7 @@ $extensionProperties = $params['sGroup']->getServiceGroupProperties();
                         <a href="mailto:<?php xecho($params['sGroup']->getEmail()); ?>">
                             <?php xecho($params['sGroup']->getEmail()); ?>
                         </a>
-                        <?php } else {echo('PROTECTED - Auth Required');} ?>
+                        <?php } else {echo('PROTECTED - Registration required');} ?>
                     </td>
                 </tr>
             </table>

--- a/htdocs/web_portal/views/site/view_site.php
+++ b/htdocs/web_portal/views/site/view_site.php
@@ -58,7 +58,7 @@ $extensionProperties = $site->getSiteProperties();
                 <a href="mailto:<?php xecho($site->getEmail()) ?>">
                 <?php xecho($site->getEmail()) ?>
                 </a>
-            <?php } else echo('PROTECTED - Auth Required'); ?>
+            <?php } else echo('PROTECTED - Registration required'); ?>
             </td>
         </tr>
         <tr class="site_table_row_2">
@@ -66,7 +66,7 @@ $extensionProperties = $site->getSiteProperties();
             if ($params['authenticated']) {
                 xecho($site->getTelephone());
             } else
-                echo('PROTECTED - Auth Required');
+                echo('PROTECTED - Registration required');
             ?></td>
         </tr>
         <tr class="site_table_row_1">
@@ -74,7 +74,7 @@ $extensionProperties = $site->getSiteProperties();
             if ($params['authenticated']) {
                 xecho($site->getEmergencyTel());
             } else
-                echo('PROTECTED - Auth Required');
+                echo('PROTECTED - Registration required');
             ?></td>
         </tr>
         <tr class="site_table_row_2">
@@ -82,7 +82,7 @@ $extensionProperties = $site->getSiteProperties();
             if ($params['authenticated']) {
                 xecho($site->getCsirtTel());
             } else
-                echo('PROTECTED - Auth Required')
+                echo('PROTECTED - Registration required')
                 ?></td>
         </tr>
         <tr class="site_table_row_1">
@@ -92,7 +92,7 @@ $extensionProperties = $site->getSiteProperties();
                 <a href="mailto:<?php xecho($site->getCsirtEmail()) ?>">
                 <?php xecho($site->getCsirtEmail()) ?>
                 </a>
-            <?php } else echo('PROTECTED - Auth Required'); ?>
+            <?php } else echo('PROTECTED - Registration required'); ?>
             </td>
         </tr>
         <tr class="site_table_row_2">
@@ -102,7 +102,7 @@ $extensionProperties = $site->getSiteProperties();
                 <a href="mailto:<?php xecho($site->getEmergencyEmail()) ?>">
                 <?php xecho($site->getEmergencyEmail()) ?>
                 </a>
-            <?php } else echo('PROTECTED - Auth Required'); ?>
+            <?php } else echo('PROTECTED - Registration required'); ?>
             </td>
         </tr>
         <tr class="site_table_row_1">
@@ -112,7 +112,7 @@ $extensionProperties = $site->getSiteProperties();
                 <a href="mailto:<?php xecho($site->getHelpdeskEmail()); ?>">
                 <?php xecho($site->getHelpdeskEmail()) ?>
                 </a>
-            <?php } else echo('PROTECTED - Auth Required'); ?>
+            <?php } else echo('PROTECTED - Registration required'); ?>
             </td>
         </tr>
         <tr class="site_table_row_2">
@@ -154,7 +154,7 @@ $extensionProperties = $site->getSiteProperties();
                 <?php if (!$portalIsReadOnly): ?>
                 <a href="index.php?Page_Type=Edit_Certification_Status&amp;id=<?php echo($site->getId()) ?>">Change</a>
                 <?php endif; ?>
-            <?php } else echo('PROTECTED - Auth Required'); ?>
+            <?php } else echo('PROTECTED - Registration required'); ?>
                     </td>
                 </tr>
 
@@ -203,7 +203,7 @@ $extensionProperties = $site->getSiteProperties();
                 <a href="<?php xecho($site->getHomeUrl()) ?>">
                 <?php xecho($site->getHomeUrl()) ?>
                 </a>
-            <?php } else echo('PROTECTED - Auth Required'); ?>
+            <?php } else echo('PROTECTED - Registration required'); ?>
             </td>
                 </tr>
                 <tr class="site_table_row_2">
@@ -213,7 +213,7 @@ $extensionProperties = $site->getSiteProperties();
             if ($params['authenticated']) {
                 xecho($site->getGiisUrl());
             } else
-                echo('PROTECTED - Auth Required');
+                echo('PROTECTED - Registration required');
             ?>
                     </td>
                 </tr>
@@ -224,7 +224,7 @@ $extensionProperties = $site->getSiteProperties();
             if ($params['authenticated']) {
                 xecho($site->getIpRange());
             } else
-                echo('PROTECTED - Auth Required');
+                echo('PROTECTED - Registration required');
             ?>
                     </td>
                 </tr>
@@ -235,7 +235,7 @@ $extensionProperties = $site->getSiteProperties();
             if ($params['authenticated']) {
                 xecho($site->getIpV6Range());
             } else
-                echo('PROTECTED - Auth Required');
+                echo('PROTECTED - Registration required');
             ?>
                     </td>
                 </tr>
@@ -246,7 +246,7 @@ $extensionProperties = $site->getSiteProperties();
                             if ($params['authenticated']) {
                                 xecho($site->getDomain());
                             } else
-                                echo('PROTECTED - Auth Required');
+                                echo('PROTECTED - Registration required');
                         ?>
                     </td>
                 </tr>


### PR DESCRIPTION
Resolves #248.

This PR corrects the spelling and also improves the messages, wherever they occur in the codebase, to clarify that registration is required and not just "auth" as you need a grid cert to get that far anyway.

Also makes the PHP logic around one of the instances consistent with the others in the same file.