### PR TITLE
Add styling to read only message

### DIFF
--- a/htdocs/web_portal/static_html/read_only_warning.html
+++ b/htdocs/web_portal/static_html/read_only_warning.html
@@ -1,1 +1,3 @@
-<div style="color:red;">Read only Mode</div>
+<div style="float: left; margin-left: 4px; color:red;">
+  <p>READ ONLY MODE</p>
+</div>


### PR DESCRIPTION
Resolves #65 (which isn't quite 4 years old yet).

This corrects the placement of the message so it appears below the GOCDB + version line and also changes it to all caps to make it more obvious.

Only tested by making edits through Firefox Web Dev tools Inspector, though it only touches HTML so should be safe, but actual testing would be a good idea.