### PR TITLE
Add scripts for API comparison

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,70 @@
+API Comparison Scripts
+===========================
+
+* [Setup](#setup)
+* [Running all scripts](#allscripts)
+* [Running individual scripts](#individualscripts)
+* [Notes](#notes)
+
+## Setup <a id="setup"></a>
+* URLs for two GOCDB hosts must be defined in `get_xml.sh` by `oracle_URL` and `mariadb_URL`
+* A certificate and private key must be placed in `/etc/grid-security/hostcert/`, for accessing protected API methods
+* Lists of API methods, their protection levels, and unique file names in `get_xml.sh` should be updated
+  * Defined by `arr_methods_all`, `arr_permissions_all` and `arr_files_all`, and/or individual flags
+  * Includes updating `get_downtime` and `get_downtime_nested_services`, which are filtered by date
+
+Also required when comparing databases connected to the same host as the comparison scripts being run:
+
+* `oracle_URL` and `mariadb_URL` set equal, to trigger "switching" between databases
+* Database connection files for the two databases, with paths defined in `switch_to_oracle.sh` and `switch_to_mariadb.sh`
+  * Current paths: `/etc/gocdb/database_connection.php` and `/etc/gocdb/maria_database_connection.php`
+* `bootstrap_doctrine.php`, with path defined in `switch_to_oracle.sh` and `switch_to_mariadb.sh`
+  * Current path: `/usr/share/GOCDB5/lib/Doctrine/bootstrap_doctrine.php`
+* To allow "switching", `bootstrap_doctrine.php` must contain the following lines (or equivalent):
+  * `include "/etc/gocdb/database_connection.php";` or `include "/etc/gocdb/maria_database_connection.php";`
+  * `use Doctrine\DBAL\Event\Listeners\OracleSessionInit;` or `//use Doctrine\DBAL\Event\Listeners\OracleSessionInit;`
+
+## Running all scripts <a id="allscripts"></a>
+* The recommended way to perform a comparison is via `run_scripts.sh`
+* Paths to other scripts are relative (`run_scripts.sh` is currently expected to be run from within this directory)
+* Directories required will be created if necessary, with names defined in `run_scripts.sh` and passed to scripts called
+* `run_scripts.sh` has two modes, defined by the presence or absence of `--reduced`:
+
+1. `run_scripts.sh` (recommended)
+    * Suitable when comparing databases connected to the same host as the comparison scripts being run
+    * This allows every line of each pair of XML files to be compared
+    * Calls `get_xml.sh`, `get_diff.sh` and `line_count.sh`
+    * `switch_to_oracle.sh` and `switch_to_mariadb.sh` will also be called by `get_xml.sh`
+
+2. `run_scripts.sh --reduced`
+    * Necessary when comparing databases on different hosts, as their different URLs will appear as differences
+    * This will remove lines containing the `GOCDB_PORTAL_URL` tag from XML files before a diff is performed
+    * Calls `get_xml.sh`, `remove_tags.sh`, `get_diff.sh --reduced` and `line_count.sh`
+
+## Running individual scripts <a id="individualscripts"></a>
+* Although it is typically more convenient to run scripts via `run_scripts.sh`, each script may be run individually
+* In this case, all directories required are assumed to exist
+* Directory names may be passed via flags, otherwise must correspond to defaults specified within each script
+
+1. `get_xml.sh`
+  * Uses wget to save XML files by calling each (specified) API method for the two databases
+  * By default, all API methods are accessed, but individual methods may be accessed instead via flags
+  * Currently set up to compare databases on the same host that `get_xml.sh` is run on
+    * Uses `switch_to_oracle.sh` and `switch_to_mariadb.sh` to change database, when the URLs are set equal
+    * Paths to other scripts are relative (`get_xml.sh` is currently expected to be run from within this directory)
+
+2. `remove_tags.sh` (optional)
+  * Cuts out `GOCDB_PORTAL_URL` tags from XML files saved by `get_xml.sh`
+  * Necessary when connecting to databases on different hosts to remove misleading "differences"
+  * Original XML files are preserved (copies that have the tags removed are created in separate directories)
+
+3. `get_diff.sh`
+  * Carries out diffs between all pairs of saved XML files created by `get_xml.sh` (and `remove_tags.sh`)
+  * Must be passed `--reduced` for files created by `remove_tags.sh` to be used
+
+4. `line_count.sh`
+  * Counts the length of the diff text files created by `get_diff.sh`
+
+## Notes <a id="notes"></a>
+* Temporary text files are created and removed automatically by some scripts
+* Significant differences are likely to be found if the two databases are not sorted consistently

--- a/scripts/current_db.sh
+++ b/scripts/current_db.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# Script to print currently connected database
+# Output changed via ./switch_to_oracle.sh and ./switch_to_mariadb.sh
+
+echo Current DB: MariaDB

--- a/scripts/get_diff.sh
+++ b/scripts/get_diff.sh
@@ -1,0 +1,142 @@
+#!/bin/bash
+
+# Script to carry out diffs between all pairs of XML files
+# Loops through each pair of XML files, performing and saving a diff
+# Outputs the number of diffs carried out successfully
+
+# A string to sanity check the XML download success, defined by $search_string
+
+#Requires:
+    # Directories for temp, oracle_dir/oracle_reduced_dir, mariadb_dir/mariadb_reduced_dir and diff_dir
+    # XML files in oracle_dir/oracle_reduced_dir and mariadb_dir/mariadb_reduced_dir
+
+# If true, diff "reduced" files which have tags (e.g. GOCDB_PORTAL_URL) removed
+reduced_xml=${reduced_xml:-false}
+
+# Default directories where XML is saved
+oracle_dir=${oracle_dir:-oracle_xml}
+mariadb_dir=${mariadb_dir:-mariadb_xml}
+
+# Default directories where "reduced" XML is saved
+oracle_reduced_dir=${oracle_reduced_dir:-oracle_xml_reduced}
+mariadb_reduced_dir=${mariadb_reduced_dir:-mariadb_xml_reduced}
+
+# Default directory for diffs of XML files to be saved
+diff_dir=${diff_dir:-diff_xml}
+
+# Default directory for temporary text files
+temp_dir=${temp_dir:-temp}
+
+# String to check XML files look ok
+search_string="<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+
+# Define flags
+while test $# -gt 0; do
+    case "$1" in
+        -h|--help)
+            echo "options:"
+            echo "-h, --help                show brief help"
+            echo "--reduced                 diff reduced XML files, which certain tags removed"
+            echo "--temp_dir                temporary directory for text files"
+            echo "--oracle_dir              directory for Oracle XML files are saved"
+            echo "--mariadb_dir             directory where MariaDB XML files are saved"
+            echo "--oracle_reduced_dir      directory where reduced Oracle XML files are saved"
+            echo "--mariadb_reduced_dir     directory where reduced MariaDB XML files are saved"
+            echo "--diff_dir                directory for diff of XML files"
+            exit 0
+            ;;
+        --reduced=*)
+            reduced_xml="${1#*=}"
+            shift
+            ;;
+        --temp_dir=*)
+            temp_dir="${1#*=}"
+            shift
+            ;;
+        --oracle_dir=*)
+            oracle_dir="${1#*=}"
+            shift
+            ;;
+        --mariadb_dir=*)
+            mariadb_dir="${1#*=}"
+            shift
+            ;;
+        --oracle_reduced_dir=*)
+            oracle_reduced_dir="${1#*=}"
+            shift
+            ;;
+        --mariadb_reduced_dir=*)
+            mariadb_reduced_dir="${1#*=}"
+            shift
+            ;;
+        --diff_dir=*)
+            diff_dir="${1#*=}"
+            shift
+            ;;
+        *)
+            echo Invalid flag: "$1"
+            exit 1
+            ;;
+    esac
+done
+
+# Directories where XML is saved
+if $reduced_xml; then
+    oracle_dir=$oracle_reduced_dir
+    mariadb_dir=$mariadb_reduced_dir
+fi
+
+# Number of diff files created
+diff_count=0
+
+# Array for diff files that were not created
+arr_file_failures=()
+
+# Temporary text file for list of XML files
+xml_list=${temp_dir}/xmls.txt
+
+# Create and count list of XML files
+ls $oracle_dir > $xml_list
+length=`wc -l < $xml_list`
+
+# Loop through each XML file
+for (( i = 1; i <= $length; i++ ))
+do
+    # Get XML file name
+    xml_file=`head -$i $xml_list | tail -1`
+
+    # Get path for Oracle and MariaDB XML files
+    oracle_xml_file=${oracle_dir}/${xml_file}
+    mariadb_xml_file=${mariadb_dir}/${xml_file}
+
+    # Get XML file name
+    xml_file_no_extension=`basename $xml_file | cut -f 1 -d .`
+    diff_file=${diff_dir}/${xml_file_no_extension}.txt
+
+    # Check if XML file contains the search string for basic validation
+    if grep -q "$search_string" "$oracle_xml_file" && grep -q "$search_string" "$mariadb_xml_file"; then
+        diff $oracle_xml_file $mariadb_xml_file > $diff_file
+        diff_count=$((diff_count+1))
+        echo $xml_file diff performed!
+    else
+        echo "Error: Cannot perform diff for $xml_file"
+        arr_file_failures+=($diff_file)
+    fi
+
+done
+
+echo
+echo diffs created successfully: $diff_count
+echo
+
+if [[ ${#arr_file_failures[@]} = 0 ]]; then
+    echo All diffs successful!
+else
+    echo XML download failures:
+    for i in "${!arr_file_failures[@]}"
+    do
+        echo ${arr_file_failures[i]}
+    done
+fi
+
+rm $xml_list

--- a/scripts/get_xml.sh
+++ b/scripts/get_xml.sh
@@ -1,0 +1,289 @@
+#!/bin/bash
+
+# Script to save XMl files by accessing the API output of two GOCDB hosts
+# Loops through all (specified) API methods
+# Accesses data using wget and saves XML files
+# Counts files downloaded successfully, and lists failed downloads
+
+# API methods, required permissions and XML file names are defined in $arr_methods etc.
+# A string to sanity check the XML download success is defined by $search_string
+# The databases being compared are defined by $oracle_URL and $mariadb_URL
+
+#Requires:
+    # Directories for oracle_dir and mariadb_dir
+    # Certificate and private key in /etc/grid-security/hostcert/ for accessing protected methods
+
+# Default directories where XML is saved
+oracle_dir=${oracle_dir:-oracle_xml}
+mariadb_dir=${mariadb_dir:-mariadb_xml}
+
+# Base URLs for databases being compared
+oracle_URL="https://host-172-16-102-162.nubes.stfc.ac.uk"
+mariadb_URL=$oracle_URL
+
+# Directory for certificate and private key
+# used for authentication when accessing private methods
+cert_dir="/etc/grid-security/hostcert/"
+
+# Array for API method names (get_ not required)
+arr_methods=()
+# Array for XML file names to save
+arr_files=()
+# Array for API method protection level (2 requires a authentication)
+arr_permissions=()
+
+# Array for XML files that failed to download
+arr_file_failures=()
+
+# Define full lists, used by default (no method flags)
+arr_methods_all=("site" "site_list" "site_contacts" "site_security_info" "roc_list" "roc_contacts" "downtime&startdate=2021-01-01" "downtime_nested_services&startdate=2021-01-01" "service_endpoint" "service" "service_types" "user" "downtime_to_broadcast" "cert_status_changes" "cert_status_date" "service_group" "service_group_role" "ngi" "project_contacts" "site_count_per_country")
+arr_files_all=("sites" "sites_list" "site_contacts" "site_security_info" "roc_list" "roc_contacts" "downtimes" "downtime_services" "service_endpoints" "services" "service_types" "users" "downtimes_to_broadcast" "cert_status_changes" "cert_status_dates" "service_groups" "service_group_roles" "ngis" "project_contacts" "site_counts")
+arr_permissions_all=(2 1 2 2 1 2 1 1 1 1 1 2 1 2 2 2 2 2 2 1)
+
+# String to check XML has been downloaded
+search_string="<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+
+# Add methods and file names to arrays based on flags
+while test $# -gt 0; do
+    case "$1" in
+        -h|--help)
+            echo "options:"
+            echo "-h, --help                show brief help"
+            echo "--oracle_dir              directory to save Oracle XML files"
+            echo "--mariadb_dir             directory to save MariaDB XML files"
+            echo "--sites                   get sites data"
+            echo "--sites_list              get list of sites"
+            echo "--site_contacts           get persons with site roles"
+            echo "--site_security_info      get site security data"
+            echo "--roc_list                get list of NGIs"
+            echo "--roc_contacts            get NGI contact data"
+            echo "--downtimes               get downtimes data"
+            echo "--downtime_services       get downtimes data"
+            echo "--service_endpoints       get service endpoints data"
+            echo "--services                get service data"
+            echo "--service_types           get servie types data"
+            echo "--users                   get users data"
+            echo "--downtimes_to_broadcast  get recently declated downtimes"
+            echo "--cert_status_changes     get cert status changes data"
+            echo "--cert_status_dates       get cert status dates data"
+            echo "--service_groups          get service group data"
+            echo "--service_group_roles     get service group role data"
+            echo "--ngis                    get ngis data"
+            echo "--project_contacts        get project contact data"
+            echo "--site_counts             get count of sites per country"
+            exit 0
+            ;;
+        --oracle_dir=*)
+            oracle_dir="${1#*=}"
+            shift
+            ;;
+        --mariadb_dir=*)
+            mariadb_dir="${1#*=}"
+            shift
+            ;;
+        --sites)
+            shift
+            arr_methods+=("site")
+            arr_files+=("sites")
+            arr_permissions+=(2)
+            ;;
+        --sites_list)
+            shift
+            arr_methods+=("site_list")
+            arr_files+=("sites_list")
+            arr_permissions+=(1)
+            ;;
+        --site_contacts)
+            shift
+            arr_methods+=("site_contacts")
+            arr_files+=("site_contacts")
+            arr_permissions+=(2)
+            ;;
+        --site_security_info)
+            shift
+            arr_methods+=("site_security_info")
+            arr_files+=("site_security_info")
+            arr_permissions+=(2)
+            ;;
+        --roc_list)
+            shift
+            arr_methods+=("roc_list")
+            arr_files+=("roc_list")
+            arr_permissions+=(1)
+            ;;
+        --roc_contacts)
+            shift
+            arr_methods+=("roc_contacts")
+            arr_files+=("roc_contacts")
+            arr_permissions+=(2)
+            ;;
+        --downtimes)
+            shift
+            arr_methods+=("downtime&startdate=2021-01-01")
+            arr_files+=("downtimes")
+            arr_permissions+=(1)
+            ;;
+        --downtime_services)
+            shift
+            arr_methods+=("downtime_nested_services&startdate=2021-01-01")
+            arr_files+=("downtime_services")
+            arr_permissions+=(1)
+            ;;
+        --service_endpoints)
+            shift
+            arr_methods+=("service_endpoint")
+            arr_files+=("service_endpoints")
+            arr_permissions+=(1)
+            ;;
+        --services)
+            shift
+            arr_methods+=("service")
+            arr_files+=("services")
+            arr_permissions+=(1)
+            ;;
+        --service_types)
+            shift
+            arr_methods+=("service_types")
+            arr_files+=("service_types")
+            arr_permissions+=(1)
+            ;;
+        --users)
+            shift
+            arr_methods+=("user")
+            arr_files+=("users")
+            arr_permissions+=(2)
+            ;;
+        --downtimes_to_broadcast)
+            shift
+            arr_methods+=("downtime_to_broadcast")
+            arr_files+=("downtimes_to_broadcast")
+            arr_permissions+=(1)
+            ;;
+        --cert_status_changes)
+            shift
+            arr_methods+=("cert_status_changes")
+            arr_files+=("cert_status_changes")
+            arr_permissions+=(2)
+            ;;
+        --cert_status_dates)
+            shift
+            arr_methods+=("cert_status_date")
+            arr_files+=("cert_status_dates")
+            arr_permissions+=(2)
+            ;;
+        --service_groups)
+            shift
+            arr_methods+=("service_group")
+            arr_files+=("service_groups")
+            arr_permissions+=(2)
+            ;;
+        --service_group_roles)
+            shift
+            arr_methods+=("service_group_role")
+            arr_files+=("service_group_roles")
+            arr_permissions+=(2)
+            ;;
+        --ngis)
+            shift
+            arr_methods+=("ngi")
+            arr_files+=("ngis")
+            arr_permissions+=(2)
+            ;;
+        --project_contacts)
+            shift
+            arr_methods+=("project_contacts")
+            arr_files+=("project_contacts")
+            arr_permissions+=(2)
+            ;;
+        --site_counts)
+            shift
+            arr_methods+=("site_count_per_country")
+            arr_files+=("site_counts")
+            arr_permissions+=(1)
+            ;;
+        *)
+            echo Invalid flag
+            exit 1
+            ;;
+    esac
+done
+
+# If no methods specified, use all methods
+if [ -z "$arr_methods" ]; then
+    arr_methods=("${arr_methods_all[@]}")
+    arr_files=("${arr_files_all[@]}")
+    arr_permissions=("${arr_permissions_all[@]}")
+fi
+
+# Loop through each API method
+for i in "${!arr_methods[@]}"
+do
+    if [[ ${arr_permissions[i]} = 2 ]]; then
+        # Authentication required
+        privacy="private"
+        wgetOptionsOracle="-q --no-check-certificate --certificate=${cert_dir}hostcert.pem --private-key=${cert_dir}hostkey.pem --private-key-type=PEM"
+        wgetOptionsMaria=$wgetOptionsOracle
+    else
+        # Authentication not required
+        privacy="public"
+        wgetOptionsOracle="-q --no-check-certificate"
+        wgetOptionsMaria=$wgetOptionsOracle
+    fi
+
+    # XML filename
+    xml_file=${arr_files[i]}.xml
+
+    # Define location of XML files
+    oracle_file=${oracle_dir}/$xml_file
+    mariadb_file=${mariadb_dir}/$xml_file
+
+    # Track if the XML files are created successfully
+    success=true
+
+    echo
+    echo Attempting to download ${xml_file}...
+
+    # Get XMl file from Oracle API
+    if [[ ${oracle_URL} = ${mariadb_URL} ]]; then
+        ./switch_to_oracle.sh
+    fi
+    wget $wgetOptionsOracle -O $oracle_file "${oracle_URL}/gocdbpi/${privacy}/?method=get_${arr_methods[i]}"
+
+    # Check if XML file contains the search string for basic validation
+    if grep -q "$search_string" "$oracle_file"; then
+        echo $oracle_file downloaded successfully!
+    else
+        echo $oracle_file download failed
+        success=false
+        arr_file_failures+=($oracle_file)
+    fi
+
+    # Get XMl file from MariaDB API
+    if [[ ${oracle_URL} = ${mariadb_URL} ]]; then
+        ./switch_to_mariadb.sh
+    fi
+    wget $wgetOptionsMaria -O $mariadb_file "${mariadb_URL}/gocdbpi/${privacy}/?method=get_${arr_methods[i]}"
+
+    # Check if XML file contains the search string for basic validation
+    if grep -q "$search_string" "$mariadb_file"; then
+        echo $mariadb_file downloaded successfully!
+    else
+        echo $mariadb_file download failed
+        success=false
+        arr_file_failures+=($mariadb_file)
+    fi
+
+done
+
+echo
+
+# echo number of files downloaded successfully, and list failures
+if [[ ${#arr_file_failures[@]} = 0 ]]; then
+    echo All XML downloads successful!
+else
+    echo XML download failures:
+    for i in "${!arr_file_failures[@]}"
+    do
+        echo ${arr_file_failures[i]}
+    done
+fi

--- a/scripts/line_count.sh
+++ b/scripts/line_count.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+
+#Script to count length of diff files
+# Loops through each diff file, counting the number of lines
+# Also counts the number of lines in the corresponding XML files
+# Outputs the lengths of each diff files, counting the number of length 0
+
+#Requires:
+    # Directories for temp, oracle_dir, mariadb_dir and diff_dir
+    # XML files in oracle_dir and mariadb_dir
+
+# Default directory for temporary text files
+temp_dir=${temp_dir:-temp}
+
+# Default directories where XML is saved
+oracle_dir=${oracle_dir:-oracle_xml}
+mariadb_dir=${mariadb_dir:-mariadb_xml}
+
+# Default directory for diffs of XML files to be saved
+diff_dir=${diff_dir:-diff_xml}
+
+# Add methods and file names to arrays based on flags
+while test $# -gt 0; do
+    case "$1" in
+        -h|--help)
+            echo "options:"
+            echo "-h, --help                show brief help"
+            echo "--temp_dir                temporary directory for text files"
+            echo "--oracle_dir              directory where Oracle XML files are saved"
+            echo "--mariadb_dir             directory where MariaDB XML files are saved"
+            echo "--diff_dir                directory where diffs of XML files are saved"
+            exit 0
+            ;;
+        --temp_dir=*)
+            temp_dir="${1#*=}"
+            shift
+            ;;
+        --oracle_dir=*)
+            oracle_dir="${1#*=}"
+            shift
+            ;;
+        --mariadb_dir=*)
+            mariadb_dir="${1#*=}"
+            shift
+            ;;
+        --diff_dir=*)
+            diff_dir="${1#*=}"
+            shift
+            ;;
+        *)
+            echo Invalid flag: "$1"
+            exit 1
+            ;;
+    esac
+done
+
+# Temporary text file for list of diff files
+diff_list=${temp_dir}/diffs.txt
+
+# Create and count list of diffs
+ls $diff_dir > $diff_list
+length=`wc -l < $diff_list`
+
+# Count files with no differences
+num_files_pass=0
+num_files_invalid=0
+
+# Loop through diffs
+for (( i = 1; i <= $length; i++ ))
+do
+    # Get each diff file and its length
+    diff_file=`head -$i $diff_list | tail -1`
+    diff_lines=`wc -l < ${diff_dir}/$diff_file`
+
+    if [[ ${diff_lines} = 0 ]]; then
+        num_files_pass=$((num_files_pass+1))
+    fi
+
+    # Get XML file name
+    xml_file=`basename ${diff_dir}/$diff_file | cut -f 1 -d .`
+
+    # Get length of XML files
+    total_lines_oracle=`wc -l < ${oracle_dir}/${xml_file}.xml`
+    total_lines_mariadb=`wc -l < ${mariadb_dir}/${xml_file}.xml`
+
+    # Check XML files are non-zero in length
+    if [[ ${total_lines_oracle} = 0 || ${total_lines_mariadb} = 0 ]]; then
+        num_files_invalid=$((num_files_invalid+1))
+        echo $diff_file
+    else
+        # Approx percentage difference (returns integer)
+        percent=$((100 * $diff_lines / $total_lines_oracle))
+        printf "\r%30s (%6d lines): %5d (%3d%%) lines different\n" $diff_file $total_lines_oracle $diff_lines $percent
+    fi
+
+done
+
+num_files_fail=$((length - num_files_pass))
+
+echo
+echo Invalid files: $num_files_invalid
+echo Files OK: $num_files_pass
+echo Files with differences: $num_files_fail
+
+rm $diff_list

--- a/scripts/remove_tags.sh
+++ b/scripts/remove_tags.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+
+# Script to remove tags from XML files
+# Loops through all XML files and removes lines containing the tag specified
+# Currently only used for GOCDB_PORTAL_URL, but could be generalised
+
+#Requires:
+    # Directories for temp, oracle_reduced_dir and mariadb_reduced_dir
+    # XML files in oracle_dir and mariadb_dir
+
+# Default directory for temporary text files
+temp_dir=${temp_dir:-temp}
+
+# Default directories where XML is saved
+oracle_dir=${oracle_dir:-oracle_xml}
+mariadb_dir=${mariadb_dir:-mariadb_xml}
+
+# Default directories where "reduced" XML is saved
+oracle_reduced_dir=${oracle_reduced_dir:-oracle_xml_reduced}
+mariadb_reduced_dir=${mariadb_reduced_dir:-mariadb_xml_reduced}
+
+# Add methods and file names to arrays based on flags
+while test $# -gt 0; do
+    case "$1" in
+        -h|--help)
+            echo "options:"
+            echo "-h, --help                show brief help"
+            echo "--temp_dir                temporary directory for text files"
+            echo "--oracle_dir              directory where Oracle XML files are saved"
+            echo "--mariadb_dir             directory where MariaDB XML files are saved"
+            echo "--oracle_reduced_dir      directory for reduced Oracle XML files"
+            echo "--mariadb_reduced_dir     directory for reduced MariaDB XML files"
+            exit 0
+            ;;
+        --temp_dir=*)
+            temp_dir="${1#*=}"
+            shift
+            ;;
+        --oracle_dir=*)
+            oracle_dir="${1#*=}"
+            shift
+            ;;
+        --mariadb_dir=*)
+            mariadb_dir="${1#*=}"
+            shift
+            ;;
+        --oracle_reduced_dir=*)
+            oracle_reduced_dir="${1#*=}"
+            shift
+            ;;
+        --mariadb_reduced_dir=*)
+            mariadb_reduced_dir="${1#*=}"
+            shift
+            ;;
+        *)
+            echo Invalid flag: "$1"
+            exit 1
+            ;;
+    esac
+done
+
+# Temporary text file for list of XML files
+xml_list=${temp_dir}/xmls.txt
+
+# Create of list of XML files
+ls ${oracle_dir} > $xml_list
+length=`wc -l < $xml_list`
+
+# Loop through XML files
+for (( i = 1; i <= $length; i++ ))
+do
+    # Get each diff file and its length
+    xml_file=`head -$i $xml_list | tail -1`
+
+    # Create copies of XML files
+    cp ${oracle_dir}/$xml_file ${oracle_reduced_dir}/$xml_file
+    cp ${mariadb_dir}/$xml_file ${mariadb_reduced_dir}/$xml_file
+
+    # Cut out lines
+    sed -i '/<GOCDB_PORTAL_URL>/d' ${oracle_reduced_dir}/$xml_file
+    sed -i '/<GOCDB_PORTAL_URL>/d' ${mariadb_reduced_dir}/$xml_file
+
+    # Get length of original and new XML files
+    original_lines=`wc -l < ${oracle_dir}/${xml_file}`
+    new_lines=`wc -l < ${oracle_reduced_dir}/${xml_file}`
+
+    # Number of lines deleted
+    if [[ ${new_lines} < ${original_lines} && ${new_lines} > 0 ]]; then
+        deleted_lines=$((original_lines - new_lines))
+        printf "\r%5d lines deleted for %s\n" $deleted_lines $xml_file
+    fi
+done
+
+rm $xml_list

--- a/scripts/run_scripts.sh
+++ b/scripts/run_scripts.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+
+# Script to set up directories and calls all other scripts used for comparing database API outputs
+
+# Names of required directories are defined by $dirs and passed to all other scripts
+
+# Directories that must exist (created if not):
+    # temp: stores temporary text files e.g. lists of XML files
+    # oracle_xml: stores XML results from accessing Oracle's API methods
+    # mariadb_xml: stores XML results from accessing MariaDB's API methods
+    # diff_xml: stores text files resulting from the diff of pairs of XML files
+
+# Directories that may exist (created if needed):
+    # oracle_xml_reduced: stores oracle_xml files with certain tags cut out
+    # mariadb_xml_reduced: stores mariadb_xml files with certain tags cut out
+
+# If true, diff "reduced" files which have tags (e.g. GOCDB_PORTAL_URL) removed
+reduced_xml=${reduced_xml:-false}
+
+# Define flags
+while test $# -gt 0; do
+    case "$1" in
+        -h|--help)
+            echo "options:"
+            echo "-h, --help           show brief help"
+            echo "--reduced            diff XML files with certain tags moved if set to true"
+            exit 0
+            ;;
+        --reduced=*)
+            reduced_xml="${1#*=}"
+            shift
+            ;;
+        *)
+            echo Invalid flag: "$1"
+            exit 1
+            ;;
+    esac
+done
+
+# Directories that must always exist
+dirs=('temp' 'oracle_xml' 'mariadb_xml' 'diff_xml')
+
+# Directories must exist if using "reduced" XML
+if $reduced_xml; then
+    dirs+=('oracle_xml_reduced' 'mariadb_xml_reduced')
+fi
+
+# Create directories if necessary
+for i in "${!dirs[@]}"
+do
+    if [ ! -d "${dirs[i]}" ]; then
+        echo "Creating directory ${dirs[i]}"
+        mkdir ./${dirs[i]}
+        echo "Directory created"
+    fi
+done
+
+# Get XML files and save in directories defined by $dirs
+xml_flags="--oracle_dir=${dirs[1]} --mariadb_dir=${dirs[2]}"
+echo
+echo Calling get_xml.sh
+echo Options: $xml_flags
+echo
+./get_xml.sh $xml_flags
+
+# Reduce XML files and save in directories defined by $dirs
+if $reduced_xml; then
+    remove_flags="--temp_dir=${dirs[0]} --oracle_dir=${dirs[1]} --mariadb_dir=${dirs[2]}"
+    remove_flags+=" --oracle_reduced_dir=${dirs[4]} --mariadb_reduced_dir=${dirs[5]}"
+    echo
+    echo Calling remove_tags.sh
+    echo Options: $remove_flags
+    echo
+    ./remove_tags.sh $remove_flags
+
+    diff_flags="--oracle_reduced_dir=${dirs[4]} --mariadb_reduced_dir=${dirs[5]}"
+
+else
+    diff_flags="--oracle_dir=${dirs[1]} --mariadb_dir=${dirs[2]}"
+fi
+
+diff_flags+=" --temp_dir=${dirs[0]} --diff_dir=${dirs[3]} --reduced=${reduced_xml}"
+
+# diff paris of XML files and save in directory defined by $dirs
+echo
+echo Calling get_diff.sh
+echo Options: $diff_flags
+echo
+./get_diff.sh $diff_flags
+
+# Count differences in XML files from length of diff files
+count_flags="--temp_dir=${dirs[0]} --oracle_dir=${dirs[1]} --mariadb_dir=${dirs[2]} --diff_dir=${dirs[3]}"
+echo
+echo Calling line_count.sh
+echo Options: $count_flags
+echo
+./line_count.sh $count_flags

--- a/scripts/switch_to_mariadb.sh
+++ b/scripts/switch_to_mariadb.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# Script used for swapping GOCDB database connections to MariaDB
+# No changes made if already configured for MariaDB
+
+# Requires:
+    # /usr/share/GOCDB5/lib/Doctrine/bootstrap_doctrine.php
+    # /etc/gocdb/maria_database_connection.php containing MariaDB connection details
+    # ./current_db.sh containing echo of current database
+
+echo "Switching to MariaDB"
+
+# Comment out OracleSessionInit in bootstrap_doctrine.php
+search="use\ Doctrine\\\\DBAL\\\\Event\\\\Listeners\\\\OracleSessionInit;"
+replace="\/\/use\ Doctrine\\\\DBAL\\\\Event\\\\Listeners\\\\OracleSessionInit;"
+sed -i "s/^$search/$replace/" /usr/share/GOCDB5/lib/Doctrine/bootstrap_doctrine.php
+
+# Replace database_connection.php with maria_database_connection.php in bootstrap_doctrine.php
+search="\/etc\/gocdb\/database_connection.php"
+replace="\/etc\/gocdb\/maria_database_connection.php"
+sed -i "s/$search/$replace/" /usr/share/GOCDB5/lib/Doctrine/bootstrap_doctrine.php
+
+# Update text echoed by current_db.sh to show current DB is MariaDB
+sed -i "s/Oracle/MariaDB/" ./current_db.sh
+
+# Restart Apache
+systemctl reload httpd

--- a/scripts/switch_to_oracle.sh
+++ b/scripts/switch_to_oracle.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# Script used for swapping GOCDB database connections to Oracle
+# No changes made if already configured for Oracle
+
+# Requires:
+    # /usr/share/GOCDB5/lib/Doctrine/bootstrap_doctrine.php
+    # /etc/gocdb/database_connection.php containing Oracle connection details
+    # ./current_db.sh containing echo of current database
+
+echo "Switching to Oracle"
+
+# Uncomment OracleSessionInit in bootstrap_doctrine.php
+search="\/\/use Doctrine\\\\DBAL\\\\Event\\\\Listeners\\\\OracleSessionInit;"
+replace="use Doctrine\\\\DBAL\\\\Event\\\\Listeners\\\\OracleSessionInit;"
+sed -i "s/^$search/$replace/" /usr/share/GOCDB5/lib/Doctrine/bootstrap_doctrine.php
+
+# Replace maria_database_connection.php with database_connection.php in bootstrap_doctrine.php
+search="\/etc\/gocdb\/maria_database_connection.php"
+replace="\/etc\/gocdb\/database_connection.php"
+sed -i "s/$search/$replace/" /usr/share/GOCDB5/lib/Doctrine/bootstrap_doctrine.php
+
+# Update text echoed by current_db.sh to show current DB is Oracle
+sed -i "s/MariaDB/Oracle/" ./current_db.sh
+
+# Restart Apache
+systemctl reload httpd


### PR DESCRIPTION
These are a collection of scripts that can be useful when comparing the API output from two databases. Overall, the scripts are designed to access each API method from both databases and save the results as XML files, carry out diffs of the XML files, and count the length of the diffs. This functionality is largely carried out by get_xml.sh, get_diff.sh and line_count.sh, respectively.

Ideally, both databases should be accessed via the same host, so `GOCDB_PORTAL_URL` is the same for both, minimising differences. In this case, remove_tags.sh can be ignored. However, if using two different hosts, remove_tags.sh can be used to cut lines containing <GOCDB_PORTAL_URL> from XML files. This is not a particularly elegant solution, but as these tags should not contain any unique information, it should not hurt the validity of comparison significantly.

If using the same host, switch_to_mariadb.sh and switch_to_oracle.sh allow switching between two databases. They assume maria_database_connection.php and database_connection.php store the connection details for MariaDB and Oracle respectively. They also update current_db.sh, which simply echos the current database based on the last switch that was called.

All required scripts can be run via run_scripts.sh. This can be used to define and create all directories that are used by other scripts, and optionally allows remove_tags.sh to be correctly used in combination with the other scripts.

The main change required to use these scripts is to update `$oracle_URL` and `$mariadb_URL` in get_xml.sh to the correct host URLs, as well as potentially the wget options depending on host details. It may also be useful/necessary to update the get_downtime and get_downtime_nested_services method calls defined in get_xml.sh. The full files with no parameters would be too large to access, so currently only downtimes with start dates from 01/01/2021 are requested. Otherwise, run_scripts.sh should hopefully run everything without issues.

Temporary text files are written and removed, so be careful where/how these scripts are run.

Note: A significant number of differences will be flagged if the API is not sorted consistently (see #298).