### PR TITLE
Add support for EOSC IdPs out of the box

### DIFF
--- a/htdocs/web_portal/components/Get_User_Principle.php
+++ b/htdocs/web_portal/components/Get_User_Principle.php
@@ -116,7 +116,12 @@ function Get_User_AuthToken(){
         MyStaticAuthTokenHolder::getInstance()->setAuthToken($auth);
         return $auth;
     }
-    return null;
+
+    // We don't want the portal to be exposed without authentication (even
+    // though no actual info is displayed to an unauthenticated user),
+    // so if we have not set the principle/userDetails,
+    // re-direct to our Discovery Service.
+    redirectUserToDiscoveryPage();
 }
 
 /**
@@ -190,7 +195,12 @@ function Get_User_Principle(){
         }
         return $principleString;
     }
-    return null;
+
+    // We don't want the portal to be exposed without authentication (even
+    // though no actual info is displayed to an unauthenticated user),
+    // so if we have not set the principle/userDetails,
+    // re-direct to our Discovery Service.
+    redirectUserToDiscoveryPage();
 }
 
 /**
@@ -217,9 +227,21 @@ function Get_User_Principle_PI() {
         }
     }
 
+    # Returning null here is necessary, because parts of the API are exposed
+    # publically, without authentication.
     return null;
 }
 
+/*
+ * Prevent the current page from being loaded and redirect the user
+ * to the IdP discovery page (a.k.a the landing page).
+ */
+function redirectUserToDiscoveryPage()
+{
+    $url = \Factory::getConfigService()->getServerBaseUrl();
+    header("Location: " . $url);
+    die();
+}
 
 
 

--- a/lib/Authentication/AuthTokens/ShibAuthToken.php
+++ b/lib/Authentication/AuthTokens/ShibAuthToken.php
@@ -79,11 +79,11 @@ class ShibAuthToken implements IAuthentication {
     public function getPrinciple() {
        return $this->principal;
     }
-    
-    
-    
+
+
+
     private function getAttributesInitToken(){
-        $hostname = $_SERVER['HTTP_HOST']; // don't use $_SERVER['SERVER_NAME'] as this don't support DNS 
+        $hostname = $_SERVER['HTTP_HOST']; // don't use $_SERVER['SERVER_NAME'] as this don't support DNS
         // specify location of the Shib Logout handler
         \Factory::$properties['LOGOUTURL'] = 'https://'.$hostname.'/Shibboleth.sso/Logout';
         $idp = isset($_SERVER['Shib-Identity-Provider']) ? $_SERVER['Shib-Identity-Provider'] : '';
@@ -152,8 +152,8 @@ class ShibAuthToken implements IAuthentication {
             }
             if(empty($_SERVER['entitlement'])){
                 die('Did not receive the required entitlement attribute from the EGI Dev Proxy IdP, please contact gocdb-admins');
-            } 
-            $entitlementValuesArray = explode(';', $_SERVER['entitlement']); 
+            }
+            $entitlementValuesArray = explode(';', $_SERVER['entitlement']);
             if( !in_array('urn:mace:egi.eu:res:gocdb#aai.egi.eu', $entitlementValuesArray) ){
                  $HTML = '<ul><li>You authenticated to the EGI Dev Identity Provider using a method that does not provide a GOCDB entitlement.</li><li>Login is required with a gocdb entitlement.</li><li>To gain access, you will need to login to the Proxy IdP using a scheme that provides a gocdb entitlement.</li><li>Please logout or restart your browser and attempt to login again.</li></ul>';
                  $HTML .= "<div style='text-align: center;'>";
@@ -164,6 +164,46 @@ class ShibAuthToken implements IAuthentication {
             }
             $this->principal = $_SERVER['epuid'];
             $this->userDetails = array('AuthenticationRealm' => array('EGI Proxy IdP'));
+            return;
+        }
+        else if($idp == 'https://aai-demo.eosc-portal.eu/proxy/saml2/idp/metadata.php'){
+            if( empty($_SERVER['voPersonID'])){
+                die('Did not receive required voPersonID attributes from the EOSC Demo Proxy Identity Provider to complete authentication, please contact gocdb-admins');
+            }
+            if(empty($_SERVER['entitlement'])){
+                die('Did not receive the required entitlement attribute from the EOSC Demo Proxy Identity Provider, please contact gocdb-admins');
+            }
+            $entitlementValuesArray = explode(';', $_SERVER['entitlement']);
+            if( !in_array('urn:geant:eosc-portal.eu:res:gocdb.eosc-portal.eu#aai.eosc-portal.eu', $entitlementValuesArray) ){
+                 $HTML = '<ul><li>You authenticated to the EOSC Demo Proxy Identity Provider using a method that does not provide a GOCDB entitlement.</li><li>Login is required with a GOCDB entitlement.</li><li>To gain access, you will need to login to the Proxy IdP using a scheme that provides a gocdb entitlement.</li><li>Please logout or restart your browser and attempt to login again.</li></ul>';
+                 $HTML .= "<div style='text-align: center;'>";
+                 $HTML .= '<a href="'.htmlspecialchars(\Factory::$properties['LOGOUTURL']).'"><b><font colour="red">Logout</font></b></a>';
+                 $HTML .= "</div>";
+                 echo ($HTML);
+                 die();
+            }
+            $this->principal = $_SERVER['voPersonID'];
+            $this->userDetails = array('AuthenticationRealm' => array('EOSC Demo Proxy IdP'));
+            return;
+        }
+        else if($idp == 'https://aai.eosc-portal.eu/proxy/saml2/idp/metadata.php'){
+            if( empty($_SERVER['voPersonID'])){
+                die('Did not receive required voPersonID attributes from the EOSC Proxy Identity Provider to complete authentication, please contact gocdb-admins');
+            }
+            if(empty($_SERVER['entitlement'])){
+                die('Did not receive the required entitlement attribute from the EOSC Proxy Identity Provider, please contact gocdb-admins');
+            }
+            $entitlementValuesArray = explode(';', $_SERVER['entitlement']);
+            if( !in_array('urn:geant:eosc-portal.eu:res:gocdb.eosc-portal.eu#aai.eosc-portal.eu', $entitlementValuesArray) ){
+                 $HTML = '<ul><li>You authenticated to the EOSC Proxy Identity Provider using a method that does not provide a GOCDB entitlement.</li><li>Login is required with a GOCDB entitlement.</li><li>To gain access, you will need to login to the Proxy IdP using a scheme that provides a gocdb entitlement.</li><li>Please logout or restart your browser and attempt to login again.</li></ul>';
+                 $HTML .= "<div style='text-align: center;'>";
+                 $HTML .= '<a href="'.htmlspecialchars(\Factory::$properties['LOGOUTURL']).'"><b><font colour="red">Logout</font></b></a>';
+                 $HTML .= "</div>";
+                 echo ($HTML);
+                 die();
+            }
+            $this->principal = $_SERVER['voPersonID'];
+            $this->userDetails = array('AuthenticationRealm' => array('EOSC Proxy IdP'));
             return;
         }
     }

--- a/lib/Authentication/AuthTokens/ShibAuthToken.php
+++ b/lib/Authentication/AuthTokens/ShibAuthToken.php
@@ -174,7 +174,7 @@ class ShibAuthToken implements IAuthentication {
                 die('Did not receive the required entitlement attribute from the EOSC Demo Proxy Identity Provider, please contact gocdb-admins');
             }
             $entitlementValuesArray = explode(';', $_SERVER['entitlement']);
-            if( !in_array('urn:geant:eosc-portal.eu:res:gocdb.eosc-portal.eu#aai.eosc-portal.eu', $entitlementValuesArray) ){
+            if( !in_array('urn:geant:eosc-portal.eu:res:gocdb.eosc-portal.eu', $entitlementValuesArray) ){
                  $HTML = '<ul><li>You authenticated to the EOSC Demo Proxy Identity Provider using a method that does not provide a GOCDB entitlement.</li><li>Login is required with a GOCDB entitlement.</li><li>To gain access, you will need to login to the Proxy IdP using a scheme that provides a gocdb entitlement.</li><li>Please logout or restart your browser and attempt to login again.</li></ul>';
                  $HTML .= "<div style='text-align: center;'>";
                  $HTML .= '<a href="'.htmlspecialchars(\Factory::$properties['LOGOUTURL']).'"><b><font colour="red">Logout</font></b></a>';
@@ -194,7 +194,7 @@ class ShibAuthToken implements IAuthentication {
                 die('Did not receive the required entitlement attribute from the EOSC Proxy Identity Provider, please contact gocdb-admins');
             }
             $entitlementValuesArray = explode(';', $_SERVER['entitlement']);
-            if( !in_array('urn:geant:eosc-portal.eu:res:gocdb.eosc-portal.eu#aai.eosc-portal.eu', $entitlementValuesArray) ){
+            if( !in_array('urn:geant:eosc-portal.eu:res:gocdb.eosc-portal.eu', $entitlementValuesArray) ){
                  $HTML = '<ul><li>You authenticated to the EOSC Proxy Identity Provider using a method that does not provide a GOCDB entitlement.</li><li>Login is required with a GOCDB entitlement.</li><li>To gain access, you will need to login to the Proxy IdP using a scheme that provides a gocdb entitlement.</li><li>Please logout or restart your browser and attempt to login again.</li></ul>';
                  $HTML .= "<div style='text-align: center;'>";
                  $HTML .= '<a href="'.htmlspecialchars(\Factory::$properties['LOGOUTURL']).'"><b><font colour="red">Logout</font></b></a>';

--- a/lib/Gocdb_Services/PI/GetNGIContacts.php
+++ b/lib/Gocdb_Services/PI/GetNGIContacts.php
@@ -285,6 +285,7 @@ class GetNGIContacts implements IPIQuery, IPIQueryPageable, IPIQueryRenderable {
                             $xmlContact->addChild('CERTDN', $serv->getIdStringByAuthType($user, 'X.509'));
                             $xmlContact->addChild('EGICHECKIN', $serv->getIdStringByAuthType($user, 'EGI Proxy IdP'));
                             $xmlContact->addChild('IRISIAM', $serv->getIdStringByAuthType($user, 'IRIS IAM - OIDC'));
+                            $xmlContact->addChild('EOSCAAI', $serv->getIdStringByAuthType($user, 'EOSC Proxy IdP'));
                         } else {
                             $xmlContact->addChild('CERTDN', $serv->getDefaultIdString($user));
                         }

--- a/lib/Gocdb_Services/PI/GetProjectContacts.php
+++ b/lib/Gocdb_Services/PI/GetProjectContacts.php
@@ -264,6 +264,7 @@ class GetProjectContacts implements IPIQuery, IPIQueryPageable, IPIQueryRenderab
                             $xmlContact->addChild('CERTDN', $serv->getIdStringByAuthType($user, 'X.509'));
                             $xmlContact->addChild('EGICHECKIN', $serv->getIdStringByAuthType($user, 'EGI Proxy IdP'));
                             $xmlContact->addChild('IRISIAM', $serv->getIdStringByAuthType($user, 'IRIS IAM - OIDC'));
+                            $xmlContact->addChild('EOSCAAI', $serv->getIdStringByAuthType($user, 'EOSC Proxy IdP'));
                         } else {
                             $xmlContact->addChild('CERTDN', $serv->getDefaultIdString($user));
                         }

--- a/lib/Gocdb_Services/PI/GetServiceGroupRole.php
+++ b/lib/Gocdb_Services/PI/GetServiceGroupRole.php
@@ -299,6 +299,7 @@ class GetServiceGroupRole implements IPIQuery, IPIQueryPageable, IPIQueryRendera
                     $xmlUser->addChild ( 'CERTDN', $serv->getIdStringByAuthType ( $user, 'X.509' ) );
                     $xmlUser->addChild ( 'EGICHECKIN', $serv->getIdStringByAuthType ( $user, 'EGI Proxy IdP' ) );
                     $xmlUser->addChild ( 'IRISIAM', $serv->getIdStringByAuthType ( $user, 'IRIS IAM - OIDC' ) );
+                    $xmlUser->addChild('EOSCAAI', $serv->getIdStringByAuthType($user, 'EOSC Proxy IdP'));
                 } else {
                     $xmlUser->addChild ( 'CERTDN', $serv->getDefaultIdString ( $user ) );
                 }

--- a/lib/Gocdb_Services/PI/GetSiteContacts.php
+++ b/lib/Gocdb_Services/PI/GetSiteContacts.php
@@ -315,6 +315,7 @@ class GetSiteContacts implements IPIQuery, IPIQueryPageable, IPIQueryRenderable 
                             $xmlContact->addChild ( 'CERTDN', $serv->getIdStringByAuthType ( $user, 'X.509' ) );
                             $xmlContact->addChild ( 'EGICHECKIN', $serv->getIdStringByAuthType ( $user, 'EGI Proxy IdP' ) );
                             $xmlContact->addChild ( 'IRISIAM', $serv->getIdStringByAuthType ( $user, 'IRIS IAM - OIDC' ) );
+                            $xmlContact->addChild('EOSCAAI', $serv->getIdStringByAuthType($user, 'EOSC Proxy IdP'));
                         } else {
                             $xmlContact->addChild ( 'CERTDN', $serv->getDefaultIdString ( $user ) );
                         }

--- a/lib/Gocdb_Services/PI/GetUser.php
+++ b/lib/Gocdb_Services/PI/GetUser.php
@@ -306,6 +306,7 @@ class GetUser implements IPIQuery, IPIQueryPageable, IPIQueryRenderable {
                 $xmlUser->addChild('CERTDN', $serv->getIdStringByAuthType($user, 'X.509'));
                 $xmlUser->addChild('EGICHECKIN', $serv->getIdStringByAuthType($user, 'EGI Proxy IdP'));
                 $xmlUser->addChild('IRISIAM', $serv->getIdStringByAuthType($user, 'IRIS IAM - OIDC'));
+                $xmlUser->addChild('EOSCAAI', $serv->getIdStringByAuthType($user, 'EOSC Proxy IdP'));
             } else {
                 $xmlUser->addChild('CERTDN', $serv->getDefaultIdString($user));
             }

--- a/lib/Gocdb_Services/User.php
+++ b/lib/Gocdb_Services/User.php
@@ -490,9 +490,9 @@ class User extends AbstractEntityService{
         // Hardcoded authentication realms in same order as in token definitions
         $x509Realms = ['X.509'];
         if ($reducedRealms) {
-            $shibRealms = ['EGI Proxy IdP'];
+            $shibRealms = ['EGI Proxy IdP', 'EOSC Proxy IdP'];
         } else {
-            $shibRealms = ['EUDAT_SSO_IDP', 'UK_ACCESS_FED', 'EGI Proxy IdP'];
+            $shibRealms = ['EUDAT_SSO_IDP', 'UK_ACCESS_FED', 'EGI Proxy IdP', 'EOSC Proxy IdP'];
         }
         $irisRealms = ['IRIS IAM - OIDC'];
 

--- a/lib/Gocdb_Services/User.php
+++ b/lib/Gocdb_Services/User.php
@@ -721,9 +721,6 @@ class User extends AbstractEntityService{
 
         // Check the ID string does not already exist
         $this->valdidateUniqueIdString($keyValue);
-
-        // Check auth type is valid
-        $this->valdidateAuthType($keyName);
     }
 
     /**
@@ -808,9 +805,6 @@ class User extends AbstractEntityService{
             $this->valdidateUniqueIdString($keyValue);
         }
 
-        // Check auth type is valid
-        $this->valdidateAuthType($keyName);
-
         // If the identifiers key has changed, check there isn't an existing identifier with that key
         if ($keyName !== $identifier->getKeyName()) {
             $existingIdentifiers = $user->getUserIdentifiers();
@@ -819,17 +813,6 @@ class User extends AbstractEntityService{
                     throw new \Exception("An identifier with that name already exists for this object");
                 }
             }
-        }
-    }
-
-    /**
-     * Validate authentication type based on known list.
-     * @param string $authType
-     * @throws \Exception
-     */
-    protected function valdidateAuthType($authType) {
-        if (!in_array($authType, $this->getAuthTypes(false))) {
-            throw new \Exception("The authentication type entered is invalid");
         }
     }
 


### PR DESCRIPTION
Use "voPersonID" to consume the user's identifier, rather than ePUID - as that has been deprecated following the (AAI teams?) adoption of the AARC-G026 guidelines.

Depends on #346 