### PR TITLE
Update to titles for users

### DIFF
--- a/config/gocdb_schema.xml
+++ b/config/gocdb_schema.xml
@@ -243,7 +243,7 @@
 	<field>
 	    <fname>TITLE</fname>
 	    <length>255</length>
-	    <regex>/^[a-zA-Z\s\-']+$/</regex>
+	    <regex>/^[a-zA-Z\s\-']*$/</regex>
 	</field>
 	<field>
 	    <fname>CERTIFICATE_DN</fname>

--- a/htdocs/web_portal/views/user/edit_user.php
+++ b/htdocs/web_portal/views/user/edit_user.php
@@ -6,7 +6,7 @@
             Title
         </span>
         <?php
-            $titles = array('Mr', 'Mrs', 'Miss', 'Ms', 'Prof', 'Dr');
+          $titles = array('', 'Dr', 'Miss', 'Mr', 'Mrs',  'Ms', 'Mx', 'Prof');
         ?>
         <select name="TITLE" class="add_edit_form">
         <?php

--- a/htdocs/web_portal/views/user/register.php
+++ b/htdocs/web_portal/views/user/register.php
@@ -13,7 +13,7 @@
             <ul>
                <li>By registering a GOCDB account you are agreeing to abide by the <a href="/aup.html" target="_blank" title="opens in new window">GOCDB Acceptable Use Policy and Conditions of Use <img src="/portal/img/new_window.png" alt="new window logo" class="new_window"></a>.
                </li>
-               <li>Personal data, which you provide below and that is collected when you use GOCDB, will be processed in accordance with the <a href="/privacy.html" target="_blank" title="opens in new window">GOCDB Privacy Notice <img src="/portal/img/new_window.png" alt="new window logo"  class="new_window"></a>. 
+               <li>Personal data, which you provide below and that is collected when you use GOCDB, will be processed in accordance with the <a href="/privacy.html" target="_blank" title="opens in new window">GOCDB Privacy Notice <img src="/portal/img/new_window.png" alt="new window logo"  class="new_window"></a>.
                </li><br>
                <li>Please read both the above documents before registering your account.
               </li>
@@ -42,14 +42,15 @@
         <span class="input_name">
             Title
         </span>
-
+        <?php
+            $titles = array('', 'Dr', 'Miss', 'Mr', 'Mrs',  'Ms', 'Mx', 'Prof');
+        ?>
         <select name="TITLE" class="add_edit_form">
-            <option value="Mr">Mr</option>
-            <option value="Mrs">Mrs</option>
-            <option value="Miss">Miss</option>
-            <option value="Ms">Ms</option>
-            <option value="Prof">Prof</option>
-            <option value="Dr">Dr</option>
+          <?php
+            foreach($titles as $title) {
+              echo '<option value="'.$title.'">'.$title.'</option>';
+            }
+          ?>
         </select>
 
         <span class="input_name">


### PR DESCRIPTION
Fixes #176. On user edit and registration pages:

* Add title 'Mx'
* Add option for empty title
* Update Gocdb schema to allow empty string titles (simpler to
maintain than having a null option on the drop down)
* Reorder titles to be in alphabetical order

I have tested the edit page. I have not been able to test the registration page (though the code is very similar). It should be tested before merging.