### PR TITLE
Fix adding/editing a Site on MariaDB

### DIFF
--- a/lib/Gocdb_Services/Site.php
+++ b/lib/Gocdb_Services/Site.php
@@ -189,6 +189,10 @@ class Site extends AbstractEntityService{
             throw new \Exception("Invalid scope update action");
         }
 
+        // Replace lat/long with null if no value entered
+        $this->emptyStringToNull($newValues['Site']['LATITUDE']);
+        $this->emptyStringToNull($newValues['Site']['LONGITUDE']);
+
         $this->em->getConnection()->beginTransaction();
         try {
             // Set the site's member variables
@@ -363,6 +367,13 @@ class Site extends AbstractEntityService{
             if (count($errors) > 0) {
                 throw new \Exception($errors[0]); // show the first message.
             }
+        }
+    }
+
+    // Replaces empty string with null
+    private function emptyStringToNull(&$var) {
+        if ($var === '') {
+            $var = null;
         }
     }
 
@@ -727,6 +738,10 @@ class Site extends AbstractEntityService{
 
         //check there are the required number of OPTIONAL scopes specified
         $this->checkNumberOfScopes($values['Scope_ids']);
+
+        // Replace lat/long with null if no value entered
+        $this->emptyStringToNull($values['Site']['LATITUDE']);
+        $this->emptyStringToNull($values['Site']['LONGITUDE']);
 
         // Populate the entity
         try {


### PR DESCRIPTION
Resolves #257

Currently longitude and latitude are not required and can be left blank, but with MariaDB (and possibly other updated databases) this leads to an exception when adding/editing sites:

> An exception occurred while executing 'UPDATE Sites SET latitude = ?, longitude = ?, alarmEmail = ? WHERE id = ?' with params ["", "", "", 13]: SQLSTATE[22007]: Invalid datetime format: 1366 Incorrect double value: '' for column \`gocdb\`.\`Sites\`.\`latitude\` at row 1

Unentered latitude and/or longitude when adding/editing a site are replaced with `null` to solve this.