### PR TITLE
Fix adding roles on MariaDB

### DIFF
--- a/lib/Gocdb_Services/Role.php
+++ b/lib/Gocdb_Services/Role.php
@@ -520,6 +520,9 @@ class Role extends AbstractEntityService{
             $roleType = $this->getRoleTypeByName($roleTypeName);
             $r = new \Role($roleType, $user, $entity, $roleStatus);
             $this->em->persist($r);
+            
+            // Ensure roleId has been generated
+            $this->em->flush();
 
             // create a RoleActionRecord after role has been persisted (to get id)
             $rar = \RoleActionRecord::construct($user, $r, \RoleStatus::PENDING);


### PR DESCRIPTION
Resolves #125

`roleId` is currently generated using the default identifier generation strategy, which differs between Oracle (`SEQUENCE` ) and MariaDB (`IDENTITY`). This value is required to create a RoleActionRecord, but under the `IDENTITY` strategy, the value is not created until insertion. In general:

> Generated entity identifiers / primary keys are guaranteed to be available after the next successful flush operation that involves the entity in question. You can not rely on a generated identifier to be available directly after invoking persist.

Adding an additional flush provides a cross platform way to ensure `roleId` exists when needed.
