### PR TITLE
Monitoring checks to use the same url

### DIFF
--- a/htdocs/web_portal/GOCDB_monitor/check.php
+++ b/htdocs/web_portal/GOCDB_monitor/check.php
@@ -9,9 +9,8 @@ $res[2] = test_url(
             \Factory::getConfigService()->GetPiUrl().
             get_testPiMethod()
             );
-//$res[3] = test_url(PORTAL_URL);
 $res[3] = test_url(
-            \Factory::getConfigService()->getServerBaseUrl()
+            \Factory::getConfigService()->GetPortalURL()
             );
 
 

--- a/htdocs/web_portal/GOCDB_monitor/ops_monitor_check.php
+++ b/htdocs/web_portal/GOCDB_monitor/ops_monitor_check.php
@@ -3,13 +3,10 @@ require_once "tests.php";
 
 // function returns associative array
 $res[1] = test_db_connection();
-//$res[2] = test_url(PI_URL);
+
 $res[2] = test_url(Factory::getConfigService()->GetPiUrl().get_testPiMethod());
 
-//$res[3] = test_url(PORTAL_URL);
-
-//$res[3] = test_url(SERVER_BASE_URL);
-$res[3] = test_url(Factory::getConfigService()->getServerBaseUrl());
+$res[3] = test_url(Factory::getConfigService()->GetPortalURL());
 
 $counts=array(
         "ok" => 0,


### PR DESCRIPTION
Fixes #317 

Standardise on using the portal url in the monitoring checks.