### PR TITLE
URL-based configuration monitoring fixes

### DIFF
--- a/htdocs/web_portal/GOCDB_monitor/check.php
+++ b/htdocs/web_portal/GOCDB_monitor/check.php
@@ -23,7 +23,7 @@ foreach ($res as $r){
 
 if ($counts["error"] != 0) {
     echo("An error has been detected while checking GOCDB services. ".
-            "Please check https://goc.egi.eu/portal/GOCDB_monitor/ to find out more\n");
+        "Please check https://goc.egi.eu/portal/GOCDB_monitor/ to find out more\n");
     exit(2); // return Nagios error code for CRITICAL
 }
 else if ($counts["warn"] != 0) {

--- a/htdocs/web_portal/GOCDB_monitor/check.php
+++ b/htdocs/web_portal/GOCDB_monitor/check.php
@@ -2,9 +2,14 @@
 require_once "tests.php";
 
 $res[1] = test_db_connection();
-$res[2] = test_url(PI_URL);
+$res[2] = test_url(
+            Factory::getConfigService()->GetPiUrl().
+            get_testPiMethod()
+            );
 //$res[3] = test_url(PORTAL_URL);
-$res[3] = test_url(SERVER_BASE_URL);
+$res[3] = test_url(
+            Factory::getConfigService()->getServerBaseUrl()
+            );
 
 
 $counts=array(	"ok" => 0,
@@ -17,7 +22,8 @@ foreach ($res as $r){
 }
 
 if ($counts["error"] != 0) {
-    echo("An error has been detected while checking GOCDB services. Please check https://goc.egi.eu/portal/GOCDB_monitor/ to find out more\n");
+    echo("An error has been detected while checking GOCDB services. ".
+            "Please check https://goc.egi.eu/portal/GOCDB_monitor/ to find out more\n");
     exit(2); // return Nagios error code for CRITICAL
 }
 else if ($counts["warn"] != 0) {

--- a/htdocs/web_portal/GOCDB_monitor/index.php
+++ b/htdocs/web_portal/GOCDB_monitor/index.php
@@ -6,9 +6,15 @@
 require_once __DIR__ . '/tests.php';
 
 echo "<p>URLs as defined by local_info.xml</p>";
-echo "<p>PI URL is: ".PI_URL."</p>";
-echo "<p>Portal URl is: ".PORTAL_URL."</p>";
-echo "<p>Server Base URL is: ".SERVER_BASE_URL."</p>";
+
+$piUrl = Factory::getConfigService()->GetPiUrl().get_testPiMethod();
+echo "<p>PI URL is: ".$piUrl."</p>";
+
+$portalUrl = Factory::getConfigService()->GetPortalURL();
+echo "<p>Portal URl is: ".$portalUrl."</p>";
+
+$baseUrl = Factory::getConfigService()->getServerBaseUrl();
+echo "<p>Server Base URL is: ".$baseUrl."</p>";
 
 // GOCDB5 DB connection
 $res = test_db_connection();
@@ -16,12 +22,12 @@ $test_statuses["GOCDB5 DB connection"] = $res["status"];
 $test_messages["GOCDB5 DB connection"] = $res["message"];
 
 // GOCDBPI v5
-$res = test_url(PI_URL);
+$res = test_url($piUrl);
 $test_statuses["GOCDBPI_v5 availability"] = $res["status"];
 $test_messages["GOCDBPI_v5 availability"] = $res["message"];
 
 // GOCDB5 web portal
-$res = test_url(SERVER_BASE_URL);
+$res = test_url($portalUrl);
 $test_statuses["GOCDB5 central portal availability"] = $res["status"];
 $test_messages["GOCDB5 central portal availability"] = $res["message"];
 

--- a/htdocs/web_portal/GOCDB_monitor/ops_monitor_check.php
+++ b/htdocs/web_portal/GOCDB_monitor/ops_monitor_check.php
@@ -3,9 +3,13 @@ require_once "tests.php";
 
 // function returns associative array
 $res[1] = test_db_connection();
-$res[2] = test_url(PI_URL);
+//$res[2] = test_url(PI_URL);
+$res[2] = test_url(Factory::getConfigService()->GetPiUrl().get_testPiMethod());
+
 //$res[3] = test_url(PORTAL_URL);
-$res[3] = test_url(SERVER_BASE_URL);
+
+//$res[3] = test_url(SERVER_BASE_URL);
+$res[3] = test_url(Factory::getConfigService()->getServerBaseUrl());
 
 $counts=array(
         "ok" => 0,

--- a/htdocs/web_portal/GOCDB_monitor/tests.php
+++ b/htdocs/web_portal/GOCDB_monitor/tests.php
@@ -1,18 +1,10 @@
 <?php
+require_once __DIR__ . '/../../../lib/Gocdb_Services/Factory.php';
 
-$localInfoLocation = __DIR__."/../../../config/local_info.xml";
-$localInfoXML = simplexml_load_file($localInfoLocation);
-$webPortalURL = $localInfoXML->local_info->web_portal_url;
-$piURL = $localInfoXML->local_info->pi_url; // e.g. https://localhost/gocdbpi
-$baseURL = $localInfoXML->local_info->server_base_url;
-
-
-define("PI_URL", $piURL."/public/?method=get_site_list"); //https://localhost/gocdbpi/public/?method=get_site_list
-define("PORTAL_URL", $webPortalURL);
-define("SERVER_BASE_URL", $baseURL);
-//define("SERVER_SSLCERT", "/etc/grid-security/hostcert.pem");
-//define("SERVER_SSLKEY", "/etc/pki/tls/private/hostkey.pem");
-
+// Initialise the configuration service.
+// If non-default location for xml configuration file is needed
+// use Factory::ConfigService->setLocalInfoFileLocation(...)
+\Factory::getConfigService()->setLocalInfoOverride($_SERVER['SERVER_NAME']);
 
 $test_statuses =  array(
         "GOCDB5 DB connection" 						=> "unknown",
@@ -40,16 +32,14 @@ $test_messages =  array(
 );
 
 $disp = array(
-        "unknown" => "<td align='center' bgcolor='#A0A0A0'><font size='1'><i>unknown</i></font></td>",
-        "warn" => "<td align='center' bgcolor='#FFAA00'><font size='1'>WARNING</font></td>",
-        "error" => "<td align='center' bgcolor='#F00000'><font size='1'>ERROR</font></td>",
-        "ok" => "<td align='center' bgcolor='#00D000'><font size='1'>OK</font></td>",
+        "unknown"   => "<td align='center' bgcolor='#A0A0A0'><font size='1'><i>unknown</i></font></td>",
+        "warn"      => "<td align='center' bgcolor='#FFAA00'><font size='1'>WARNING</font></td>",
+        "error"     => "<td align='center' bgcolor='#F00000'><font size='1'>ERROR</font></td>",
+        "ok"        => "<td align='center' bgcolor='#00D000'><font size='1'>OK</font></td>",
 );
 
 // Test the connection to the database using Doctrine
 function test_db_connection(){
-    require_once __DIR__ . '/../../../lib/Gocdb_Services/Factory.php';
-
     try {
         $entityManager = Factory::getNewEntityManager();
         $entityManager->getConnection()->connect();
@@ -110,6 +100,10 @@ function get_https2($url){
     }
 
     return $return;
+}
+
+function get_testPiMethod () {
+    return  "/public/?method=get_site_list";
 }
 
 ?>

--- a/htdocs/web_portal/controllers/site/view_all.php
+++ b/htdocs/web_portal/controllers/site/view_all.php
@@ -95,12 +95,16 @@ function showAllSites(){
         }
         $filterParams['scope_match'] = $scopeMatch;
 
-    } elseif (\Factory::getConfigService()->getDefaultFilterByScope()) {
+    // If there are more HTTP variables than "Page_Type=Sites" we assume the user
+    // clicked the [Filter] button and had all the paramter dialogues set as they required,
+    // so we aim to  filter by defualt scope only when the left Sites menu is clicked.
+
+    } elseif ((count($_GET) == 1) and \Factory::getConfigService()->getDefaultFilterByScope()) {
         $scopeVal = \Factory::getConfigService()->getDefaultScopeName();
         $selectedScopes[] = $scopeVal;
         $filterParams['scope'] = $scopeVal;
         $filterParams['scope_match'] = 'all';
-}
+    }
 
     $serv = \Factory::getSiteService();
 

--- a/lib/Gocdb_Services/Config.php
+++ b/lib/Gocdb_Services/Config.php
@@ -306,6 +306,15 @@ class Config {
     }
 
     /**
+     * The PI URL as recorded in local_info.xml.
+     */
+    public function getPiUrl(){
+        $localInfo = $this->GetLocalInfoXML();
+        $url = $localInfo->pi_url;
+        return strval($url);
+    }
+
+    /**
      * The base server URL as recorded in local_info.xml. This URL is used with the
      * PI query output, e.g. for building paging/HATEOAS links.
      */

--- a/lib/Gocdb_Services/NGI.php
+++ b/lib/Gocdb_Services/NGI.php
@@ -521,8 +521,7 @@ class NGI extends AbstractEntityService{
     }
 
     private function checkNumberOfScopes($scopeIds){
-        require_once __DIR__ . '/Config.php';
-        $minumNumberOfScopes = $this->$configService->getMinimumScopesRequired('ngi');
+        $minumNumberOfScopes = $this->configService->getMinimumScopesRequired('ngi');
         if(sizeof($scopeIds)<$minumNumberOfScopes){
             throw new \Exception("A NGI must have at least " . $minumNumberOfScopes . " scope(s) assigned to it.");
         }


### PR DESCRIPTION
Resolves #263 

Enable monitoring pages to use url-based configuration plus minor logic fixes.
