### PR TITLE
Add manual test for testing role request emails 

### DIFF
--- a/lib/Doctrine/deploy/sampleData/NGIs.xml
+++ b/lib/Doctrine/deploy/sampleData/NGIs.xml
@@ -12,4 +12,17 @@
     <SECURITY_EMAIL>cert@switch.ch</SECURITY_EMAIL>
     <SITE_COUNT>7</SITE_COUNT>
   </NGI>
+  <NGI PRIMARY_KEY="33001H0" NAME="NGI_FIFE">
+    <PRIMARY_KEY>33001H0</PRIMARY_KEY>
+    <NAME>NGI_FIFE</NAME>
+    <OBJECT_ID>20721</OBJECT_ID>
+    <DESCRIPTION/>
+    <EMAIL>ngi-fife-contact@sample.com</EMAIL>
+    <GGUS_SU/>
+    <ROD_EMAIL/>
+    <HELPDESK_EMAIL/>
+    <SECURITY_EMAIL>ngi-fife-sec@sample.com</SECURITY_EMAIL>
+    <SITE_COUNT>7</SITE_COUNT>
+  </NGI>
+
 </results>

--- a/lib/Doctrine/deploy/sampleData/UsersAndRoles.xml
+++ b/lib/Doctrine/deploy/sampleData/UsersAndRoles.xml
@@ -9,7 +9,7 @@
         <DESCRIPTION>
         </DESCRIPTION>
         <GOCDB_PORTAL_URL>https://testing.host.com/portal/index.php?Page_Type=View_Object&amp;object_id=6653&amp;grid_id=0</GOCDB_PORTAL_URL>
-        <EMAIL>sample@sample.com</EMAIL>
+        <EMAIL>GriffinPeterson@sample.com</EMAIL>
         <TEL>+49 7247 82 0000</TEL>
         <WORKING_HOURS_START></WORKING_HOURS_START>
         <WORKING_HOURS_END></WORKING_HOURS_END>
@@ -18,8 +18,8 @@
         <ACTIVE></ACTIVE>
         <HOMESITE>SWITCH</HOMESITE>
         <USER_ROLE>
-            <USER_ROLE>Regional Staff (ROD)</USER_ROLE>
-            <ON_ENTITY>NGI_CH</ON_ENTITY>
+            <USER_ROLE>EGI CSIRT Officer</USER_ROLE>
+            <ON_ENTITY>EGI</ON_ENTITY>
             <ENTITY_TYPE>group</ENTITY_TYPE>
         </USER_ROLE>
     </EGEE_USER>
@@ -31,7 +31,7 @@
         <TITLE></TITLE>
         <DESCRIPTION></DESCRIPTION>
         <GOCDB_PORTAL_URL>https://testing.host.com/portal/index.php?Page_Type=View_Object&amp;object_id=6326&amp;grid_id=0</GOCDB_PORTAL_URL>
-        <EMAIL>sample@sample.com</EMAIL>
+        <EMAIL>AmyWong@sample.com</EMAIL>
         <TEL>+49 040 0000 1763</TEL>
         <WORKING_HOURS_START></WORKING_HOURS_START>
         <WORKING_HOURS_END></WORKING_HOURS_END>
@@ -39,25 +39,9 @@
         <APPROVED></APPROVED>
         <ACTIVE></ACTIVE>
         <HOMESITE>T3_CH_PSI</HOMESITE>
-
         <USER_ROLE>
-            <USER_ROLE>CIC Staff</USER_ROLE>
+            <USER_ROLE>Chief Operations Officer</USER_ROLE>
             <ON_ENTITY>EGI</ON_ENTITY>
-            <ENTITY_TYPE>group</ENTITY_TYPE>
-        </USER_ROLE>
-        <USER_ROLE>
-            <USER_ROLE>COD Staff</USER_ROLE>
-            <ON_ENTITY>EGI</ON_ENTITY>
-            <ENTITY_TYPE>group</ENTITY_TYPE>
-        </USER_ROLE>
-        <USER_ROLE>
-            <USER_ROLE>Regional Staff (ROD)</USER_ROLE>
-            <ON_ENTITY>NGI_CH</ON_ENTITY>
-            <ENTITY_TYPE>group</ENTITY_TYPE>
-        </USER_ROLE>
-        <USER_ROLE>
-            <USER_ROLE>Site Operations Manager</USER_ROLE>
-            <ON_ENTITY>NGI_CH</ON_ENTITY>
             <ENTITY_TYPE>group</ENTITY_TYPE>
         </USER_ROLE>
     </EGEE_USER>
@@ -68,7 +52,7 @@
         <TITLE></TITLE>
         <DESCRIPTION></DESCRIPTION>
         <GOCDB_PORTAL_URL>https://testing.host.com/portal/index.php?Page_Type=View_Object&amp;object_id=6326&amp;grid_id=0</GOCDB_PORTAL_URL>
-        <EMAIL>sample@sample.com</EMAIL>
+        <EMAIL>NevilleLongbottom@sample.com</EMAIL>
         <TEL>+49 040 0000 1763</TEL>
         <WORKING_HOURS_START></WORKING_HOURS_START>
         <WORKING_HOURS_END></WORKING_HOURS_END>
@@ -78,22 +62,7 @@
         <HOMESITE>UZH</HOMESITE>
 
         <USER_ROLE>
-            <USER_ROLE>CIC Staff</USER_ROLE>
-            <ON_ENTITY>EGI</ON_ENTITY>
-            <ENTITY_TYPE>group</ENTITY_TYPE>
-        </USER_ROLE>
-        <USER_ROLE>
-            <USER_ROLE>COD Staff</USER_ROLE>
-            <ON_ENTITY>EGI</ON_ENTITY>
-            <ENTITY_TYPE>group</ENTITY_TYPE>
-        </USER_ROLE>
-        <USER_ROLE>
-            <USER_ROLE>Regional Staff (ROD)</USER_ROLE>
-            <ON_ENTITY>NGI_CH</ON_ENTITY>
-            <ENTITY_TYPE>group</ENTITY_TYPE>
-        </USER_ROLE>
-        <USER_ROLE>
-            <USER_ROLE>Site Operations Manager</USER_ROLE>
+            <USER_ROLE>NGI Operations Manager</USER_ROLE>
             <ON_ENTITY>NGI_CH</ON_ENTITY>
             <ENTITY_TYPE>group</ENTITY_TYPE>
         </USER_ROLE>
@@ -106,7 +75,7 @@
         <TITLE></TITLE>
         <DESCRIPTION></DESCRIPTION>
         <GOCDB_PORTAL_URL>https://testing.host.com/portal/index.php?Page_Type=View_Object&amp;object_id=6326&amp;grid_id=0</GOCDB_PORTAL_URL>
-        <EMAIL>sample@sample.com</EMAIL>
+        <EMAIL>DonnaMoss@sample.com</EMAIL>
         <TEL>+49 040 0000 1763</TEL>
         <WORKING_HOURS_START></WORKING_HOURS_START>
         <WORKING_HOURS_END></WORKING_HOURS_END>
@@ -116,9 +85,14 @@
         <HOMESITE>UNIBE-LHEP</HOMESITE>
 
         <USER_ROLE>
-            <USER_ROLE>COD Staff</USER_ROLE>
+            <USER_ROLE>Regional Staff (ROD)</USER_ROLE>
             <ON_ENTITY>NGI_CH</ON_ENTITY>
             <ENTITY_TYPE>group</ENTITY_TYPE>
+        </USER_ROLE>
+        <USER_ROLE>
+            <USER_ROLE>Site Operations Manager</USER_ROLE>
+            <ON_ENTITY>UNIBE-LHEP</ON_ENTITY>
+            <ENTITY_TYPE>site</ENTITY_TYPE>
         </USER_ROLE>
     </EGEE_USER>
 
@@ -128,7 +102,7 @@
         <TITLE></TITLE>
         <DESCRIPTION></DESCRIPTION>
         <GOCDB_PORTAL_URL>https://testing.host.com/portal/index.php?Page_Type=View_Object&amp;object_id=6326&amp;grid_id=0</GOCDB_PORTAL_URL>
-        <EMAIL>sample@sample.com</EMAIL>
+        <EMAIL>RichardWinters@sample.com</EMAIL>
         <TEL>+49 040 0000 1763</TEL>
         <WORKING_HOURS_START></WORKING_HOURS_START>
         <WORKING_HOURS_END></WORKING_HOURS_END>
@@ -137,10 +111,5 @@
         <ACTIVE></ACTIVE>
         <HOMESITE>UNIGE-DPNC</HOMESITE>
 
-        <USER_ROLE>
-            <USER_ROLE>COD Staff</USER_ROLE>
-            <ON_ENTITY>NGI_CH</ON_ENTITY>
-            <ENTITY_TYPE>group</ENTITY_TYPE>
-        </USER_ROLE>
     </EGEE_USER>
 </results>

--- a/tests/manualTests/TestRoleRequestEmail.php
+++ b/tests/manualTests/TestRoleRequestEmail.php
@@ -1,0 +1,77 @@
+<?php
+
+# This is designed to sanity check the role request email functionality.
+# It is not a unit test, it is designed to be run against the sample data.
+# Usage: php tests/manualTests/TestRoleRequestEmail.php
+require_once 'lib/Gocdb_Services/NotificationService.php';
+
+$requesting_user_id = 5; // This corresponds to Richard Winters.
+$requesting_user = \Factory::getUserService()->getUser($requesting_user_id);
+
+echo "=====================================================================\n";
+# Test 1, requesting a role over a site with existing role approvers
+
+$site_id = 5; // This corresponds to UNIBE-LHEP
+# Get Site object from above ID.
+$site = \Factory::getSiteService()->getSite($site_id);
+
+# Have Richard appear to request the "Site Operations Manager" role over
+# UNIBE-LHEP. This request should go to Donna, who also has the
+# "Site Operations Manager" role.
+$role_requested = new \Role(
+      new \RoleType("Site Operations Manager"),
+      $requesting_user, $site, RoleStatus::PENDING);
+
+$notificationService = \Factory::getNotificationService();
+$notificationService->roleRequest($role_requested, $requesting_user, $site);
+
+echo "=====================================================================\n";
+# Test 2, requesting a role over a site with no existing role approvers.
+$site_id = 6; // This corresponds to T3_CH_PSI
+# Get Site object from above ID.
+$site = \Factory::getSiteService()->getSite($site_id);
+
+# Have Richard appear to request the "Site Operations Manager" role over
+# T3_CH_PSI. As this Site has no one with a role over it the request should
+# email Neville (NGI Operations Manager of NGI_CH) but not Donna (who cannot
+# approve the role as "Regional Staff (ROD)")
+$role_requested = new \Role(
+      new \RoleType("Site Operations Manager"),
+      $requesting_user, $site, RoleStatus::PENDING);
+
+$notificationService = \Factory::getNotificationService();
+$notificationService->roleRequest($role_requested, $requesting_user, $site);
+
+echo "=====================================================================\n";
+# Test 3, requesting a role over a NGI with existing role approvers.
+$ngi_id = 2; // This corresponds to NGI_CH
+# Get Site object from above ID.
+$ngi = \Factory::getNgiService()->getNgi($ngi_id);
+
+# Have Richard appear to request the "NGI Operations Manager" role over
+# NGI_CH. This request should go to Neville, who also has the
+# "NGI Operations Manager" role but not Donna (who cannot approve the role as
+# "Regional Staff (ROD)")
+$role_requested = new \Role(
+      new \RoleType("NGI Operations Manager"),
+      $requesting_user, $ngi, RoleStatus::PENDING);
+
+$notificationService = \Factory::getNotificationService();
+$notificationService->roleRequest($role_requested, $requesting_user, $ngi);
+
+echo "=====================================================================\n";
+# Test 4, requesting a role over a site with no existing role approvers.
+$ngi_id = 3; // This corresponds to NGI_FIFE
+# Get Site object from above ID.
+$ngi = \Factory::getNgiService()->getNgi($ngi_id);
+
+# Have Richard appear to request the "NGI Operations Manager" role over
+# NGI_CH. This request should go to Griffin and Amy, who have Project roles.
+$role_requested = new \Role(
+      new \RoleType("NGI Operations Manager"),
+      $requesting_user, $ngi, RoleStatus::PENDING);
+
+$notificationService = \Factory::getNotificationService();
+$notificationService->roleRequest($role_requested, $requesting_user, $ngi);
+
+?>


### PR DESCRIPTION
Depends on #171.

Allows a basic sanity check for the role request email functionality.

To help with this, this PR also:
- Reworks the sample Users to:
    - ensure the sample project, NGI and one of the sample sites has atleast one user with a role over it. These roles are also saner than before (i.e. no site level roles over an NGI).
    - change fake emails so they are unique to each fake user.
- Adds a second NGI to the sample data to allow us to test what happens if a someone requests a role over a NGI without a user with a suitable role.