### PR TITLE
Define character set and collation for entity tables

### DIFF
--- a/lib/Doctrine/entities/APIAuthentication.php
+++ b/lib/Doctrine/entities/APIAuthentication.php
@@ -20,7 +20,7 @@
   *
   * @author George Ryall (github.com/GRyall)
   *
-  * @Entity @Table(name="APIAuthenticationEntities",uniqueConstraints={@UniqueConstraint(name="siteIdentifier", columns={"parentSite_id", "type", "identifier"})})
+  * @Entity @Table(name="APIAuthenticationEntities", options={"collate"="utf8mb4_bin", "charset"="utf8mb4"}, uniqueConstraints={@UniqueConstraint(name="siteIdentifier", columns={"parentSite_id", "type", "identifier"})})
   */
    class APIAuthentication
   {

--- a/lib/Doctrine/entities/ArchivedNGI.php
+++ b/lib/Doctrine/entities/ArchivedNGI.php
@@ -19,7 +19,7 @@
  *
  * @author George Ryall
  * @author David Meredith <david.meredith@stfc.ac.uk>
- * @Entity @Table(name="ArchivedNGIs")
+ * @Entity @Table(name="ArchivedNGIs", options={"collate"="utf8mb4_bin", "charset"="utf8mb4"})
  */
 class ArchivedNGI {
 

--- a/lib/Doctrine/entities/ArchivedService.php
+++ b/lib/Doctrine/entities/ArchivedService.php
@@ -19,7 +19,7 @@
  *
  * @author George Ryall
  * @author David Meredith <david.meredith@stfc.ac.uk>
- * @Entity @Table(name="ArchivedServices")
+ * @Entity @Table(name="ArchivedServices", options={"collate"="utf8mb4_bin", "charset"="utf8mb4"})
  */
 class ArchivedService {
 

--- a/lib/Doctrine/entities/ArchivedServiceGroup.php
+++ b/lib/Doctrine/entities/ArchivedServiceGroup.php
@@ -19,7 +19,7 @@
  *
  * @author George Ryall
  * @author David Meredith <david.meredith@stfc.ac.uk>
- * @Entity @Table(name="ArchivedServiceGroups")
+ * @Entity @Table(name="ArchivedServiceGroups", options={"collate"="utf8mb4_bin", "charset"="utf8mb4"})
  */
 class ArchivedServiceGroup {
 

--- a/lib/Doctrine/entities/ArchivedSite.php
+++ b/lib/Doctrine/entities/ArchivedSite.php
@@ -19,7 +19,7 @@
  *
  * @author George Ryall
  * @author David Meredith <david.meredith@stfc.ac.uk>
- * @Entity @Table(name="ArchivedSites")
+ * @Entity @Table(name="ArchivedSites", options={"collate"="utf8mb4_bin", "charset"="utf8mb4"})
  */
 class ArchivedSite {
 

--- a/lib/Doctrine/entities/CertificationStatus.php
+++ b/lib/Doctrine/entities/CertificationStatus.php
@@ -23,7 +23,7 @@ use Doctrine\Common\Collections\ArrayCollection;
  * @author John Casson
  * @author David Meredith <david.meredith@stfc.ac.uk>
  *
- * @Entity @Table(name="CertificationStatuses")
+ * @Entity @Table(name="CertificationStatuses", options={"collate"="utf8mb4_bin", "charset"="utf8mb4"})
  */
 class CertificationStatus {
 

--- a/lib/Doctrine/entities/CertificationStatusLog.php
+++ b/lib/Doctrine/entities/CertificationStatusLog.php
@@ -19,7 +19,7 @@
  * Site's certStatusLogs are also cascade deleted.
  *
  * @author David Meredith <david.meredith@stfc.ac.uk>
- * @Entity @Table(name="CertificationStatusLogs")
+ * @Entity @Table(name="CertificationStatusLogs", options={"collate"="utf8mb4_bin", "charset"="utf8mb4"})
  */
 class CertificationStatusLog {
 

--- a/lib/Doctrine/entities/Country.php
+++ b/lib/Doctrine/entities/Country.php
@@ -22,7 +22,7 @@ use Doctrine\Common\Collections\ArrayCollection;
  * @author John Casson
  * @author David Meredith <david.meredith@stfc.ac.uk>
  *
- * @Entity @Table(name="Countries")
+ * @Entity @Table(name="Countries", options={"collate"="utf8mb4_bin", "charset"="utf8mb4"})
  */
 class Country {
 

--- a/lib/Doctrine/entities/Downtime.php
+++ b/lib/Doctrine/entities/Downtime.php
@@ -27,7 +27,7 @@ use Doctrine\Common\Collections\ArrayCollection;
  *
  * @author David Meredith <david.meredithh@stfc.ac.uk>
  * @author John Casson
- * @Entity @Table(name="Downtimes")
+ * @Entity @Table(name="Downtimes", options={"collate"="utf8mb4_bin", "charset"="utf8mb4"})
  */
 class Downtime {
 

--- a/lib/Doctrine/entities/EndpointLocation.php
+++ b/lib/Doctrine/entities/EndpointLocation.php
@@ -26,7 +26,7 @@ use Doctrine\Common\Collections\ArrayCollection;
  * @author David Meredith <david.meredith@stfc.ac.uk>
  * @author John Casson
  *
- * @Entity @Table(name="EndpointLocations")
+ * @Entity @Table(name="EndpointLocations", options={"collate"="utf8mb4_bin", "charset"="utf8mb4"})
  */
 class EndpointLocation {
 

--- a/lib/Doctrine/entities/EndpointProperty.php
+++ b/lib/Doctrine/entities/EndpointProperty.php
@@ -28,7 +28,7 @@
  *
  * @author David Meredith <david.meredith@stfc.ac.uk>
  *
- * @Entity @Table(name="Endpoint_Properties", uniqueConstraints={@UniqueConstraint(name="endpointproperty_keypairs", columns={"parentEndpoint_id", "keyName"})})
+ * @Entity @Table(name="Endpoint_Properties", options={"collate"="utf8mb4_bin", "charset"="utf8mb4"}, uniqueConstraints={@UniqueConstraint(name="endpointproperty_keypairs", columns={"parentEndpoint_id", "keyName"})})
  */
 class EndpointProperty {
 

--- a/lib/Doctrine/entities/Infrastructure.php
+++ b/lib/Doctrine/entities/Infrastructure.php
@@ -20,7 +20,7 @@ use Doctrine\Common\Collections\ArrayCollection;
  * @author John Casson
  * @author David Meredith <david.meredith@stfc.ac.uk>
  *
- * @Entity @Table(name="Infrastructures")
+ * @Entity @Table(name="Infrastructures", options={"collate"="utf8mb4_bin", "charset"="utf8mb4"})
  */
 class Infrastructure {
 

--- a/lib/Doctrine/entities/NGI.php
+++ b/lib/Doctrine/entities/NGI.php
@@ -27,7 +27,7 @@ require_once 'IScopedEntity.php';
  * @author David Meredith <david.meredithh@stfc.ac.uk>
  * @author John Casson
  *
- * @Entity @Table(name="NGIs")
+ * @Entity @Table(name="NGIs", options={"collate"="utf8mb4_bin", "charset"="utf8mb4"})
  */
 class NGI extends OwnedEntity implements IScopedEntity {
 

--- a/lib/Doctrine/entities/OwnedEntity.php
+++ b/lib/Doctrine/entities/OwnedEntity.php
@@ -26,7 +26,7 @@ use Doctrine\Common\Collections\ArrayCollection;
  * @author David Meredith <david.meredithh@stfc.ac.uk>
  * @author John Casson
  *
- * @Entity  @Table(name="OwnedEntities")
+ * @Entity  @Table(name="OwnedEntities", options={"collate"="utf8mb4_bin", "charset"="utf8mb4"})
  * @InheritanceType("JOINED")
  * @DiscriminatorColumn(name="discr", type="string")
  * @DiscriminatorMap({"site" = "Site", "ngi" = "NGI", "project" = "Project",

--- a/lib/Doctrine/entities/PrimaryKey.php
+++ b/lib/Doctrine/entities/PrimaryKey.php
@@ -24,7 +24,7 @@
  *
  * @author John Casson
  *
- * @Entity @Table(name="PrimaryKeys")
+ * @Entity @Table(name="PrimaryKeys", options={"collate"="utf8mb4_bin", "charset"="utf8mb4"})
  */
 class PrimaryKey {
 

--- a/lib/Doctrine/entities/Project.php
+++ b/lib/Doctrine/entities/Project.php
@@ -23,7 +23,7 @@ use Doctrine\Common\Collections\ArrayCollection;
  *
  * @author David Meredith <david.meredith@stfc.ac.uk>
  *
- * @Entity @Table(name="Projects")
+ * @Entity @Table(name="Projects", options={"collate"="utf8mb4_bin", "charset"="utf8mb4"})
  */
 class Project extends OwnedEntity {
 

--- a/lib/Doctrine/entities/RetrieveAccountRequest.php
+++ b/lib/Doctrine/entities/RetrieveAccountRequest.php
@@ -22,7 +22,7 @@
  *
  * @author John Casson
  * @author David Meredith <david.meredith@stfc.ac.uk>
- * @Entity @Table(name="RetrieveAccountRequests")
+ * @Entity @Table(name="RetrieveAccountRequests", options={"collate"="utf8mb4_bin", "charset"="utf8mb4"})
  */
 class RetrieveAccountRequest {
 

--- a/lib/Doctrine/entities/Role.php
+++ b/lib/Doctrine/entities/Role.php
@@ -32,7 +32,7 @@
  *
  * @author David Meredith <david.meredithh@stfc.ac.uk>
  * @author John Casson
- * @Entity @Table(name="Roles", uniqueConstraints={@UniqueConstraint(name="NoDuplicateRoles", columns={"user_id", "roleType_id", "ownedEntity_id"})})
+ * @Entity @Table(name="Roles", options={"collate"="utf8mb4_bin", "charset"="utf8mb4"}, uniqueConstraints={@UniqueConstraint(name="NoDuplicateRoles", columns={"user_id", "roleType_id", "ownedEntity_id"})})
  *
  */
 class Role {

--- a/lib/Doctrine/entities/RoleActionRecord.php
+++ b/lib/Doctrine/entities/RoleActionRecord.php
@@ -24,7 +24,7 @@
  * Once created, object is immutable.
  *
  * @author David Meredith <david.meredith@stfc.ac.uk>
- * @Entity @Table(name="RoleActionRecords")
+ * @Entity @Table(name="RoleActionRecords", options={"collate"="utf8mb4_bin", "charset"="utf8mb4"})
  */
 class RoleActionRecord {
 

--- a/lib/Doctrine/entities/RoleType.php
+++ b/lib/Doctrine/entities/RoleType.php
@@ -20,7 +20,7 @@
  * @author John Casson
  * @author David Meredith <david.meredith@stfc.ac.uk>
  *
- * @Entity @Table(name="RoleTypes")
+ * @Entity @Table(name="RoleTypes", options={"collate"="utf8mb4_bin", "charset"="utf8mb4"})
  */
 class RoleType {
 

--- a/lib/Doctrine/entities/Scope.php
+++ b/lib/Doctrine/entities/Scope.php
@@ -24,7 +24,7 @@
  * only linked to Scope instances).
  *
  * @author David Meredith <david.meredith@stfc.ac.uk>
- * @Entity @Table(name="Scopes")
+ * @Entity @Table(name="Scopes", options={"collate"="utf8mb4_bin", "charset"="utf8mb4"})
  */
 class Scope {
 

--- a/lib/Doctrine/entities/Service.php
+++ b/lib/Doctrine/entities/Service.php
@@ -25,7 +25,7 @@ require_once __DIR__ . '/IScopedEntity.php';
  *
  * @author David Meredith <david.meredithh@stfc.ac.uk>
  * @author John Casson
- * @Entity @Table(name="Services")
+ * @Entity @Table(name="Services", options={"collate"="utf8mb4_bin", "charset"="utf8mb4"})
  */
 class Service implements IScopedEntity {
 

--- a/lib/Doctrine/entities/ServiceGroup.php
+++ b/lib/Doctrine/entities/ServiceGroup.php
@@ -25,7 +25,7 @@ use Doctrine\Common\Collections\ArrayCollection;
  * @author John Casson
  * @author David Meredith <david.meredith@stfc.ac.uk>
  *
- * @Entity @Table(name="ServiceGroups")
+ * @Entity @Table(name="ServiceGroups", options={"collate"="utf8mb4_bin", "charset"="utf8mb4"})
  */
 class ServiceGroup extends OwnedEntity implements IScopedEntity {
 

--- a/lib/Doctrine/entities/ServiceGroupProperty.php
+++ b/lib/Doctrine/entities/ServiceGroupProperty.php
@@ -28,7 +28,7 @@
  *
  * @author James McCarthy
  * @author David Meredith <david.meredith@stfc.ac.uk>
- * @Entity @Table(name="ServiceGroup_Properties", uniqueConstraints={@UniqueConstraint(name="sgroup_keypairs", columns={"parentServiceGroup_id", "keyName"})})
+ * @Entity @Table(name="ServiceGroup_Properties", options={"collate"="utf8mb4_bin", "charset"="utf8mb4"}, uniqueConstraints={@UniqueConstraint(name="sgroup_keypairs", columns={"parentServiceGroup_id", "keyName"})})
  */
 class ServiceGroupProperty {
 

--- a/lib/Doctrine/entities/ServiceProperty.php
+++ b/lib/Doctrine/entities/ServiceProperty.php
@@ -28,7 +28,7 @@
  *
  * @author James McCarthy
  * @author David Meredith
- * @Entity @Table(name="Service_Properties", uniqueConstraints={@UniqueConstraint(name="serv_keypairs", columns={"parentService_id", "keyName"})})
+ * @Entity @Table(name="Service_Properties", options={"collate"="utf8mb4_bin", "charset"="utf8mb4"}, uniqueConstraints={@UniqueConstraint(name="serv_keypairs", columns={"parentService_id", "keyName"})})
  */
 class ServiceProperty {
 

--- a/lib/Doctrine/entities/ServiceType.php
+++ b/lib/Doctrine/entities/ServiceType.php
@@ -22,7 +22,7 @@ use Doctrine\Common\Collections\ArrayCollection;
  * @author John Casson
  * @author David Meredith <david.meredith@stfc.ac.uk>
  *
- * @Entity @Table(name="ServiceTypes")
+ * @Entity @Table(name="ServiceTypes", options={"collate"="utf8mb4_bin", "charset"="utf8mb4"})
  */
 class ServiceType {
 

--- a/lib/Doctrine/entities/Site.php
+++ b/lib/Doctrine/entities/Site.php
@@ -24,7 +24,7 @@ require_once 'NGI.php';
  * @author John Casson
  * @author David Meredith <david.meredith@stfc.ac.uk>
  *
- * @Entity @Table(name="Sites")
+ * @Entity @Table(name="Sites", options={"collate"="utf8mb4_bin", "charset"="utf8mb4"})
  */
 class Site extends OwnedEntity implements IScopedEntity{
 

--- a/lib/Doctrine/entities/SiteProperty.php
+++ b/lib/Doctrine/entities/SiteProperty.php
@@ -28,7 +28,7 @@
  *
  * @author James McCarthy
  * @author David Meredith
- * @Entity @Table(name="Site_Properties",uniqueConstraints={@UniqueConstraint(name="site_keypairs", columns={"parentSite_id", "keyName"})})
+ * @Entity @Table(name="Site_Properties", options={"collate"="utf8mb4_bin", "charset"="utf8mb4"}, uniqueConstraints={@UniqueConstraint(name="site_keypairs", columns={"parentSite_id", "keyName"})})
  */
 class SiteProperty {
 

--- a/lib/Doctrine/entities/SubGrid.php
+++ b/lib/Doctrine/entities/SubGrid.php
@@ -17,7 +17,7 @@ use Doctrine\Common\Collections\ArrayCollection;
 /**
  * @deprecated since version 5.4
  * @author John Casson
- * @Entity @Table(name="SubGrids")
+ * @Entity @Table(name="SubGrids", options={"collate"="utf8mb4_bin", "charset"="utf8mb4"})
  */
 class SubGrid {
 

--- a/lib/Doctrine/entities/Tier.php
+++ b/lib/Doctrine/entities/Tier.php
@@ -16,7 +16,7 @@ use Doctrine\Common\Collections\ArrayCollection;
 /**
  * @deprecated since version 5.4
  * @author John Casson
- * @Entity @Table(name="Tiers")
+ * @Entity @Table(name="Tiers", options={"collate"="utf8mb4_bin", "charset"="utf8mb4"})
  */
 class Tier {
 

--- a/lib/Doctrine/entities/Timezone.php
+++ b/lib/Doctrine/entities/Timezone.php
@@ -7,7 +7,7 @@ use Doctrine\Common\Collections\ArrayCollection;
  * Entities such as Sites should specify their timezone directly as attributes
  * on the owning entity rather than joining to this entity.
  * @deprecated since version 5.4
- * @Entity @Table(name="Timezones")
+ * @Entity @Table(name="Timezones", options={"collate"="utf8mb4_bin", "charset"="utf8mb4"})
  */
 class Timezone {
 

--- a/lib/Doctrine/entities/User.php
+++ b/lib/Doctrine/entities/User.php
@@ -19,7 +19,7 @@ use Doctrine\Common\Collections\ArrayCollection;
  * @author John Casson
  * @author David Meredith <david.meredith@stfc.ac.uk>
  *
- * @Entity @Table(name="Users", options={"collate"="utf8_bin"})
+ * @Entity @Table(name="Users", options={"collate"="utf8mb4_bin", "charset"="utf8mb4"})
  */
 class User {
 


### PR DESCRIPTION
Define all entity `@Table` character sets and collations, with `"collate"="utf8mb4_bin"` and `"charset"="utf8mb4"`, to ensure current Oracle behaviour (case sensitivity and full character support) is reflected in MariaDB.

This should not change the schema for existing databases, as Doctrine does not appear to update existing tables if this is added, but it will change the SQL generated when creating new tables for MariaDB. When creating tables for Oracle, these changes do not appear to make a difference.

Note: these options cannot be defined for `@JoinTable`s, such as [NGIs_Scopes](https://github.com/GOCDB/gocdb/blob/dev/lib/Doctrine/entities/NGI.php#L69), so these will have the default character set (utf8) and collation (utf8_unicode_ci), but as these tables only store IDs, this should not be a problem.