### PR TITLE
Sort API output

### DIFF
--- a/lib/Gocdb_Services/PI/GetCertStatusChanges.php
+++ b/lib/Gocdb_Services/PI/GetCertStatusChanges.php
@@ -118,7 +118,6 @@ class GetCertStatusChanges implements IPIQuery, IPIQueryPageable, IPIQueryRender
             ->Join('s.certificationStatus', 'cs')
             ->leftJoin('s.scopes', 'sc')
             ->Join('s.infrastructure', 'i')
-        //    ->orderBy('log.id', 'ASC')
         ;
 
 

--- a/lib/Gocdb_Services/PI/GetCertStatusDate.php
+++ b/lib/Gocdb_Services/PI/GetCertStatusDate.php
@@ -115,7 +115,6 @@ class GetCertStatusDate implements IPIQuery, IPIQueryPageable, IPIQueryRenderabl
             ->leftJoin('s.scopes', 'sc')
             ->join('s.infrastructure', 'i')
             ->andWhere($qb->expr()->like('i.name', '?'.++$bc))
-            //->orderBy('s.id', 'ASC')
         ;
 
         $binds[] = array($bc, 'Production');

--- a/lib/Gocdb_Services/PI/GetDowntime.php
+++ b/lib/Gocdb_Services/PI/GetDowntime.php
@@ -23,6 +23,7 @@ require_once __DIR__ . '/IPIQueryRenderable.php';
 
 
 use Doctrine\ORM\Tools\Pagination\Paginator;
+use Doctrine\Common\Collections\ArrayCollection;
 
 /**
  * Return an XML document that encodes the downtimes with optional cursor-based paging.
@@ -168,7 +169,6 @@ class GetDowntime implements IPIQuery, IPIQueryPageable, IPIQueryRenderable
             ->join('s.ngi', 'n')
             ->join('s.country', 'c')
             ->join('se.serviceType', 'st')
-            //->orderBy('d.startDate', 'DESC')
             ; //try just joins!
 
 
@@ -714,7 +714,11 @@ class GetDowntime implements IPIQuery, IPIQueryPageable, IPIQueryRenderable
             $helpers->addIfNotEmpty($xmlDowntime, 'GOCDB_PORTAL_URL', $portalUrl);
 
             $xmlImpactedSE = $xmlDowntime->addChild('SERVICES');
-            foreach ($downtime->getServices() as $service) {
+
+            // Sort services
+            $orderedServices = $this->helpers->orderArrById($downtime->getServices());
+
+            foreach ($orderedServices as $service) {
                 $xmlServices = $xmlImpactedSE->addChild('SERVICE');
                 $helpers->addIfNotEmpty($xmlServices, 'PRIMARY_KEY', $service->getId() . 'G0');
                 $helpers->addIfNotEmpty($xmlServices, 'HOSTNAME', $service->getHostName());
@@ -724,8 +728,11 @@ class GetDowntime implements IPIQuery, IPIQueryPageable, IPIQueryRenderable
                 $helpers->addIfNotEmpty($xmlServices, 'HOSTED_BY', $service->getParentSite()->getShortName());
                 if ($this->renderMultipleEndpoints) {
                     $xmlEndpoints = $xmlServices->addChild('AFFECTED_ENDPOINTS');
-                    //Loop through the affected endpoints
-                    foreach ($downtime->getEndpointLocations() as $endpoint) {
+
+                    // Sort endpoints
+                    $orderedEndpoints = $this->helpers->orderArrById($downtime->getEndpointLocations());
+
+                    foreach ($orderedEndpoints as $endpoint) {
                         // Only show the endpoint if is from the current service
                         if ($endpoint->getService() == $service) {
                             $xmlEndpoint = $xmlEndpoints->addChild('ENDPOINT');
@@ -767,7 +774,11 @@ class GetDowntime implements IPIQuery, IPIQueryPageable, IPIQueryRenderable
         }
 
         foreach ($downtimes as $downtime) {
-            foreach ($downtime->getServices() as $service) {
+
+            // Sort services
+            $orderedServices = $this->helpers->orderArrById($downtime->getServices());
+
+            foreach ($orderedServices as $service) {
                 $xmlDowntime = $xml->addChild('DOWNTIME');
                 // ID is the internal object id/sequence
                 $xmlDowntime->addAttribute("ID", $downtime->getId());
@@ -786,7 +797,11 @@ class GetDowntime implements IPIQuery, IPIQueryPageable, IPIQueryRenderable
                     $xmlEndpoints = $xmlDowntime->addChild('AFFECTED_ENDPOINTS');
                     //Loop through all the endpoints of a downtime but only render
                     //those from the current service
-                    foreach ($downtime->getEndpointLocations() as $endpoint) {
+
+                    // Sort endpoints
+                    $orderedEndpoints = $this->helpers->orderArrById($downtime->getEndpointLocations());
+
+                    foreach ($orderedEndpoints as $endpoint) {
                         if (in_array($endpoint, $service->getEndpointLocations()->toArray())) {
                             $xmlEndpoint = $xmlEndpoints->addChild('ENDPOINT');
                             $xmlEndpoint->addChild('ID', $endpoint->getId());
@@ -850,7 +865,11 @@ class GetDowntime implements IPIQuery, IPIQueryPageable, IPIQueryRenderable
 
             //Iterate through the downtime's affected services
             $xmlImpactedSE = $xmlDowntime->addChild('SERVICES');
-            foreach ($downtimeArray ['services'] as $service) {
+
+            // Sort services - must be correct type for sorting
+            $orderedServices = $this->helpers->orderArrById(new ArrayCollection($downtimeArray['services']));
+
+            foreach ($orderedServices as $service) {
                 $xmlService = $xmlImpactedSE->addChild('SERVICE');
                 $helpers->addIfNotEmpty($xmlService, 'PRIMARY_KEY', $service['id'] . 'G0');
                 $helpers->addIfNotEmpty($xmlService, 'HOSTNAME', htmlspecialchars($service ['hostName']));
@@ -863,11 +882,17 @@ class GetDowntime implements IPIQuery, IPIQueryPageable, IPIQueryRenderable
                 if ($this->renderMultipleEndpoints) {
                     // Slice the service's endpointLocations array and store just each endpointLocation's Id
                     $currentServiceEndpointIDs = array();
+
+                    // No benefit sorting
                     foreach ($service['endpointLocations'] as $serviceEndpoint) {
                         $currentServiceEndpointIDs[] = $serviceEndpoint['id'];
                     }
                     $xmlEndpoints = $xmlService->addChild('AFFECTED_ENDPOINTS');
-                    foreach ($downtimeArray['endpointLocations'] as $dtEndpoint) {
+
+                    // Sort service endpoints
+                    $orderedDtEndpoints = $this->helpers->orderArrById(new ArrayCollection($downtimeArray['endpointLocations']));
+
+                    foreach ($orderedDtEndpoints as $dtEndpoint) {
                         // Does this downtimeEndpoint ALSO belong to the current current service?
                         // (we only want to render the current service's endpoints
                         // that are affected by the downtime, NOT all of the
@@ -909,7 +934,11 @@ class GetDowntime implements IPIQuery, IPIQueryPageable, IPIQueryRenderable
         $helpers = $this->helpers;
         $xml = new \SimpleXMLElement("<results/>");
         foreach ($downtimes as $downtimeArray) {
-            foreach ($downtimeArray ['services'] as $service) {
+
+            // Sort services - must be correct type for sorting
+            $orderedServices = $this->helpers->orderArrById(new ArrayCollection($downtimeArray['services']));
+
+            foreach ($orderedServices as $service) {
                 // <DOWNTIME> element and attributes start
                 $xmlDowntime = $xml->addChild('DOWNTIME');
                 $xmlDowntime->addAttribute("ID", $downtimeArray ['id']);
@@ -933,6 +962,8 @@ class GetDowntime implements IPIQuery, IPIQueryPageable, IPIQueryRenderable
                 if ($this->renderMultipleEndpoints) {
                     // Slice the service's endpointLocations array and store just each endpointLocation's Id
                     $currentServiceEndpointIDs = array();
+
+                    // No benefit sorting
                     foreach ($service['endpointLocations'] as $serviceEndpoint) {
                         $currentServiceEndpointIDs[] = $serviceEndpoint['id'];
                     }
@@ -941,7 +972,11 @@ class GetDowntime implements IPIQuery, IPIQueryPageable, IPIQueryRenderable
                     //$arrayData = print_r($downtimeArray['endpointLocations'], true);
                     //$xmlEndpoints = $xmlDowntime->addChild ( 'downtimesAffectedEndpoints', htmlspecialchars($arrayData));
                     $xmlEndpoints = $xmlDowntime->addChild('AFFECTED_ENDPOINTS');
-                    foreach ($downtimeArray['endpointLocations'] as $dtEndpoint) {
+
+                    // Sort downtime endpoints - must be correct type for sorting
+                    $orderedDtEndpoints = $this->helpers->orderArrById(new ArrayCollection($downtimeArray['endpointLocations']));
+
+                    foreach ($orderedDtEndpoints as $dtEndpoint) {
                         // Does this downtimeEndpoint ALSO belong to the current current service?
                         // (we only want to render the current service's endpoints
                         // that are affected by the downtime, NOT all of the

--- a/lib/Gocdb_Services/PI/GetDowntimesToBroadcast.php
+++ b/lib/Gocdb_Services/PI/GetDowntimesToBroadcast.php
@@ -153,7 +153,6 @@ class GetDowntimeToBroadcast implements IPIQuery, IPIQueryPageable, IPIQueryRend
             ->join('s.ngi', 'n')
             ->join('s.country', 'c')
             ->andWhere($qb->expr()->gt('d.insertDate', '?'.++$bc))
-            //->orderBy('d.startDate', 'DESC')
           ;
 
         //Bind interval days
@@ -325,7 +324,11 @@ class GetDowntimeToBroadcast implements IPIQuery, IPIQueryPageable, IPIQueryRend
 
         foreach($downtimes as $downtime) {
             // duplicate the downtime for each affected service
-            foreach($downtime->getServices() as $se){
+
+            // Sort services
+            $orderedServices = $this->helpers->orderArrById($downtime->getServices());
+
+            foreach ($orderedServices as $se) {
                 $xmlDowntime = $xml->addChild('DOWNTIME');
                 $xmlDowntime->addAttribute("ID", $downtime->getId());
                 // Note, we are preserving the v4 primary keys here.
@@ -342,7 +345,11 @@ class GetDowntimeToBroadcast implements IPIQuery, IPIQueryPageable, IPIQueryRend
                 $xmlDowntime->addChild('GOCDB_PORTAL_URL', $portalUrl);
                 $xmlEndpoints = $xmlDowntime->addChild ( 'AFFECTED_ENDPOINTS' );
                 if($this->renderMultipleEndpoints){
-                    foreach($downtime->getEndpointLocations() as $endpoint){
+
+                    // Sort endpoints
+                    $orderedEndpoints = $this->helpers->orderArrById($downtime->getEndpointLocations());
+
+                    foreach ($orderedEndpoints as $endpoint) {
                         $xmlEndpoint = $xmlEndpoints->addChild ( 'ENDPOINT' );
                         $xmlEndpoint->addChild ( 'ID', $endpoint->getId());
                         $xmlEndpoint->addChild ( 'NAME', $endpoint->getName());

--- a/lib/Gocdb_Services/PI/GetNGI.php
+++ b/lib/Gocdb_Services/PI/GetNGI.php
@@ -110,10 +110,9 @@ class GetNGI implements IPIQuery, IPIQueryPageable, IPIQueryRenderable {
         $qb = $this->em->createQueryBuilder();
 
         //Initialize base query
-        $qb->select('n')
+        $qb->select('n', 'sc')
             ->from('NGI', 'n')
             ->leftJoin('n.scopes', 'sc')
-            //->orderBy('n.id', 'ASC')
             ;
 
         // Order by ASC (oldest first: 1, 2, 3, 4)
@@ -286,8 +285,12 @@ class GetNGI implements IPIQuery, IPIQueryPageable, IPIQueryRenderable {
             $xmlNgi->addChild("SITE_COUNT", count($ngi->getSites()));
             // scopes
             $xmlScopes = $xmlNgi->addChild('SCOPES');
-            foreach ($ngi->getScopes() as $scope) {
-            $xmlScopes->addChild('SCOPE', xssafe($scope->getName()));
+
+            // Sort scopes
+            $orderedScopes = $this->helpers->orderArrById($ngi->getScopes());
+
+            foreach ($orderedScopes as $scope) {
+                $xmlScopes->addChild('SCOPE', xssafe($scope->getName()));
             }
         }
 
@@ -342,9 +345,11 @@ class GetNGI implements IPIQuery, IPIQueryPageable, IPIQueryRenderable {
 
             $xmlNgiAsoc = $xmlNgi->addChild("Associations");
 
-            $sites = $ngi->getSites();
-            foreach ($sites as $site) {
-            $xmlNgiAsoc->addChild("ChildDomainID", $site->getPrimaryKey());
+            // Sort sites
+            $orderedSites = $this->helpers->orderArrById($ngi->getSites());
+
+            foreach ($orderedSites as $site) {
+                $xmlNgiAsoc->addChild("ChildDomainID", $site->getPrimaryKey());
             }
         }
 

--- a/lib/Gocdb_Services/PI/GetNGIContacts.php
+++ b/lib/Gocdb_Services/PI/GetNGIContacts.php
@@ -114,7 +114,6 @@ class GetNGIContacts implements IPIQuery, IPIQueryPageable, IPIQueryRenderable {
         //Initialize base query
         $qb	->select('n')
         ->from('NGI', 'n')
-        //->orderBy('n.id', 'ASC')
         ;
 
         // Order by ASC (oldest first: 1, 2, 3, 4)
@@ -266,7 +265,11 @@ class GetNGIContacts implements IPIQuery, IPIQueryPageable, IPIQueryRenderable {
             $portalUrl = $this->baseUrl.'/index.php?Page_Type=NGI&id=' . $ngi->getId ();
             $portalUrl = htmlspecialchars ( $portalUrl );
             $helpers->addIfNotEmpty ( $xmlNgi, 'GOCDB_PORTAL_URL', $portalUrl );
-            foreach($ngi->getRoles() as $role) {
+
+            // Sort roles
+            $orderedRoles = $this->helpers->orderArrById($ngi->getRoles());
+
+            foreach ($orderedRoles as $role) {
                 if ($role->getStatus() == "STATUS_GRANTED") {   //Only show users who are granted the role, not pending
                     $rtype = $role->getRoleType()->getName();
                     if($this->roleT == '%%' || $rtype == $this->roleT) {

--- a/lib/Gocdb_Services/PI/GetProjectContacts.php
+++ b/lib/Gocdb_Services/PI/GetProjectContacts.php
@@ -242,7 +242,10 @@ class GetProjectContacts implements IPIQuery, IPIQueryPageable, IPIQueryRenderab
             $xmlProjUser->addAttribute("ID", $project->getId());
             $xmlProjUser->addAttribute('NAME', $project->getName());
 
-            foreach($project->getRoles() as $role){
+            // Sort roles
+            $orderedRoles = $this->helpers->orderArrById($project->getRoles());
+
+            foreach ($orderedRoles as $role) {
                 if($role->getStatus() == \RoleStatus::GRANTED &&
                 $role->getRoleType()->getName() != \RoleTypeName::CIC_STAFF){
 

--- a/lib/Gocdb_Services/PI/GetService.php
+++ b/lib/Gocdb_Services/PI/GetService.php
@@ -391,13 +391,21 @@ class GetService implements IPIQuery, IPIQueryPageable, IPIQueryRenderable {
 
             if ($this->renderMultipleEndpoints) {
                 $xmlEndpoints = $xmlSe->addChild('ENDPOINTS');
-                foreach ($se->getEndpointLocations() as $endpoint) {
+
+                // Sort endpoints
+                $orderedEndpoints = $this->helpers->orderArrById($se->getEndpointLocations());
+
+                foreach ($orderedEndpoints as $endpoint) {
                     $xmlEndpoint = $xmlEndpoints->addChild('ENDPOINT');
                     $xmlEndpoint->addChild('ID', $endpoint->getId());
                     $xmlEndpoint->addChild('NAME', xssafe($endpoint->getName()));
                     // Endpoint Extensions
                     $xmlExtensions = $xmlEndpoint->addChild('EXTENSIONS');
-                    foreach ($endpoint->getEndpointProperties() as $prop) {
+
+                    // Sort endpoint properties
+                    $orderedEndpointProps = $this->helpers->orderArrById($endpoint->getEndpointProperties());
+
+                    foreach ($orderedEndpointProps as $prop) {
                         $xmlProperty = $xmlExtensions->addChild('EXTENSION');
                         $xmlProperty->addChild('LOCAL_ID', $prop->getId());
                         $xmlProperty->addChild('KEY', $prop->getKeyName());
@@ -417,13 +425,21 @@ class GetService implements IPIQuery, IPIQueryPageable, IPIQueryRenderable {
 
             // scopes
             $xmlScopes = $xmlSe->addChild('SCOPES');
-            foreach($se->getScopes() as $scope){
+
+            // Sort scopes
+            $orderedScopes = $this->helpers->orderArrById($se->getScopes());
+
+            foreach ($orderedScopes as $scope) {
                $xmlScopes->addChild('SCOPE', xssafe($scope->getName()));
             }
 
             // Service Extensions
             $xmlExtensions = $xmlSe->addChild('EXTENSIONS');
-            foreach ($se->getServiceProperties() as $prop) {
+
+            // Sort service properties
+            $orderedProps = $this->helpers->orderArrById($se->getServiceProperties());
+
+            foreach ($orderedProps as $prop) {
                 $xmlProperty = $xmlExtensions->addChild('EXTENSION');
                 $xmlProperty->addChild('LOCAL_ID', $prop->getId());
                 $xmlProperty->addChild('KEY', xssafe($prop->getKeyName()));

--- a/lib/Gocdb_Services/PI/GetServiceGroup.php
+++ b/lib/Gocdb_Services/PI/GetServiceGroup.php
@@ -128,7 +128,6 @@ class GetServiceGroup implements IPIQuery, IPIQueryPageable, IPIQueryRenderable 
                 ->leftJoin('s.scopes', 'sc')
                 ->leftJoin('s.endpointLocations', 'els')
                 ->leftjoin('els.endpointProperties', 'elp')
-                //->orderBy('sg.id', 'ASC')
                 ;
 
         // Order by ASC (oldest first: 1, 2, 3, 4)
@@ -303,7 +302,10 @@ class GetServiceGroup implements IPIQuery, IPIQueryPageable, IPIQueryRenderable 
             $url = htmlspecialchars($url);
             $xmlSg->addChild('GOCDB_PORTAL_URL', $url);
 
-            foreach ($sg->getServices() as $service) {
+            // Sort services
+            $orderedServices = $this->helpers->orderArrById($sg->getServices());
+
+            foreach ($orderedServices as $service) {
                 // maybe Rename SERVICE_ENDPOINT to SERVICE
                 $xmlService = $xmlSg->addChild('SERVICE_ENDPOINT');
                 $xmlService->addAttribute("PRIMARY_KEY", $service->getId() . "G0");
@@ -321,13 +323,21 @@ class GetServiceGroup implements IPIQuery, IPIQueryPageable, IPIQueryRenderable 
 
                 if ($this->renderMultipleEndpoints) {
                     $xmlEndpoints = $xmlService->addChild('ENDPOINTS');
-                    foreach ($service->getEndpointLocations() as $endpoint) {
+
+                    // Sort endpoints
+                    $orderedEndpoints = $this->helpers->orderArrById($service->getEndpointLocations());
+
+                    foreach ($orderedEndpoints as $endpoint) {
                         $xmlEndpoint = $xmlEndpoints->addChild('ENDPOINT');
                         $xmlEndpoint->addChild('ID', $endpoint->getId());
                         $xmlEndpoint->addChild('NAME', htmlspecialchars($endpoint->getName()));
                         // Endpoint Extensions
                         $xmlEndpointExtensions = $xmlEndpoint->addChild('EXTENSIONS');
-                        foreach ($endpoint->getEndpointProperties() as $prop) {
+
+                        // Sort endpoint properties
+                        $orderedEndpointProps = $this->helpers->orderArrById($endpoint->getEndpointProperties());
+
+                        foreach ($orderedEndpointProps as $prop) {
                             $xmlProperty = $xmlEndpointExtensions->addChild('EXTENSION');
                             $xmlProperty->addChild('LOCAL_ID', $prop->getId());
                             $xmlProperty->addChild('KEY', xssafe($prop->getKeyName()));
@@ -347,13 +357,21 @@ class GetServiceGroup implements IPIQuery, IPIQueryPageable, IPIQueryRenderable 
 
                 // Service scopes
                 $xmlScopes = $xmlService->addChild('SCOPES');
-                foreach ($service->getScopes() as $scope) {
+
+                // Sort scopes
+                $orderedServiceScopes = $this->helpers->orderArrById($service->getScopes());
+
+                foreach ($orderedServiceScopes as $scope) {
                     $xmlScopes->addChild('SCOPE', xssafe($scope->getName()));
                 }
 
                 // Service Extensions
                 $xmlServiceExtensions = $xmlService->addChild('EXTENSIONS');
-                foreach ($service->getServiceProperties() as $prop) {
+
+                // Sort service properties
+                $orderedServiceProps = $this->helpers->orderArrById($service->getServiceProperties());
+
+                foreach ($orderedServiceProps as $prop) {
                     $xmlProperty = $xmlServiceExtensions->addChild('EXTENSION');
                     $xmlProperty->addChild('LOCAL_ID', $prop->getId());
                     $xmlProperty->addChild('KEY', xssafe($prop->getKeyName()));
@@ -363,13 +381,21 @@ class GetServiceGroup implements IPIQuery, IPIQueryPageable, IPIQueryRenderable 
 
             // SG scopes
             $xmlScopes = $xmlSg->addChild('SCOPES');
-            foreach ($sg->getScopes() as $scope) {
+
+            // Sort scopes
+            $orderedSgScopes = $this->helpers->orderArrById($sg->getScopes());
+
+            foreach ($orderedSgScopes as $scope) {
                 $xmlScopes->addChild('SCOPE', xssafe($scope->getName()));
             }
 
             // SG extensions
             $xmlSGExtensions = $xmlSg->addChild('EXTENSIONS');
-            foreach ($sg->getServiceGroupProperties() as $sgProp) {
+
+            // Sort service group properties
+            $orderedSgProps = $this->helpers->orderArrById($sg->getServiceGroupProperties());
+
+            foreach ($orderedSgProps as $sgProp) {
                 $xmlSgProperty = $xmlSGExtensions->addChild('EXTENSION');
                 $xmlSgProperty->addChild('LOCAL_ID', $sgProp->getId());
                 $xmlSgProperty->addChild('KEY', xssafe($sgProp->getKeyName()));

--- a/lib/Gocdb_Services/PI/GetServiceGroupRole.php
+++ b/lib/Gocdb_Services/PI/GetServiceGroupRole.php
@@ -119,7 +119,6 @@ class GetServiceGroupRole implements IPIQuery, IPIQueryPageable, IPIQueryRendera
         ->leftJoin('sg.roles', 'r')
         ->leftJoin('r.user', 'u')
         ->leftJoin('r.roleType', 'rt')
-        //->orderBy('sg.id', 'ASC')
         ;
 
         // Order by ASC (oldest first: 1, 2, 3, 4)
@@ -288,7 +287,11 @@ class GetServiceGroupRole implements IPIQuery, IPIQueryPageable, IPIQueryRendera
             $url = $this->baseUrl.'/index.php?Page_Type=Service_Group&id=' . $sg->getId ();
             $url = htmlspecialchars ( $url );
             $xmlSg->addChild ( 'GOCDB_PORTAL_URL', $url );
-            foreach ( $sg->getRoles () as $role ) {
+
+            // Sort roles
+            $orderedRoles = $this->helpers->orderArrById($sg->getRoles());
+
+            foreach ($orderedRoles as $role) {
                 $user = $role->getUser ();
                 $xmlUser = $xmlSg->addChild ( 'USER' );
                 $xmlUser->addChild ( 'FORENAME', $user->getForename () );

--- a/lib/Gocdb_Services/PI/GetServiceTypes.php
+++ b/lib/Gocdb_Services/PI/GetServiceTypes.php
@@ -72,8 +72,8 @@ class GetServiceTypes implements IPIQuery, IPIQueryRenderable {
 
         //Initialize base query
         $qb	->select('st')
-        ->from('ServiceType', 'st'); // no ordering, should specify by oldest first to be consistent for future
-        //->orderBy('st.id', 'ASC'); // oldest first
+        ->from('ServiceType', 'st')
+        ->orderBy('st.id', 'ASC'); // oldest first
 
         /*Pass parameters to the ParameterBuilder and allow it to add relevant where clauses
          * based on set parameters.

--- a/lib/Gocdb_Services/PI/GetSite.php
+++ b/lib/Gocdb_Services/PI/GetSite.php
@@ -132,9 +132,6 @@ class GetSite implements IPIQuery, IPIQueryPageable, IPIQueryRenderable {
                 ->leftJoin('s.infrastructure', 'i')
                 ->leftJoin('s.subGrid', 'sgrid')
                 ->leftJoin('s.tier', 'ti')
-                //->leftJoin('s.timezone', 'tz') // deprecated, dont use the tz entity
-                //->orderBy('s.shortName', 'ASC');
-                //->orderBy('s.id', 'ASC')  // oldest first
         ;
 
         // Order by ASC (oldest first: 1, 2, 3, 4)
@@ -360,12 +357,20 @@ class GetSite implements IPIQuery, IPIQueryPageable, IPIQueryRenderable {
 
             // scopes
             $xmlScopes = $xmlSite->addChild('SCOPES');
-            foreach($site->getScopes() as $scope){
+
+            // Sort scopes
+            $orderedScopes = $this->helpers->orderArrById($site->getScopes());
+
+            foreach ($orderedScopes as $scope) {
                $xmlScope = $xmlScopes->addChild('SCOPE', xssafe($scope->getName()));
             }
 
             $xmlExtensions = $xmlSite->addChild('EXTENSIONS');
-            foreach ($site->getSiteProperties() as $siteProp) {
+
+            // Sort site properties
+            $orderedSiteProps = $this->helpers->orderArrById($site->getSiteProperties());
+
+            foreach ($orderedSiteProps as $siteProp) {
                 //if ($siteProp != "") {
                     $xmlSiteProperty = $xmlExtensions->addChild('EXTENSION');
                     $xmlSiteProperty->addChild('LOCAL_ID', $siteProp->getId());
@@ -491,8 +496,11 @@ class GetSite implements IPIQuery, IPIQueryPageable, IPIQueryRenderable {
             $helpers->addExtIfNotEmpty($xmlSiteExtParent, 'Domain_Name', $site->getDomain());
 
             $xmlNgiAsoc = $xmlSite->addChild("Associations");
-            $services = $site->getServices();
-            foreach ($services as $service) {
+
+            // Sort services
+            $orderedServices = $this->helpers->orderArrById($site->getServices());
+
+            foreach ($orderedServices as $service) {
                 $xmlNgiAsoc->addChild("ChildDomainID", $service->getID());
             }
         }

--- a/lib/Gocdb_Services/PI/GetSiteContacts.php
+++ b/lib/Gocdb_Services/PI/GetSiteContacts.php
@@ -122,8 +122,6 @@ class GetSiteContacts implements IPIQuery, IPIQueryPageable, IPIQueryRenderable 
         ->leftJoin('s.roles', 'r')
         ->leftJoin('r.user', 'u')
         ->leftJoin('r.roleType', 'rt')
-        //->orderBy('s.shortName', 'ASC');
-        //->orderBy('s.id', 'ASC') // oldest first
         ;
 
         // Order by ASC (oldest first: 1, 2, 3, 4)
@@ -295,7 +293,11 @@ class GetSiteContacts implements IPIQuery, IPIQueryPageable, IPIQueryRenderable 
 
             $xmlSite->addChild ( 'PRIMARY_KEY', $site->getPrimaryKey () );
             $xmlSite->addChild ( 'SHORT_NAME', $site->getShortName () );
-            foreach ( $site->getRoles () as $role ) {
+
+            // Sort roles
+            $orderedRoles = $this->helpers->orderArrById($site->getRoles());
+
+            foreach ($orderedRoles as $role) {
                 if ($role->getStatus () == "STATUS_GRANTED") { // Only show users who are granted the role, not pending
 
                     $rtype = $role->getRoleType ()->getName ();

--- a/lib/Gocdb_Services/PI/GetSiteCountPerCountry.php
+++ b/lib/Gocdb_Services/PI/GetSiteCountPerCountry.php
@@ -66,8 +66,9 @@ class GetSiteCountPerCountry implements IPIQuery, IPIQueryRenderable{
 
         $qb = $this->em->createQueryBuilder();
 
-        //Main query
-        $qb	->select('COUNT(c.name) as cCount', 'c.name')
+        // Main query
+        // Ordered by case insensitive country names
+        $qb	->select('COUNT(c.name) as cCount', 'c.name', 'LOWER(c.name) as HIDDEN lowerCaseName')
             ->from('Site', 's')
             ->leftJoin('s.scopes', 'sc')
             ->join('s.ngi', 'n')
@@ -75,7 +76,7 @@ class GetSiteCountPerCountry implements IPIQuery, IPIQueryRenderable{
             ->join('s.certificationStatus', 'cs')
             ->join('s.infrastructure', 'i')
             ->groupBy('c.name')
-            ->orderBy('c.name');
+            ->orderBy('lowerCaseName');
 
 
         //If a scope was specified attach the sub query to query by EGI scope
@@ -131,9 +132,10 @@ class GetSiteCountPerCountry implements IPIQuery, IPIQueryRenderable{
 
         $qb = $this->em->createQueryBuilder();
 
-        $qb	->select('c.name')
+        // Ordered by case insensitive country names
+        $qb	->select('c.name', 'LOWER(c.name) as HIDDEN lowerCaseName')
             ->from('Country', 'c')
-            ->orderBy('c.name');
+            ->orderBy('lowerCaseName');
 
         $query[1] = $qb->getQuery();
         $this->query = $query;

--- a/lib/Gocdb_Services/PI/GetSiteSecurityInfo.php
+++ b/lib/Gocdb_Services/PI/GetSiteSecurityInfo.php
@@ -122,8 +122,6 @@ class GetSiteSecurityInfo implements IPIQuery, IPIQueryPageable, IPIQueryRendera
         ->leftJoin('s.country', 'c')
         ->leftJoin('s.certificationStatus', 'cs')
         ->leftJoin('s.infrastructure', 'i')
-        //->orderBy('s.shortName', 'ASC');
-        //->orderBy('s.id', 'ASC') // oldest first
         ;
 
         // Order by ASC (oldest first: 1, 2, 3, 4)

--- a/lib/Gocdb_Services/PI/GetUser.php
+++ b/lib/Gocdb_Services/PI/GetUser.php
@@ -23,6 +23,7 @@ require_once __DIR__ . '/IPIQueryPageable.php';
 require_once __DIR__ . '/IPIQueryRenderable.php';
 
 //use Doctrine\ORM\Tools\Pagination\Paginator;
+use Doctrine\Common\Collections\ArrayCollection;
 
 /**
  * Return an XML document that encodes the users with optional cursor paging.
@@ -122,7 +123,6 @@ class GetUser implements IPIQuery, IPIQueryPageable, IPIQueryRenderable {
         $qb->select('u', 'r')
                 ->from('User', 'u')
                 ->leftJoin('u.roles', 'r')
-                //->orderBy('u.id', 'ASC') // oldest first
         ;
 
         // Order by ASC (oldest first: 1, 2, 3, 4)
@@ -323,7 +323,11 @@ class GetUser implements IPIQuery, IPIQueryPageable, IPIQueryRenderable {
             /*
              * Add a USER_ROLE element to the XML for each role this user holds.
              */
-            foreach ($user->getRoles() as $role) {
+
+            // Sort roles
+            $orderedRoles = $this->helpers->orderArrById($user->getRoles());
+
+            foreach ($orderedRoles as $role) {
                 if ($role->getStatus() == "STATUS_GRANTED") {
                     $xmlRole = $xmlUser->addChild('USER_ROLE');
                     $xmlRole->addChild('USER_ROLE', $role->getRoleType()->getName());
@@ -364,7 +368,11 @@ class GetUser implements IPIQuery, IPIQueryPageable, IPIQueryRenderable {
                     $xmlProjects = $xmlRole->addChild('RECOGNISED_IN_PROJECTS');
                     $parentProjectsForRole = $this->roleAuthorisationService
                             ->getReachableProjectsFromOwnedEntity($role->getOwnedEntity());
-                    foreach($parentProjectsForRole as $_proj){
+
+                    // Sort project(s) - must be correct type for sorting
+                    $orderedProjects = $this->helpers->orderArrById(new ArrayCollection($parentProjectsForRole));
+
+                    foreach ($orderedProjects as $_proj) {
                        $xmlProj = $xmlProjects->addChild('PROJECT', $_proj->getName());
                        $xmlProj->addAttribute('ID', $_proj->getId());
                     }

--- a/lib/Gocdb_Services/PI/QueryBuilders/Helpers.php
+++ b/lib/Gocdb_Services/PI/QueryBuilders/Helpers.php
@@ -15,6 +15,7 @@ namespace org\gocdb\services;
  */
 
 use Doctrine\ORM\Tools\Pagination\Paginator;
+use Doctrine\Common\Collections\Criteria;
 
 /**
  * Contains helper functions for API queries.
@@ -432,5 +433,16 @@ class Helpers {
 //         $lastLink->addAttribute("href", $urlBase.$lastQueryUrl);
     }
 
+    /**
+     * Sorts an array of entities by ascending ID
+     * @param ArrayCollection $arr array of entities to be ordered
+     * @return ArrayCollection
+     */
+    public function orderArrById($arr) {
+        $criteria = Criteria::create()
+            ->orderBy(array("id" => Criteria::ASC));
+        $orderedArr = $arr->matching($criteria);
+        return $orderedArr;
+    }
 
 }


### PR DESCRIPTION
All top level entities are sorted by ID using the query builder, apart from countries which are sorted alphabetically, ignoring case. Entities accessed via entity->getX are sorted by their ID using Doctrine Criteria through a helper function.

This provides consistency, which is particularly useful for comparing different databases' API outputs (e.g. Oracle and MariaDB).