### PR TITLE
Prevent database connection pile-up during tests

### DIFF
--- a/tests/doctrine/DoctrineCleanInsert1Test.php
+++ b/tests/doctrine/DoctrineCleanInsert1Test.php
@@ -1,4 +1,5 @@
 <?php
+
 require_once dirname(__FILE__) . '/TestUtil.php';
 require_once dirname(__FILE__) . "/bootstrap.php";
 use Doctrine\ORM\EntityManager;
@@ -16,178 +17,200 @@ use Doctrine\ORM\EntityManager;
  * @author David Meredith <david.meredith@stfc.ac.uk>
  * @author Johnn Casson <john.casson@stfc.ac.uk>
  */
-class DoctrineCleanInsert1Test extends PHPUnit_Extensions_Database_TestCase {
-
-  private $em;
-  private $egiScope;
-  private $localScope;
-  private $eudatScope;
+class DoctrineCleanInsert1Test extends PHPUnit_Extensions_Database_TestCase
+{
+    private $em;
+    private $egiScope;
+    private $localScope;
+    private $eudatScope;
 
   /**
    * Overridden.
    */
-  public static function setUpBeforeClass() {
-    parent::setUpBeforeClass();
+    public static function setUpBeforeClass()
+    {
+        parent::setUpBeforeClass();
 
-    echo "\n\n-------------------------------------------------\n";
-    echo "Executing DoctrineCleanInsert1Test. . .\n";
-  }
+        echo "\n\n-------------------------------------------------\n";
+        echo "Executing DoctrineCleanInsert1Test. . .\n";
+    }
 
   /**
    * Overridden. Returns the test database connection.
    * @return PHPUnit_Extensions_Database_DB_IDatabaseConnection
    */
-  protected function getConnection() {
-    require_once dirname(__FILE__) . '/bootstrap_pdo.php';
-    return getConnectionToTestDB();
-  }
+    protected function getConnection()
+    {
+        require_once dirname(__FILE__) . '/bootstrap_pdo.php';
+        return getConnectionToTestDB();
+    }
 
   /**
    * Overridden. Returns the test dataset.
    * Defines how the initial state of the database should look before each test is executed.
    * @return PHPUnit_Extensions_Database_DataSet_IDataSet
    */
-  protected function getDataSet() {
-    return $this->createFlatXMLDataSet(dirname(__FILE__) . '/truncateDataTables.xml');
-    // Use below to return an empty data set if we don't want to truncate and seed
-    //return new PHPUnit_Extensions_Database_DataSet_DefaultDataSet();
-  }
+    protected function getDataSet()
+    {
+        return $this->createFlatXMLDataSet(dirname(__FILE__) . '/truncateDataTables.xml');
+      // Use below to return an empty data set if we don't want to truncate and seed
+      //return new PHPUnit_Extensions_Database_DataSet_DefaultDataSet();
+    }
 
   /**
    * Overridden.
    */
-  protected function getSetUpOperation() {
-    // CLEAN_INSERT is default
-    //return PHPUnit_Extensions_Database_Operation_Factory::CLEAN_INSERT();
-    //return PHPUnit_Extensions_Database_Operation_Factory::UPDATE();
-    //return PHPUnit_Extensions_Database_Operation_Factory::NONE();
-    //
-    // Issue a DELETE from <table> which is more portable than a
-    // TRUNCATE table <table> (some DBs require high privileges for truncate statements
-    // and also do not allow truncates across tables with FK contstraints e.g. Oracle)
-    return PHPUnit_Extensions_Database_Operation_Factory::DELETE_ALL();
-  }
+    protected function getSetUpOperation()
+    {
+      // CLEAN_INSERT is default
+      //return PHPUnit_Extensions_Database_Operation_Factory::CLEAN_INSERT();
+      //return PHPUnit_Extensions_Database_Operation_Factory::UPDATE();
+      //return PHPUnit_Extensions_Database_Operation_Factory::NONE();
+      //
+      // Issue a DELETE from <table> which is more portable than a
+      // TRUNCATE table <table> (some DBs require high privileges for truncate statements
+      // and also do not allow truncates across tables with FK contstraints e.g. Oracle)
+        return PHPUnit_Extensions_Database_Operation_Factory::DELETE_ALL();
+    }
 
   /**
    * Overridden.
    */
-  protected function getTearDownOperation() {
-    // NONE is default
-    return PHPUnit_Extensions_Database_Operation_Factory::NONE();
-  }
+    protected function getTearDownOperation()
+    {
+      // NONE is default
+        return PHPUnit_Extensions_Database_Operation_Factory::NONE();
+    }
 
   /**
    * Sets up the fixture, e.g create a new entityManager for each test run
    * This method is called before each test method is executed.
    */
-  protected function setUp() {
-    parent::setUp();
-    $this->em = $this->createEntityManager();
-  }
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->em = $this->createEntityManager();
+    }
 
+  /**
+   * Run after each test function to prevent pile-up of database connections.
+   */
+    protected function tearDown()
+    {
+        parent::tearDown();
+        if (!is_null($this->em)) {
+            $this->em->getConnection()->close();
+        }
+    }
   /**
    * @todo Still need to setup connection to different databases.
    * @return EntityManager
    */
-  private function createEntityManager(){
-    //require dirname(__FILE__).'/../bootstrap.php';
-    require dirname(__FILE__).'/bootstrap_doctrine.php';
-    return $entityManager;
-  }
+    private function createEntityManager()
+    {
+      //require dirname(__FILE__).'/../bootstrap.php';
+        require dirname(__FILE__) . '/bootstrap_doctrine.php';
+        return $entityManager;
+    }
 
   /**
    * Called after setUp() and before each test. Used for common assertions
    * across all tests.
    */
-  protected function assertPreConditions() {
-    $con = $this->getConnection();
-    $fixture = dirname(__FILE__) . '/truncateDataTables.xml';
-    $tables = simplexml_load_file($fixture);
+    protected function assertPreConditions()
+    {
+        $con = $this->getConnection();
+        $fixture = dirname(__FILE__) . '/truncateDataTables.xml';
+        $tables = simplexml_load_file($fixture);
 
-    foreach($tables as $tableName) {
-      //print $tableName->getName() . "\n";
-      $sql = "SELECT * FROM ".$tableName->getName();
-      $result = $con->createQueryTable('results_table', $sql);
-      //echo 'row count: '.$result->getRowCount() ;
-      if($result->getRowCount() != 0){
-        throw new RuntimeException("Invalid fixture. Table has rows: ".$tableName->getName());
-      }
+        foreach ($tables as $tableName) {
+          //print $tableName->getName() . "\n";
+            $sql = "SELECT * FROM " . $tableName->getName();
+            $result = $con->createQueryTable('results_table', $sql);
+          //echo 'row count: '.$result->getRowCount() ;
+            if ($result->getRowCount() != 0) {
+                throw new RuntimeException("Invalid fixture. Table has rows: " . $tableName->getName());
+            }
+        }
     }
-  }
 
-  public function testAssertTestEntityMangersAreDifferent(){
-    print __METHOD__ . "\n";
-    $em1 = $this->createEntityManager();
-    $em2 = $this->createEntityManager();
-    // Below asserts that two variables do not have the same type and value.
-    // Used on objects, it asserts that two variables do not reference the same object.
-    $this->assertNotSame($em1, $em2);
-    if($em1 === $em2){
-      $this->fail();
+    public function testAssertTestEntityMangersAreDifferent()
+    {
+        print __METHOD__ . "\n";
+        $em1 = $this->createEntityManager();
+        $em2 = $this->createEntityManager();
+      // Below asserts that two variables do not have the same type and value.
+      // Used on objects, it asserts that two variables do not reference the same object.
+        $this->assertNotSame($em1, $em2);
+        if ($em1 === $em2) {
+            $this->fail();
+        }
     }
-  }
 
 
-  public function testJoinServicesToSite_RefetchSiteLazyLoadSEs() {
-    print __METHOD__ . "\n";
-    // create a sinlge site and add 3 service endpoints
-    $n = 3;
-    $site = TestUtil::createSampleSite('site' . $n);
-    $this->em->persist($site);
-    for ($i = 0; $i < $n; $i++) {
-      $se = TestUtil::createSampleService("serv" . $i);
-      $site->addServiceDoJoin($se);
-      $se->setParentSiteDoJoin($site);
-      $this->em->persist($se);
-    }
-    $seCount = count($site->getServices());
-    $this->assertTrue($seCount == $n);
-    $this->em->flush();
-    $this->em->clear();
-    $this->em->close();
+    public function testJoinServicesToSite_RefetchSiteLazyLoadSEs()
+    {
+        print __METHOD__ . "\n";
+      // create a sinlge site and add 3 service endpoints
+        $n = 3;
+        $site = TestUtil::createSampleSite('site' . $n);
+        $this->em->persist($site);
+        for ($i = 0; $i < $n; $i++) {
+            $se = TestUtil::createSampleService("serv" . $i);
+            $site->addServiceDoJoin($se);
+            $se->setParentSiteDoJoin($site);
+            $this->em->persist($se);
+        }
+        $seCount = count($site->getServices());
+        $this->assertTrue($seCount == $n);
+        $this->em->flush();
+        $this->em->clear();
+        $this->em->getConnection()->close();
+        $this->em->close();
 
-    $em2 = $this->createEntityManager();
-    $refetchedSite = $em2->getRepository('Site')->findOneBy(array('shortName' => 'site' . $n));
-    $this->assertNotNull($refetchedSite);
-    $em2->clear();
-    $em2->close();
-    // close causes all managed entities ($refetchedSite) to become detached
-    // and the em2 can't be used again.
+        $em2 = $this->createEntityManager();
+        $refetchedSite = $em2->getRepository('Site')->findOneBy(array('shortName' => 'site' . $n));
+        $this->assertNotNull($refetchedSite);
+        $em2->clear();
+        $em2->close();
+      // close causes all managed entities ($refetchedSite) to become detached
+      // and the em2 can't be used again.
 
                                             /** Why the following works **/
-    /* When doctrine fetches an entity its default is to lazy load related entities - it does
-     * not directly hydrate them it creates a proxy. Although the entity manager is closed the
-     * code below is able to get the service count, name and parent site. This is because when
-     * doctrine creates a proxy the proxy also contains an instance of the EntityManager and it's
-     * dependancies which can then be used when the proxy is called to hydrate the entity and provide
-     * the required data.
-     */
+      /* When doctrine fetches an entity its default is to lazy load related entities - it does
+       * not directly hydrate them it creates a proxy. Although the entity manager is closed the
+       * code below is able to get the service count, name and parent site. This is because when
+       * doctrine creates a proxy the proxy also contains an instance of the EntityManager and it's
+       * dependancies which can then be used when the proxy is called to hydrate the entity and provide
+       * the required data.
+       */
 
 
-    $seList = $refetchedSite->getServices();
+        $seList = $refetchedSite->getServices();
 
-    $this->assertCount(3, $seList);
-  }
+        $this->assertCount(3, $seList);
+    }
 
 
   /**
    * @link http://stackoverflow.com/questions/7877987/read-objects-persisted-but-not-yet-flushed-with-doctrine issue with doctrine
    */
-  public function testShowDoctrineReadFailiureUntilCommitted(){
-    print __METHOD__ . "\n";
-    $n = 1;
-    // create a new site and persist (but do not flush yet)
-    $site = TestUtil::createSampleSite('site' . $n/*, 'pk' . $n*/);
-    $this->em->beginTransaction();
-    $this->em->persist($site);
-    // After persist, Doctrine querying does not return our site until we flush, hence we get 0
-    // returned from our repository.
-    $this->assertEquals(0, count($this->em->getRepository('Site')->findOneBy(array('shortName' => 'site' . $n))));
-    // When we flush or commit we get one.
-    $this->em->commit();
-    $this->em->flush();
-    $this->assertEquals(1, count($this->em->getRepository('Site')->findOneBy(array('shortName' => 'site' . $n))));
-  }
+    public function testShowDoctrineReadFailiureUntilCommitted()
+    {
+        print __METHOD__ . "\n";
+        $n = 1;
+      // create a new site and persist (but do not flush yet)
+        $site = TestUtil::createSampleSite('site' . $n/*, 'pk' . $n*/);
+        $this->em->beginTransaction();
+        $this->em->persist($site);
+      // After persist, Doctrine querying does not return our site until we flush, hence we get 0
+      // returned from our repository.
+        $this->assertEquals(0, count($this->em->getRepository('Site')->findOneBy(array('shortName' => 'site' . $n))));
+      // When we flush or commit we get one.
+        $this->em->commit();
+        $this->em->flush();
+        $this->assertEquals(1, count($this->em->getRepository('Site')->findOneBy(array('shortName' => 'site' . $n))));
+    }
 
 
   /**
@@ -197,265 +220,280 @@ class DoctrineCleanInsert1Test extends PHPUnit_Extensions_Database_TestCase {
    * relation have to be managed in userland application code. Doctrine
    * cannot magically update your collections to be consistent.").
    */
-  public function testShowBiDirectionalJoinConsitencyManagement() {
-    print __METHOD__ . "\n";
-    $ngi = TestUtil::createSampleNGI('myngi');
-    $site = TestUtil::createSampleSite('mysite'/*, 'pk1'*/);
+    public function testShowBiDirectionalJoinConsitencyManagement()
+    {
+        print __METHOD__ . "\n";
+        $ngi = TestUtil::createSampleNGI('myngi');
+        $site = TestUtil::createSampleSite('mysite'/*, 'pk1'*/);
 
-    // Important:
-    // The inverse side of a bi-directional relationship MUST be correctly managed.
-    // If  $ngi->addSiteDoJoin($site) is not called (try commenting out next line),
-    // the commented out assertion on next line would fail as $ngi->getSites()
-    // will return 0 when running in same TX.
-    // "$siteCount = $ngi->getSites(); $this->assertTrue($siteCount == 1);"
-    $ngi->addSiteDoJoin($site);
-    //$site->setNgiDoJoin($ngi);  // optional, calling this does no harm.
+      // Important:
+      // The inverse side of a bi-directional relationship MUST be correctly managed.
+      // If  $ngi->addSiteDoJoin($site) is not called (try commenting out next line),
+      // the commented out assertion on next line would fail as $ngi->getSites()
+      // will return 0 when running in same TX.
+      // "$siteCount = $ngi->getSites(); $this->assertTrue($siteCount == 1);"
+        $ngi->addSiteDoJoin($site);
+      //$site->setNgiDoJoin($ngi);  // optional, calling this does no harm.
 
-    // Important:
-    // Similarly, two invocations of "$ngi->addSiteDoJoin($site)" in the same TX
-    // will add two sites to NGI causing getSites() to return 2 !
-    // (looks like Doctrine's ArrayCollection can
-    // only distinguish object instances based on obj FK ID).
+      // Important:
+      // Similarly, two invocations of "$ngi->addSiteDoJoin($site)" in the same TX
+      // will add two sites to NGI causing getSites() to return 2 !
+      // (looks like Doctrine's ArrayCollection can
+      // only distinguish object instances based on obj FK ID).
 
-    $this->em->persist($site); // is now managed
-    $this->em->persist($ngi);  // is now managed
-    $siteCount = count($ngi->getSites());
-    $this->assertTrue($siteCount == 1);
-    $this->em->flush();
+        $this->em->persist($site); // is now managed
+        $this->em->persist($ngi);  // is now managed
+        $siteCount = count($ngi->getSites());
+        $this->assertTrue($siteCount == 1);
+        $this->em->flush();
 
-    // start new TX
-    $this->em = $this->createEntityManager();
-    $this->assertTrue(
-      count($this->em->getRepository('NGI')->findOneBy(array('name' => 'myngi'))->getSites()) == 1
-    );
+      // start new TX
+        $this->em = $this->createEntityManager();
+        $this->assertTrue(
+            count($this->em->getRepository('NGI')->findOneBy(array('name' => 'myngi'))->getSites()) == 1
+        );
 
-    $testConn = $this->getConnection();
-    $result = $testConn->createQueryTable('results_table', "SELECT * FROM NGIs");
-    $this->assertTrue($result->getRowCount() == 1);
-    $result = $testConn->createQueryTable('results_table', "SELECT * FROM Sites");
-    $this->assertTrue($result->getRowCount() == 1);
+        $testConn = $this->getConnection();
+        $result = $testConn->createQueryTable('results_table', "SELECT * FROM NGIs");
+        $this->assertTrue($result->getRowCount() == 1);
+        $result = $testConn->createQueryTable('results_table', "SELECT * FROM Sites");
+        $this->assertTrue($result->getRowCount() == 1);
 
-    // Assert that the FK joins worked as expected.
-    $result = $testConn->createQueryTable(
-      'results_table',"SELECT * FROM NGIs inner join Sites on NGIs.id = Sites.ngi_id"
-    );
-    $this->assertTrue($result->getRowCount() == 1);
-  }
-
-  public function testJoinServicesToSite() {
-    print __METHOD__ . "\n";
-
-    $n = 3;
-    $site = TestUtil::createSampleSite('site' . $n/*, 'pk' . $n*/);
-    $this->em->persist($site);
-    for ($i = 0; $i < $n; $i++) {
-      $se = TestUtil::createSampleService("serv" . $i);
-      $site->addServiceDoJoin($se);
-      // below is ok but not striclty required.
-      $se->setParentSiteDoJoin($site);
-      $this->em->persist($se);
+      // Assert that the FK joins worked as expected.
+        $result = $testConn->createQueryTable(
+            'results_table',
+            "SELECT * FROM NGIs inner join Sites on NGIs.id = Sites.ngi_id"
+        );
+        $this->assertTrue($result->getRowCount() == 1);
     }
-    $seCount = count($site->getServices());
-    //print 'debug '.$seCount."\n";
-    $this->assertTrue($seCount == $n);
-    $this->em->flush();
 
-    // with same connection
-    $this->assertTrue(
-      count($this->em->getRepository('Site')->findOneBy(array('shortName'=>'site'.$n))->getServices()) == $n
-    );
+    public function testJoinServicesToSite()
+    {
+        print __METHOD__ . "\n";
 
-    // start new connection
-    $this->em->close();
-    $this->em = $this->createEntityManager();
-    $this->assertTrue(
-      count($this->em->getRepository('Site')->findOneBy(array('shortName'=>'site'.$n))->getServices()) == $n
-    );
-  }
+        $n = 3;
+        $site = TestUtil::createSampleSite('site' . $n/*, 'pk' . $n*/);
+        $this->em->persist($site);
+        for ($i = 0; $i < $n; $i++) {
+            $se = TestUtil::createSampleService("serv" . $i);
+            $site->addServiceDoJoin($se);
+          // below is ok but not striclty required.
+            $se->setParentSiteDoJoin($site);
+            $this->em->persist($se);
+        }
+        $seCount = count($site->getServices());
+      //print 'debug '.$seCount."\n";
+        $this->assertTrue($seCount == $n);
+        $this->em->flush();
 
-  public function testJoinCertStatusLogToSite(){
-     print __METHOD__ . "\n";
-     $n = 3;
-     $site = TestUtil::createSampleSite('mysite1');
-     $this->em->persist($site);
-     for ($i = 0; $i < $n; $i++) {
-      $certLog = new \CertificationStatusLog();
-      $certLog->setAddedBy("/some/dn_$i");
-      $this->em->persist($certLog);
-      $site->addCertificationStatusLog($certLog);
-     }
-     $this->em->merge($site);
-     $logCount = count($site->getCertificationStatusLog());
-     $this->assertTrue($logCount == $n);
-     $this->em->flush();
+      // with same connection
+        $this->assertTrue(
+            count($this->em->getRepository('Site')->findOneBy(array('shortName' => 'site' . $n))->getServices()) == $n
+        );
 
-     // start new connection
-     $this->em->close();
-     $this->em = $this->createEntityManager();
+      // start new connection
+        $this->em->getConnection()->close();
+        $this->em->close();
+        $this->em = $this->createEntityManager();
+        $this->assertTrue(
+            count($this->em->getRepository('Site')->findOneBy(array('shortName' => 'site' . $n))->getServices()) == $n
+        );
+    }
 
-     // fetch the site and check that the logs are present
-     $siteRefetched = $this->em->getRepository('Site')->findOneBy(array('shortName' => 'mysite1'));
-     $this->assertTrue(count($siteRefetched->getCertificationStatusLog()) == $n);
+    public function testJoinCertStatusLogToSite()
+    {
+        print __METHOD__ . "\n";
+        $n = 3;
+        $site = TestUtil::createSampleSite('mysite1');
+        $this->em->persist($site);
+        for ($i = 0; $i < $n; $i++) {
+            $certLog = new \CertificationStatusLog();
+            $certLog->setAddedBy("/some/dn_$i");
+            $this->em->persist($certLog);
+            $site->addCertificationStatusLog($certLog);
+        }
+        $this->em->merge($site);
+        $logCount = count($site->getCertificationStatusLog());
+        $this->assertTrue($logCount == $n);
+        $this->em->flush();
 
-     // check that the cascade delete removes all the certStatusLogs too
-     $this->em->remove($siteRefetched);
-     $this->em->flush();
+       // start new connection
+        $this->em->getConnection()->close();
+        $this->em->close();
+        $this->em = $this->createEntityManager();
 
-      $testConn = $this->getConnection();
-      $result = $testConn->createQueryTable(
-        'results_table',"SELECT CertificationStatusLogs.id FROM CertificationStatusLogs"
-      );
-      $this->assertTrue($result->getRowCount() == 0);
+       // fetch the site and check that the logs are present
+        $siteRefetched = $this->em->getRepository('Site')->findOneBy(array('shortName' => 'mysite1'));
+        $this->assertTrue(count($siteRefetched->getCertificationStatusLog()) == $n);
 
-      // check deletion of cert log don't delete site
+       // check that the cascade delete removes all the certStatusLogs too
+        $this->em->remove($siteRefetched);
+        $this->em->flush();
 
-  }
+        $testConn = $this->getConnection();
+        $result = $testConn->createQueryTable(
+            'results_table',
+            "SELECT CertificationStatusLogs.id FROM CertificationStatusLogs"
+        );
+        $this->assertTrue($result->getRowCount() == 0);
+
+        // check deletion of cert log don't delete site
+    }
 
 
   /**
    * Ensure that a Site may have many scope associations
    */
-  public function testSiteScopeMultiplicity(){
-    print __METHOD__ . "\n";
-    $this->createAndPersistScopes();
-    $n = 1;
-    $this->em->beginTransaction();
-    $site = TestUtil::createSampleSite('site' . $n/*, 'pk' . $n*/);
-    $site->addScope($this->localScope);
-    $site->addScope($this->egiScope);
-    $site->addScope($this->eudatScope);
-    $this->em->persist($site);
-    $this->em->commit();
-    $this->em->flush();
-  }
+    public function testSiteScopeMultiplicity()
+    {
+        print __METHOD__ . "\n";
+        $this->createAndPersistScopes();
+        $n = 1;
+        $this->em->beginTransaction();
+        $site = TestUtil::createSampleSite('site' . $n/*, 'pk' . $n*/);
+        $site->addScope($this->localScope);
+        $site->addScope($this->egiScope);
+        $site->addScope($this->eudatScope);
+        $this->em->persist($site);
+        $this->em->commit();
+        $this->em->flush();
+    }
 
   /**
    * Ensure that a SE may have many scope associations
    */
-  public function testSEScopeMultiplicity(){
-    print __METHOD__ . "\n";
-    $this->createAndPersistScopes();
-    $this->em->beginTransaction();
-    $se = TestUtil::createSampleService("serv");
-    $se->addScope($this->localScope);
-    $se->addScope($this->egiScope);
-    $se->addScope($this->eudatScope);
-    $this->em->persist($se);
-    $this->em->commit();
-    $this->em->flush();
-  }
+    public function testSEScopeMultiplicity()
+    {
+        print __METHOD__ . "\n";
+        $this->createAndPersistScopes();
+        $this->em->beginTransaction();
+        $se = TestUtil::createSampleService("serv");
+        $se->addScope($this->localScope);
+        $se->addScope($this->egiScope);
+        $se->addScope($this->eudatScope);
+        $this->em->persist($se);
+        $this->em->commit();
+        $this->em->flush();
+    }
 
-  public function testJoinSiteToScopes(){
-    print __METHOD__ . "\n";
-    $this->createAndPersistScopes();
-    $n = 1; // TODO - change this to 3 and un-comment the add egiScope and eudatScope lines below
-    $site = TestUtil::createSampleSite('site' . $n/*, 'pk' . $n*/);
-    $site->addScope($this->localScope);
-    //$site->addScope($this->egiScope);
-    //$site->addScope($this->eudatScope);
+    public function testJoinSiteToScopes()
+    {
+        print __METHOD__ . "\n";
+        $this->createAndPersistScopes();
+        $n = 1; // TODO - change this to 3 and un-comment the add egiScope and eudatScope lines below
+        $site = TestUtil::createSampleSite('site' . $n/*, 'pk' . $n*/);
+        $site->addScope($this->localScope);
+      //$site->addScope($this->egiScope);
+      //$site->addScope($this->eudatScope);
 
-    $this->em->persist($site);
-    $this->em->flush();
-    $this->assertTrue(count($site->getScopes()) == $n);
+        $this->em->persist($site);
+        $this->em->flush();
+        $this->assertTrue(count($site->getScopes()) == $n);
 
-    $testConn = $this->getConnection();
-    $result = $testConn->createQueryTable('results_table',
-      "SELECT Sites.id FROM Sites
+        $testConn = $this->getConnection();
+        $result = $testConn->createQueryTable(
+            'results_table',
+            "SELECT Sites.id FROM Sites
        inner join Sites_Scopes
        on Sites.id = Sites_Scopes.site_id
        inner join Scopes
        on Scopes.id = Sites_Scopes.scope_id"
-    );
-    $this->assertTrue($result->getRowCount() == $n);
-  }
+        );
+        $this->assertTrue($result->getRowCount() == $n);
+    }
 
 
-  public function testJoinServiceToScopes() {
-    print __METHOD__ . "\n";
-    $n = 1; // TODO - change this to 3 and un-comment the add egiScope and eudatScope lines below
-    $this->createAndPersistScopes();
-    $se = TestUtil::createSampleService("serv");
-    $se->addScope($this->egiScope);
-    //$se->addScope($this->localScope);
-    //$se->addScope($this->eudatScope);
-    $this->assertTrue(count($se->getScopes()) == $n);
-    $this->em->persist($se);
-    $this->em->flush();
-    $this->assertTrue(count($se->getScopes()) == $n);
+    public function testJoinServiceToScopes()
+    {
+        print __METHOD__ . "\n";
+        $n = 1; // TODO - change this to 3 and un-comment the add egiScope and eudatScope lines below
+        $this->createAndPersistScopes();
+        $se = TestUtil::createSampleService("serv");
+        $se->addScope($this->egiScope);
+      //$se->addScope($this->localScope);
+      //$se->addScope($this->eudatScope);
+        $this->assertTrue(count($se->getScopes()) == $n);
+        $this->em->persist($se);
+        $this->em->flush();
+        $this->assertTrue(count($se->getScopes()) == $n);
 
-    $testConn = $this->getConnection();
-    $result = $testConn->createQueryTable('results_table',
-      "SELECT Services.id FROM Services
+        $testConn = $this->getConnection();
+        $result = $testConn->createQueryTable(
+            'results_table',
+            "SELECT Services.id FROM Services
        inner join Services_Scopes
        on Services.id = Services_Scopes.service_id
        inner join Scopes
        on Scopes.id = Services_Scopes.scope_id"
-    );
-    $this->assertTrue($result->getRowCount() == $n);
-  }
+        );
+        $this->assertTrue($result->getRowCount() == $n);
+    }
 
   /**
    * Add multiple endpointLocations to a single Service
    */
-  public function testJoinServiceToManyEndpointLocations(){
-    print __METHOD__ . "\n";
-    $n = 3; // we will want to be able to add many endpointLocations to a service
-    $se = TestUtil::createSampleService("myservicehostname");
-    $this->em->persist($se);
-    for ($i = 0; $i < $n; $i++) {
-      $el = TestUtil::createSampleEndpointLocation();
-      $se->addEndpointLocationDoJoin($el);
-      // below is ok but not striclty required.
-      //$el->setServiceDoJoin($se);
-      $this->em->persist($el);
+    public function testJoinServiceToManyEndpointLocations()
+    {
+        print __METHOD__ . "\n";
+        $n = 3; // we will want to be able to add many endpointLocations to a service
+        $se = TestUtil::createSampleService("myservicehostname");
+        $this->em->persist($se);
+        for ($i = 0; $i < $n; $i++) {
+            $el = TestUtil::createSampleEndpointLocation();
+            $se->addEndpointLocationDoJoin($el);
+          // below is ok but not striclty required.
+          //$el->setServiceDoJoin($se);
+            $this->em->persist($el);
+        }
+        $elCount = count($se->getEndpointLocations());
+        $this->assertTrue($elCount == $n);
+      // flush is the line that throws the expected exe
+        $this->em->flush();
+
+      // in same TX
+        $this->assertTrue(
+            count($this->em->getRepository('Service')->findOneBy(array('hostName' => 'myservicehostname'))->getEndpointLocations()) == $n
+        );
+
+      // start new TX
+        $this->em->getConnection()->close();
+        $this->em->close();
+        $this->em = $this->createEntityManager();
+        $this->assertTrue(
+            count($this->em->getRepository('Service')->findOneBy(array('hostName' => 'myservicehostname'))->getEndpointLocations()) == $n
+        );
     }
-    $elCount = count($se->getEndpointLocations());
-    $this->assertTrue($elCount == $n);
-    // flush is the line that throws the expected exe
-    $this->em->flush();
-
-    // in same TX
-    $this->assertTrue(
-      count($this->em->getRepository('Service')->findOneBy(array('hostName'=>'myservicehostname'))->getEndpointLocations()) == $n
-    );
-
-    // start new TX
-    $this->em->close();
-    $this->em = $this->createEntityManager();
-    $this->assertTrue(
-      count($this->em->getRepository('Service')->findOneBy(array('hostName'=>'myservicehostname'))->getEndpointLocations()) == $n
-    );
-  }
 
   /**
    * Test that rollback works as expected by creating a site, adding services,
    * persisting then calling rollback (note am not flushing or commiting) and
    * checking that there are no sites and servcies in the DB.
    */
-  public function testRollback() {
-    print __METHOD__ . "\n";
-    $n = 3;
-    $site = TestUtil::createSampleSite('site' . $n/*, 'pk' . $n*/);
-    // need to start new TX to do a later rollback.
-    $this->em->beginTransaction();
-    $this->em->persist($site); // is now managed
-    for ($i = 0; $i < $n; $i++) {
-      $se = TestUtil::createSampleService("serv" . $i);
-      $site->addServiceDoJoin($se);
-      // below is ok but not striclty required.
-      $se->setParentSiteDoJoin($site);
-      $this->em->persist($se);  // is now managed
-    }
-    $seCount = count($site->getServices());
-    $this->assertTrue($seCount == $n);
-    $this->em->rollback();
+    public function testRollback()
+    {
+        print __METHOD__ . "\n";
+        $n = 3;
+        $site = TestUtil::createSampleSite('site' . $n/*, 'pk' . $n*/);
+      // need to start new TX to do a later rollback.
+        $this->em->beginTransaction();
+        $this->em->persist($site); // is now managed
+        for ($i = 0; $i < $n; $i++) {
+            $se = TestUtil::createSampleService("serv" . $i);
+            $site->addServiceDoJoin($se);
+          // below is ok but not striclty required.
+            $se->setParentSiteDoJoin($site);
+            $this->em->persist($se);  // is now managed
+        }
+        $seCount = count($site->getServices());
+        $this->assertTrue($seCount == $n);
+        $this->em->rollback();
 
-    $testConn = $this->getConnection();
-    $result = $testConn->createQueryTable('results_table', "SELECT * FROM Sites");
-    $this->assertTrue($result->getRowCount() == 0);
-    $result = $testConn->createQueryTable('results_table', "SELECT * FROM Services");
-    $this->assertTrue($result->getRowCount() == 0);
-  }
+        $testConn = $this->getConnection();
+        $result = $testConn->createQueryTable('results_table', "SELECT * FROM Sites");
+        $this->assertTrue($result->getRowCount() == 0);
+        $result = $testConn->createQueryTable('results_table', "SELECT * FROM Services");
+        $this->assertTrue($result->getRowCount() == 0);
+    }
 
 
   /**
@@ -466,192 +504,197 @@ class DoctrineCleanInsert1Test extends PHPUnit_Extensions_Database_TestCase {
    *
    * @expectedException \Doctrine\DBAL\DBALException
    */
-  public function testExpectedFK_ViolationOnSiteDeleteWithoutCascade(){
-    print __METHOD__ . "\n";
-    $n = 1;
-    $site = TestUtil::createSampleSite('site' . $n/*, 'pk' . $n*/);
-    $this->em->persist($site); // is now managed
-    for ($i = 0; $i < $n; $i++) {
-      $se = TestUtil::createSampleService("serv" . $i);
-      $site->addServiceDoJoin($se);
-      // below is ok but not striclty required.
-      $se->setParentSiteDoJoin($site);
-      $this->em->persist($se);  // is now managed
+    public function testExpectedFK_ViolationOnSiteDeleteWithoutCascade()
+    {
+        print __METHOD__ . "\n";
+        $n = 1;
+        $site = TestUtil::createSampleSite('site' . $n/*, 'pk' . $n*/);
+        $this->em->persist($site); // is now managed
+        for ($i = 0; $i < $n; $i++) {
+            $se = TestUtil::createSampleService("serv" . $i);
+            $site->addServiceDoJoin($se);
+          // below is ok but not striclty required.
+            $se->setParentSiteDoJoin($site);
+            $this->em->persist($se);  // is now managed
+        }
+        $this->em->flush();
+
+      // start new TX
+        $this->em->getConnection()->close();
+        $this->em->close();
+        $this->em = $this->createEntityManager();
+        $refetchedSite = $this->em->getRepository('Site')->findOneBy(array('shortName' => 'site' . $n));
+        $this->assertTrue($refetchedSite->getShortName() == 'site' . $n);
+
+      // Now try to delete site.
+      // We expect a FK violation wrapped as a DBALException.
+      // If the fail statement is called below, then it could be an issue with
+      // with the DB. For example, Sqlite with Doctrine does not enforce FK constraints !
+      // see: http://stackoverflow.com/a/4599894
+
+      // We shouldn't be able to remove the site as we need to remove the
+      // services first as we have no cascade-delete option set.
+        $this->em->remove($refetchedSite);
+        $this->em->flush();
+        $this->fail('Should not get to this point - DBALException expected');
     }
-    $this->em->flush();
-
-    // start new TX
-    $this->em->close();
-    $this->em = $this->createEntityManager();
-    $refetchedSite = $this->em->getRepository('Site')->findOneBy(array('shortName' => 'site' . $n));
-    $this->assertTrue($refetchedSite->getShortName() == 'site'.$n);
-
-    // Now try to delete site.
-    // We expect a FK violation wrapped as a DBALException.
-    // If the fail statement is called below, then it could be an issue with
-    // with the DB. For example, Sqlite with Doctrine does not enforce FK constraints !
-    // see: http://stackoverflow.com/a/4599894
-
-    // We shouldn't be able to remove the site as we need to remove the
-    // services first as we have no cascade-delete option set.
-    $this->em->remove($refetchedSite);
-    $this->em->flush();
-    $this->fail('Should not get to this point - DBALException expected');
-
-  }
 
 
   /**
    * Assert that deletion of an OwnedEntity superclass will delete its joined
    * extending class (e.g. Site and NGI).
    */
-  public function testCascadeDeleteFromOwnedEntity(){
-    print __METHOD__ . "\n";
-    // create and commit a new site
-    $s = TestUtil::createSampleSite("SITENAME"/*, "PK01"*/);
-    $this->em->persist($s);
-    $this->em->flush();
+    public function testCascadeDeleteFromOwnedEntity()
+    {
+        print __METHOD__ . "\n";
+      // create and commit a new site
+        $s = TestUtil::createSampleSite("SITENAME"/*, "PK01"*/);
+        $this->em->persist($s);
+        $this->em->flush();
 
-    // lookup the site's super class (OwnedEntity)
-    $siteID = $s->getId();
-    $ownedEntity = $this->em->find("OwnedEntity", $siteID);
-    $this->assertNotNull($ownedEntity);
-    $this->assertTrue($ownedEntity instanceof OwnedEntity);
-    $this->assertEquals($siteID, $ownedEntity->getId());
+      // lookup the site's super class (OwnedEntity)
+        $siteID = $s->getId();
+        $ownedEntity = $this->em->find("OwnedEntity", $siteID);
+        $this->assertNotNull($ownedEntity);
+        $this->assertTrue($ownedEntity instanceof OwnedEntity);
+        $this->assertEquals($siteID, $ownedEntity->getId());
 
-    // remove the super class - this should cascade delete the site
-    $this->em->remove($ownedEntity);
-    $this->em->flush();
+      // remove the super class - this should cascade delete the site
+        $this->em->remove($ownedEntity);
+        $this->em->flush();
 
-    // Assert that the super class was deleted and site was cascade deleted
-    // first using doctrine
-    $siteAgain = $this->em->find("Site", $siteID);
-    $this->assertNull($siteAgain);
-    $ownedEntityAgain = $this->em->find("OwnedEntity", $siteID);
-    $this->assertNull($ownedEntityAgain);
-    // second using separate db connection
-    $testConn = $this->getConnection();
-    $result = $testConn->createQueryTable('results_table', "SELECT * FROM OwnedEntities");
-    $this->assertTrue($result->getRowCount() == 0);
-    $result = $testConn->createQueryTable('results_table', "SELECT * FROM Sites");
-    $this->assertTrue($result->getRowCount() == 0);
-  }
+      // Assert that the super class was deleted and site was cascade deleted
+      // first using doctrine
+        $siteAgain = $this->em->find("Site", $siteID);
+        $this->assertNull($siteAgain);
+        $ownedEntityAgain = $this->em->find("OwnedEntity", $siteID);
+        $this->assertNull($ownedEntityAgain);
+      // second using separate db connection
+        $testConn = $this->getConnection();
+        $result = $testConn->createQueryTable('results_table', "SELECT * FROM OwnedEntities");
+        $this->assertTrue($result->getRowCount() == 0);
+        $result = $testConn->createQueryTable('results_table', "SELECT * FROM Sites");
+        $this->assertTrue($result->getRowCount() == 0);
+    }
 
 
   /**
    * @expectedException \Doctrine\ORM\ORMInvalidArgumentException
    */
-  public function testShowMergeIsRequiredBetweenDifferentPersistenceCtxt(){
-    print __METHOD__ . "\n";
-    // User
-    $u = TestUtil::createSampleUser("Test", "Testing");
-    $identifier= TestUtil::createSampleUserIdentifier("X.509", "/c=test");
-    $u->addUserIdentifierDoJoin($identifier);
-    $this->em->persist($identifier);
+    public function testShowMergeIsRequiredBetweenDifferentPersistenceCtxt()
+    {
+        print __METHOD__ . "\n";
+      // User
+        $u = TestUtil::createSampleUser("Test", "Testing");
+        $identifier = TestUtil::createSampleUserIdentifier("X.509", "/c=test");
+        $u->addUserIdentifierDoJoin($identifier);
+        $this->em->persist($identifier);
 
-    $regFLSupportRT = TestUtil::createSampleRoleType(RoleTypeName::REG_FIRST_LINE_SUPPORT/*, RoleTypeClass::REGIONAL_USER*/);
-    $this->em->persist($u);
-    $this->em->persist($regFLSupportRT);
-    $this->em->flush();
+        $regFLSupportRT = TestUtil::createSampleRoleType(RoleTypeName::REG_FIRST_LINE_SUPPORT/*, RoleTypeClass::REGIONAL_USER*/);
+        $this->em->persist($u);
+        $this->em->persist($regFLSupportRT);
+        $this->em->flush();
 
-    // If we create a new $this->em as below, we would need to merge detatched $u
-    // and $regFLSupportRT entities back into this persistence context
-    // before we can call a persist again (a persist on these entities
-    // called either by a CASCADE or direct call)!
-    $this->em = $this->createEntityManager(); // simply requires bootstrap_doctrine.php
-    //$u = $this->em->merge($u);
-    //$regFLSupportRT = $this->em->merge($regFLSupportRT);
+      // If we create a new $this->em as below, we would need to merge detatched $u
+      // and $regFLSupportRT entities back into this persistence context
+      // before we can call a persist again (a persist on these entities
+      // called either by a CASCADE or direct call)!
+        $this->em = $this->createEntityManager(); // simply requires bootstrap_doctrine.php
+      //$u = $this->em->merge($u);
+      //$regFLSupportRT = $this->em->merge($regFLSupportRT);
 
-    // Create new NGI
-    $n = TestUtil::createSampleNGI("MYNGI");
-    $this->em->persist($n);
+      // Create new NGI
+        $n = TestUtil::createSampleNGI("MYNGI");
+        $this->em->persist($n);
 
-    $roleNgi = TestUtil::createSampleRole($u, $regFLSupportRT, $n, RoleStatus::GRANTED);
-    $this->em->persist($roleNgi);
-    // the flush below is what causes the expected exception
-    $this->em->flush();
-  }
+        $roleNgi = TestUtil::createSampleRole($u, $regFLSupportRT, $n, RoleStatus::GRANTED);
+        $this->em->persist($roleNgi);
+      // the flush below is what causes the expected exception
+        $this->em->flush();
+    }
 
-  public function testSiteV4PK(){
-    print __METHOD__ . "\n";
-    $this->em->getConnection()->beginTransaction();
-    $pk = new \PrimaryKey();
-    $this->em->persist($pk);
-    // Below line is interesting - Oracle returns a value for $pk->getId()
-    // (i.e. before flush) while MySQL does not return a value until the
-    // flush. Either way, the subsequent rollback causes the PK to be removed
-    // which is the required behaviour.
-    //$this->assertEmpty($pk->getId());
-    //print "the pk is before: [".$pk->getId()."]\n";
+    public function testSiteV4PK()
+    {
+        print __METHOD__ . "\n";
+        $this->em->getConnection()->beginTransaction();
+        $pk = new \PrimaryKey();
+        $this->em->persist($pk);
+      // Below line is interesting - Oracle returns a value for $pk->getId()
+      // (i.e. before flush) while MySQL does not return a value until the
+      // flush. Either way, the subsequent rollback causes the PK to be removed
+      // which is the required behaviour.
+      //$this->assertEmpty($pk->getId());
+      //print "the pk is before: [".$pk->getId()."]\n";
 
-    $this->em->flush(); // sync in-memory state with db so that the pk Id has a value
-    //print "the pk is after: [".$pk->getId()."]\n";
-    // We expect after the flush the pk to have an id value
-    $this->assertNotEmpty($pk->getId());
-    $site = new \Site();
-    $site->setPrimaryKey($pk->getId() . "G0");
-    $site->setShortName('testshortname');
-    $this->em->persist($site);
-    $this->em->flush();
+        $this->em->flush(); // sync in-memory state with db so that the pk Id has a value
+      //print "the pk is after: [".$pk->getId()."]\n";
+      // We expect after the flush the pk to have an id value
+        $this->assertNotEmpty($pk->getId());
+        $site = new \Site();
+        $site->setPrimaryKey($pk->getId() . "G0");
+        $site->setShortName('testshortname');
+        $this->em->persist($site);
+        $this->em->flush();
 
-    // Rollback so that we don't commit the new pks and site to the DB
-    $this->em->getConnection()->rollback();
+      // Rollback so that we don't commit the new pks and site to the DB
+        $this->em->getConnection()->rollback();
 
-    $testConn = $this->getConnection();
-    $result = $testConn->createQueryTable('results_table', "SELECT * FROM Sites");
-    $this->assertTrue($result->getRowCount() == 0);
-    $result = $testConn->createQueryTable('results_table', "SELECT * FROM PrimaryKeys");
-    $this->assertTrue($result->getRowCount() == 0);
-  }
+        $testConn = $this->getConnection();
+        $result = $testConn->createQueryTable('results_table', "SELECT * FROM Sites");
+        $this->assertTrue($result->getRowCount() == 0);
+        $result = $testConn->createQueryTable('results_table', "SELECT * FROM PrimaryKeys");
+        $this->assertTrue($result->getRowCount() == 0);
+    }
 
   /**
    * Assert that the onDelete="CASCADE" FK mapping defined on 'EndpointLocation.service'
    * attribute does actually cascade delete a services endpoints when those
    * endpoints don't have any other joined associations, e.g. with Downtimes.
    */
-  public function testServiceToEndpointCascadeDelete_WithNoDTs(){
-    print __METHOD__ . "\n";
-    // create a linked entity graph as below:
-    //
-    //     se        (1 service)
-    //    / | \
-    // el1 el2 el3   (3 endpoints)
+    public function testServiceToEndpointCascadeDelete_WithNoDTs()
+    {
+        print __METHOD__ . "\n";
+      // create a linked entity graph as below:
+      //
+      //     se        (1 service)
+      //    / | \
+      // el1 el2 el3   (3 endpoints)
 
-    $se = TestUtil::createSampleService('service1');
-    $el1 = TestUtil::createSampleEndpointLocation();
-    $el2 = TestUtil::createSampleEndpointLocation();
-    $el3 = TestUtil::createSampleEndpointLocation();
-    $se->addEndpointLocationDoJoin($el1);
-    $se->addEndpointLocationDoJoin($el2);
-    $se->addEndpointLocationDoJoin($el3);
+        $se = TestUtil::createSampleService('service1');
+        $el1 = TestUtil::createSampleEndpointLocation();
+        $el2 = TestUtil::createSampleEndpointLocation();
+        $el3 = TestUtil::createSampleEndpointLocation();
+        $se->addEndpointLocationDoJoin($el1);
+        $se->addEndpointLocationDoJoin($el2);
+        $se->addEndpointLocationDoJoin($el3);
 
-    // persist and flush
-    $this->em->persist($se);
-    $this->em->persist($el1);
-    $this->em->persist($el2);
-    $this->em->persist($el3);
-    $this->em->flush();
+      // persist and flush
+        $this->em->persist($se);
+        $this->em->persist($el1);
+        $this->em->persist($el2);
+        $this->em->persist($el3);
+        $this->em->flush();
 
-    // Delete the service, and assert the endpoints are cascade deleted too !
-    // Impt: This should work because we have NOT joined any downtimes to the
-    // endpoints and so the cascade is free to work at the DB level using
-    // the onDelete="CASCADE" FK mapping defined on 'EndpointLocation.service' attribute.
-    // see: See: http://docs.doctrine-project.org/en/2.0.x/reference/working-with-objects.html#removing-entities
-    //
-    $this->em->remove($se);
-    $this->em->flush();
+      // Delete the service, and assert the endpoints are cascade deleted too !
+      // Impt: This should work because we have NOT joined any downtimes to the
+      // endpoints and so the cascade is free to work at the DB level using
+      // the onDelete="CASCADE" FK mapping defined on 'EndpointLocation.service' attribute.
+      // see: See: http://docs.doctrine-project.org/en/2.0.x/reference/working-with-objects.html#removing-entities
+      //
+        $this->em->remove($se);
+        $this->em->flush();
 
-    // Assert that there are still three EndpointLocations and one Downtimes in the database
-    $testConn = $this->getConnection();
-    $result = $testConn->createQueryTable('results_table', "SELECT * FROM EndpointLocations");
-    $this->assertTrue($result->getRowCount() == 0);
-    $result = $testConn->createQueryTable('results_table', "SELECT * FROM Downtimes");
-    $this->assertTrue($result->getRowCount() == 0);
-    $result = $testConn->createQueryTable('results_table', "SELECT * FROM Services");
-    $this->assertTrue($result->getRowCount() == 0);
-    $result = $testConn->createQueryTable('results_table', "SELECT * FROM Downtimes_EndpointLocations");
-    $this->assertTrue($result->getRowCount() == 0);
-  }
+      // Assert that there are still three EndpointLocations and one Downtimes in the database
+        $testConn = $this->getConnection();
+        $result = $testConn->createQueryTable('results_table', "SELECT * FROM EndpointLocations");
+        $this->assertTrue($result->getRowCount() == 0);
+        $result = $testConn->createQueryTable('results_table', "SELECT * FROM Downtimes");
+        $this->assertTrue($result->getRowCount() == 0);
+        $result = $testConn->createQueryTable('results_table', "SELECT * FROM Services");
+        $this->assertTrue($result->getRowCount() == 0);
+        $result = $testConn->createQueryTable('results_table', "SELECT * FROM Downtimes_EndpointLocations");
+        $this->assertTrue($result->getRowCount() == 0);
+    }
 
   /**
    * Assert that the onDelete="CASCADE" FK mapping defined on 'EndpointLocation.service'
@@ -661,54 +704,55 @@ class DoctrineCleanInsert1Test extends PHPUnit_Extensions_Database_TestCase {
    *
    * @expectedException \Doctrine\DBAL\DBALException
    */
-  public function testExpectedFK_ViolationOnServiceToEndpointCascadeDelete_WithDTs(){
-    print __METHOD__ . "\n";
-    // create a linked entity graph as beow:
-    //
-    //     se        (1 service)
-    //    /
-    // el1           (1 endpoints)
-    //    \
-    //     dt1       (1 downtime)
+    public function testExpectedFK_ViolationOnServiceToEndpointCascadeDelete_WithDTs()
+    {
+        print __METHOD__ . "\n";
+      // create a linked entity graph as beow:
+      //
+      //     se        (1 service)
+      //    /
+      // el1           (1 endpoints)
+      //    \
+      //     dt1       (1 downtime)
 
-    $se = TestUtil::createSampleService('service1');
-    $el1 = TestUtil::createSampleEndpointLocation();
-    $se->addEndpointLocationDoJoin($el1);
+        $se = TestUtil::createSampleService('service1');
+        $el1 = TestUtil::createSampleEndpointLocation();
+        $se->addEndpointLocationDoJoin($el1);
 
-    $dt1 = new Downtime();
-    $dt1->setDescription('downtime description');
-    $dt1->setSeverity("WARNING");
-    $dt1->setClassification("UNSCHEDULED");
+        $dt1 = new Downtime();
+        $dt1->setDescription('downtime description');
+        $dt1->setSeverity("WARNING");
+        $dt1->setClassification("UNSCHEDULED");
 
-    $dt1->addEndpointLocation($el1);
+        $dt1->addEndpointLocation($el1);
 
-    // persist and flush
-    $this->em->persist($se);
-    $this->em->persist($el1);
-    $this->em->persist($dt1);
-    $this->em->flush();
+      // persist and flush
+        $this->em->persist($se);
+        $this->em->persist($el1);
+        $this->em->persist($dt1);
+        $this->em->flush();
 
-    // Assert that there are expected EndpointLocations and one Downtimes in the database
-    $testConn = $this->getConnection();
-    $result = $testConn->createQueryTable('results_table', "SELECT * FROM EndpointLocations");
-    $this->assertTrue($result->getRowCount() == 1);
-    $result = $testConn->createQueryTable('results_table', "SELECT * FROM Downtimes");
-    $this->assertTrue($result->getRowCount() == 1);
-    $result = $testConn->createQueryTable('results_table', "SELECT * FROM Downtimes_EndpointLocations");
-    $this->assertTrue($result->getRowCount() == 1);
+      // Assert that there are expected EndpointLocations and one Downtimes in the database
+        $testConn = $this->getConnection();
+        $result = $testConn->createQueryTable('results_table', "SELECT * FROM EndpointLocations");
+        $this->assertTrue($result->getRowCount() == 1);
+        $result = $testConn->createQueryTable('results_table', "SELECT * FROM Downtimes");
+        $this->assertTrue($result->getRowCount() == 1);
+        $result = $testConn->createQueryTable('results_table', "SELECT * FROM Downtimes_EndpointLocations");
+        $this->assertTrue($result->getRowCount() == 1);
 
-    // Try and delete the service
-    // We expect a FK violation wrapped as a DBALException.
-    // If the fail statement is called below, then it could be an issue with
-    // with the DB. For example, Sqlite with Doctrine does not enforce FK constraints !
-    // see: http://stackoverflow.com/a/4599894
+      // Try and delete the service
+      // We expect a FK violation wrapped as a DBALException.
+      // If the fail statement is called below, then it could be an issue with
+      // with the DB. For example, Sqlite with Doctrine does not enforce FK constraints !
+      // see: http://stackoverflow.com/a/4599894
 
-    // We shouldn't be able to remove the site as we need to remove the
-    // services first as we have no cascade-delete option set.
-    $this->em->remove($se);
-    $this->em->flush();
-    $this->fail('Should not get to this point - DBALException expected');
-  }
+      // We shouldn't be able to remove the site as we need to remove the
+      // services first as we have no cascade-delete option set.
+        $this->em->remove($se);
+        $this->em->flush();
+        $this->fail('Should not get to this point - DBALException expected');
+    }
 
   /**
    * Show how Bidirectional relationships must be correctly managed in
@@ -717,122 +761,124 @@ class DoctrineCleanInsert1Test extends PHPUnit_Extensions_Database_TestCase {
    * relation have to be managed in userland application code. Doctrine
    * cannot magically update your collections to be consistent.").
    */
-  public function testDowntimeEndpoint_BidirectionalJoinConsistencyManagement(){
-    print __METHOD__ . "\n";
-    // create a linked entity graph as beow:
-    //
-    //     se        (1 service)
-    //    / | \
-    // el1 el2 el3   (3 endpoints)
-    //    \ | /
-    //     dt1       (1 downtime)
+    public function testDowntimeEndpoint_BidirectionalJoinConsistencyManagement()
+    {
+        print __METHOD__ . "\n";
+      // create a linked entity graph as beow:
+      //
+      //     se        (1 service)
+      //    / | \
+      // el1 el2 el3   (3 endpoints)
+      //    \ | /
+      //     dt1       (1 downtime)
 
-    $se = TestUtil::createSampleService('service1');
-    $el1 = TestUtil::createSampleEndpointLocation();
-    $el2 = TestUtil::createSampleEndpointLocation();
-    $el3 = TestUtil::createSampleEndpointLocation();
-    $se->addEndpointLocationDoJoin($el1);
-    $se->addEndpointLocationDoJoin($el2);
-    $se->addEndpointLocationDoJoin($el3);
+        $se = TestUtil::createSampleService('service1');
+        $el1 = TestUtil::createSampleEndpointLocation();
+        $el2 = TestUtil::createSampleEndpointLocation();
+        $el3 = TestUtil::createSampleEndpointLocation();
+        $se->addEndpointLocationDoJoin($el1);
+        $se->addEndpointLocationDoJoin($el2);
+        $se->addEndpointLocationDoJoin($el3);
 
-    $dt1 = new Downtime();
-    $dt1->setDescription('downtime description');
-    $dt1->setSeverity("WARNING");
-    $dt1->setClassification("UNSCHEDULED");
+        $dt1 = new Downtime();
+        $dt1->setDescription('downtime description');
+        $dt1->setSeverity("WARNING");
+        $dt1->setClassification("UNSCHEDULED");
 
-    $dt1->addEndpointLocation($el1);
-    $dt1->addEndpointLocation($el2);
-    $dt1->addEndpointLocation($el3);
+        $dt1->addEndpointLocation($el1);
+        $dt1->addEndpointLocation($el2);
+        $dt1->addEndpointLocation($el3);
 
-    // persist and flush
-    $this->em->persist($se);
-    $this->em->persist($el1);
-    $this->em->persist($el2);
-    $this->em->persist($el3);
-    $this->em->persist($dt1);
-    $this->em->flush();
+      // persist and flush
+        $this->em->persist($se);
+        $this->em->persist($el1);
+        $this->em->persist($el2);
+        $this->em->persist($el3);
+        $this->em->persist($dt1);
+        $this->em->flush();
 
-    // Now delete the relationship between dt1 and el1 + el2 using OWNING
-    // SIDE ONLY; since downtime is the OWNING side we must remove el1 + el2
-    // from downtime to actually delete the relationships in the DB
-    // (on the subsequent flush). Since we have only removed the relationship
-    // on the downtime side, our in-mem entity model is now inconsistent !
-    $dt1->getEndpointLocations()->removeElement($el1);
-    //$el1->getDowntimes()->removeElement($dt1);
-    $dt1->getEndpointLocations()->removeElement($el2);
-    //$el2->getDowntimes()->removeElement($dt1);
+      // Now delete the relationship between dt1 and el1 + el2 using OWNING
+      // SIDE ONLY; since downtime is the OWNING side we must remove el1 + el2
+      // from downtime to actually delete the relationships in the DB
+      // (on the subsequent flush). Since we have only removed the relationship
+      // on the downtime side, our in-mem entity model is now inconsistent !
+        $dt1->getEndpointLocations()->removeElement($el1);
+      //$el1->getDowntimes()->removeElement($dt1);
+        $dt1->getEndpointLocations()->removeElement($el2);
+      //$el2->getDowntimes()->removeElement($dt1);
 
-    $this->em->flush();
+        $this->em->flush();
 
-    // Entity model in DB now looks like this:
-    //     se
-    //    / | \
-    // el1 el2 el3
-    //        /
-    //     dt1      (note FKs/relationships have been removed)
+      // Entity model in DB now looks like this:
+      //     se
+      //    / | \
+      // el1 el2 el3
+      //        /
+      //     dt1      (note FKs/relationships have been removed)
 
-    // Assert that there are still three EndpointLocations and one Downtimes in the database
-    $testConn = $this->getConnection();
-    $result = $testConn->createQueryTable('results_table', "SELECT * FROM EndpointLocations");
-    $this->assertTrue($result->getRowCount() == 3);
-    $result = $testConn->createQueryTable('results_table', "SELECT * FROM Downtimes");
-    $this->assertTrue($result->getRowCount() == 1);
-    $result = $testConn->createQueryTable('results_table', "SELECT * FROM Downtimes_EndpointLocations");
-    $this->assertTrue($result->getRowCount() == 1);
+      // Assert that there are still three EndpointLocations and one Downtimes in the database
+        $testConn = $this->getConnection();
+        $result = $testConn->createQueryTable('results_table', "SELECT * FROM EndpointLocations");
+        $this->assertTrue($result->getRowCount() == 3);
+        $result = $testConn->createQueryTable('results_table', "SELECT * FROM Downtimes");
+        $this->assertTrue($result->getRowCount() == 1);
+        $result = $testConn->createQueryTable('results_table', "SELECT * FROM Downtimes_EndpointLocations");
+        $this->assertTrue($result->getRowCount() == 1);
 
-    // Assert that our in-mem entity model is now inconsistent with DB
-    // when VIEWED FROM THE ENDPOINT SIDE.
-    $this->assertEquals(1, count($el1->getDowntimes()));
-    $this->assertEquals(1, count($el2->getDowntimes()));
-    $this->assertEquals(1, count($el3->getDowntimes()));
+      // Assert that our in-mem entity model is now inconsistent with DB
+      // when VIEWED FROM THE ENDPOINT SIDE.
+        $this->assertEquals(1, count($el1->getDowntimes()));
+        $this->assertEquals(1, count($el2->getDowntimes()));
+        $this->assertEquals(1, count($el3->getDowntimes()));
 
-    // Assert that our in-mem entity model is consistent with DB
-    // when VIEWED FROM THE DOWNTIME SIDE:
-    // dt1 still has el3 linked (as expected) but not el1 or el2.
-    // Note we use first() method to fetch first array collection entry!
-    // (calling get(0) would not work as expected because the collection
-    // is a map so array key values are preserved - el3 was added 3rd so it
-    // preserves its zero-offset key value of 2).
-    $this->assertEquals(1, count($dt1->getEndpointLocations()));
-    $this->assertSame($el3, $dt1->getEndpointLocations()->first());
-    $this->assertSame($el3, $dt1->getEndpointLocations()->get(2));
+      // Assert that our in-mem entity model is consistent with DB
+      // when VIEWED FROM THE DOWNTIME SIDE:
+      // dt1 still has el3 linked (as expected) but not el1 or el2.
+      // Note we use first() method to fetch first array collection entry!
+      // (calling get(0) would not work as expected because the collection
+      // is a map so array key values are preserved - el3 was added 3rd so it
+      // preserves its zero-offset key value of 2).
+        $this->assertEquals(1, count($dt1->getEndpointLocations()));
+        $this->assertSame($el3, $dt1->getEndpointLocations()->first());
+        $this->assertSame($el3, $dt1->getEndpointLocations()->get(2));
 
-    // Next lines keep our in-mem inverse side consistent with DB. If we
-    // didn't do this, then our first assertion on the following lines below
-    // would fail! This shows that you have to keep your bi-directional
-    // relationships consistent in userland/application code, doctrine
-    // won't do this for you!
-    $el1->getDowntimes()->removeElement($dt1);
-    $el2->getDowntimes()->removeElement($dt1);
+      // Next lines keep our in-mem inverse side consistent with DB. If we
+      // didn't do this, then our first assertion on the following lines below
+      // would fail! This shows that you have to keep your bi-directional
+      // relationships consistent in userland/application code, doctrine
+      // won't do this for you!
+        $el1->getDowntimes()->removeElement($dt1);
+        $el2->getDowntimes()->removeElement($dt1);
 
-    // After updating the 'in-memory' entity model, check that el1 and el2
-    // have no linked downtimes while el3 still has dt linked.
-    // This mirrors what we have in the DB.
-    $this->assertEquals(0, count($el1->getDowntimes()));
-    $this->assertEquals(0, count($el2->getDowntimes()));
-    $this->assertEquals(1, count($el3->getDowntimes()));
+      // After updating the 'in-memory' entity model, check that el1 and el2
+      // have no linked downtimes while el3 still has dt linked.
+      // This mirrors what we have in the DB.
+        $this->assertEquals(0, count($el1->getDowntimes()));
+        $this->assertEquals(0, count($el2->getDowntimes()));
+        $this->assertEquals(1, count($el3->getDowntimes()));
 
-    // our collection key value is still same
-    $this->assertSame($el3, $dt1->getEndpointLocations()->get(2));
-  }
+      // our collection key value is still same
+        $this->assertSame($el3, $dt1->getEndpointLocations()->get(2));
+    }
 
-  private function createAndPersistScopes(){
-    $this->egiScope = new Scope();
-    $this->egiScope->setName('EGI');
-    $this->egiScope->setDescription('The egi project');
+    private function createAndPersistScopes()
+    {
+        $this->egiScope = new Scope();
+        $this->egiScope->setName('EGI');
+        $this->egiScope->setDescription('The egi project');
 
-    $this->localScope = new Scope();
-    $this->localScope->setDescription('Local scope means no project');
-    $this->localScope->setName('Local');
+        $this->localScope = new Scope();
+        $this->localScope->setDescription('Local scope means no project');
+        $this->localScope->setName('Local');
 
-    $this->eudatScope = new Scope();
-    $this->eudatScope->setName('EUDAT');
-    $this->eudatScope->setDescription('The eudat project');
+        $this->eudatScope = new Scope();
+        $this->eudatScope->setName('EUDAT');
+        $this->eudatScope->setDescription('The eudat project');
 
-    $this->em->persist($this->egiScope);
-    $this->em->persist($this->localScope);
-    $this->em->persist($this->eudatScope);
-  }
+        $this->em->persist($this->egiScope);
+        $this->em->persist($this->localScope);
+        $this->em->persist($this->eudatScope);
+    }
 
 
   // below two tests have now been deprecated, but they are good to keep
@@ -906,5 +952,3 @@ class DoctrineCleanInsert1Test extends PHPUnit_Extensions_Database_TestCase {
       }
   }*/
 }
-
-?>

--- a/tests/doctrine/DowntimeServiceEndpointTest1.php
+++ b/tests/doctrine/DowntimeServiceEndpointTest1.php
@@ -1,4 +1,5 @@
 <?php
+
 require_once dirname(__FILE__) . '/TestUtil.php';
 use Doctrine\ORM\EntityManager;
 require_once dirname(__FILE__) . '/bootstrap.php';
@@ -12,96 +13,114 @@ require_once dirname(__FILE__) . '/../../lib/DAOs/ServiceDAO.php';
  *
  * @author David Meredith
  */
-class DowntimeServiceEndpointTest1 extends PHPUnit_Extensions_Database_TestCase {
-  private $em;
+class DowntimeServiceEndpointTest1 extends PHPUnit_Extensions_Database_TestCase
+{
+    private $em;
 
   /**
   * Overridden.
   */
-  public static function setUpBeforeClass() {
-    parent::setUpBeforeClass();
-    echo "\n\n-------------------------------------------------\n";
-    echo "Executing DowntimeServiceEndpointTest1. . .\n";
-  }
+    public static function setUpBeforeClass()
+    {
+        parent::setUpBeforeClass();
+        echo "\n\n-------------------------------------------------\n";
+        echo "Executing DowntimeServiceEndpointTest1. . .\n";
+    }
 
   /**
   * Overridden. Returns the test database connection.
   * @return PHPUnit_Extensions_Database_DB_IDatabaseConnection
   */
-  protected function getConnection() {
-    require_once dirname(__FILE__) . '/bootstrap_pdo.php';
-    return getConnectionToTestDB();
-  }
+    protected function getConnection()
+    {
+        require_once dirname(__FILE__) . '/bootstrap_pdo.php';
+        return getConnectionToTestDB();
+    }
 
   /**
   * Overridden. Returns the test dataset.
   * Defines how the initial state of the database should look before each test is executed.
   * @return PHPUnit_Extensions_Database_DataSet_IDataSet
   */
-  protected function getDataSet() {
-    return $this->createFlatXMLDataSet(dirname(__FILE__) . '/truncateDataTables.xml');
-    // Use below to return an empty data set if we don't want to truncate and seed
-    //return new PHPUnit_Extensions_Database_DataSet_DefaultDataSet();
-  }
+    protected function getDataSet()
+    {
+        return $this->createFlatXMLDataSet(dirname(__FILE__) . '/truncateDataTables.xml');
+      // Use below to return an empty data set if we don't want to truncate and seed
+      //return new PHPUnit_Extensions_Database_DataSet_DefaultDataSet();
+    }
 
   /**
   * Overridden.
   */
-  protected function getSetUpOperation() {
-    // CLEAN_INSERT is default
-    //return PHPUnit_Extensions_Database_Operation_Factory::CLEAN_INSERT();
-    //return PHPUnit_Extensions_Database_Operation_Factory::UPDATE();
-    //return PHPUnit_Extensions_Database_Operation_Factory::NONE();
-    //
-    // Issue a DELETE from <table> which is more portable than a
-    // TRUNCATE table <table> (some DBs require high privileges for truncate statements
-    // and also do not allow truncates across tables with FK contstraints e.g. Oracle)
-    return PHPUnit_Extensions_Database_Operation_Factory::DELETE_ALL();
-  }
+    protected function getSetUpOperation()
+    {
+      // CLEAN_INSERT is default
+      //return PHPUnit_Extensions_Database_Operation_Factory::CLEAN_INSERT();
+      //return PHPUnit_Extensions_Database_Operation_Factory::UPDATE();
+      //return PHPUnit_Extensions_Database_Operation_Factory::NONE();
+      //
+      // Issue a DELETE from <table> which is more portable than a
+      // TRUNCATE table <table> (some DBs require high privileges for truncate statements
+      // and also do not allow truncates across tables with FK contstraints e.g. Oracle)
+        return PHPUnit_Extensions_Database_Operation_Factory::DELETE_ALL();
+    }
 
   /**
   * Overridden.
   */
-  protected function getTearDownOperation() {
-    // NONE is default
-    return PHPUnit_Extensions_Database_Operation_Factory::NONE();
-  }
+    protected function getTearDownOperation()
+    {
+      // NONE is default
+        return PHPUnit_Extensions_Database_Operation_Factory::NONE();
+    }
 
   /**
   * Sets up the fixture, e.g create a new entityManager for each test run
   * This method is called before each test method is executed.
   */
-  protected function setUp() {
-    parent::setUp();
-    $this->em = $this->createEntityManager();
-  }
-
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->em = $this->createEntityManager();
+    }
+  /**
+   * Run after each test function to prevent pile-up of database connections.
+   */
+    protected function tearDown()
+    {
+        parent::tearDown();
+        if (!is_null($this->em)) {
+            $this->em->getConnection()->close();
+        }
+    }
   /**
   * @todo Still need to setup connection to different databases.
   * @return EntityManager
   */
-  private function createEntityManager() {
-    require dirname(__FILE__) . '/bootstrap_doctrine.php';
-    return $entityManager;
-  }
+    private function createEntityManager()
+    {
+        require dirname(__FILE__) . '/bootstrap_doctrine.php';
+        return $entityManager;
+    }
 
   /**
   * Called after setUp() and before each test. Used for common assertions
   * across all tests.
   */
-  protected function assertPreConditions() {
-    $con = $this->getConnection();
-    $fixture = dirname(__FILE__) . '/truncateDataTables.xml';
-    $tables = simplexml_load_file($fixture);
+    protected function assertPreConditions()
+    {
+        $con = $this->getConnection();
+        $fixture = dirname(__FILE__) . '/truncateDataTables.xml';
+        $tables = simplexml_load_file($fixture);
 
-    foreach ($tables as $tableName) {
-      $sql = "SELECT * FROM " . $tableName->getName();
-      $result = $con->createQueryTable('results_table', $sql);
-      if ($result->getRowCount() != 0) {
-        throw new RuntimeException("Invalid fixture. Table has rows: " . $tableName->getName());
-      }
+        foreach ($tables as $tableName) {
+            $sql = "SELECT * FROM " . $tableName->getName();
+            $result = $con->createQueryTable('results_table', $sql);
+            if ($result->getRowCount() != 0) {
+                throw new RuntimeException("Invalid fixture. Table has rows: " . $tableName->getName());
+            }
+        }
     }
-  }
 
   /**
   * Delete service1 and ensure the DAO cascade deletes the service's
@@ -109,33 +128,34 @@ class DowntimeServiceEndpointTest1 extends PHPUnit_Extensions_Database_TestCase 
   * from other services and any orphan downtimes that were never joined
   * to the service in the first place.
   */
-  public function testServiceDAO_removeServiceAndJoinedDTs() {
-    print __METHOD__ . "\n";
-    include __DIR__ . '/resources/sampleFixtureData4.php';
+    public function testServiceDAO_removeServiceAndJoinedDTs()
+    {
+        print __METHOD__ . "\n";
+        include __DIR__ . '/resources/sampleFixtureData4.php';
 
-    // Remove Service
-    // Impt: When deleting a service, we can't rely solely on the
-    // 'onDelete=cascade' defined on the 'EndpointLocation->service'
-    // to correctly cascade-delete the EL. This is because downtimes can also be linked
-    // to the EL.  Therefore, if we don't invoke an $em->remove() on the EL
-    // (either via cascade="remove" or manually invoking em->remove() on each EL),
-    // Doctrine will not have flagged the EL as removed and so will not automatically delete the
-    // relevant row(s) in 'DOWNTIMES_ENDPOINTLOCATIONS' join table.
-    // This would cause a FK integrity/violation constraint exception
-    // on the 'DOWNTIMES_ENDPOINTLOCATIONS.ENDPOINTLOCATION_ID' FK column.
-    // This is why we need to do a managed delete using the ServiceDAO
-    $serviceDao = new ServiceDAO();
-    $serviceDao->setEntityManager($this->em);
-    $serviceDao->removeService($service1);
-    $this->em->flush();
+      // Remove Service
+      // Impt: When deleting a service, we can't rely solely on the
+      // 'onDelete=cascade' defined on the 'EndpointLocation->service'
+      // to correctly cascade-delete the EL. This is because downtimes can also be linked
+      // to the EL.  Therefore, if we don't invoke an $em->remove() on the EL
+      // (either via cascade="remove" or manually invoking em->remove() on each EL),
+      // Doctrine will not have flagged the EL as removed and so will not automatically delete the
+      // relevant row(s) in 'DOWNTIMES_ENDPOINTLOCATIONS' join table.
+      // This would cause a FK integrity/violation constraint exception
+      // on the 'DOWNTIMES_ENDPOINTLOCATIONS.ENDPOINTLOCATION_ID' FK column.
+      // This is why we need to do a managed delete using the ServiceDAO
+        $serviceDao = new ServiceDAO();
+        $serviceDao->setEntityManager($this->em);
+        $serviceDao->removeService($service1);
+        $this->em->flush();
 
-    // use DB connection to check data has been deleted
-    $con = $this->getConnection();
-    $result = $con->createQueryTable('results_table', "SELECT * FROM EndpointLocations");
-    $this->assertTrue($result->getRowCount() == 2);
-    $result = $con->createQueryTable('results_table', "SELECT * FROM Downtimes");
-    $this->assertTrue($result->getRowCount() == 4); // 3 DTs linked to service2 and orphanDT
-  }
+      // use DB connection to check data has been deleted
+        $con = $this->getConnection();
+        $result = $con->createQueryTable('results_table', "SELECT * FROM EndpointLocations");
+        $this->assertTrue($result->getRowCount() == 2);
+        $result = $con->createQueryTable('results_table', "SELECT * FROM Downtimes");
+        $this->assertTrue($result->getRowCount() == 4); // 3 DTs linked to service2 and orphanDT
+    }
 
   /**
   * Delete service2 and ensure the DAO cascade deletes the service's
@@ -143,237 +163,240 @@ class DowntimeServiceEndpointTest1 extends PHPUnit_Extensions_Database_TestCase 
   * from other services and any orphan downtimes that were never joined
   * to the service in the first place.
   */
-  public function testServiceDAO_removeService2AndJoinedDTs() {
-    print __METHOD__ . "\n";
-    include __DIR__ . '/resources/sampleFixtureData4.php';
+    public function testServiceDAO_removeService2AndJoinedDTs()
+    {
+        print __METHOD__ . "\n";
+        include __DIR__ . '/resources/sampleFixtureData4.php';
 
-    $serviceDao = new ServiceDAO();
-    $serviceDao->setEntityManager($this->em);
-    $serviceDao->removeService($service2);
-    $this->em->flush();
+        $serviceDao = new ServiceDAO();
+        $serviceDao->setEntityManager($this->em);
+        $serviceDao->removeService($service2);
+        $this->em->flush();
 
-    // use DB connection to check data has been deleted
-    $con = $this->getConnection();
-    $result = $con->createQueryTable('results_table', "SELECT * FROM EndpointLocations");
-    $this->assertTrue($result->getRowCount() == 2);
-    $result = $con->createQueryTable('results_table', "SELECT * FROM Downtimes");
-    $this->assertTrue($result->getRowCount() == 7); // 6 DTs linked to service1 and orphanDT
-  }
+      // use DB connection to check data has been deleted
+        $con = $this->getConnection();
+        $result = $con->createQueryTable('results_table', "SELECT * FROM EndpointLocations");
+        $this->assertTrue($result->getRowCount() == 2);
+        $result = $con->createQueryTable('results_table', "SELECT * FROM Downtimes");
+        $this->assertTrue($result->getRowCount() == 7); // 6 DTs linked to service1 and orphanDT
+    }
 
   /**
   * Delete both services and enure the DAO cascade deletes both servcies
   * joined endpoints and downtimes, leaving only the sites and the single orphan downtime.
   */
-  public function testServiceDAO_removeService1And2AndJoinedDTs() {
-    print __METHOD__ . "\n";
-    include __DIR__ . '/resources/sampleFixtureData4.php';
+    public function testServiceDAO_removeService1And2AndJoinedDTs()
+    {
+        print __METHOD__ . "\n";
+        include __DIR__ . '/resources/sampleFixtureData4.php';
 
-    $serviceDao = new ServiceDAO();
-    $serviceDao->setEntityManager($this->em);
-    $serviceDao->removeService($service2);
-    $serviceDao->removeService($service1);
-    $this->em->flush();
+        $serviceDao = new ServiceDAO();
+        $serviceDao->setEntityManager($this->em);
+        $serviceDao->removeService($service2);
+        $serviceDao->removeService($service1);
+        $this->em->flush();
 
-    // use DB connection to check data has been deleted
-    $con = $this->getConnection();
-    $result = $con->createQueryTable('results_table', "SELECT * FROM EndpointLocations");
-    $this->assertTrue($result->getRowCount() == 0);
-    $result = $con->createQueryTable('results_table', "SELECT * FROM Downtimes");
-    $this->assertTrue($result->getRowCount() == 1); // orphanDT
-    $result = $con->createQueryTable('results_table', "SELECT * FROM Sites");
-    $this->assertTrue($result->getRowCount() == 2); // site1 and site2
-  }
+      // use DB connection to check data has been deleted
+        $con = $this->getConnection();
+        $result = $con->createQueryTable('results_table', "SELECT * FROM EndpointLocations");
+        $this->assertTrue($result->getRowCount() == 0);
+        $result = $con->createQueryTable('results_table', "SELECT * FROM Downtimes");
+        $this->assertTrue($result->getRowCount() == 1); // orphanDT
+        $result = $con->createQueryTable('results_table', "SELECT * FROM Sites");
+        $this->assertTrue($result->getRowCount() == 2); // site1 and site2
+    }
 
   /**
   * Delete site1 and ensure only site2 and the orphan downtime remain.
   */
-  public function testSiteService_removeSite() {
-    print __METHOD__ . "\n";
-    include __DIR__ . '/resources/sampleFixtureData4.php';
+    public function testSiteService_removeSite()
+    {
+        print __METHOD__ . "\n";
+        include __DIR__ . '/resources/sampleFixtureData4.php';
 
-    $adminUser = TestUtil::createSampleUser('some', 'admin');
-    $identifier= TestUtil::createSampleUserIdentifier('X.509', '/some/admin');
-    $adminUser->addUserIdentifierDoJoin($identifier);
-    $this->em->persist($identifier);
-    $adminUser->setAdmin(TRUE);
-    $this->em->persist($adminUser);
+        $adminUser = TestUtil::createSampleUser('some', 'admin');
+        $identifier = TestUtil::createSampleUserIdentifier('X.509', '/some/admin');
+        $adminUser->addUserIdentifierDoJoin($identifier);
+        $this->em->persist($identifier);
+        $adminUser->setAdmin(true);
+        $this->em->persist($adminUser);
 
-    $siteService = new org\gocdb\services\Site();
-    $siteService->setEntityManager($this->em);
-    $siteService->deleteSite($site1, $adminUser, false);
+        $siteService = new org\gocdb\services\Site();
+        $siteService->setEntityManager($this->em);
+        $siteService->deleteSite($site1, $adminUser, false);
 
-    // use DB connection to check data has been deleted
-    $con = $this->getConnection();
-    $result = $con->createQueryTable('results_table', "SELECT * FROM EndpointLocations");
-    $this->assertTrue($result->getRowCount() == 0);
-    $result = $con->createQueryTable('results_table', "SELECT * FROM Downtimes");
-    $this->assertTrue($result->getRowCount() == 1); // orphanDT
-    $result = $con->createQueryTable('results_table', "SELECT * FROM Sites");
-    $this->assertTrue($result->getRowCount() == 1); // site2
-  }
+      // use DB connection to check data has been deleted
+        $con = $this->getConnection();
+        $result = $con->createQueryTable('results_table', "SELECT * FROM EndpointLocations");
+        $this->assertTrue($result->getRowCount() == 0);
+        $result = $con->createQueryTable('results_table', "SELECT * FROM Downtimes");
+        $this->assertTrue($result->getRowCount() == 1); // orphanDT
+        $result = $con->createQueryTable('results_table', "SELECT * FROM Sites");
+        $this->assertTrue($result->getRowCount() == 1); // site2
+    }
 
   /**
   * Delete the parent NGI and ensure all sites, servcies, endponts and downtimes
   * are deleted leaving only the orphan dowmtime.
   */
-  public function testNgiService_removeNgi() {
-    print __METHOD__ . "\n";
-    include __DIR__ . '/resources/sampleFixtureData4.php';
+    public function testNgiService_removeNgi()
+    {
+        print __METHOD__ . "\n";
+        include __DIR__ . '/resources/sampleFixtureData4.php';
 
-    $adminUser = TestUtil::createSampleUser('some', 'admin');
-    $identifier= TestUtil::createSampleUserIdentifier('X.509', '/some/admin');
-    $adminUser->addUserIdentifierDoJoin($identifier);
-    $this->em->persist($identifier);
-    $adminUser->setAdmin(TRUE);
-    $this->em->persist($adminUser);
+        $adminUser = TestUtil::createSampleUser('some', 'admin');
+        $identifier = TestUtil::createSampleUserIdentifier('X.509', '/some/admin');
+        $adminUser->addUserIdentifierDoJoin($identifier);
+        $this->em->persist($identifier);
+        $adminUser->setAdmin(true);
+        $this->em->persist($adminUser);
 
-    $ngiService = new org\gocdb\services\NGI();
-    $ngiService->setEntityManager($this->em);
-    $ngiService->deleteNgi($ngi, $adminUser, FALSE);
+        $ngiService = new org\gocdb\services\NGI();
+        $ngiService->setEntityManager($this->em);
+        $ngiService->deleteNgi($ngi, $adminUser, false);
 
-    // use DB connection to check data has been deleted
-    $con = $this->getConnection();
-    $result = $con->createQueryTable('results_table', "SELECT * FROM EndpointLocations");
-    $this->assertTrue($result->getRowCount() == 0);
-    $result = $con->createQueryTable('results_table', "SELECT * FROM Downtimes");
-    $this->assertTrue($result->getRowCount() == 1); // orphanDT
-    $result = $con->createQueryTable('results_table', "SELECT * FROM Sites");
-    $this->assertTrue($result->getRowCount() == 0); // site2
-  }
+      // use DB connection to check data has been deleted
+        $con = $this->getConnection();
+        $result = $con->createQueryTable('results_table', "SELECT * FROM EndpointLocations");
+        $this->assertTrue($result->getRowCount() == 0);
+        $result = $con->createQueryTable('results_table', "SELECT * FROM Downtimes");
+        $this->assertTrue($result->getRowCount() == 1); // orphanDT
+        $result = $con->createQueryTable('results_table', "SELECT * FROM Sites");
+        $this->assertTrue($result->getRowCount() == 0); // site2
+    }
 
 
   /**
   * Test the <code>$serviceDAO->removeEndpoint($endpoint)</code> method.
   */
-  public function testServiceDAORemoveEndpoint(){
-    print __METHOD__ . "\n";
-    /* create a linked entity graph as beow:
-    *
-    *         se  -----|    (1 service)
-    *       / | \      |
-    *    el1 el2 el3   |    (3 endpoints)
-    *     |  \ | /     |
-    *    dt0  dt1  ----|    (1 downtime)
-    */
+    public function testServiceDAORemoveEndpoint()
+    {
+        print __METHOD__ . "\n";
+      /* create a linked entity graph as beow:
+      *
+      *         se  -----|    (1 service)
+      *       / | \      |
+      *    el1 el2 el3   |    (3 endpoints)
+      *     |  \ | /     |
+      *    dt0  dt1  ----|    (1 downtime)
+      */
 
-    $dt1 = new Downtime();
-    $dt1->setDescription('downtime description');
-    $dt1->setSeverity("WARNING");
-    $dt1->setClassification("UNSCHEDULED");
+        $dt1 = new Downtime();
+        $dt1->setDescription('downtime description');
+        $dt1->setSeverity("WARNING");
+        $dt1->setClassification("UNSCHEDULED");
 
-    $dt0 = new Downtime();
-    $dt0->setDescription('downtime description');
-    $dt0->setSeverity("WARNING");
-    $dt0->setClassification("UNSCHEDULED");
+        $dt0 = new Downtime();
+        $dt0->setDescription('downtime description');
+        $dt0->setSeverity("WARNING");
+        $dt0->setClassification("UNSCHEDULED");
 
-    $se = TestUtil::createSampleService('service1');
-    $el1 = TestUtil::createSampleEndpointLocation();
-    $el2 = TestUtil::createSampleEndpointLocation();
-    $el3 = TestUtil::createSampleEndpointLocation();
-    $se->addEndpointLocationDoJoin($el1);
-    $se->addEndpointLocationDoJoin($el2);
-    $se->addEndpointLocationDoJoin($el3);
-    //$se->_addDowntime($dt1); // we don't call this in client code !
+        $se = TestUtil::createSampleService('service1');
+        $el1 = TestUtil::createSampleEndpointLocation();
+        $el2 = TestUtil::createSampleEndpointLocation();
+        $el3 = TestUtil::createSampleEndpointLocation();
+        $se->addEndpointLocationDoJoin($el1);
+        $se->addEndpointLocationDoJoin($el2);
+        $se->addEndpointLocationDoJoin($el3);
+      //$se->_addDowntime($dt1); // we don't call this in client code !
 
-    $dt1->addEndpointLocation($el1);
-    $dt1->addEndpointLocation($el2);
-    $dt1->addEndpointLocation($el3);
-    $dt1->addService($se);
+        $dt1->addEndpointLocation($el1);
+        $dt1->addEndpointLocation($el2);
+        $dt1->addEndpointLocation($el3);
+        $dt1->addService($se);
 
-    $dt0->addEndpointLocation($el1);
-    //$dt0->addService($se); // note we don't add this relationship for purposes of the test
+        $dt0->addEndpointLocation($el1);
+      //$dt0->addService($se); // note we don't add this relationship for purposes of the test
 
-    // persist and flush
-    $this->em->persist($se);
-    $this->em->persist($el1);
-    $this->em->persist($el2);
-    $this->em->persist($el3);
-    $this->em->persist($dt1);
-    $this->em->persist($dt0);
-    $this->em->flush();
+      // persist and flush
+        $this->em->persist($se);
+        $this->em->persist($el1);
+        $this->em->persist($el2);
+        $this->em->persist($el3);
+        $this->em->persist($dt1);
+        $this->em->persist($dt0);
+        $this->em->flush();
 
-    // create DAO to test
-    $serviceDao = new ServiceDAO();
-    $serviceDao->setEntityManager($this->em);
+      // create DAO to test
+        $serviceDao = new ServiceDAO();
+        $serviceDao->setEntityManager($this->em);
 
-    // remove first endpoint causing dt0 to be orphaned
-    $serviceDao->removeEndpoint($el1);
-    $this->em->flush();
+      // remove first endpoint causing dt0 to be orphaned
+        $serviceDao->removeEndpoint($el1);
+        $this->em->flush();
 
-    /* Assert expected object graph
-    *       se   -----|   (1 service)
-    *      |  \       |
-    *     el2 el3     |   (2 endpoints)
-    *       |  |      |
-    *     dt0 dt1-----|   (2 downtime)
-    */
-    $testConn = $this->getConnection();
-    $result = $testConn->createQueryTable('results_table', "SELECT * FROM EndpointLocations");
-    $this->assertTrue($result->getRowCount() == 2);
-    $result = $testConn->createQueryTable('results_table', "SELECT * FROM Downtimes");
-    $this->assertTrue($result->getRowCount() == 2);
-    $result = $testConn->createQueryTable('results_table', "SELECT * FROM Downtimes_EndpointLocations");
-    $this->assertTrue($result->getRowCount() == 2);
+      /* Assert expected object graph
+      *       se   -----|   (1 service)
+      *      |  \       |
+      *     el2 el3     |   (2 endpoints)
+      *       |  |      |
+      *     dt0 dt1-----|   (2 downtime)
+      */
+        $testConn = $this->getConnection();
+        $result = $testConn->createQueryTable('results_table', "SELECT * FROM EndpointLocations");
+        $this->assertTrue($result->getRowCount() == 2);
+        $result = $testConn->createQueryTable('results_table', "SELECT * FROM Downtimes");
+        $this->assertTrue($result->getRowCount() == 2);
+        $result = $testConn->createQueryTable('results_table', "SELECT * FROM Downtimes_EndpointLocations");
+        $this->assertTrue($result->getRowCount() == 2);
 
-     // Assert expected object graph in ORM Mem
-    $this->assertEquals(1, count($el2->getDowntimes()));
-    $this->assertEquals(1, count($el3->getDowntimes()));
-    $this->assertEquals(2, count($se->getEndpointLocations()));
-    $this->assertEquals(1, count($se->getDowntimes()));
-    $this->assertEquals(2, count($dt1->getEndpointLocations()));
-    $this->assertEquals(1, count($dt1->getServices()));
+       // Assert expected object graph in ORM Mem
+        $this->assertEquals(1, count($el2->getDowntimes()));
+        $this->assertEquals(1, count($el3->getDowntimes()));
+        $this->assertEquals(2, count($se->getEndpointLocations()));
+        $this->assertEquals(1, count($se->getDowntimes()));
+        $this->assertEquals(2, count($dt1->getEndpointLocations()));
+        $this->assertEquals(1, count($dt1->getServices()));
 
-    // remove another el
-    $serviceDao->removeEndpoint($el2);
-    $this->em->flush();
+      // remove another el
+        $serviceDao->removeEndpoint($el2);
+        $this->em->flush();
 
-    /* Assert expected object graph in DB
-    *      se -----| (1 service)
-    *        \     |
-    *         el3  | (1 endpoints)
-    *         /    |
-    *  dt0 dt1-----| (2 downtime)
-    */
-    $testConn = $this->getConnection();
-    $result = $testConn->createQueryTable('results_table', "SELECT * FROM EndpointLocations");
-    $this->assertTrue($result->getRowCount() == 1);
-    $result = $testConn->createQueryTable('results_table', "SELECT * FROM Downtimes");
-    $this->assertTrue($result->getRowCount() == 2);
-    $result = $testConn->createQueryTable('results_table', "SELECT * FROM Downtimes_EndpointLocations");
-    $this->assertTrue($result->getRowCount() == 1);
+      /* Assert expected object graph in DB
+      *      se -----| (1 service)
+      *        \     |
+      *         el3  | (1 endpoints)
+      *         /    |
+      *  dt0 dt1-----| (2 downtime)
+      */
+        $testConn = $this->getConnection();
+        $result = $testConn->createQueryTable('results_table', "SELECT * FROM EndpointLocations");
+        $this->assertTrue($result->getRowCount() == 1);
+        $result = $testConn->createQueryTable('results_table', "SELECT * FROM Downtimes");
+        $this->assertTrue($result->getRowCount() == 2);
+        $result = $testConn->createQueryTable('results_table', "SELECT * FROM Downtimes_EndpointLocations");
+        $this->assertTrue($result->getRowCount() == 1);
 
-    // Assert expected object graph in ORM Mem
-    $this->assertEquals(1, count($el3->getDowntimes()));
-    $this->assertEquals(1, count($se->getEndpointLocations()));
-    $this->assertEquals(1, count($se->getDowntimes()));
-    $this->assertEquals(1, count($dt1->getEndpointLocations()));
-    $this->assertEquals(1, count($dt1->getServices()));
+      // Assert expected object graph in ORM Mem
+        $this->assertEquals(1, count($el3->getDowntimes()));
+        $this->assertEquals(1, count($se->getEndpointLocations()));
+        $this->assertEquals(1, count($se->getDowntimes()));
+        $this->assertEquals(1, count($dt1->getEndpointLocations()));
+        $this->assertEquals(1, count($dt1->getServices()));
 
-    // remove another el
-    $serviceDao->removeEndpoint($el3);
-    $this->em->flush();
+      // remove another el
+        $serviceDao->removeEndpoint($el3);
+        $this->em->flush();
 
-    /* Assert expected object graph in DB
-    *      se -----| (1 service)
-    *              |
-    *              | (1 endpoints)
-    *              |
-    *  dt0 dt1-----| (2 downtime)
-    */
-    $testConn = $this->getConnection();
-    $result = $testConn->createQueryTable('results_table', "SELECT * FROM EndpointLocations");
-    $this->assertTrue($result->getRowCount() == 0);
-    $result = $testConn->createQueryTable('results_table', "SELECT * FROM Downtimes");
-    $this->assertTrue($result->getRowCount() == 2);
-    $result = $testConn->createQueryTable('results_table', "SELECT * FROM Downtimes_EndpointLocations");
-    $this->assertTrue($result->getRowCount() == 0);
+      /* Assert expected object graph in DB
+      *      se -----| (1 service)
+      *              |
+      *              | (1 endpoints)
+      *              |
+      *  dt0 dt1-----| (2 downtime)
+      */
+        $testConn = $this->getConnection();
+        $result = $testConn->createQueryTable('results_table', "SELECT * FROM EndpointLocations");
+        $this->assertTrue($result->getRowCount() == 0);
+        $result = $testConn->createQueryTable('results_table', "SELECT * FROM Downtimes");
+        $this->assertTrue($result->getRowCount() == 2);
+        $result = $testConn->createQueryTable('results_table', "SELECT * FROM Downtimes_EndpointLocations");
+        $this->assertTrue($result->getRowCount() == 0);
 
-    // Assert expected object graph in ORM Mem
-    $this->assertEquals(0, count($se->getEndpointLocations()));
-    $this->assertEquals(1, count($se->getDowntimes()));
-    $this->assertEquals(0, count($dt1->getEndpointLocations()));
-    $this->assertEquals(1, count($dt1->getServices()));
-  }
-
+      // Assert expected object graph in ORM Mem
+        $this->assertEquals(0, count($se->getEndpointLocations()));
+        $this->assertEquals(1, count($se->getDowntimes()));
+        $this->assertEquals(0, count($dt1->getEndpointLocations()));
+        $this->assertEquals(1, count($dt1->getServices()));
+    }
 }
-?>

--- a/tests/doctrine/ExtensionsTest.php
+++ b/tests/doctrine/ExtensionsTest.php
@@ -1,4 +1,5 @@
 <?php
+
 require_once dirname(__FILE__) . '/TestUtil.php';
 require_once dirname(__FILE__) . '/../../lib/Gocdb_Services/ServiceService.php';
 require_once dirname(__FILE__) . '/../../lib/Gocdb_Services/RoleActionMappingService.php';
@@ -13,549 +14,570 @@ require_once dirname(__FILE__) . '/bootstrap.php';
 *
 * @author James McCarthy
 */
-class ExtensionsTest extends PHPUnit_Extensions_Database_TestCase {
-
-  private $em;
+class ExtensionsTest extends PHPUnit_Extensions_Database_TestCase
+{
+    private $em;
 
   /**
    * Overridden.
    */
-  public static function setUpBeforeClass() {
-    parent::setUpBeforeClass();
-    echo "\n\n-------------------------------------------------\n";
-    echo "Executing ExtensionsTest. . .\n";
-  }
+    public static function setUpBeforeClass()
+    {
+        parent::setUpBeforeClass();
+        echo "\n\n-------------------------------------------------\n";
+        echo "Executing ExtensionsTest. . .\n";
+    }
 
   /**
    * Overridden. Returns the test database connection.
    * @return PHPUnit_Extensions_Database_DB_IDatabaseConnection
    */
-  protected function getConnection() {
-    require_once dirname(__FILE__) . '/bootstrap_pdo.php';
-    return getConnectionToTestDB();
-  }
+    protected function getConnection()
+    {
+        require_once dirname(__FILE__) . '/bootstrap_pdo.php';
+        return getConnectionToTestDB();
+    }
 
   /**
    * Overridden. Returns the test dataset.
    * Defines how the initial state of the database should look before each test is executed.
    * @return PHPUnit_Extensions_Database_DataSet_IDataSet
    */
-  protected function getDataSet() {
-    return $this->createFlatXMLDataSet(dirname(__FILE__) . '/truncateDataTables.xml');
-  }
+    protected function getDataSet()
+    {
+        return $this->createFlatXMLDataSet(dirname(__FILE__) . '/truncateDataTables.xml');
+    }
 
   /**
    * Overridden.
    */
-  protected function getSetUpOperation() {
-    // CLEAN_INSERT is default
-    //return PHPUnit_Extensions_Database_Operation_Factory::CLEAN_INSERT();
-    //return PHPUnit_Extensions_Database_Operation_Factory::UPDATE();
-    //return PHPUnit_Extensions_Database_Operation_Factory::NONE();
-    //
+    protected function getSetUpOperation()
+    {
+      // CLEAN_INSERT is default
+      //return PHPUnit_Extensions_Database_Operation_Factory::CLEAN_INSERT();
+      //return PHPUnit_Extensions_Database_Operation_Factory::UPDATE();
+      //return PHPUnit_Extensions_Database_Operation_Factory::NONE();
+      //
         // Issue a DELETE from <table> which is more portable than a
-    // TRUNCATE table <table> (some DBs require high privileges for truncate statements
-    // and also do not allow truncates across tables with FK contstraints e.g. Oracle)
-    return PHPUnit_Extensions_Database_Operation_Factory::DELETE_ALL();
-  }
+      // TRUNCATE table <table> (some DBs require high privileges for truncate statements
+      // and also do not allow truncates across tables with FK contstraints e.g. Oracle)
+        return PHPUnit_Extensions_Database_Operation_Factory::DELETE_ALL();
+    }
 
   /**
    * Overridden.
    */
-  protected function getTearDownOperation() {
-    // NONE is default
-    return PHPUnit_Extensions_Database_Operation_Factory::NONE();
-  }
+    protected function getTearDownOperation()
+    {
+      // NONE is default
+        return PHPUnit_Extensions_Database_Operation_Factory::NONE();
+    }
 
   /**
    * Sets up the fixture, e.g create a new entityManager for each test run
    * This method is called before each test method is executed.
    */
-  protected function setUp() {
-    parent::setUp();
-    $this->em = $this->createEntityManager();
-  }
-
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->em = $this->createEntityManager();
+    }
+  /**
+   * Run after each test function to prevent pile-up of database connections.
+   */
+    protected function tearDown()
+    {
+        parent::tearDown();
+        if (!is_null($this->em)) {
+            $this->em->getConnection()->close();
+        }
+    }
   /**
    * @todo Still need to setup connection to different databases.
    * @return EntityManager
    */
-  private function createEntityManager() {
-    require dirname(__FILE__) . '/bootstrap_doctrine.php';
-    return $entityManager;
-  }
+    private function createEntityManager()
+    {
+        require dirname(__FILE__) . '/bootstrap_doctrine.php';
+        return $entityManager;
+    }
 
   /**
    * Called after setUp() and before each test. Used for common assertions
    * across all tests.
    */
-  protected function assertPreConditions() {
-    $con = $this->getConnection();
-    $fixture = dirname(__FILE__) . '/truncateDataTables.xml';
-    $tables = simplexml_load_file($fixture);
+    protected function assertPreConditions()
+    {
+        $con = $this->getConnection();
+        $fixture = dirname(__FILE__) . '/truncateDataTables.xml';
+        $tables = simplexml_load_file($fixture);
 
-    foreach ($tables as $tableName) {
-      $sql = "SELECT * FROM " . $tableName->getName();
-      $result = $con->createQueryTable('results_table', $sql);
-      if ($result->getRowCount() != 0) {
-        throw new RuntimeException("Invalid fixture. Table has rows: " . $tableName->getName());
-      }
+        foreach ($tables as $tableName) {
+            $sql = "SELECT * FROM " . $tableName->getName();
+            $result = $con->createQueryTable('results_table', $sql);
+            if ($result->getRowCount() != 0) {
+                throw new RuntimeException("Invalid fixture. Table has rows: " . $tableName->getName());
+            }
+        }
     }
-  }
 
   /**
    * An example test showing the creation of a site and properties and that
    * all data is removed on deletion of a site or property
    */
-  public function testSitePropertyDeletions() {
-    print __METHOD__ . "\n";
+    public function testSitePropertyDeletions()
+    {
+        print __METHOD__ . "\n";
 
-    //Create a site
-    $site = TestUtil::createSampleSite("TestSite");
-    //Create site property
-    $prop1 = TestUtil::createSampleSiteProperty("VO-ATLAS", "true");
-    $prop2 = TestUtil::createSampleSiteProperty("VO-CMS", "true");
-    $prop3 = TestUtil::createSampleSiteProperty("VO-ALICE", "true");
+      //Create a site
+        $site = TestUtil::createSampleSite("TestSite");
+      //Create site property
+        $prop1 = TestUtil::createSampleSiteProperty("VO-ATLAS", "true");
+        $prop2 = TestUtil::createSampleSiteProperty("VO-CMS", "true");
+        $prop3 = TestUtil::createSampleSiteProperty("VO-ALICE", "true");
 
-    $site->addSitePropertyDoJoin($prop1);
-    $site->addSitePropertyDoJoin($prop2);
-    $site->addSitePropertyDoJoin($prop3);
+        $site->addSitePropertyDoJoin($prop1);
+        $site->addSitePropertyDoJoin($prop2);
+        $site->addSitePropertyDoJoin($prop3);
 
-    //Set some extra details of the site
-    $site->setEmail("myTest@email.com");
-    $site->setTelephone("012345678910");
-    $site->setLocation("United Kingdom");
+      //Set some extra details of the site
+        $site->setEmail("myTest@email.com");
+        $site->setTelephone("012345678910");
+        $site->setLocation("United Kingdom");
 
-    //Persist the site & property in the entity manager
-    $this->em->persist($site);
-    $this->em->persist($prop1);
-    $this->em->persist($prop2);
-    $this->em->persist($prop3);
+      //Persist the site & property in the entity manager
+        $this->em->persist($site);
+        $this->em->persist($prop1);
+        $this->em->persist($prop2);
+        $this->em->persist($prop3);
 
-    //Commit the site to the database
-    $this->em->flush();
+      //Commit the site to the database
+        $this->em->flush();
 
-    //Check that the site has 3 properties associated with it
-    $properties = $site->getSiteProperties();
-    $this->assertTrue(count($properties) == 3);
+      //Check that the site has 3 properties associated with it
+        $properties = $site->getSiteProperties();
+        $this->assertTrue(count($properties) == 3);
 
 
-    //Create an admin user that can delete a property
-    $adminUser = TestUtil::createSampleUser('my', 'admin');
-    $identifier= TestUtil::createSampleUserIdentifier('X.509', '/my/admin');
-    $adminUser->addUserIdentifierDoJoin($identifier);
-    $this->em->persist($identifier);
-    $adminUser->setAdmin(TRUE);
-    $this->em->persist($adminUser);
+      //Create an admin user that can delete a property
+        $adminUser = TestUtil::createSampleUser('my', 'admin');
+        $identifier = TestUtil::createSampleUserIdentifier('X.509', '/my/admin');
+        $adminUser->addUserIdentifierDoJoin($identifier);
+        $this->em->persist($identifier);
+        $adminUser->setAdmin(true);
+        $this->em->persist($adminUser);
 
-    //flush the user to the DB - so that the RoleAuthorisationService can find it in the DB
-    $this->em->flush();
+      //flush the user to the DB - so that the RoleAuthorisationService can find it in the DB
+        $this->em->flush();
 
-    //Delete the property from the site
-    $siteService = new org\gocdb\services\Site();
-    $siteService->setEntityManager($this->em);
-    $roleActionMappingService = new org\gocdb\services\RoleActionMappingService();
-    $roleActionAuthService = new org\gocdb\services\RoleActionAuthorisationService($roleActionMappingService);
-    $roleActionAuthService->setEntityManager($this->em);
-    $siteService->setRoleActionAuthorisationService($roleActionAuthService);
-    $siteService->deleteSiteProperties($site, $adminUser, array($prop1));
+      //Delete the property from the site
+        $siteService = new org\gocdb\services\Site();
+        $siteService->setEntityManager($this->em);
+        $roleActionMappingService = new org\gocdb\services\RoleActionMappingService();
+        $roleActionAuthService = new org\gocdb\services\RoleActionAuthorisationService($roleActionMappingService);
+        $roleActionAuthService->setEntityManager($this->em);
+        $siteService->setRoleActionAuthorisationService($roleActionAuthService);
+        $siteService->deleteSiteProperties($site, $adminUser, array($prop1));
 
-    //Check that the site now only has 2 properties
-    $properties = $site->getSiteProperties();
-    $this->assertTrue(count($properties) == 2);
-    $this->em->flush();
+      //Check that the site now only has 2 properties
+        $properties = $site->getSiteProperties();
+        $this->assertTrue(count($properties) == 2);
+        $this->em->flush();
 
-    //Check this via the database
-    $con = $this->getConnection();
+      //Check this via the database
+        $con = $this->getConnection();
 
-    //Get site id to use in sql statements
-    $siteId = $site->getId();
+      //Get site id to use in sql statements
+        $siteId = $site->getId();
 
-    $result = $con->createQueryTable('results', "SELECT * FROM Site_Properties WHERE PARENTSITE_ID = '$siteId'");
-    //Assert that only 2 site properties exist in the database for this site
-    $this->assertEquals(2, $result->getRowCount());
+        $result = $con->createQueryTable('results', "SELECT * FROM Site_Properties WHERE PARENTSITE_ID = '$siteId'");
+      //Assert that only 2 site properties exist in the database for this site
+        $this->assertEquals(2, $result->getRowCount());
 
-    //Now delete the site and check that it cascades the delete to remove the sites associated properties
-    $siteService->deleteSite($site, $adminUser, false);
-    $this->em->flush();
+      //Now delete the site and check that it cascades the delete to remove the sites associated properties
+        $siteService->deleteSite($site, $adminUser, false);
+        $this->em->flush();
 
-    //Check site is gone
-    $result = $con->createQueryTable('results', "SELECT * FROM Sites WHERE ID = '$siteId'");
-    $this->assertEquals(0, $result->getRowCount());
+      //Check site is gone
+        $result = $con->createQueryTable('results', "SELECT * FROM Sites WHERE ID = '$siteId'");
+        $this->assertEquals(0, $result->getRowCount());
 
-    //Check properties are gone
-    $result = $con->createQueryTable('results', "SELECT * FROM Site_Properties WHERE PARENTSITE_ID = '$siteId'");
-    $this->assertEquals(0, $result->getRowCount());
-  }
+      //Check properties are gone
+        $result = $con->createQueryTable('results', "SELECT * FROM Site_Properties WHERE PARENTSITE_ID = '$siteId'");
+        $this->assertEquals(0, $result->getRowCount());
+    }
 
   /**
    * An example test showing the creation of a service and properties and that
    * all data is removed on deletion of a service or property
    */
-  public function testServicePropertyDeletions() {
-    print __METHOD__ . "\n";
+    public function testServicePropertyDeletions()
+    {
+        print __METHOD__ . "\n";
 
-    //Create a service
-    $service = TestUtil::createSampleService("TestService");
+      //Create a service
+        $service = TestUtil::createSampleService("TestService");
 
-    //Create a NGI
-    $ngi = TestUtil::createSampleNGI("TestNGI");
-    //Create a site
-    $site = TestUtil::createSampleSite("TestSite");
+      //Create a NGI
+        $ngi = TestUtil::createSampleNGI("TestNGI");
+      //Create a site
+        $site = TestUtil::createSampleSite("TestSite");
 
-    //Join service to site, and site to NGI.
-    $ngi->addSiteDoJoin($site);
+      //Join service to site, and site to NGI.
+        $ngi->addSiteDoJoin($site);
 
-    $site->addServiceDoJoin($service);
+        $site->addServiceDoJoin($service);
 
-    //Create service property
-    $prop1 = TestUtil::createSampleServiceProperty("VO-Atlas", "true");
-    $prop2 = TestUtil::createSampleServiceProperty("VO-CMS", "true");
-    $prop3 = TestUtil::createSampleServiceProperty("VO-Alice", "true");
+      //Create service property
+        $prop1 = TestUtil::createSampleServiceProperty("VO-Atlas", "true");
+        $prop2 = TestUtil::createSampleServiceProperty("VO-CMS", "true");
+        $prop3 = TestUtil::createSampleServiceProperty("VO-Alice", "true");
 
-    $service->addServicePropertyDoJoin($prop1);
-    $service->addServicePropertyDoJoin($prop2);
-    $service->addServicePropertyDoJoin($prop3);
+        $service->addServicePropertyDoJoin($prop1);
+        $service->addServicePropertyDoJoin($prop2);
+        $service->addServicePropertyDoJoin($prop3);
 
-    //Persist the service & property in the entity manager
-    $this->em->persist($service);
-    $this->em->persist($ngi);
-    $this->em->persist($site);
-    $this->em->persist($prop1);
-    $this->em->persist($prop2);
-    $this->em->persist($prop3);
+      //Persist the service & property in the entity manager
+        $this->em->persist($service);
+        $this->em->persist($ngi);
+        $this->em->persist($site);
+        $this->em->persist($prop1);
+        $this->em->persist($prop2);
+        $this->em->persist($prop3);
 
-    //Commit the service to the database
-    $this->em->flush();
+      //Commit the service to the database
+        $this->em->flush();
 
-    //Check that the service has 3 properties associated with it
-    $properties = $service->getServiceProperties();
-    $this->assertTrue(count($properties) == 3);
+      //Check that the service has 3 properties associated with it
+        $properties = $service->getServiceProperties();
+        $this->assertTrue(count($properties) == 3);
 
-    //Create an admin user that can delete a property
-    $adminUser = TestUtil::createSampleUser('my', 'admin');
-    $identifier= TestUtil::createSampleUserIdentifier('X.509', '/my/admin');
-    $adminUser->addUserIdentifierDoJoin($identifier);
-    $this->em->persist($identifier);
-    $adminUser->setAdmin(TRUE);
-    $this->em->persist($adminUser);
+      //Create an admin user that can delete a property
+        $adminUser = TestUtil::createSampleUser('my', 'admin');
+        $identifier = TestUtil::createSampleUserIdentifier('X.509', '/my/admin');
+        $adminUser->addUserIdentifierDoJoin($identifier);
+        $this->em->persist($identifier);
+        $adminUser->setAdmin(true);
+        $this->em->persist($adminUser);
 
-    //flush the user to the DB - so that the RoleAuthorisationService can find it in the DB
-    $this->em->flush();
+      //flush the user to the DB - so that the RoleAuthorisationService can find it in the DB
+        $this->em->flush();
 
-    //Delete the property from the service
-    $serviceService = new org\gocdb\services\ServiceService();
-    $serviceService->setEntityManager($this->em);
-    $roleActionMappingService = new org\gocdb\services\RoleActionMappingService();
-    $roleActionAuthService = new org\gocdb\services\RoleActionAuthorisationService($roleActionMappingService);
-    $roleActionAuthService->setEntityManager($this->em);
-    $serviceService->setRoleActionAuthorisationService($roleActionAuthService);
-    //$serviceService->deleteServiceProperty($service, $adminUser, $prop1);
-    $serviceService->deleteServiceProperties($service, $adminUser, array($prop1));
+      //Delete the property from the service
+        $serviceService = new org\gocdb\services\ServiceService();
+        $serviceService->setEntityManager($this->em);
+        $roleActionMappingService = new org\gocdb\services\RoleActionMappingService();
+        $roleActionAuthService = new org\gocdb\services\RoleActionAuthorisationService($roleActionMappingService);
+        $roleActionAuthService->setEntityManager($this->em);
+        $serviceService->setRoleActionAuthorisationService($roleActionAuthService);
+      //$serviceService->deleteServiceProperty($service, $adminUser, $prop1);
+        $serviceService->deleteServiceProperties($service, $adminUser, array($prop1));
 
-    //Check that the service now only has 2 properties
-    $properties = $service->getServiceProperties();
-    $this->assertTrue(count($properties) == 2);
-    $this->em->flush();
+      //Check that the service now only has 2 properties
+        $properties = $service->getServiceProperties();
+        $this->assertTrue(count($properties) == 2);
+        $this->em->flush();
 
-    //Check this via the database
-    $con = $this->getConnection();
+      //Check this via the database
+        $con = $this->getConnection();
 
-    //Get service id to use in sql statements
-    $servId = $service->getId();
+      //Get service id to use in sql statements
+        $servId = $service->getId();
 
-    $result = $con->createQueryTable('results', "SELECT * FROM Service_Properties WHERE PARENTSERVICE_ID = '$servId'");
-    //Assert that only 2 service properties exist in the database for this service
-    $this->assertEquals(2, $result->getRowCount());
+        $result = $con->createQueryTable('results', "SELECT * FROM Service_Properties WHERE PARENTSERVICE_ID = '$servId'");
+      //Assert that only 2 service properties exist in the database for this service
+        $this->assertEquals(2, $result->getRowCount());
 
-    //Now delete the service and check that it cascades the delete to remove the services associated properties
-    $serviceService->deleteService($service, $adminUser, true);
-    $this->em->flush();
+      //Now delete the service and check that it cascades the delete to remove the services associated properties
+        $serviceService->deleteService($service, $adminUser, true);
+        $this->em->flush();
 
-    //Check service is gone
-    $result = $con->createQueryTable('results', "SELECT * FROM Services WHERE ID = '$servId'");
-    $this->assertEquals(0, $result->getRowCount());
+      //Check service is gone
+        $result = $con->createQueryTable('results', "SELECT * FROM Services WHERE ID = '$servId'");
+        $this->assertEquals(0, $result->getRowCount());
 
-    //Check properties are gone
-    $result = $con->createQueryTable('results', "SELECT * FROM Service_Properties WHERE PARENTSERVICE_ID = '$servId'");
-    $this->assertEquals(0, $result->getRowCount());
-  }
+      //Check properties are gone
+        $result = $con->createQueryTable('results', "SELECT * FROM Service_Properties WHERE PARENTSERVICE_ID = '$servId'");
+        $this->assertEquals(0, $result->getRowCount());
+    }
 
   /**
    * An example test showing the creation of a service group and properties
    * and that all data is removed on deletion of a service group or property
    */
-  public function testServiceGroupPropertyDeletions() {
-    print __METHOD__ . "\n";
+    public function testServiceGroupPropertyDeletions()
+    {
+        print __METHOD__ . "\n";
 
-    //Create a service
-    $service = TestUtil::createSampleService("TestService");
+      //Create a service
+        $service = TestUtil::createSampleService("TestService");
 
-    //Create a NGI
-    $ngi = TestUtil::createSampleNGI("TestNGI");
-    //Create a site
-    $site = TestUtil::createSampleSite("TestSite");
+      //Create a NGI
+        $ngi = TestUtil::createSampleNGI("TestNGI");
+      //Create a site
+        $site = TestUtil::createSampleSite("TestSite");
 
-    //Create a service group
-    $sg = TestUtil::createSampleServiceGroup("TestServiceGroup");
+      //Create a service group
+        $sg = TestUtil::createSampleServiceGroup("TestServiceGroup");
 
-    //Join service to site, and site to NGI.
-    $ngi->addSiteDoJoin($site);
-    $site->addServiceDoJoin($service);
+      //Join service to site, and site to NGI.
+        $ngi->addSiteDoJoin($site);
+        $site->addServiceDoJoin($service);
 
-    //Finally add service to service group
-    $sg->addService($service);
+      //Finally add service to service group
+        $sg->addService($service);
 
-    //Create service group properties
-    $prop1 = TestUtil::createSampleServiceGroupProperty("VO-Atlas", "true");
-    $prop2 = TestUtil::createSampleServiceGroupProperty("VO-CMS", "true");
-    $prop3 = TestUtil::createSampleServiceGroupProperty("VO-Alice", "true");
+      //Create service group properties
+        $prop1 = TestUtil::createSampleServiceGroupProperty("VO-Atlas", "true");
+        $prop2 = TestUtil::createSampleServiceGroupProperty("VO-CMS", "true");
+        $prop3 = TestUtil::createSampleServiceGroupProperty("VO-Alice", "true");
 
-    $sg->addServiceGroupPropertyDoJoin($prop1);
-    $sg->addServiceGroupPropertyDoJoin($prop2);
-    $sg->addServiceGroupPropertyDoJoin($prop3);
+        $sg->addServiceGroupPropertyDoJoin($prop1);
+        $sg->addServiceGroupPropertyDoJoin($prop2);
+        $sg->addServiceGroupPropertyDoJoin($prop3);
 
-    //Persist the service, ngi, site, service group & property in the entity manager
-    $this->em->persist($service);
-    $this->em->persist($ngi);
-    $this->em->persist($site);
-    $this->em->persist($sg);
-    $this->em->persist($prop1);
-    $this->em->persist($prop2);
-    $this->em->persist($prop3);
+      //Persist the service, ngi, site, service group & property in the entity manager
+        $this->em->persist($service);
+        $this->em->persist($ngi);
+        $this->em->persist($site);
+        $this->em->persist($sg);
+        $this->em->persist($prop1);
+        $this->em->persist($prop2);
+        $this->em->persist($prop3);
 
-    //Commit the entites to the database
-    $this->em->flush();
+      //Commit the entites to the database
+        $this->em->flush();
 
-    //Check that the service group has 3 properties associated with it
-    $properties = $sg->getServiceGroupProperties();
-    $this->assertTrue(count($properties) == 3);
+      //Check that the service group has 3 properties associated with it
+        $properties = $sg->getServiceGroupProperties();
+        $this->assertTrue(count($properties) == 3);
 
-    //Create an admin user that can delete a property
-    $adminUser = TestUtil::createSampleUser('my', 'admin');
-    $identifier= TestUtil::createSampleUserIdentifier('X.509', '/my/admin');
-    $adminUser->addUserIdentifierDoJoin($identifier);
-    $this->em->persist($identifier);
-    $adminUser->setAdmin(TRUE);
-    $this->em->persist($adminUser);
+      //Create an admin user that can delete a property
+        $adminUser = TestUtil::createSampleUser('my', 'admin');
+        $identifier = TestUtil::createSampleUserIdentifier('X.509', '/my/admin');
+        $adminUser->addUserIdentifierDoJoin($identifier);
+        $this->em->persist($identifier);
+        $adminUser->setAdmin(true);
+        $this->em->persist($adminUser);
 
-    //flush the user to the DB - so that the RoleAuthorisationService can find it in the DB
-    $this->em->flush();
+      //flush the user to the DB - so that the RoleAuthorisationService can find it in the DB
+        $this->em->flush();
 
-    //Delete the property from the service group
-    $roleActionMappingService = new org\gocdb\services\RoleActionMappingService();
-    $roleService = new org\gocdb\services\Role();
-    $roleService->setEntityManager($this->em);
-    $authService = new org\gocdb\services\RoleActionAuthorisationService($roleActionMappingService/* , $roleService */);
-    $authService->setEntityManager($this->em);
-    $sgService = new org\gocdb\services\ServiceGroup($authService);
-    $sgService->setEntityManager($this->em);
-    $sgService->setRoleActionAuthorisationService($authService);
+      //Delete the property from the service group
+        $roleActionMappingService = new org\gocdb\services\RoleActionMappingService();
+        $roleService = new org\gocdb\services\Role();
+        $roleService->setEntityManager($this->em);
+        $authService = new org\gocdb\services\RoleActionAuthorisationService($roleActionMappingService/* , $roleService */);
+        $authService->setEntityManager($this->em);
+        $sgService = new org\gocdb\services\ServiceGroup($authService);
+        $sgService->setEntityManager($this->em);
+        $sgService->setRoleActionAuthorisationService($authService);
 
-    //$sgService->deleteServiceGroupProperty($sg, $adminUser, $prop1);
-    $sgService->deleteServiceGroupProperties($sg, $adminUser, array($prop1));
+      //$sgService->deleteServiceGroupProperty($sg, $adminUser, $prop1);
+        $sgService->deleteServiceGroupProperties($sg, $adminUser, array($prop1));
 
-    //Check that the sg now only has 2 properties
-    $properties = $sg->getServiceGroupProperties();
-    $this->assertTrue(count($properties) == 2);
-    $this->em->flush();
+      //Check that the sg now only has 2 properties
+        $properties = $sg->getServiceGroupProperties();
+        $this->assertTrue(count($properties) == 2);
+        $this->em->flush();
 
-    //Check this via the database
-    $con = $this->getConnection();
+      //Check this via the database
+        $con = $this->getConnection();
 
-    //Get servicegroup id to use in sql statements
-    $sgId = $sg->getId();
+      //Get servicegroup id to use in sql statements
+        $sgId = $sg->getId();
 
-    $result = $con->createQueryTable('results', "SELECT * FROM ServiceGroup_Properties WHERE PARENTSERVICEGROUP_ID = '$sgId'");
-    //Assert that only 2 service group properties exist in the database for this service
-    $this->assertEquals(2, $result->getRowCount());
+        $result = $con->createQueryTable('results', "SELECT * FROM ServiceGroup_Properties WHERE PARENTSERVICEGROUP_ID = '$sgId'");
+      //Assert that only 2 service group properties exist in the database for this service
+        $this->assertEquals(2, $result->getRowCount());
 
-    //Now delete the service group and check that it cascades the delete to remove the services associated properties
-    $sgService->deleteServiceGroup($sg, $adminUser, true);
-    $this->em->flush();
+      //Now delete the service group and check that it cascades the delete to remove the services associated properties
+        $sgService->deleteServiceGroup($sg, $adminUser, true);
+        $this->em->flush();
 
-    //Check service group is gone
-    $result = $con->createQueryTable('results', "SELECT * FROM ServiceGroups WHERE ID = '$sgId'");
-    $this->assertEquals(0, $result->getRowCount());
+      //Check service group is gone
+        $result = $con->createQueryTable('results', "SELECT * FROM ServiceGroups WHERE ID = '$sgId'");
+        $this->assertEquals(0, $result->getRowCount());
 
-    //Check properties are gone
-    $result = $con->createQueryTable('results', "SELECT * FROM ServiceGroup_Properties WHERE PARENTSERVICEGROUP_ID = '$sgId'");
-    $this->assertEquals(0, $result->getRowCount());
-  }
+      //Check properties are gone
+        $result = $con->createQueryTable('results', "SELECT * FROM ServiceGroup_Properties WHERE PARENTSERVICEGROUP_ID = '$sgId'");
+        $this->assertEquals(0, $result->getRowCount());
+    }
 
   /**
    * Show the creation of an endpoint and properties and that
    * all data is removed on deletion of an endpoint or property
    */
-  public function testEndpointPropertyDeletions() {
-    print __METHOD__ . "\n";
+    public function testEndpointPropertyDeletions()
+    {
+        print __METHOD__ . "\n";
 
-    $service = TestUtil::createSampleService("TestService");
-    $ngi = TestUtil::createSampleNGI("TestNGI");
-    $site = TestUtil::createSampleSite("TestSite");
-    $endpoint = TestUtil::createSampleEndpointLocation();
+        $service = TestUtil::createSampleService("TestService");
+        $ngi = TestUtil::createSampleNGI("TestNGI");
+        $site = TestUtil::createSampleSite("TestSite");
+        $endpoint = TestUtil::createSampleEndpointLocation();
 
-    //Join Service endpoint to site, service to site, and site to NGI.
-    $ngi->addSiteDoJoin($site);
-    $site->addServiceDoJoin($service);
-    $service->addEndpointLocationDoJoin($endpoint);
+      //Join Service endpoint to site, service to site, and site to NGI.
+        $ngi->addSiteDoJoin($site);
+        $site->addServiceDoJoin($service);
+        $service->addEndpointLocationDoJoin($endpoint);
 
-    //Create properties
-    $prop1 = TestUtil::createSampleEndpointProperty("VO-Atlas", "true");
-    $prop2 = TestUtil::createSampleEndpointProperty("VO-CMS", "true");
-    $prop3 = TestUtil::createSampleEndpointProperty("VO-Alice", "true");
+      //Create properties
+        $prop1 = TestUtil::createSampleEndpointProperty("VO-Atlas", "true");
+        $prop2 = TestUtil::createSampleEndpointProperty("VO-CMS", "true");
+        $prop3 = TestUtil::createSampleEndpointProperty("VO-Alice", "true");
 
-    $endpoint->addEndpointPropertyDoJoin($prop1);
-    $endpoint->addEndpointPropertyDoJoin($prop2);
-    $endpoint->addEndpointPropertyDoJoin($prop3);
-
-
-    //Persist in the entity manager
-    $this->em->persist($service);
-    $this->em->persist($ngi);
-    $this->em->persist($site);
-    $this->em->persist($endpoint);
-    $this->em->persist($prop1);
-    $this->em->persist($prop2);
-    $this->em->persist($prop3);
+        $endpoint->addEndpointPropertyDoJoin($prop1);
+        $endpoint->addEndpointPropertyDoJoin($prop2);
+        $endpoint->addEndpointPropertyDoJoin($prop3);
 
 
-    //Commit to the database
-    $this->em->flush();
+      //Persist in the entity manager
+        $this->em->persist($service);
+        $this->em->persist($ngi);
+        $this->em->persist($site);
+        $this->em->persist($endpoint);
+        $this->em->persist($prop1);
+        $this->em->persist($prop2);
+        $this->em->persist($prop3);
 
-    //Check endpoint has 3 properties associated with it
-    $properties = $endpoint->getEndpointProperties();
-    $this->assertTrue(count($properties) == 3);
+
+      //Commit to the database
+        $this->em->flush();
+
+      //Check endpoint has 3 properties associated with it
+        $properties = $endpoint->getEndpointProperties();
+        $this->assertTrue(count($properties) == 3);
 
 
-    //Create an admin user that can delete a property
-    $adminUser = TestUtil::createSampleUser('my', 'admin');
-    $identifier = TestUtil::createSampleUserIdentifier('X.509', '/my/admin');
-    $adminUser->addUserIdentifierDoJoin($identifier);
-    $this->em->persist($identifier);
-    $adminUser->setAdmin(TRUE);
-    $this->em->persist($adminUser);
+      //Create an admin user that can delete a property
+        $adminUser = TestUtil::createSampleUser('my', 'admin');
+        $identifier = TestUtil::createSampleUserIdentifier('X.509', '/my/admin');
+        $adminUser->addUserIdentifierDoJoin($identifier);
+        $this->em->persist($identifier);
+        $adminUser->setAdmin(true);
+        $this->em->persist($adminUser);
 
-    //flush the user to the DB - so that the RoleAuthorisationService can find it in the DB
-    $this->em->flush();
+      //flush the user to the DB - so that the RoleAuthorisationService can find it in the DB
+        $this->em->flush();
 
-    //Delete the property from the service
-    $serviceService = new org\gocdb\services\ServiceService();
-    $serviceService->setEntityManager($this->em);
-    $roleActionMappingService = new org\gocdb\services\RoleActionMappingService();
-    $roleActionAuthService = new org\gocdb\services\RoleActionAuthorisationService($roleActionMappingService);
-    $roleActionAuthService->setEntityManager($this->em);
-    $serviceService->setRoleActionAuthorisationService($roleActionAuthService);
+      //Delete the property from the service
+        $serviceService = new org\gocdb\services\ServiceService();
+        $serviceService->setEntityManager($this->em);
+        $roleActionMappingService = new org\gocdb\services\RoleActionMappingService();
+        $roleActionAuthService = new org\gocdb\services\RoleActionAuthorisationService($roleActionMappingService);
+        $roleActionAuthService->setEntityManager($this->em);
+        $serviceService->setRoleActionAuthorisationService($roleActionAuthService);
 
-    $serviceService->deleteEndpointProperties($service, $adminUser, array($prop1));
+        $serviceService->deleteEndpointProperties($service, $adminUser, array($prop1));
 
-    //Check that the service endpoint now only has 2 properties
-    $properties = $endpoint->getEndpointProperties();
-    $this->assertTrue(count($properties) == 2);
-    $this->em->flush();
+      //Check that the service endpoint now only has 2 properties
+        $properties = $endpoint->getEndpointProperties();
+        $this->assertTrue(count($properties) == 2);
+        $this->em->flush();
 
-    //Check this via the database
-    $con = $this->getConnection();
+      //Check this via the database
+        $con = $this->getConnection();
 
-    //Get service id to use in sql statements
-    $endpointId = $endpoint->getId();
+      //Get service id to use in sql statements
+        $endpointId = $endpoint->getId();
 
-    $result = $con->createQueryTable('results', "SELECT * FROM Endpoint_Properties WHERE PARENTENDPOINT_ID = '$endpointId'");
-    //Assert that only 2 service properties exist in the database for this service
-    $this->assertEquals(2, $result->getRowCount());
+        $result = $con->createQueryTable('results', "SELECT * FROM Endpoint_Properties WHERE PARENTENDPOINT_ID = '$endpointId'");
+      //Assert that only 2 service properties exist in the database for this service
+        $this->assertEquals(2, $result->getRowCount());
 
-    //Now delete the endpont and check that it cascade deletes
-    //the endpoint's associated properties
-    $serviceService->deleteEndpoint($endpoint, $adminUser);
-    $this->em->flush();
+      //Now delete the endpont and check that it cascade deletes
+      //the endpoint's associated properties
+        $serviceService->deleteEndpoint($endpoint, $adminUser);
+        $this->em->flush();
 
-    //Check endpoint is gone
-    $result = $con->createQueryTable('results', "SELECT * FROM EndpointLocations WHERE ID = '$endpointId'");
-    $this->assertEquals(0, $result->getRowCount());
+      //Check endpoint is gone
+        $result = $con->createQueryTable('results', "SELECT * FROM EndpointLocations WHERE ID = '$endpointId'");
+        $this->assertEquals(0, $result->getRowCount());
 
-    //Check properties are gone
-    $result = $con->createQueryTable('results', "SELECT * FROM Endpoint_Properties WHERE PARENTENDPOINT_ID = '$endpointId'");
-    $this->assertEquals(0, $result->getRowCount());
-  }
+      //Check properties are gone
+        $result = $con->createQueryTable('results', "SELECT * FROM Endpoint_Properties WHERE PARENTENDPOINT_ID = '$endpointId'");
+        $this->assertEquals(0, $result->getRowCount());
+    }
 
   /**
    * An example test showing the creation of a user and identifiers and that
    * all data is removed on deletion of a user or identifier
    */
-  public function testUserIdentifierDeletions() {
-    print __METHOD__ . "\n";
+    public function testUserIdentifierDeletions()
+    {
+        print __METHOD__ . "\n";
 
-    // Create a user
-    $user = TestUtil::createSampleUser("Test", "Testing");
-    // Create user identifiers
-    $identifier1 = TestUtil::createSampleUserIdentifier("Auth type 1", "/c=test1");
-    $identifier2 = TestUtil::createSampleUserIdentifier("Auth type 2", "/c=test2");
-    $identifier3 = TestUtil::createSampleUserIdentifier("Auth type 3", "/c=test3");
+      // Create a user
+        $user = TestUtil::createSampleUser("Test", "Testing");
+      // Create user identifiers
+        $identifier1 = TestUtil::createSampleUserIdentifier("Auth type 1", "/c=test1");
+        $identifier2 = TestUtil::createSampleUserIdentifier("Auth type 2", "/c=test2");
+        $identifier3 = TestUtil::createSampleUserIdentifier("Auth type 3", "/c=test3");
 
-    $user->addUserIdentifierDoJoin($identifier1);
-    $user->addUserIdentifierDoJoin($identifier2);
-    $user->addUserIdentifierDoJoin($identifier3);
+        $user->addUserIdentifierDoJoin($identifier1);
+        $user->addUserIdentifierDoJoin($identifier2);
+        $user->addUserIdentifierDoJoin($identifier3);
 
-    // Set some extra details of the user
-    $user->setEmail("myTest@email.com");
-    $user->setTelephone("012345678910");
+      // Set some extra details of the user
+        $user->setEmail("myTest@email.com");
+        $user->setTelephone("012345678910");
 
-    // Persist the user & identifiers in the entity manager
-    $this->em->persist($user);
-    $this->em->persist($identifier1);
-    $this->em->persist($identifier2);
-    $this->em->persist($identifier3);
+      // Persist the user & identifiers in the entity manager
+        $this->em->persist($user);
+        $this->em->persist($identifier1);
+        $this->em->persist($identifier2);
+        $this->em->persist($identifier3);
 
-    // Commit the user to the database
-    $this->em->flush();
+      // Commit the user to the database
+        $this->em->flush();
 
-    // Check that the user has 3 identifiers associated with it
-    $identifiers = $user->getUserIdentifiers();
-    $this->assertTrue(count($identifiers) === 3);
+      // Check that the user has 3 identifiers associated with it
+        $identifiers = $user->getUserIdentifiers();
+        $this->assertTrue(count($identifiers) === 3);
 
 
-    // Create an admin user that can delete an identifier
-    $adminUser = TestUtil::createSampleUser('my', 'admin');
-    $identifier= TestUtil::createSampleUserIdentifier('X.509', '/my/admin');
-    $adminUser->addUserIdentifierDoJoin($identifier);
-    $this->em->persist($identifier);
-    $adminUser->setAdmin(TRUE);
-    $this->em->persist($adminUser);
+      // Create an admin user that can delete an identifier
+        $adminUser = TestUtil::createSampleUser('my', 'admin');
+        $identifier = TestUtil::createSampleUserIdentifier('X.509', '/my/admin');
+        $adminUser->addUserIdentifierDoJoin($identifier);
+        $this->em->persist($identifier);
+        $adminUser->setAdmin(true);
+        $this->em->persist($adminUser);
 
-    // Flush the user to the DB - so that the RoleAuthorisationService can find it in the DB
-    $this->em->flush();
+      // Flush the user to the DB - so that the RoleAuthorisationService can find it in the DB
+        $this->em->flush();
 
-    // Delete the identifier from the user
-    $userService = new org\gocdb\services\User();
-    $userService->setEntityManager($this->em);
-    $userService->deleteUserIdentifier($user, $identifier1, $adminUser);
+      // Delete the identifier from the user
+        $userService = new org\gocdb\services\User();
+        $userService->setEntityManager($this->em);
+        $userService->deleteUserIdentifier($user, $identifier1, $adminUser);
 
-    // Check that the user now only has 2 identifiers
-    $identifiers = $user->getUserIdentifiers();
-    $this->assertTrue(count($identifiers) == 2);
-    $this->em->flush();
+      // Check that the user now only has 2 identifiers
+        $identifiers = $user->getUserIdentifiers();
+        $this->assertTrue(count($identifiers) == 2);
+        $this->em->flush();
 
-    // Check this via the database
-    $con = $this->getConnection();
+      // Check this via the database
+        $con = $this->getConnection();
 
-    // Get user id to use in sql statements
-    $userId = $user->getId();
+      // Get user id to use in sql statements
+        $userId = $user->getId();
 
-    $result = $con->createQueryTable('results', "SELECT * FROM User_Identifiers WHERE PARENTUSER_ID = '$userId'");
-    // Assert that only 2 user identifiers exist in the database for this user
-    $this->assertEquals(2, $result->getRowCount());
+        $result = $con->createQueryTable('results', "SELECT * FROM User_Identifiers WHERE PARENTUSER_ID = '$userId'");
+      // Assert that only 2 user identifiers exist in the database for this user
+        $this->assertEquals(2, $result->getRowCount());
 
-    // Now delete the user and check that it cascades the delete to remove the user's associated identifiers
-    $userService->deleteUser($user, $adminUser);
-    $this->em->flush();
+      // Now delete the user and check that it cascades the delete to remove the user's associated identifiers
+        $userService->deleteUser($user, $adminUser);
+        $this->em->flush();
 
-    // Check user is gone
-    $result = $con->createQueryTable('results', "SELECT * FROM Users WHERE ID = '$userId'");
-    $this->assertEquals(0, $result->getRowCount());
+      // Check user is gone
+        $result = $con->createQueryTable('results', "SELECT * FROM Users WHERE ID = '$userId'");
+        $this->assertEquals(0, $result->getRowCount());
 
-    // Check identifiers are gone
-    $result = $con->createQueryTable('results', "SELECT * FROM User_Identifiers WHERE PARENTUSER_ID = '$userId'");
-    $this->assertEquals(0, $result->getRowCount());
-  }
+      // Check identifiers are gone
+        $result = $con->createQueryTable('results', "SELECT * FROM User_Identifiers WHERE PARENTUSER_ID = '$userId'");
+        $this->assertEquals(0, $result->getRowCount());
+    }
 }
-?>

--- a/tests/doctrine/NGIServiceTest.php
+++ b/tests/doctrine/NGIServiceTest.php
@@ -1,4 +1,5 @@
 <?php
+
 require_once dirname(__FILE__) . '/TestUtil.php';
 
 use Doctrine\ORM\EntityManager;
@@ -12,141 +13,158 @@ require_once dirname(__FILE__) . '/../../lib/Gocdb_Services/NGI.php';
  *
  * @author David Meredith
  */
-class NGIServiceTest extends PHPUnit_Extensions_Database_TestCase {
-  private $em;
+class NGIServiceTest extends PHPUnit_Extensions_Database_TestCase
+{
+    private $em;
 
   /**
    * Overridden.
    */
-  public static function setUpBeforeClass() {
-    parent::setUpBeforeClass();
-    echo "\n\n-------------------------------------------------\n";
-    echo "Executing NGIServiceTest. . .\n";
-  }
+    public static function setUpBeforeClass()
+    {
+        parent::setUpBeforeClass();
+        echo "\n\n-------------------------------------------------\n";
+        echo "Executing NGIServiceTest. . .\n";
+    }
 
   /**
    * Overridden. Returns the test database connection.
    * @return PHPUnit_Extensions_Database_DB_IDatabaseConnection
    */
-  protected function getConnection() {
-    require_once dirname(__FILE__) . '/bootstrap_pdo.php';
-    return getConnectionToTestDB();
-  }
+    protected function getConnection()
+    {
+        require_once dirname(__FILE__) . '/bootstrap_pdo.php';
+        return getConnectionToTestDB();
+    }
 
   /**
    * Overridden. Returns the test dataset.
    * Defines how the initial state of the database should look before each test is executed.
    * @return PHPUnit_Extensions_Database_DataSet_IDataSet
    */
-  protected function getDataSet() {
-    return $this->createFlatXMLDataSet(dirname(__FILE__) . '/truncateDataTables.xml');
-    // Use below to return an empty data set if we don't want to truncate and seed
-    //return new PHPUnit_Extensions_Database_DataSet_DefaultDataSet();
-  }
+    protected function getDataSet()
+    {
+        return $this->createFlatXMLDataSet(dirname(__FILE__) . '/truncateDataTables.xml');
+      // Use below to return an empty data set if we don't want to truncate and seed
+      //return new PHPUnit_Extensions_Database_DataSet_DefaultDataSet();
+    }
 
   /**
    * Overridden.
    */
-  protected function getSetUpOperation() {
-    // CLEAN_INSERT is default
-    //return PHPUnit_Extensions_Database_Operation_Factory::CLEAN_INSERT();
-    //return PHPUnit_Extensions_Database_Operation_Factory::UPDATE();
-    //return PHPUnit_Extensions_Database_Operation_Factory::NONE();
-    //
-    // Issue a DELETE from <table> which is more portable than a
-    // TRUNCATE table <table> (some DBs require high privileges for truncate statements
-    // and also do not allow truncates across tables with FK contstraints e.g. Oracle)
-    return PHPUnit_Extensions_Database_Operation_Factory::DELETE_ALL();
-  }
+    protected function getSetUpOperation()
+    {
+      // CLEAN_INSERT is default
+      //return PHPUnit_Extensions_Database_Operation_Factory::CLEAN_INSERT();
+      //return PHPUnit_Extensions_Database_Operation_Factory::UPDATE();
+      //return PHPUnit_Extensions_Database_Operation_Factory::NONE();
+      //
+      // Issue a DELETE from <table> which is more portable than a
+      // TRUNCATE table <table> (some DBs require high privileges for truncate statements
+      // and also do not allow truncates across tables with FK contstraints e.g. Oracle)
+        return PHPUnit_Extensions_Database_Operation_Factory::DELETE_ALL();
+    }
 
   /**
    * Overridden.
    */
-  protected function getTearDownOperation() {
-    // NONE is default
-    return PHPUnit_Extensions_Database_Operation_Factory::NONE();
-  }
+    protected function getTearDownOperation()
+    {
+      // NONE is default
+        return PHPUnit_Extensions_Database_Operation_Factory::NONE();
+    }
 
   /**
    * Sets up the fixture, e.g create a new entityManager for each test run
    * This method is called before each test method is executed.
    */
-  protected function setUp() {
-    parent::setUp();
-    $this->em = $this->createEntityManager();
-  }
-
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->em = $this->createEntityManager();
+    }
+  /**
+   * Run after each test function to prevent pile-up of database connections.
+   */
+    protected function tearDown()
+    {
+        parent::tearDown();
+        if (!is_null($this->em)) {
+            $this->em->getConnection()->close();
+        }
+    }
   /**
    * @todo Still need to setup connection to different databases.
    * @return EntityManager
    */
-  private function createEntityManager() {
-    require dirname(__FILE__) . '/bootstrap_doctrine.php';
-    return $entityManager;
-  }
+    private function createEntityManager()
+    {
+        require dirname(__FILE__) . '/bootstrap_doctrine.php';
+        return $entityManager;
+    }
 
   /**
    * Called after setUp() and before each test. Used for common assertions
    * across all tests.
    */
-  protected function assertPreConditions() {
-    $con = $this->getConnection();
-    $fixture = dirname(__FILE__) . '/truncateDataTables.xml';
-    $tables = simplexml_load_file($fixture);
+    protected function assertPreConditions()
+    {
+        $con = $this->getConnection();
+        $fixture = dirname(__FILE__) . '/truncateDataTables.xml';
+        $tables = simplexml_load_file($fixture);
 
-    foreach ($tables as $tableName) {
-      $sql = "SELECT * FROM " . $tableName->getName();
-      $result = $con->createQueryTable('results_table', $sql);
-      if ($result->getRowCount() != 0) {
-        throw new RuntimeException("Invalid fixture. Table has rows: " . $tableName->getName());
-      }
+        foreach ($tables as $tableName) {
+            $sql = "SELECT * FROM " . $tableName->getName();
+            $result = $con->createQueryTable('results_table', $sql);
+            if ($result->getRowCount() != 0) {
+                throw new RuntimeException("Invalid fixture. Table has rows: " . $tableName->getName());
+            }
+        }
     }
-  }
 
   /**
    * Test the NGI service deleteNGI() method which recursively deletes child
    * sites and services, roles etc.
    */
-  public function testNgiService_deleteNgi() {
-    print __METHOD__ . "\n";
-    include __DIR__ . '/resources/sampleFixtureData1.php';
+    public function testNgiService_deleteNgi()
+    {
+        print __METHOD__ . "\n";
+        include __DIR__ . '/resources/sampleFixtureData1.php';
 
-    // create an admin user (required to call the NGI service)
-    $adminUser = TestUtil::createSampleUser('some', 'admin');
-    $identifier= TestUtil::createSampleUserIdentifier('X.509', '/some/admin');
-    $adminUser->addUserIdentifierDoJoin($identifier);
-    $this->em->persist($identifier);
-    $adminUser->setAdmin(TRUE);
-    $this->em->persist($adminUser);
+      // create an admin user (required to call the NGI service)
+        $adminUser = TestUtil::createSampleUser('some', 'admin');
+        $identifier = TestUtil::createSampleUserIdentifier('X.509', '/some/admin');
+        $adminUser->addUserIdentifierDoJoin($identifier);
+        $this->em->persist($identifier);
+        $adminUser->setAdmin(true);
+        $this->em->persist($adminUser);
 
-    // Now delete the ngi using the NGI service.
-    $ngiService = new org\gocdb\services\NGI();
-    $ngiService->setEntityManager($this->em);
-    $ngiService->deleteNgi($ngi, $adminUser, FALSE);
+      // Now delete the ngi using the NGI service.
+        $ngiService = new org\gocdb\services\NGI();
+        $ngiService->setEntityManager($this->em);
+        $ngiService->deleteNgi($ngi, $adminUser, false);
 
 
-    // since we deleted the NGI, we expect an empty DB !
-    $result = $testConn->createQueryTable('results_table', "SELECT * FROM Roles");
-    $this->assertTrue($result->getRowCount() == 0);
+      // since we deleted the NGI, we expect an empty DB !
+        $result = $testConn->createQueryTable('results_table', "SELECT * FROM Roles");
+        $this->assertTrue($result->getRowCount() == 0);
 
-    $result = $testConn->createQueryTable('results_table', "SELECT * FROM NGIs");
-    $this->assertTrue($result->getRowCount() == 0);
+        $result = $testConn->createQueryTable('results_table', "SELECT * FROM NGIs");
+        $this->assertTrue($result->getRowCount() == 0);
 
-    $result = $testConn->createQueryTable('results_table', "SELECT * FROM Sites");
-    $this->assertTrue($result->getRowCount() == 0);
+        $result = $testConn->createQueryTable('results_table', "SELECT * FROM Sites");
+        $this->assertTrue($result->getRowCount() == 0);
 
-    $result = $testConn->createQueryTable('results_table', "SELECT * FROM Services");
-    $this->assertTrue($result->getRowCount() == 0);
+        $result = $testConn->createQueryTable('results_table', "SELECT * FROM Services");
+        $this->assertTrue($result->getRowCount() == 0);
 
-    $result = $testConn->createQueryTable('results_table', "SELECT * FROM Downtimes");
-    $this->assertTrue($result->getRowCount() == 0);
+        $result = $testConn->createQueryTable('results_table', "SELECT * FROM Downtimes");
+        $this->assertTrue($result->getRowCount() == 0);
 
-    $result = $testConn->createQueryTable('results_table', "SELECT * FROM EndpointLocations");
-    $this->assertTrue($result->getRowCount() == 0);
+        $result = $testConn->createQueryTable('results_table', "SELECT * FROM EndpointLocations");
+        $this->assertTrue($result->getRowCount() == 0);
 
-    $result = $testConn->createQueryTable('results_table', "SELECT * FROM CertificationStatusLogs");
-    $this->assertTrue($result->getRowCount() == 0);
-  }
-
+        $result = $testConn->createQueryTable('results_table', "SELECT * FROM CertificationStatusLogs");
+        $this->assertTrue($result->getRowCount() == 0);
+    }
 }
-?>

--- a/tests/doctrine/RoleCascadeDeletionsTest.php
+++ b/tests/doctrine/RoleCascadeDeletionsTest.php
@@ -25,127 +25,145 @@ require_once dirname(__FILE__) . '/bootstrap.php';
  *
  * @author David Meredith
  */
-class RoleCascadeDeletionsTest extends PHPUnit_Extensions_Database_TestCase {
-
-  private $em;
+class RoleCascadeDeletionsTest extends PHPUnit_Extensions_Database_TestCase
+{
+    private $em;
 
   /**
    * Overridden.
    */
-  public static function setUpBeforeClass() {
-    parent::setUpBeforeClass();
-    echo "\n\n-------------------------------------------------\n";
-    echo "Executing RoleCascadeDeletionsTest. . .\n";
-  }
+    public static function setUpBeforeClass()
+    {
+        parent::setUpBeforeClass();
+        echo "\n\n-------------------------------------------------\n";
+        echo "Executing RoleCascadeDeletionsTest. . .\n";
+    }
 
   /**
    * Overridden. Returns the test database connection.
    * @return PHPUnit_Extensions_Database_DB_IDatabaseConnection
    */
-  protected function getConnection() {
-    require_once dirname(__FILE__) . '/bootstrap_pdo.php';
-    return getConnectionToTestDB();
-  }
+    protected function getConnection()
+    {
+        require_once dirname(__FILE__) . '/bootstrap_pdo.php';
+        return getConnectionToTestDB();
+    }
 
   /**
    * Overridden. Returns the test dataset.
    * Defines how the initial state of the database should look before each test is executed.
    * @return PHPUnit_Extensions_Database_DataSet_IDataSet
    */
-  protected function getDataSet() {
-    return $this->createFlatXMLDataSet(dirname(__FILE__) . '/truncateDataTables.xml');
-    // Use below to return an empty data set if we don't want to truncate and seed
-    //return new PHPUnit_Extensions_Database_DataSet_DefaultDataSet();
-  }
+    protected function getDataSet()
+    {
+        return $this->createFlatXMLDataSet(dirname(__FILE__) . '/truncateDataTables.xml');
+      // Use below to return an empty data set if we don't want to truncate and seed
+      //return new PHPUnit_Extensions_Database_DataSet_DefaultDataSet();
+    }
 
   /**
    * Overridden.
    */
-  protected function getSetUpOperation() {
-    // CLEAN_INSERT is default
-    //return PHPUnit_Extensions_Database_Operation_Factory::CLEAN_INSERT();
-    //return PHPUnit_Extensions_Database_Operation_Factory::UPDATE();
-    //return PHPUnit_Extensions_Database_Operation_Factory::NONE();
-    //
-    // Issue a DELETE from <table> which is more portable than a
-    // TRUNCATE table <table> (some DBs require high privileges for truncate statements
-    // and also do not allow truncates across tables with FK contstraints e.g. Oracle)
-    return PHPUnit_Extensions_Database_Operation_Factory::DELETE_ALL();
-  }
+    protected function getSetUpOperation()
+    {
+      // CLEAN_INSERT is default
+      //return PHPUnit_Extensions_Database_Operation_Factory::CLEAN_INSERT();
+      //return PHPUnit_Extensions_Database_Operation_Factory::UPDATE();
+      //return PHPUnit_Extensions_Database_Operation_Factory::NONE();
+      //
+      // Issue a DELETE from <table> which is more portable than a
+      // TRUNCATE table <table> (some DBs require high privileges for truncate statements
+      // and also do not allow truncates across tables with FK contstraints e.g. Oracle)
+        return PHPUnit_Extensions_Database_Operation_Factory::DELETE_ALL();
+    }
 
   /**
    * Overridden.
    */
-  protected function getTearDownOperation() {
-    // NONE is default
-    return PHPUnit_Extensions_Database_Operation_Factory::NONE();
-  }
+    protected function getTearDownOperation()
+    {
+      // NONE is default
+        return PHPUnit_Extensions_Database_Operation_Factory::NONE();
+    }
 
   /**
    * Sets up the fixture, e.g create a new entityManager for each test run
    * This method is called before each test method is executed.
    */
-  protected function setUp() {
-    parent::setUp();
-    $this->em = $this->createEntityManager();
-  }
-
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->em = $this->createEntityManager();
+    }
+  /**
+   * Run after each test function to prevent pile-up of database connections.
+   */
+    protected function tearDown()
+    {
+        parent::tearDown();
+        if (!is_null($this->em)) {
+            $this->em->getConnection()->close();
+        }
+    }
   /**
    * @todo Still need to setup connection to different databases.
    * @return EntityManager
    */
-  private function createEntityManager() {
-    require dirname(__FILE__) . '/bootstrap_doctrine.php';
-    return $entityManager;
-  }
+    private function createEntityManager()
+    {
+        require dirname(__FILE__) . '/bootstrap_doctrine.php';
+        return $entityManager;
+    }
 
   /**
    * Called after setUp() and before each test. Used for common assertions
    * across all tests.
    */
-  protected function assertPreConditions() {
-    $con = $this->getConnection();
-    $fixture = dirname(__FILE__) . '/truncateDataTables.xml';
-    $tables = simplexml_load_file($fixture);
+    protected function assertPreConditions()
+    {
+        $con = $this->getConnection();
+        $fixture = dirname(__FILE__) . '/truncateDataTables.xml';
+        $tables = simplexml_load_file($fixture);
 
-    foreach ($tables as $tableName) {
-      //print $tableName->getName() . "\n";
-      $sql = "SELECT * FROM " . $tableName->getName();
-      $result = $con->createQueryTable('results_table', $sql);
-      //echo 'row count: '.$result->getRowCount() ;
-      if ($result->getRowCount() != 0) {
-        throw new RuntimeException("Invalid fixture. Table has rows: " . $tableName->getName());
-      }
+        foreach ($tables as $tableName) {
+          //print $tableName->getName() . "\n";
+            $sql = "SELECT * FROM " . $tableName->getName();
+            $result = $con->createQueryTable('results_table', $sql);
+          //echo 'row count: '.$result->getRowCount() ;
+            if ($result->getRowCount() != 0) {
+                throw new RuntimeException("Invalid fixture. Table has rows: " . $tableName->getName());
+            }
+        }
     }
-  }
 
   /**
    * Create a linked OwnedEntity graph with user with Roles over those OwnedEntities.
    * Next, delete the User and assert that all the user's Roles were also deleted by the domain
    * model's automatic onDelete=CASCADE defined on the Role's FK mapping to User.
    */
-  public function testRolesCascadeDelete_OnUserDeletion() {
-    print __METHOD__ . "\n";
-    include __DIR__ . '/resources/sampleFixtureData1.php';
+    public function testRolesCascadeDelete_OnUserDeletion()
+    {
+        print __METHOD__ . "\n";
+        include __DIR__ . '/resources/sampleFixtureData1.php';
 
-    // Delete the user. The onDelete=CASCADE defined in Role's user FK mapping
-    // will remove all the user's roles.
-    $this->em->remove($userWithRoles);
-    $this->em->flush();
+      // Delete the user. The onDelete=CASCADE defined in Role's user FK mapping
+      // will remove all the user's roles.
+        $this->em->remove($userWithRoles);
+        $this->em->flush();
 
-    // Need to clear the identity map (all objects become detached) so that
-    // when we re-fetch the user, it will be looked from db not served by entity map
-    $this->em->clear();
+      // Need to clear the identity map (all objects become detached) so that
+      // when we re-fetch the user, it will be looked from db not served by entity map
+        $this->em->clear();
 
-    $userWithRoles = $this->em->find("User", $userId);
-    $this->assertNull($userWithRoles);
+        $userWithRoles = $this->em->find("User", $userId);
+        $this->assertNull($userWithRoles);
 
-    $testConn = $this->getConnection();
-    $result = $testConn->createQueryTable('results_table', "SELECT * FROM Users");
-    $this->assertTrue($result->getRowCount() == 0);
-    $result = $testConn->createQueryTable('results_table', "SELECT * FROM Roles");
-    $this->assertTrue($result->getRowCount() == 0);
-  }
+        $testConn = $this->getConnection();
+        $result = $testConn->createQueryTable('results_table', "SELECT * FROM Users");
+        $this->assertTrue($result->getRowCount() == 0);
+        $result = $testConn->createQueryTable('results_table', "SELECT * FROM Roles");
+        $this->assertTrue($result->getRowCount() == 0);
+    }
 
   /**
    * Create a linked OwnedEntity graph with user with Roles over those OwnedEntities.
@@ -155,134 +173,134 @@ class RoleCascadeDeletionsTest extends PHPUnit_Extensions_Database_TestCase {
    *
    * Delete all the OwnedEntities
    */
-  public function testRolesCascadeDelete_OnOwnedEntityDeletion1() {
-    print __METHOD__ . "\n";
-    include __DIR__ . '/resources/sampleFixtureData1.php';
+    public function testRolesCascadeDelete_OnOwnedEntityDeletion1()
+    {
+        print __METHOD__ . "\n";
+        include __DIR__ . '/resources/sampleFixtureData1.php';
 
-    // Queue Deletion of ngi, site1 (and its services) and assert that the relevant
-    // user roles were also deleted as expected by the onDelete=cascades configured in the entity model.
-    // Note, we are not removing site2 as we want to keep this site and user's roles.
-    $siteDAO = new SiteDAO();
-    $serviceDAO = new ServiceDAO();
-    $ngiDAO = new NGIDAO();
-    $siteDAO->setEntityManager($this->em);
-    $serviceDAO->setEntityManager($this->em);
-    $ngiDAO->setEntityManager($this->em);
+      // Queue Deletion of ngi, site1 (and its services) and assert that the relevant
+      // user roles were also deleted as expected by the onDelete=cascades configured in the entity model.
+      // Note, we are not removing site2 as we want to keep this site and user's roles.
+        $siteDAO = new SiteDAO();
+        $serviceDAO = new ServiceDAO();
+        $ngiDAO = new NGIDAO();
+        $siteDAO->setEntityManager($this->em);
+        $serviceDAO->setEntityManager($this->em);
+        $ngiDAO->setEntityManager($this->em);
 
-    // ordering of removal is NOT significant here !
-    $ngiDAO->removeNGI($ngi);
-    $siteDAO->removeSite($site1);
-    $siteDAO->removeSite($site2);
-    $serviceDAO->removeService($service1);
-    $serviceDAO->removeService($service2);
+      // ordering of removal is NOT significant here !
+        $ngiDAO->removeNGI($ngi);
+        $siteDAO->removeSite($site1);
+        $siteDAO->removeSite($site2);
+        $serviceDAO->removeService($service1);
+        $serviceDAO->removeService($service2);
 
-    $this->em->flush();
+        $this->em->flush();
 
-    // Need to clear the identity map (all objects become detached) so that
-    // when we re-fetch the user, it will be looked from db not served by entity map
-    $this->em->clear();
+      // Need to clear the identity map (all objects become detached) so that
+      // when we re-fetch the user, it will be looked from db not served by entity map
+        $this->em->clear();
 
-    // Need to re-fetch the user from the DB again, if don't, then user already
-    // has his eargerly fetched roles present in UserProxy object
-    $userWithRoles = $this->em->find("User", $userId);
-    $this->assertEquals(0, count($userWithRoles->getRoles()));
+      // Need to re-fetch the user from the DB again, if don't, then user already
+      // has his eargerly fetched roles present in UserProxy object
+        $userWithRoles = $this->em->find("User", $userId);
+        $this->assertEquals(0, count($userWithRoles->getRoles()));
 
-    $testConn = $this->getConnection();
-    $result = $testConn->createQueryTable('results_table', "SELECT * FROM Roles");
-    $this->assertTrue($result->getRowCount() == 0);
-    $result = $testConn->createQueryTable('results_table', "SELECT * FROM Sites");
-    $this->assertTrue($result->getRowCount() == 0);
-    $result = $testConn->createQueryTable('results_table', "SELECT * FROM NGIs");
-    $this->assertTrue($result->getRowCount() == 0);
-    $result = $testConn->createQueryTable('results_table', "SELECT * FROM Services");
-    $this->assertTrue($result->getRowCount() == 0);
-  }
+        $testConn = $this->getConnection();
+        $result = $testConn->createQueryTable('results_table', "SELECT * FROM Roles");
+        $this->assertTrue($result->getRowCount() == 0);
+        $result = $testConn->createQueryTable('results_table', "SELECT * FROM Sites");
+        $this->assertTrue($result->getRowCount() == 0);
+        $result = $testConn->createQueryTable('results_table', "SELECT * FROM NGIs");
+        $this->assertTrue($result->getRowCount() == 0);
+        $result = $testConn->createQueryTable('results_table', "SELECT * FROM Services");
+        $this->assertTrue($result->getRowCount() == 0);
+    }
 
   /**
    * Delete both Services but not the ngi
    * @see testRolesCascadeDelete_OnOwnedEntityDeletion1
    */
-  public function testRolesCascadeDelete_OnOwnedEntityDeletion2() {
-    print __METHOD__ . "\n";
-    include __DIR__ . '/resources/sampleFixtureData1.php';
+    public function testRolesCascadeDelete_OnOwnedEntityDeletion2()
+    {
+        print __METHOD__ . "\n";
+        include __DIR__ . '/resources/sampleFixtureData1.php';
 
-    $siteDAO = new SiteDAO();
-    $serviceDAO = new ServiceDAO();
-    $ngiDAO = new NGIDAO();
-    $siteDAO->setEntityManager($this->em);
-    $serviceDAO->setEntityManager($this->em);
-    $ngiDAO->setEntityManager($this->em);
+        $siteDAO = new SiteDAO();
+        $serviceDAO = new ServiceDAO();
+        $ngiDAO = new NGIDAO();
+        $siteDAO->setEntityManager($this->em);
+        $serviceDAO->setEntityManager($this->em);
+        $ngiDAO->setEntityManager($this->em);
 
-    // ordering of removal is NOT significant here !
-    $serviceDAO->removeService($service1);
-    $serviceDAO->removeService($service2);
-    $siteDAO->removeSite($site1);
-    $siteDAO->removeSite($site2);
-    //$ngiDAO->removeNGI($ngi); // don't remove NGI
+      // ordering of removal is NOT significant here !
+        $serviceDAO->removeService($service1);
+        $serviceDAO->removeService($service2);
+        $siteDAO->removeSite($site1);
+        $siteDAO->removeSite($site2);
+      //$ngiDAO->removeNGI($ngi); // don't remove NGI
 
-    $this->em->flush();
+        $this->em->flush();
 
-    // Need to clear the identity map (all objects become detached) so that
-    // when we re-fetch the user, it will be looked from db not served by entity map
-    $this->em->clear();
+      // Need to clear the identity map (all objects become detached) so that
+      // when we re-fetch the user, it will be looked from db not served by entity map
+        $this->em->clear();
 
-    // Need to re-fetch the user from the DB again, if don't, then user already
-    // has his eargerly fetched roles present in UserProxy object
-    $userWithRoles = $this->em->find("User", $userId);
-    // user should have 2 remaining roles still from ngi
-    $this->assertEquals(2, count($userWithRoles->getRoles()));
+      // Need to re-fetch the user from the DB again, if don't, then user already
+      // has his eargerly fetched roles present in UserProxy object
+        $userWithRoles = $this->em->find("User", $userId);
+      // user should have 2 remaining roles still from ngi
+        $this->assertEquals(2, count($userWithRoles->getRoles()));
 
-    $testConn = $this->getConnection();
-    $result = $testConn->createQueryTable('results_table', "SELECT * FROM Roles");
-    $this->assertTrue($result->getRowCount() == 2);
-    $result = $testConn->createQueryTable('results_table', "SELECT * FROM NGIs");
-    $this->assertTrue($result->getRowCount() == 1);
-  }
+        $testConn = $this->getConnection();
+        $result = $testConn->createQueryTable('results_table', "SELECT * FROM Roles");
+        $this->assertTrue($result->getRowCount() == 2);
+        $result = $testConn->createQueryTable('results_table', "SELECT * FROM NGIs");
+        $this->assertTrue($result->getRowCount() == 1);
+    }
 
   /**
    * Delete the ngi but not the sites
    * @see testRolesCascadeDelete_OnOwnedEntityDeletion1
    */
-  public function testRolesCascadeDelete_OnOwnedEntityDeletion3() {
-    print __METHOD__ . "\n";
-    include __DIR__ . '/resources/sampleFixtureData1.php';
+    public function testRolesCascadeDelete_OnOwnedEntityDeletion3()
+    {
+        print __METHOD__ . "\n";
+        include __DIR__ . '/resources/sampleFixtureData1.php';
 
-    // Queue Deletion of ngi and assert that the relevant
-    // ngi user roles were also deleted.
-    $ngiDAO = new NGIDAO();
-    $ngiDAO->setEntityManager($this->em);
+      // Queue Deletion of ngi and assert that the relevant
+      // ngi user roles were also deleted.
+        $ngiDAO = new NGIDAO();
+        $ngiDAO->setEntityManager($this->em);
 
-    // need to delete the relationships between ngi and sites before deleting
-    // the ngi - remember to unlink from both sides of the relationship
-    $ngi->getSites()->removeElement($site1);
-    $site1->setNgiDoJoin(null);
-    $ngi->getSites()->removeElement($site2);
-    $site2->setNgiDoJoin(null);
+      // need to delete the relationships between ngi and sites before deleting
+      // the ngi - remember to unlink from both sides of the relationship
+        $ngi->getSites()->removeElement($site1);
+        $site1->setNgiDoJoin(null);
+        $ngi->getSites()->removeElement($site2);
+        $site2->setNgiDoJoin(null);
 
-    // Now delete the NGI
-    $ngiDAO->removeNGI($ngi);
+      // Now delete the NGI
+        $ngiDAO->removeNGI($ngi);
 
-    $this->em->flush();
+        $this->em->flush();
 
-    // Need to clear the identity map (all objects become detached) so that
-    // when we re-fetch the user, it will be looked from db not served by entity map
-    $this->em->clear();
+      // Need to clear the identity map (all objects become detached) so that
+      // when we re-fetch the user, it will be looked from db not served by entity map
+        $this->em->clear();
 
-    // Need to re-fetch the user from the DB again, if don't, then user already
-    // has his eargerly fetched roles present in UserProxy object
-    $userWithRoles = $this->em->find("User", $userId);
-    // user should have 4 remaining roles still from sites that exist in DB
-    $this->assertEquals(4, count($userWithRoles->getRoles()));
+      // Need to re-fetch the user from the DB again, if don't, then user already
+      // has his eargerly fetched roles present in UserProxy object
+        $userWithRoles = $this->em->find("User", $userId);
+      // user should have 4 remaining roles still from sites that exist in DB
+        $this->assertEquals(4, count($userWithRoles->getRoles()));
 
-    $testConn = $this->getConnection();
-    $result = $testConn->createQueryTable('results_table', "SELECT * FROM Roles");
-    $this->assertTrue($result->getRowCount() == 4);
-    $result = $testConn->createQueryTable('results_table', "SELECT * FROM Sites");
-    $this->assertTrue($result->getRowCount() == 2);
-    $result = $testConn->createQueryTable('results_table', "SELECT * FROM NGIs");
-    $this->assertTrue($result->getRowCount() == 0);
-  }
-
+        $testConn = $this->getConnection();
+        $result = $testConn->createQueryTable('results_table', "SELECT * FROM Roles");
+        $this->assertTrue($result->getRowCount() == 4);
+        $result = $testConn->createQueryTable('results_table', "SELECT * FROM Sites");
+        $this->assertTrue($result->getRowCount() == 2);
+        $result = $testConn->createQueryTable('results_table', "SELECT * FROM NGIs");
+        $this->assertTrue($result->getRowCount() == 0);
+    }
 }
-
-?>

--- a/tests/doctrine/RoleServiceTest.php
+++ b/tests/doctrine/RoleServiceTest.php
@@ -1,11 +1,12 @@
 <?php
+
 require_once dirname(__FILE__) . '/TestUtil.php';
 use Doctrine\ORM\EntityManager;
 require_once dirname(__FILE__) . '/bootstrap.php';
-require_once dirname(__FILE__). '/../../lib/Gocdb_Services/Role.php';
-require_once dirname(__FILE__). '/../../lib/Gocdb_Services/Site.php';
-require_once dirname(__FILE__). '/../../lib/Gocdb_Services/RoleActionMappingService.php';
-require_once dirname(__FILE__). '/../../lib/Gocdb_Services/RoleActionAuthorisationService.php';
+require_once dirname(__FILE__) . '/../../lib/Gocdb_Services/Role.php';
+require_once dirname(__FILE__) . '/../../lib/Gocdb_Services/Site.php';
+require_once dirname(__FILE__) . '/../../lib/Gocdb_Services/RoleActionMappingService.php';
+require_once dirname(__FILE__) . '/../../lib/Gocdb_Services/RoleActionAuthorisationService.php';
 
 /**
  * Test the role functionality.
@@ -18,610 +19,635 @@ require_once dirname(__FILE__). '/../../lib/Gocdb_Services/RoleActionAuthorisati
  * @author David Meredith
  * @author John Casson
  */
-class RoleServiceTest extends PHPUnit_Extensions_Database_TestCase {
-  private $em;
-  private $egiScope;
-  private $localScope;
-  private $eudatScope;
+class RoleServiceTest extends PHPUnit_Extensions_Database_TestCase
+{
+    private $em;
+    private $egiScope;
+    private $localScope;
+    private $eudatScope;
 
 
   /**
    * Overridden.
    */
-  public static function setUpBeforeClass() {
-    parent::setUpBeforeClass();
-    echo "\n\n-------------------------------------------------\n";
-    echo "Executing RoleServiceTest. . .\n";
-  }
+    public static function setUpBeforeClass()
+    {
+        parent::setUpBeforeClass();
+        echo "\n\n-------------------------------------------------\n";
+        echo "Executing RoleServiceTest. . .\n";
+    }
 
   /**
    * Overridden. Returns the test database connection.
    * @return PHPUnit_Extensions_Database_DB_IDatabaseConnection
    */
-  protected function getConnection() {
-    require_once dirname(__FILE__) . '/bootstrap_pdo.php';
-    return getConnectionToTestDB();
-  }
+    protected function getConnection()
+    {
+        require_once dirname(__FILE__) . '/bootstrap_pdo.php';
+        return getConnectionToTestDB();
+    }
 
   /**
    * Overridden. Returns the test dataset.
    * Defines how the initial state of the database should look before each test is executed.
    * @return PHPUnit_Extensions_Database_DataSet_IDataSet
    */
-  protected function getDataSet() {
-    return $this->createFlatXMLDataSet(dirname(__FILE__) . '/truncateDataTables.xml');
-    // Use below to return an empty data set if we don't want to truncate and seed
-    //return new PHPUnit_Extensions_Database_DataSet_DefaultDataSet();
-  }
+    protected function getDataSet()
+    {
+        return $this->createFlatXMLDataSet(dirname(__FILE__) . '/truncateDataTables.xml');
+      // Use below to return an empty data set if we don't want to truncate and seed
+      //return new PHPUnit_Extensions_Database_DataSet_DefaultDataSet();
+    }
 
   /**
    * Overridden.
    */
-  protected function getSetUpOperation() {
-    // CLEAN_INSERT is default
-    //return PHPUnit_Extensions_Database_Operation_Factory::CLEAN_INSERT();
-    //return PHPUnit_Extensions_Database_Operation_Factory::UPDATE();
-    //return PHPUnit_Extensions_Database_Operation_Factory::NONE();
-    //
-    // Issue a DELETE from <table> which is more portable than a
-    // TRUNCATE table <table> (some DBs require high privileges for truncate statements
-    // and also do not allow truncates across tables with FK contstraints e.g. Oracle)
-    return PHPUnit_Extensions_Database_Operation_Factory::DELETE_ALL();
-  }
+    protected function getSetUpOperation()
+    {
+      // CLEAN_INSERT is default
+      //return PHPUnit_Extensions_Database_Operation_Factory::CLEAN_INSERT();
+      //return PHPUnit_Extensions_Database_Operation_Factory::UPDATE();
+      //return PHPUnit_Extensions_Database_Operation_Factory::NONE();
+      //
+      // Issue a DELETE from <table> which is more portable than a
+      // TRUNCATE table <table> (some DBs require high privileges for truncate statements
+      // and also do not allow truncates across tables with FK contstraints e.g. Oracle)
+        return PHPUnit_Extensions_Database_Operation_Factory::DELETE_ALL();
+    }
 
   /**
    * Overridden.
    */
-  protected function getTearDownOperation() {
-    // NONE is default
-    return PHPUnit_Extensions_Database_Operation_Factory::NONE();
-  }
+    protected function getTearDownOperation()
+    {
+      // NONE is default
+        return PHPUnit_Extensions_Database_Operation_Factory::NONE();
+    }
 
   /**
    * Sets up the fixture, e.g create a new entityManager for each test run
    * This method is called before each test method is executed.
    */
-  protected function setUp() {
-    parent::setUp();
-    $this->em = $this->createEntityManager();
-  }
-
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->em = $this->createEntityManager();
+    }
+  /**
+   * Run after each test function to prevent pile-up of database connections.
+   */
+    protected function tearDown()
+    {
+        parent::tearDown();
+        if (!is_null($this->em)) {
+            $this->em->getConnection()->close();
+        }
+    }
   /**
    * @todo Still need to setup connection to different databases.
    * @return EntityManager
    */
-  private function createEntityManager(){
-    require dirname(__FILE__).'/bootstrap_doctrine.php';
-    return $entityManager;
-  }
+    private function createEntityManager()
+    {
+        require dirname(__FILE__) . '/bootstrap_doctrine.php';
+        return $entityManager;
+    }
 
   /**
    * Called after setUp() and before each test. Used for common assertions
    * across all tests.
    */
-  protected function assertPreConditions() {
-    $con = $this->getConnection();
-    $fixture = dirname(__FILE__) . '/truncateDataTables.xml';
-    $tables = simplexml_load_file($fixture);
+    protected function assertPreConditions()
+    {
+        $con = $this->getConnection();
+        $fixture = dirname(__FILE__) . '/truncateDataTables.xml';
+        $tables = simplexml_load_file($fixture);
 
-    foreach($tables as $tableName) {
-      $sql = "SELECT * FROM ".$tableName->getName();
-      $result = $con->createQueryTable('results_table', $sql);
-      if($result->getRowCount() != 0) {
-        throw new RuntimeException("Invalid fixture. Table has rows: ".$tableName->getName());
-      }
+        foreach ($tables as $tableName) {
+            $sql = "SELECT * FROM " . $tableName->getName();
+            $result = $con->createQueryTable('results_table', $sql);
+            if ($result->getRowCount() != 0) {
+                throw new RuntimeException("Invalid fixture. Table has rows: " . $tableName->getName());
+            }
+        }
     }
-  }
 
-  public function test_getPendingRolesUserCanApprove(){
-    print __METHOD__ . "\n";
-    // Create fixture data
-    // RoleTypes
-    $siteAdminRT = TestUtil::createSampleRoleType(RoleTypeName::SITE_ADMIN/*, RoleTypeClass::SITE_USER*/);
-    $siteManRT = TestUtil::createSampleRoleType(RoleTypeName::SITE_OPS_MAN/*, RoleTypeClass::SITE_MANAGER*/);
-    $regFLSupportRT = TestUtil::createSampleRoleType(RoleTypeName::REG_FIRST_LINE_SUPPORT/*, RoleTypeClass::REGIONAL_USER*/);
+    public function test_getPendingRolesUserCanApprove()
+    {
+        print __METHOD__ . "\n";
+      // Create fixture data
+      // RoleTypes
+        $siteAdminRT = TestUtil::createSampleRoleType(RoleTypeName::SITE_ADMIN/*, RoleTypeClass::SITE_USER*/);
+        $siteManRT = TestUtil::createSampleRoleType(RoleTypeName::SITE_OPS_MAN/*, RoleTypeClass::SITE_MANAGER*/);
+        $regFLSupportRT = TestUtil::createSampleRoleType(RoleTypeName::REG_FIRST_LINE_SUPPORT/*, RoleTypeClass::REGIONAL_USER*/);
 
-    $this->em->persist($regFLSupportRT);
-    $this->em->persist($siteAdminRT);
-    $this->em->persist($siteManRT);
+        $this->em->persist($regFLSupportRT);
+        $this->em->persist($siteAdminRT);
+        $this->em->persist($siteManRT);
 
-    // User
-    $u = TestUtil::createSampleUser("Test", "Testing");
-    $identifier= TestUtil::createSampleUserIdentifier("X.509", "/c=test");
-    $u->addUserIdentifierDoJoin($identifier);
-    $this->em->persist($identifier);
-    $this->em->persist($u);
-    // Site
-    $site1 = TestUtil::createSampleSite("SITENAME");
-    $this->em->persist($site1);
-    $n1 = TestUtil::createSampleNGI("NGI_UK");
-    $this->em->persist($n1);
-    $p1 = new \Project("EGI");
-    $this->em->persist($p1);
+      // User
+        $u = TestUtil::createSampleUser("Test", "Testing");
+        $identifier = TestUtil::createSampleUserIdentifier("X.509", "/c=test");
+        $u->addUserIdentifierDoJoin($identifier);
+        $this->em->persist($identifier);
+        $this->em->persist($u);
+      // Site
+        $site1 = TestUtil::createSampleSite("SITENAME");
+        $this->em->persist($site1);
+        $n1 = TestUtil::createSampleNGI("NGI_UK");
+        $this->em->persist($n1);
+        $p1 = new \Project("EGI");
+        $this->em->persist($p1);
 
-    $n1->addSiteDoJoin($site1);
-    $p1->addNgi($n1);
+        $n1->addSiteDoJoin($site1);
+        $p1->addNgi($n1);
 
-    // Create a SITE_OPS_MAN Role and link to the User, RoleType and site
-    $roleSite = TestUtil::createSampleRole($u, $siteManRT, $site1, RoleStatus::GRANTED);
-    $this->em->persist($roleSite);
+      // Create a SITE_OPS_MAN Role and link to the User, RoleType and site
+        $roleSite = TestUtil::createSampleRole($u, $siteManRT, $site1, RoleStatus::GRANTED);
+        $this->em->persist($roleSite);
 
-    // new user
-    $u2 = TestUtil::createSampleUser("Test2", "Testing2");
-    $identifier= TestUtil::createSampleUserIdentifier("X.509", "/c=test2");
-    $u2->addUserIdentifierDoJoin($identifier);
-    $this->em->persist($identifier);
-    $this->em->persist($u2);
-    // Create a pending SITE_ADMIN Role request for new user
-    $pendingSiteRole = TestUtil::createSampleRole($u2, $siteAdminRT, $site1, RoleStatus::PENDING);
-    $this->em->persist($pendingSiteRole);
-    $this->em->flush();
+      // new user
+        $u2 = TestUtil::createSampleUser("Test2", "Testing2");
+        $identifier = TestUtil::createSampleUserIdentifier("X.509", "/c=test2");
+        $u2->addUserIdentifierDoJoin($identifier);
+        $this->em->persist($identifier);
+        $this->em->persist($u2);
+      // Create a pending SITE_ADMIN Role request for new user
+        $pendingSiteRole = TestUtil::createSampleRole($u2, $siteAdminRT, $site1, RoleStatus::PENDING);
+        $this->em->persist($pendingSiteRole);
+        $this->em->flush();
 
-    // ********NOTE******** Role Service uses a new connection for its transactional methods
-    $em2 = $this->createEntityManager();
-    $roleService = new org\gocdb\services\Role();
-    $roleService->setEntityManager($em2);
-    $roleActionMappingService = new org\gocdb\services\RoleActionMappingService();
-    $roleActionAuthorisationService = new org\gocdb\services\RoleActionAuthorisationService($roleActionMappingService);
-    $roleActionAuthorisationService->setEntityManager($em2);
-    $roleService->setRoleActionAuthorisationService($roleActionAuthorisationService);
+      // ********NOTE******** Role Service uses a new connection for its transactional methods
+        $em2 = $this->createEntityManager();
+        $roleService = new org\gocdb\services\Role();
+        $roleService->setEntityManager($em2);
+        $roleActionMappingService = new org\gocdb\services\RoleActionMappingService();
+        $roleActionAuthorisationService = new org\gocdb\services\RoleActionAuthorisationService($roleActionMappingService);
+        $roleActionAuthorisationService->setEntityManager($em2);
+        $roleService->setRoleActionAuthorisationService($roleActionAuthorisationService);
 
-    $pendingGrantableRolesU1 = $roleService->getPendingRolesUserCanApprove($u);
+        $pendingGrantableRolesU1 = $roleService->getPendingRolesUserCanApprove($u);
 
-    // show that u1 has one pending role request
-    $this->assertTrue(count($pendingGrantableRolesU1) == 1);
-    $this->assertEquals($pendingSiteRole->getId(), $pendingGrantableRolesU1[0]->getId());
-    $this->assertEquals(RoleStatus::PENDING, $pendingGrantableRolesU1[0]->getStatus());
-    $this->assertEquals(RoleTypeName::SITE_ADMIN, $pendingGrantableRolesU1[0]->getRoleType()->getName());
+      // show that u1 has one pending role request
+        $this->assertTrue(count($pendingGrantableRolesU1) == 1);
+        $this->assertEquals($pendingSiteRole->getId(), $pendingGrantableRolesU1[0]->getId());
+        $this->assertEquals(RoleStatus::PENDING, $pendingGrantableRolesU1[0]->getStatus());
+        $this->assertEquals(RoleTypeName::SITE_ADMIN, $pendingGrantableRolesU1[0]->getRoleType()->getName());
 
-    // show that u2 has no pending role requests
-    $pendingGrantableRolesU2 = $roleService->getPendingRolesUserCanApprove($u2);
-    $this->assertTrue(count($pendingGrantableRolesU2) == 0);
-  }
-
-
-
-  public function test_getUserRoleNamesOverEntity(){
-    print __METHOD__ . "\n";
-    // Create fixture data
-    // RoleTypes
-    $siteAdminRT = TestUtil::createSampleRoleType(RoleTypeName::SITE_ADMIN/*, RoleTypeClass::SITE_USER*/);
-    $regFLSupportRT = TestUtil::createSampleRoleType(RoleTypeName::REG_FIRST_LINE_SUPPORT/*, RoleTypeClass::REGIONAL_USER*/);
-    $this->em->persist($regFLSupportRT);
-    $this->em->persist($siteAdminRT);
-    // User
-    $u = TestUtil::createSampleUser("Test", "Testing");
-    $identifier= TestUtil::createSampleUserIdentifier("X.509", "/c=test");
-    $u->addUserIdentifierDoJoin($identifier);
-    $this->em->persist($identifier);
-    $this->em->persist($u);
-    // Site
-    $site1 = TestUtil::createSampleSite("SITENAME"/*, "PK01"*/);
-    $this->em->persist($site1);
-    // Create a Role and link to the User, ngiRoleType and site
-    $roleSite = TestUtil::createSampleRole($u, $siteAdminRT, $site1, RoleStatus::GRANTED);
-    $this->em->persist($roleSite);
-    $this->em->flush();
-
-    // ********NOTE******** Role Service uses a new connection for its transactional methods
-    $roleService = new org\gocdb\services\Role();
-    $roleService->setEntityManager($this->createEntityManager());
-
-    // Now test that method returns expected results
-    $roleNames = $roleService->getUserRoleNamesOverEntity($site1, $u, \RoleStatus::GRANTED);
-    $this->assertEquals(1, count($roleNames));
-    $this->assertContains(RoleTypeName::SITE_ADMIN, $roleNames);
-
-    // Create new NGI
-    $n = TestUtil::createSampleNGI("MYNGI");
-    $this->em->persist($n);
-
-    $roleNgi = TestUtil::createSampleRole($u, $regFLSupportRT, $n, RoleStatus::GRANTED);
-    $this->em->persist($roleNgi);
-    $this->em->flush();
-
-    // Now test that method returns expected results
-    $roleNames = $roleService->getUserRoleNamesOverEntity($n, $u);
-    $this->assertEquals(1, count($roleNames));
-    $this->assertContains(RoleTypeName::REG_FIRST_LINE_SUPPORT, $roleNames);
-  }
+      // show that u2 has no pending role requests
+        $pendingGrantableRolesU2 = $roleService->getPendingRolesUserCanApprove($u2);
+        $this->assertTrue(count($pendingGrantableRolesU2) == 0);
+    }
 
 
-  public function testGetUserRoles(){
-    print __METHOD__ . "\n";
-    // Create two roletypes
-    $ngiRoleType = TestUtil::createSampleRoleType("RT1_NAME"/*, RoleTypeClass::SITE_USER*/);
-    $siteRoleType = TestUtil::createSampleRoleType("RT2_NAME"/*, RoleTypeClass::REGIONAL_USER*/);
-    $this->em->persist($ngiRoleType);
-    $this->em->persist($siteRoleType);
 
-    // Create a user
-    $u = TestUtil::createSampleUser("Test", "Testing");
-    $identifier= TestUtil::createSampleUserIdentifier("X.509", "/c=test");
-    $u->addUserIdentifierDoJoin($identifier);
-    $this->em->persist($identifier);
-    $this->em->persist($u);
+    public function test_getUserRoleNamesOverEntity()
+    {
+        print __METHOD__ . "\n";
+      // Create fixture data
+      // RoleTypes
+        $siteAdminRT = TestUtil::createSampleRoleType(RoleTypeName::SITE_ADMIN/*, RoleTypeClass::SITE_USER*/);
+        $regFLSupportRT = TestUtil::createSampleRoleType(RoleTypeName::REG_FIRST_LINE_SUPPORT/*, RoleTypeClass::REGIONAL_USER*/);
+        $this->em->persist($regFLSupportRT);
+        $this->em->persist($siteAdminRT);
+      // User
+        $u = TestUtil::createSampleUser("Test", "Testing");
+        $identifier = TestUtil::createSampleUserIdentifier("X.509", "/c=test");
+        $u->addUserIdentifierDoJoin($identifier);
+        $this->em->persist($identifier);
+        $this->em->persist($u);
+      // Site
+        $site1 = TestUtil::createSampleSite("SITENAME"/*, "PK01"*/);
+        $this->em->persist($site1);
+      // Create a Role and link to the User, ngiRoleType and site
+        $roleSite = TestUtil::createSampleRole($u, $siteAdminRT, $site1, RoleStatus::GRANTED);
+        $this->em->persist($roleSite);
+        $this->em->flush();
 
-    // Create an NGI
-    $ngi = TestUtil::createSampleNGI("MYNGI");
-    $this->em->persist($ngi);
+      // ********NOTE******** Role Service uses a new connection for its transactional methods
+        $roleService = new org\gocdb\services\Role();
+        $roleService->setEntityManager($this->createEntityManager());
 
-    // Create a Role and link to the User, ngiRoleType and ngi
-    $roleNgi = TestUtil::createSampleRole($u, $ngiRoleType, $ngi, RoleStatus::GRANTED);
-    $this->em->persist($roleNgi);
+      // Now test that method returns expected results
+        $roleNames = $roleService->getUserRoleNamesOverEntity($site1, $u, \RoleStatus::GRANTED);
+        $this->assertEquals(1, count($roleNames));
+        $this->assertContains(RoleTypeName::SITE_ADMIN, $roleNames);
 
-    // Create a site
-    $site1 = TestUtil::createSampleSite("SITENAME"/*, "PK01"*/);
-    $this->em->persist($site1);
+      // Create new NGI
+        $n = TestUtil::createSampleNGI("MYNGI");
+        $this->em->persist($n);
 
-    // Create another role and link to the User, siteRoleType and site
-    $roleSite = TestUtil::createSampleRole($u, $siteRoleType, $site1, RoleStatus::GRANTED) ;
-    $this->em->persist($roleSite);
+        $roleNgi = TestUtil::createSampleRole($u, $regFLSupportRT, $n, RoleStatus::GRANTED);
+        $this->em->persist($roleNgi);
+        $this->em->flush();
 
-    // Create a second and third sites and add to the NGI, but DO NOT add direct
-    // roles over those sites for the user. The user will still have role
-    // over the sites because they have a role over the NGI !
-    $site2 = TestUtil::createSampleSite("SITENAME2"/*, "PK01"*/);
-    $site3 = TestUtil::createSampleSite("SITENAME3"/*, "PK01"*/);
-    $this->em->persist($site2);
-    $this->em->persist($site3);
-    $ngi->addSiteDoJoin($site2);
-    $ngi->addSiteDoJoin($site3);
+      // Now test that method returns expected results
+        $roleNames = $roleService->getUserRoleNamesOverEntity($n, $u);
+        $this->assertEquals(1, count($roleNames));
+        $this->assertContains(RoleTypeName::REG_FIRST_LINE_SUPPORT, $roleNames);
+    }
 
-    $this->em->flush();
 
-    // ********MUST******** start a new connection to test transactional
-    // isolation of RoleService methods.
-    $em = $this->createEntityManager();
-    $roleService = new org\gocdb\services\Role();
-    $roleService->setEntityManager($em);
-    // assert that user has expected roles
-    $roles = $roleService->getUserRoles($u, RoleStatus::GRANTED);
-    $this->assertEquals(2, sizeof($roles));
-    $this->assertTrue(count($roleService->getUserRoleNamesOverEntity($ngi, $u)) == 1);
-    $this->assertTrue(count($roleService->getUserRoleNamesOverEntity($site1, $u)) == 1);
-    $this->assertTrue(count($roleService->getUserRoleNamesOverEntity($site2, $u)) == 0);
-    $this->assertTrue(count($roleService->getUserRoleNamesOverEntity($site3, $u)) == 0);
+    public function testGetUserRoles()
+    {
+        print __METHOD__ . "\n";
+      // Create two roletypes
+        $ngiRoleType = TestUtil::createSampleRoleType("RT1_NAME"/*, RoleTypeClass::SITE_USER*/);
+        $siteRoleType = TestUtil::createSampleRoleType("RT2_NAME"/*, RoleTypeClass::REGIONAL_USER*/);
+        $this->em->persist($ngiRoleType);
+        $this->em->persist($siteRoleType);
 
-    // assert that the user has an expected site count with roles over those sites
-    $mySites = $roleService->getReachableSitesFromOwnedObjectRoles($u);
-    $this->assertEquals(3, sizeof($mySites));
+      // Create a user
+        $u = TestUtil::createSampleUser("Test", "Testing");
+        $identifier = TestUtil::createSampleUserIdentifier("X.509", "/c=test");
+        $u->addUserIdentifierDoJoin($identifier);
+        $this->em->persist($identifier);
+        $this->em->persist($u);
 
-    // assert user don't have these pending/revoked roles
-    $roles = $roleService->getUserRoles($u, RoleStatus::PENDING);
-    $this->assertEmpty($roles);
-  }
+      // Create an NGI
+        $ngi = TestUtil::createSampleNGI("MYNGI");
+        $this->em->persist($ngi);
+
+      // Create a Role and link to the User, ngiRoleType and ngi
+        $roleNgi = TestUtil::createSampleRole($u, $ngiRoleType, $ngi, RoleStatus::GRANTED);
+        $this->em->persist($roleNgi);
+
+      // Create a site
+        $site1 = TestUtil::createSampleSite("SITENAME"/*, "PK01"*/);
+        $this->em->persist($site1);
+
+      // Create another role and link to the User, siteRoleType and site
+        $roleSite = TestUtil::createSampleRole($u, $siteRoleType, $site1, RoleStatus::GRANTED) ;
+        $this->em->persist($roleSite);
+
+      // Create a second and third sites and add to the NGI, but DO NOT add direct
+      // roles over those sites for the user. The user will still have role
+      // over the sites because they have a role over the NGI !
+        $site2 = TestUtil::createSampleSite("SITENAME2"/*, "PK01"*/);
+        $site3 = TestUtil::createSampleSite("SITENAME3"/*, "PK01"*/);
+        $this->em->persist($site2);
+        $this->em->persist($site3);
+        $ngi->addSiteDoJoin($site2);
+        $ngi->addSiteDoJoin($site3);
+
+        $this->em->flush();
+
+      // ********MUST******** start a new connection to test transactional
+      // isolation of RoleService methods.
+        $em = $this->createEntityManager();
+        $roleService = new org\gocdb\services\Role();
+        $roleService->setEntityManager($em);
+      // assert that user has expected roles
+        $roles = $roleService->getUserRoles($u, RoleStatus::GRANTED);
+        $this->assertEquals(2, sizeof($roles));
+        $this->assertTrue(count($roleService->getUserRoleNamesOverEntity($ngi, $u)) == 1);
+        $this->assertTrue(count($roleService->getUserRoleNamesOverEntity($site1, $u)) == 1);
+        $this->assertTrue(count($roleService->getUserRoleNamesOverEntity($site2, $u)) == 0);
+        $this->assertTrue(count($roleService->getUserRoleNamesOverEntity($site3, $u)) == 0);
+
+      // assert that the user has an expected site count with roles over those sites
+        $mySites = $roleService->getReachableSitesFromOwnedObjectRoles($u);
+        $this->assertEquals(3, sizeof($mySites));
+
+      // assert user don't have these pending/revoked roles
+        $roles = $roleService->getUserRoles($u, RoleStatus::PENDING);
+        $this->assertEmpty($roles);
+    }
 
   /**
    * @expectedException \LogicException
    */
-  public function testInvalidRoleStatus(){
-    print __METHOD__ . "\n";
-    $roleService = new org\gocdb\services\Role();
-    $this->assertFalse($roleService->isValidRoleStatus("some invalid role"));
-    $u = TestUtil::createSampleUser("Test", "Testing");
-    $identifier= TestUtil::createSampleUserIdentifier("X.509", "/c=test");
-    $u->addUserIdentifierDoJoin($identifier);
-    $this->em->persist($identifier);
-    $roleService->getUserRoles($u, "some invalid role");
-  }
+    public function testInvalidRoleStatus()
+    {
+        print __METHOD__ . "\n";
+        $roleService = new org\gocdb\services\Role();
+        $this->assertFalse($roleService->isValidRoleStatus("some invalid role"));
+        $u = TestUtil::createSampleUser("Test", "Testing");
+        $identifier = TestUtil::createSampleUserIdentifier("X.509", "/c=test");
+        $u->addUserIdentifierDoJoin($identifier);
+        $this->em->persist($identifier);
+        $roleService->getUserRoles($u, "some invalid role");
+    }
 
 
-  public function test_getReachableProjectsFromOwnedEntity(){
-    print __METHOD__ . "\n";
-    include __DIR__ . '/resources/sampleFixtureData5.php';
-    $this->em->flush();
+    public function test_getReachableProjectsFromOwnedEntity()
+    {
+        print __METHOD__ . "\n";
+        include __DIR__ . '/resources/sampleFixtureData5.php';
+        $this->em->flush();
 
 
-    // ********MUST******** start a new connection to test transactional
-    // isolation of RoleService methods.
-    $em = $this->createEntityManager();
-    $roleService = new org\gocdb\services\Role();
-    $roleService->setEntityManager($em);
+      // ********MUST******** start a new connection to test transactional
+      // isolation of RoleService methods.
+        $em = $this->createEntityManager();
+        $roleService = new org\gocdb\services\Role();
+        $roleService->setEntityManager($em);
 
 
-    $projects = $roleService->getReachableProjectsFromOwnedEntity($p1);
-    $this->assertEquals($p1, $projects[0]);
-    $this->assertTrue(count($projects) == 1);
-    $projects = $roleService->getReachableProjectsFromOwnedEntity($n1);
-    $this->assertEquals($p1, $projects[0]);
-    $this->assertTrue(count($projects) == 1);
-    $projects = $roleService->getReachableProjectsFromOwnedEntity($s1);
-    $this->assertTrue(count($projects) == 1);
-    $this->assertEquals($p1, $projects[0]);
+        $projects = $roleService->getReachableProjectsFromOwnedEntity($p1);
+        $this->assertEquals($p1, $projects[0]);
+        $this->assertTrue(count($projects) == 1);
+        $projects = $roleService->getReachableProjectsFromOwnedEntity($n1);
+        $this->assertEquals($p1, $projects[0]);
+        $this->assertTrue(count($projects) == 1);
+        $projects = $roleService->getReachableProjectsFromOwnedEntity($s1);
+        $this->assertTrue(count($projects) == 1);
+        $this->assertEquals($p1, $projects[0]);
 
 
-    $projects = $roleService->getReachableProjectsFromOwnedEntity($p2);
-    $this->assertEquals($p2, $projects[0]);
-    $projects = $roleService->getReachableProjectsFromOwnedEntity($n2);
-    $this->assertTrue(count($projects) == 2);
-    $this->assertTrue(in_array($p2, $projects));
-    $this->assertTrue(in_array($p3, $projects));
-    $projects = $roleService->getReachableProjectsFromOwnedEntity($s2);
-    $this->assertTrue(count($projects) == 2);
-    $this->assertTrue(in_array($p2, $projects));
-    $this->assertTrue(in_array($p3, $projects));
+        $projects = $roleService->getReachableProjectsFromOwnedEntity($p2);
+        $this->assertEquals($p2, $projects[0]);
+        $projects = $roleService->getReachableProjectsFromOwnedEntity($n2);
+        $this->assertTrue(count($projects) == 2);
+        $this->assertTrue(in_array($p2, $projects));
+        $this->assertTrue(in_array($p3, $projects));
+        $projects = $roleService->getReachableProjectsFromOwnedEntity($s2);
+        $this->assertTrue(count($projects) == 2);
+        $this->assertTrue(in_array($p2, $projects));
+        $this->assertTrue(in_array($p3, $projects));
 
 
-    $projects = $roleService->getReachableProjectsFromOwnedEntity($n3);
-    $this->assertTrue(count($projects) == 1);
-    $this->assertEquals($p3, $projects[0]);
-    $projects = $roleService->getReachableProjectsFromOwnedEntity($s3);
-    $this->assertTrue(count($projects) == 1);
-    $this->assertEquals($p3, $projects[0]);
-  }
+        $projects = $roleService->getReachableProjectsFromOwnedEntity($n3);
+        $this->assertTrue(count($projects) == 1);
+        $this->assertEquals($p3, $projects[0]);
+        $projects = $roleService->getReachableProjectsFromOwnedEntity($s3);
+        $this->assertTrue(count($projects) == 1);
+        $this->assertEquals($p3, $projects[0]);
+    }
 
 
-  public function test_getUserRolesByProject(){
-    print __METHOD__ . "\n";
-    include __DIR__ . '/resources/sampleFixtureData5.php';
+    public function test_getUserRolesByProject()
+    {
+        print __METHOD__ . "\n";
+        include __DIR__ . '/resources/sampleFixtureData5.php';
 
-    // create a user
-    $u = TestUtil::createSampleUser("dave", "meredith");
-    $identifier= TestUtil::createSampleUserIdentifier("X.509", "idSTring");
-    $u->addUserIdentifierDoJoin($identifier);
-    $this->em->persist($identifier);
-    $this->em->persist($u);
+      // create a user
+        $u = TestUtil::createSampleUser("dave", "meredith");
+        $identifier = TestUtil::createSampleUserIdentifier("X.509", "idSTring");
+        $u->addUserIdentifierDoJoin($identifier);
+        $this->em->persist($identifier);
+        $this->em->persist($u);
 
-    // add some roles to domain model
-    $ngiRoleType = TestUtil::createSampleRoleType("NGI_RT");
-    $siteRoleType = TestUtil::createSampleRoleType("SITE_RT");
-    $siteRoleType2 = TestUtil::createSampleRoleType("SITE_RT2");
-    $projRoleType = TestUtil::createSampleRoleType("PROJ_RT");
-    $this->em->persist($ngiRoleType);
-    $this->em->persist($siteRoleType);
-    $this->em->persist($siteRoleType2);
-    $this->em->persist($projRoleType);
+      // add some roles to domain model
+        $ngiRoleType = TestUtil::createSampleRoleType("NGI_RT");
+        $siteRoleType = TestUtil::createSampleRoleType("SITE_RT");
+        $siteRoleType2 = TestUtil::createSampleRoleType("SITE_RT2");
+        $projRoleType = TestUtil::createSampleRoleType("PROJ_RT");
+        $this->em->persist($ngiRoleType);
+        $this->em->persist($siteRoleType);
+        $this->em->persist($siteRoleType2);
+        $this->em->persist($projRoleType);
 
-    $this->em->flush();
+        $this->em->flush();
 
-    $roleService = new org\gocdb\services\Role();
+        $roleService = new org\gocdb\services\Role();
 
-    // We could create/inject a new em connection into the roleService
-    // to test the transactional isolation of its methods (rather than injecting
-    // $this->em instance), e.g.:
-    //   $em = $this->createEntityManager();
-    //   $roleService->setEntityManager($em);
-    //
-    // However, this is problematic for this test which
-    // needs to use the in_array() method to assert that the tested methods return
-    // the expected roles - in_array() uses object-instance-equality to deterine
-    // if the role exists in the array, and using a different $em instance
-    // means the returned roles will be considered different
-    // instances. We could get round this by comparing the Ids, but this makes
-    // checking more of hassle as we need to extract all the Ids from the roles
-    // into another array to assert the ids are expected, as in:
-    //   $roleIds = array();
-    //   foreach($roles as $r){ $roleIds[] = $r->getId(); }
-    //   $this->assertTrue(in_array($r1->getId(), $roleIds));
-    //   $this->assertTrue(in_array($r2->getId(), $roleIds));
-    //
-    // For this test, we will therefore re-use $this->em to ensure
-    // object-equality:
-    $roleService->setEntityManager($this->em);
+      // We could create/inject a new em connection into the roleService
+      // to test the transactional isolation of its methods (rather than injecting
+      // $this->em instance), e.g.:
+      //   $em = $this->createEntityManager();
+      //   $roleService->setEntityManager($em);
+      //
+      // However, this is problematic for this test which
+      // needs to use the in_array() method to assert that the tested methods return
+      // the expected roles - in_array() uses object-instance-equality to deterine
+      // if the role exists in the array, and using a different $em instance
+      // means the returned roles will be considered different
+      // instances. We could get round this by comparing the Ids, but this makes
+      // checking more of hassle as we need to extract all the Ids from the roles
+      // into another array to assert the ids are expected, as in:
+      //   $roleIds = array();
+      //   foreach($roles as $r){ $roleIds[] = $r->getId(); }
+      //   $this->assertTrue(in_array($r1->getId(), $roleIds));
+      //   $this->assertTrue(in_array($r2->getId(), $roleIds));
+      //
+      // For this test, we will therefore re-use $this->em to ensure
+      // object-equality:
+        $roleService->setEntityManager($this->em);
 
-    // confirm that function runs with no user roles over entity
-    $roles = $roleService->getUserRolesByProject($u, $p1);
-    $this->assertEmpty($roles);
-
-
-    // Create a Role and link to the User, ngiRoleType and ngi
-    /*
-     * p1     p2     p3
-     * |      |     /|
-     * n1     n2-r1  n3
-     * |      |      |
-     * s1     s2     s3
-     */
-    $r1 = TestUtil::createSampleRole($u, $ngiRoleType, $n2, RoleStatus::GRANTED);
-    $this->em->persist($r1);
-    $this->em->flush();
-
-    $rolesDirect = $u->getRoles();
-    $this->assertEquals(1, count($rolesDirect));
-
-    $roles = $roleService->getUserRolesByProject($u, $p1);
-    $this->assertEmpty($roles);
-    $roles = $roleService->getUserRolesByProject($u, $p2);
-    $this->assertEquals(1, count($roles));
-    $this->assertEquals($r1->getId(), $roles[0]->getId());
-    $roles = $roleService->getUserRolesByProject($u, $p3);
-    $this->assertEquals(1, count($roles));
-    $this->assertEquals($r1->getId(), $roles[0]->getId());
+      // confirm that function runs with no user roles over entity
+        $roles = $roleService->getUserRolesByProject($u, $p1);
+        $this->assertEmpty($roles);
 
 
-    /*
-     * p1     p2     p3
-     * |      |     /|
-     * n1     n2-r1  n3-r2
-     * |      |      |
-     * s1     s2     s3
-     */
-    $r2 = TestUtil::createSampleRole($u, $ngiRoleType, $n3, RoleStatus::GRANTED);
-    $this->em->persist($r2);
-    $this->em->flush();
+      // Create a Role and link to the User, ngiRoleType and ngi
+      /*
+       * p1     p2     p3
+       * |      |     /|
+       * n1     n2-r1  n3
+       * |      |      |
+       * s1     s2     s3
+       */
+        $r1 = TestUtil::createSampleRole($u, $ngiRoleType, $n2, RoleStatus::GRANTED);
+        $this->em->persist($r1);
+        $this->em->flush();
 
-    $roles = $roleService->getUserRolesByProject($u, $p1);
-    $this->assertEmpty($roles);
-    $roles = $roleService->getUserRolesByProject($u, $p2);
-    $this->assertEquals(1, count($roles));
-    $this->assertEquals($r1->getId(), $roles[0]->getId());
+        $rolesDirect = $u->getRoles();
+        $this->assertEquals(1, count($rolesDirect));
 
-    $roles = $roleService->getUserRolesByProject($u, $p3);
-    $this->assertEquals(2, count($roles));
-    $roleIds = array();
-    foreach($roles as $r){ $roleIds[] = $r->getId(); }
-    $this->assertTrue(in_array($r1->getId(), $roleIds));
-    $this->assertTrue(in_array($r2->getId(), $roleIds));
-
-    /*
-     * p1     p2     p3
-     * |      |     /|
-     * n1     n2-r1  n3-r2
-     * |      |      |
-     * s1     s2     s3-r3
-     */
-    $r3 = TestUtil::createSampleRole($u, $siteRoleType, $s3, RoleStatus::GRANTED);
-    $this->em->persist($r3);
-    $this->em->flush();
-
-    $roles = $roleService->getUserRolesByProject($u, $p1);
-    $this->assertEmpty($roles);
-    $roles = $roleService->getUserRolesByProject($u, $p2);
-    $this->assertEquals(1, count($roles));
-    $this->assertEquals($r1->getId(), $roles[0]->getId());
-
-    $roles = $roleService->getUserRolesByProject($u, $p3);
-    $this->assertEquals(3, count($roles));
-    $this->assertTrue(in_array($r1, $roles));
-    $this->assertTrue(in_array($r2, $roles));
-    $this->assertTrue(in_array($r3, $roles));
-
-    /*
-     * p1     p2     p3-r4
-     * |      |     /|
-     * n1     n2-r1  n3-r2
-     * |      |      |
-     * s1     s2     s3-r3
-     */
-    $r4 = TestUtil::createSampleRole($u, $projRoleType, $p3, RoleStatus::GRANTED);
-    $this->em->persist($r4);
-    $this->em->flush();
-
-    $rolesDirect = $u->getRoles();
-    $this->assertEquals(4, count($rolesDirect));
-
-    $roles = $roleService->getUserRolesByProject($u, $p1);
-    $this->assertEmpty($roles);
-    $roles = $roleService->getUserRolesByProject($u, $p2);
-    $this->assertEquals(1, count($roles));
-    $this->assertEquals($r1->getId(), $roles[0]->getId());
-    $roles = $roleService->getUserRolesByProject($u, $p3);
-    $this->assertEquals(4, count($roles));
-    $this->assertTrue(in_array($r1, $roles));
-    $this->assertTrue(in_array($r2, $roles));
-    $this->assertTrue(in_array($r3, $roles));
-    $this->assertTrue(in_array($r4, $roles));
-
-    /*
-     * p1     p2     p3-r4
-     * |      |     /|
-     * n1     n2-r1  n3-r2
-     * |      |      |
-     * s1     s2-r5  s3-r3
-     */
-    $r5 = TestUtil::createSampleRole($u, $siteRoleType, $s2, RoleStatus::GRANTED);
-    $this->em->persist($r5);
-    $this->em->flush();
-
-    $rolesDirect = $u->getRoles();
-    $this->assertEquals(5, count($rolesDirect));
-
-    $roles = $roleService->getUserRolesByProject($u, $p1);
-    $this->assertEmpty($roles);
-    $roles = $roleService->getUserRolesByProject($u, $p2);
-    $this->assertEquals(2, count($roles));
-    $this->assertTrue(in_array($r1, $roles));
-    $this->assertTrue(in_array($r5, $roles));
-    $roles = $roleService->getUserRolesByProject($u, $p3);
-    $this->assertEquals(5, count($roles));
-    $this->assertTrue(in_array($r1, $roles));
-    $this->assertTrue(in_array($r2, $roles));
-    $this->assertTrue(in_array($r3, $roles));
-    $this->assertTrue(in_array($r4, $roles));
-    $this->assertTrue(in_array($r5, $roles));
+        $roles = $roleService->getUserRolesByProject($u, $p1);
+        $this->assertEmpty($roles);
+        $roles = $roleService->getUserRolesByProject($u, $p2);
+        $this->assertEquals(1, count($roles));
+        $this->assertEquals($r1->getId(), $roles[0]->getId());
+        $roles = $roleService->getUserRolesByProject($u, $p3);
+        $this->assertEquals(1, count($roles));
+        $this->assertEquals($r1->getId(), $roles[0]->getId());
 
 
-    /*
-     * p1     p2     p3-r4
-     * |      |     /|
-     * n1     n2-r1  n3-r2
-     * |      |      |
-     * s1-r6  s2-r5  s3-r3
-     */
-    $r6 = TestUtil::createSampleRole($u, $siteRoleType, $s1, RoleStatus::GRANTED);
-    $this->em->persist($r6);
-    $this->em->flush();
+      /*
+       * p1     p2     p3
+       * |      |     /|
+       * n1     n2-r1  n3-r2
+       * |      |      |
+       * s1     s2     s3
+       */
+        $r2 = TestUtil::createSampleRole($u, $ngiRoleType, $n3, RoleStatus::GRANTED);
+        $this->em->persist($r2);
+        $this->em->flush();
 
-    $rolesDirect = $u->getRoles();
-    $this->assertEquals(6, count($rolesDirect));
+        $roles = $roleService->getUserRolesByProject($u, $p1);
+        $this->assertEmpty($roles);
+        $roles = $roleService->getUserRolesByProject($u, $p2);
+        $this->assertEquals(1, count($roles));
+        $this->assertEquals($r1->getId(), $roles[0]->getId());
 
-    $roles = $roleService->getUserRolesByProject($u, $p1);
-    $this->assertEquals(1, count($roles));
-    $this->assertTrue(in_array($r6, $roles));
-    $roles = $roleService->getUserRolesByProject($u, $p2);
-    $this->assertEquals(2, count($roles));
-    $this->assertTrue(in_array($r1, $roles));
-    $this->assertTrue(in_array($r5, $roles));
-    $roles = $roleService->getUserRolesByProject($u, $p3);
-    $this->assertEquals(5, count($roles));
-    $this->assertTrue(in_array($r1, $roles));
-    $this->assertTrue(in_array($r2, $roles));
-    $this->assertTrue(in_array($r3, $roles));
-    $this->assertTrue(in_array($r4, $roles));
-    $this->assertTrue(in_array($r5, $roles));
+        $roles = $roleService->getUserRolesByProject($u, $p3);
+        $this->assertEquals(2, count($roles));
+        $roleIds = array();
+        foreach ($roles as $r) {
+            $roleIds[] = $r->getId();
+        }
+        $this->assertTrue(in_array($r1->getId(), $roleIds));
+        $this->assertTrue(in_array($r2->getId(), $roleIds));
 
-    /*
-     * p1     p2     p3-r4
-     * |      |     /|
-     * n1     n2-r1  n3-r2
-     * |      |      |
-     * s1-r6  s2-r5  s3-r3,r7
-     */
-    $r7 = TestUtil::createSampleRole($u, $siteRoleType2, $s3, RoleStatus::GRANTED);
-    $this->em->persist($r7);
-    $this->em->flush();
+      /*
+       * p1     p2     p3
+       * |      |     /|
+       * n1     n2-r1  n3-r2
+       * |      |      |
+       * s1     s2     s3-r3
+       */
+        $r3 = TestUtil::createSampleRole($u, $siteRoleType, $s3, RoleStatus::GRANTED);
+        $this->em->persist($r3);
+        $this->em->flush();
 
-    $rolesDirect = $u->getRoles();
-    $this->assertEquals(7, count($rolesDirect));
+        $roles = $roleService->getUserRolesByProject($u, $p1);
+        $this->assertEmpty($roles);
+        $roles = $roleService->getUserRolesByProject($u, $p2);
+        $this->assertEquals(1, count($roles));
+        $this->assertEquals($r1->getId(), $roles[0]->getId());
 
-    $roles = $roleService->getUserRolesByProject($u, $p1);
-    $this->assertEquals(1, count($roles));
-    $this->assertTrue(in_array($r6, $roles));
-    $roles = $roleService->getUserRolesByProject($u, $p2);
-    $this->assertEquals(2, count($roles));
-    $this->assertTrue(in_array($r1, $roles));
-    $this->assertTrue(in_array($r5, $roles));
-    $roles = $roleService->getUserRolesByProject($u, $p3);
-    $this->assertEquals(6, count($roles));
-    $this->assertTrue(in_array($r1, $roles));
-    $this->assertTrue(in_array($r2, $roles));
-    $this->assertTrue(in_array($r3, $roles));
-    $this->assertTrue(in_array($r4, $roles));
-    $this->assertTrue(in_array($r5, $roles));
-    $this->assertTrue(in_array($r7, $roles));
+        $roles = $roleService->getUserRolesByProject($u, $p3);
+        $this->assertEquals(3, count($roles));
+        $this->assertTrue(in_array($r1, $roles));
+        $this->assertTrue(in_array($r2, $roles));
+        $this->assertTrue(in_array($r3, $roles));
+
+      /*
+       * p1     p2     p3-r4
+       * |      |     /|
+       * n1     n2-r1  n3-r2
+       * |      |      |
+       * s1     s2     s3-r3
+       */
+        $r4 = TestUtil::createSampleRole($u, $projRoleType, $p3, RoleStatus::GRANTED);
+        $this->em->persist($r4);
+        $this->em->flush();
+
+        $rolesDirect = $u->getRoles();
+        $this->assertEquals(4, count($rolesDirect));
+
+        $roles = $roleService->getUserRolesByProject($u, $p1);
+        $this->assertEmpty($roles);
+        $roles = $roleService->getUserRolesByProject($u, $p2);
+        $this->assertEquals(1, count($roles));
+        $this->assertEquals($r1->getId(), $roles[0]->getId());
+        $roles = $roleService->getUserRolesByProject($u, $p3);
+        $this->assertEquals(4, count($roles));
+        $this->assertTrue(in_array($r1, $roles));
+        $this->assertTrue(in_array($r2, $roles));
+        $this->assertTrue(in_array($r3, $roles));
+        $this->assertTrue(in_array($r4, $roles));
+
+      /*
+       * p1     p2     p3-r4
+       * |      |     /|
+       * n1     n2-r1  n3-r2
+       * |      |      |
+       * s1     s2-r5  s3-r3
+       */
+        $r5 = TestUtil::createSampleRole($u, $siteRoleType, $s2, RoleStatus::GRANTED);
+        $this->em->persist($r5);
+        $this->em->flush();
+
+        $rolesDirect = $u->getRoles();
+        $this->assertEquals(5, count($rolesDirect));
+
+        $roles = $roleService->getUserRolesByProject($u, $p1);
+        $this->assertEmpty($roles);
+        $roles = $roleService->getUserRolesByProject($u, $p2);
+        $this->assertEquals(2, count($roles));
+        $this->assertTrue(in_array($r1, $roles));
+        $this->assertTrue(in_array($r5, $roles));
+        $roles = $roleService->getUserRolesByProject($u, $p3);
+        $this->assertEquals(5, count($roles));
+        $this->assertTrue(in_array($r1, $roles));
+        $this->assertTrue(in_array($r2, $roles));
+        $this->assertTrue(in_array($r3, $roles));
+        $this->assertTrue(in_array($r4, $roles));
+        $this->assertTrue(in_array($r5, $roles));
 
 
-    /*
-     * p1     p2-r8  p3-r4
-     * |      |     /|
-     * n1     n2-r1  n3-r2
-     * |      |      |
-     * s1-r6  s2-r5  s3-r3,r7
-     */
-    $r8 = TestUtil::createSampleRole($u, $projRoleType, $p2, RoleStatus::GRANTED);
-    $this->em->persist($r8);
-    $this->em->flush();
+      /*
+       * p1     p2     p3-r4
+       * |      |     /|
+       * n1     n2-r1  n3-r2
+       * |      |      |
+       * s1-r6  s2-r5  s3-r3
+       */
+        $r6 = TestUtil::createSampleRole($u, $siteRoleType, $s1, RoleStatus::GRANTED);
+        $this->em->persist($r6);
+        $this->em->flush();
 
-    $rolesDirect = $u->getRoles();
-    $this->assertEquals(8, count($rolesDirect));
+        $rolesDirect = $u->getRoles();
+        $this->assertEquals(6, count($rolesDirect));
 
-    $roles = $roleService->getUserRolesByProject($u, $p1);
-    $this->assertEquals(1, count($roles));
-    $this->assertTrue(in_array($r6, $roles));
-    $roles = $roleService->getUserRolesByProject($u, $p2);
-    $this->assertEquals(3, count($roles));
-    $this->assertTrue(in_array($r1, $roles));
-    $this->assertTrue(in_array($r5, $roles));
-    $this->assertTrue(in_array($r8, $roles));
-    $roles = $roleService->getUserRolesByProject($u, $p3);
-    $this->assertEquals(6, count($roles));
-    $this->assertTrue(in_array($r1, $roles));
-    $this->assertTrue(in_array($r2, $roles));
-    $this->assertTrue(in_array($r3, $roles));
-    $this->assertTrue(in_array($r4, $roles));
-    $this->assertTrue(in_array($r5, $roles));
-    $this->assertTrue(in_array($r7, $roles));
-  }
+        $roles = $roleService->getUserRolesByProject($u, $p1);
+        $this->assertEquals(1, count($roles));
+        $this->assertTrue(in_array($r6, $roles));
+        $roles = $roleService->getUserRolesByProject($u, $p2);
+        $this->assertEquals(2, count($roles));
+        $this->assertTrue(in_array($r1, $roles));
+        $this->assertTrue(in_array($r5, $roles));
+        $roles = $roleService->getUserRolesByProject($u, $p3);
+        $this->assertEquals(5, count($roles));
+        $this->assertTrue(in_array($r1, $roles));
+        $this->assertTrue(in_array($r2, $roles));
+        $this->assertTrue(in_array($r3, $roles));
+        $this->assertTrue(in_array($r4, $roles));
+        $this->assertTrue(in_array($r5, $roles));
 
+      /*
+       * p1     p2     p3-r4
+       * |      |     /|
+       * n1     n2-r1  n3-r2
+       * |      |      |
+       * s1-r6  s2-r5  s3-r3,r7
+       */
+        $r7 = TestUtil::createSampleRole($u, $siteRoleType2, $s3, RoleStatus::GRANTED);
+        $this->em->persist($r7);
+        $this->em->flush();
+
+        $rolesDirect = $u->getRoles();
+        $this->assertEquals(7, count($rolesDirect));
+
+        $roles = $roleService->getUserRolesByProject($u, $p1);
+        $this->assertEquals(1, count($roles));
+        $this->assertTrue(in_array($r6, $roles));
+        $roles = $roleService->getUserRolesByProject($u, $p2);
+        $this->assertEquals(2, count($roles));
+        $this->assertTrue(in_array($r1, $roles));
+        $this->assertTrue(in_array($r5, $roles));
+        $roles = $roleService->getUserRolesByProject($u, $p3);
+        $this->assertEquals(6, count($roles));
+        $this->assertTrue(in_array($r1, $roles));
+        $this->assertTrue(in_array($r2, $roles));
+        $this->assertTrue(in_array($r3, $roles));
+        $this->assertTrue(in_array($r4, $roles));
+        $this->assertTrue(in_array($r5, $roles));
+        $this->assertTrue(in_array($r7, $roles));
+
+
+      /*
+       * p1     p2-r8  p3-r4
+       * |      |     /|
+       * n1     n2-r1  n3-r2
+       * |      |      |
+       * s1-r6  s2-r5  s3-r3,r7
+       */
+        $r8 = TestUtil::createSampleRole($u, $projRoleType, $p2, RoleStatus::GRANTED);
+        $this->em->persist($r8);
+        $this->em->flush();
+
+        $rolesDirect = $u->getRoles();
+        $this->assertEquals(8, count($rolesDirect));
+
+        $roles = $roleService->getUserRolesByProject($u, $p1);
+        $this->assertEquals(1, count($roles));
+        $this->assertTrue(in_array($r6, $roles));
+        $roles = $roleService->getUserRolesByProject($u, $p2);
+        $this->assertEquals(3, count($roles));
+        $this->assertTrue(in_array($r1, $roles));
+        $this->assertTrue(in_array($r5, $roles));
+        $this->assertTrue(in_array($r8, $roles));
+        $roles = $roleService->getUserRolesByProject($u, $p3);
+        $this->assertEquals(6, count($roles));
+        $this->assertTrue(in_array($r1, $roles));
+        $this->assertTrue(in_array($r2, $roles));
+        $this->assertTrue(in_array($r3, $roles));
+        $this->assertTrue(in_array($r4, $roles));
+        $this->assertTrue(in_array($r5, $roles));
+        $this->assertTrue(in_array($r7, $roles));
+    }
 }

--- a/tests/doctrine/RolesTest.php
+++ b/tests/doctrine/RolesTest.php
@@ -1,8 +1,9 @@
 <?php
+
 require_once dirname(__FILE__) . '/TestUtil.php';
-require_once dirname(__FILE__). '/../../lib/DAOs/ServiceDAO.php';
-require_once dirname(__FILE__). '/../../lib/DAOs/SiteDAO.php';
-require_once dirname(__FILE__). '/../../lib/DAOs/NGIDAO.php';
+require_once dirname(__FILE__) . '/../../lib/DAOs/ServiceDAO.php';
+require_once dirname(__FILE__) . '/../../lib/DAOs/SiteDAO.php';
+require_once dirname(__FILE__) . '/../../lib/DAOs/NGIDAO.php';
 
 use Doctrine\ORM\EntityManager;
 require_once dirname(__FILE__) . '/bootstrap.php';
@@ -18,99 +19,117 @@ require_once dirname(__FILE__) . '/bootstrap.php';
  * @author David Meredith
  * @author John Casson
  */
-class RolesTest extends PHPUnit_Extensions_Database_TestCase {
-  private $em;
-  private $egiScope;
-  private $localScope;
-  private $eudatScope;
+class RolesTest extends PHPUnit_Extensions_Database_TestCase
+{
+    private $em;
+    private $egiScope;
+    private $localScope;
+    private $eudatScope;
 
   /**
    * Overridden.
    */
-  public static function setUpBeforeClass() {
-    parent::setUpBeforeClass();
-    echo "\n\n-------------------------------------------------\n";
-    echo "Executing RolesTest. . .\n";
-  }
+    public static function setUpBeforeClass()
+    {
+        parent::setUpBeforeClass();
+        echo "\n\n-------------------------------------------------\n";
+        echo "Executing RolesTest. . .\n";
+    }
 
   /**
    * Overridden. Returns the test database connection.
    * @return PHPUnit_Extensions_Database_DB_IDatabaseConnection
    */
-  protected function getConnection() {
-    require_once dirname(__FILE__) . '/bootstrap_pdo.php';
-    return getConnectionToTestDB();
-  }
+    protected function getConnection()
+    {
+        require_once dirname(__FILE__) . '/bootstrap_pdo.php';
+        return getConnectionToTestDB();
+    }
 
   /**
    * Overridden. Returns the test dataset.
    * Defines how the initial state of the database should look before each test is executed.
    * @return PHPUnit_Extensions_Database_DataSet_IDataSet
    */
-  protected function getDataSet() {
-    return $this->createFlatXMLDataSet(dirname(__FILE__) . '/truncateDataTables.xml');
-    // Use below to return an empty data set if we don't want to truncate and seed
-    //return new PHPUnit_Extensions_Database_DataSet_DefaultDataSet();
-  }
+    protected function getDataSet()
+    {
+        return $this->createFlatXMLDataSet(dirname(__FILE__) . '/truncateDataTables.xml');
+      // Use below to return an empty data set if we don't want to truncate and seed
+      //return new PHPUnit_Extensions_Database_DataSet_DefaultDataSet();
+    }
 
   /**
    * Overridden.
    */
-  protected function getSetUpOperation() {
-    // CLEAN_INSERT is default
-    //return PHPUnit_Extensions_Database_Operation_Factory::CLEAN_INSERT();
-    //return PHPUnit_Extensions_Database_Operation_Factory::UPDATE();
-    //return PHPUnit_Extensions_Database_Operation_Factory::NONE();
-    //
-    // Issue a DELETE from <table> which is more portable than a
-    // TRUNCATE table <table> (some DBs require high privileges for truncate statements
-    // and also do not allow truncates across tables with FK contstraints e.g. Oracle)
-    return PHPUnit_Extensions_Database_Operation_Factory::DELETE_ALL();
-  }
+    protected function getSetUpOperation()
+    {
+      // CLEAN_INSERT is default
+      //return PHPUnit_Extensions_Database_Operation_Factory::CLEAN_INSERT();
+      //return PHPUnit_Extensions_Database_Operation_Factory::UPDATE();
+      //return PHPUnit_Extensions_Database_Operation_Factory::NONE();
+      //
+      // Issue a DELETE from <table> which is more portable than a
+      // TRUNCATE table <table> (some DBs require high privileges for truncate statements
+      // and also do not allow truncates across tables with FK contstraints e.g. Oracle)
+        return PHPUnit_Extensions_Database_Operation_Factory::DELETE_ALL();
+    }
 
   /**
    * Overridden.
    */
-  protected function getTearDownOperation() {
-    // NONE is default
-    return PHPUnit_Extensions_Database_Operation_Factory::NONE();
-  }
+    protected function getTearDownOperation()
+    {
+      // NONE is default
+        return PHPUnit_Extensions_Database_Operation_Factory::NONE();
+    }
 
   /**
    * Sets up the fixture, e.g create a new entityManager for each test run
    * This method is called before each test method is executed.
    */
-  protected function setUp() {
-    parent::setUp();
-    $this->em = $this->createEntityManager();
-  }
-
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->em = $this->createEntityManager();
+    }
+  /**
+   * Run after each test function to prevent pile-up of database connections.
+   */
+    protected function tearDown()
+    {
+        parent::tearDown();
+        if (!is_null($this->em)) {
+            $this->em->getConnection()->close();
+        }
+    }
   /**
    * @todo Still need to setup connection to different databases.
    * @return EntityManager
    */
-  private function createEntityManager(){
-    require dirname(__FILE__).'/bootstrap_doctrine.php';
-    return $entityManager;
-  }
+    private function createEntityManager()
+    {
+        require dirname(__FILE__) . '/bootstrap_doctrine.php';
+        return $entityManager;
+    }
 
   /**
    * Called after setUp() and before each test. Used for common assertions
    * across all tests.
    */
-  protected function assertPreConditions() {
-    $con = $this->getConnection();
-    $fixture = dirname(__FILE__) . '/truncateDataTables.xml';
-    $tables = simplexml_load_file($fixture);
+    protected function assertPreConditions()
+    {
+        $con = $this->getConnection();
+        $fixture = dirname(__FILE__) . '/truncateDataTables.xml';
+        $tables = simplexml_load_file($fixture);
 
-    foreach($tables as $tableName) {
-      $sql = "SELECT * FROM ".$tableName->getName();
-      $result = $con->createQueryTable('results_table', $sql);
-      if($result->getRowCount() != 0) {
-        throw new RuntimeException("Invalid fixture. Table has rows: ".$tableName->getName());
-      }
+        foreach ($tables as $tableName) {
+            $sql = "SELECT * FROM " . $tableName->getName();
+            $result = $con->createQueryTable('results_table', $sql);
+            if ($result->getRowCount() != 0) {
+                throw new RuntimeException("Invalid fixture. Table has rows: " . $tableName->getName());
+            }
+        }
     }
-  }
 
   /**
    * Test Role's discriminator column
@@ -118,37 +137,38 @@ class RolesTest extends PHPUnit_Extensions_Database_TestCase {
    * them all together. Assert that $newRole->getOwnedEntity()
    * returns an instanceof Site.
    */
-  public function testRoleDiscriminatorSite() {
-    print __METHOD__ . "\n";
-    // Create a roletype
-    $rt = TestUtil::createSampleRoleType("ROLENAME");
-    $this->em->persist($rt);
+    public function testRoleDiscriminatorSite()
+    {
+        print __METHOD__ . "\n";
+      // Create a roletype
+        $rt = TestUtil::createSampleRoleType("ROLENAME");
+        $this->em->persist($rt);
 
-    // Create a user
-    $u = TestUtil::createSampleUser("Test", "Testing");
-    $identifier= TestUtil::createSampleUserIdentifier("X.509", "/c=test");
-    $u->addUserIdentifierDoJoin($identifier);
-    $this->em->persist($identifier);
-    $this->em->persist($u);
+      // Create a user
+        $u = TestUtil::createSampleUser("Test", "Testing");
+        $identifier = TestUtil::createSampleUserIdentifier("X.509", "/c=test");
+        $u->addUserIdentifierDoJoin($identifier);
+        $this->em->persist($identifier);
+        $this->em->persist($u);
 
-    // Create a site
-    $s = TestUtil::createSampleSite("SITENAME"/*, "PK01"*/);
-    $this->em->persist($s);
+      // Create a site
+        $s = TestUtil::createSampleSite("SITENAME"/*, "PK01"*/);
+        $this->em->persist($s);
 
-    // Create a role and link to the user, role type and site
-    $r = TestUtil::createSampleRole($u, $rt, $s, RoleStatus::GRANTED);
-    $this->em->persist($r);
+      // Create a role and link to the user, role type and site
+        $r = TestUtil::createSampleRole($u, $rt, $s, RoleStatus::GRANTED);
+        $this->em->persist($r);
 
-    $this->em->flush();
+        $this->em->flush();
 
-    // New reference to the freshly created role entity
-    $dbRole = $this->em->find("Role", $r->getId());
-    if(!$dbRole->getOwnedEntity() instanceof Site) {
-        $this->fail();
+      // New reference to the freshly created role entity
+        $dbRole = $this->em->find("Role", $r->getId());
+        if (!$dbRole->getOwnedEntity() instanceof Site) {
+            $this->fail();
+        }
+      // if we've reached this point without error the test
+      // has passed.
     }
-    // if we've reached this point without error the test
-    // has passed.
-  }
 
   /**
   * Test Role's discriminator column
@@ -156,38 +176,39 @@ class RolesTest extends PHPUnit_Extensions_Database_TestCase {
   * them all together. Assert that $newRole->getOwnedEntity()
   * returns an instance of NGI.
   */
-  public function testRoleDiscriminatorNGI() {
-    print __METHOD__ . "\n";
-    // Create a roletype
-    $rt = TestUtil::createSampleRoleType("Name");
-    $this->em->persist($rt);
+    public function testRoleDiscriminatorNGI()
+    {
+        print __METHOD__ . "\n";
+      // Create a roletype
+        $rt = TestUtil::createSampleRoleType("Name");
+        $this->em->persist($rt);
 
-    // Create a user
-    $u = TestUtil::createSampleUser("Test", "Testing");
-    $identifier= TestUtil::createSampleUserIdentifier("X.509", "/c=test");
-    $u->addUserIdentifierDoJoin($identifier);
-    $this->em->persist($identifier);
-    $this->em->persist($u);
+      // Create a user
+        $u = TestUtil::createSampleUser("Test", "Testing");
+        $identifier = TestUtil::createSampleUserIdentifier("X.509", "/c=test");
+        $u->addUserIdentifierDoJoin($identifier);
+        $this->em->persist($identifier);
+        $this->em->persist($u);
 
-    // Create an NGI
-    $n = TestUtil::createSampleNGI("MYNGI");
-    $this->em->persist($n);
+      // Create an NGI
+        $n = TestUtil::createSampleNGI("MYNGI");
+        $this->em->persist($n);
 
-    // Create a role and link to the user, role type and site
-    $r = TestUtil::createSampleRole($u, $rt, $n, RoleStatus::GRANTED);
+      // Create a role and link to the user, role type and site
+        $r = TestUtil::createSampleRole($u, $rt, $n, RoleStatus::GRANTED);
 
-    $this->em->persist($r);
+        $this->em->persist($r);
 
-    $this->em->flush();
+        $this->em->flush();
 
-    // New reference to the freshly created role entity
-    $dbRole = $this->em->find("Role", $r->getId());
-    if(!$dbRole->getOwnedEntity() instanceof NGI) {
-      $this->fail();
+      // New reference to the freshly created role entity
+        $dbRole = $this->em->find("Role", $r->getId());
+        if (!$dbRole->getOwnedEntity() instanceof NGI) {
+            $this->fail();
+        }
+      // if we've reached this point without error the test
+      // has passed.
     }
-    // if we've reached this point without error the test
-    // has passed.
-  }
 
   /**
    * Test Role's discriminator column
@@ -196,60 +217,61 @@ class RolesTest extends PHPUnit_Extensions_Database_TestCase {
    * returns an instance of NGI.
    * @expectedException \Doctrine\DBAL\DBALException
    */
-  public function testRoleTypeIntegrityConstraint() {
-    print __METHOD__ . "\n";
-    // Create a roletype
-    $rt = TestUtil::createSampleRoleType("NAME");
-    $this->em->persist($rt);
+    public function testRoleTypeIntegrityConstraint()
+    {
+        print __METHOD__ . "\n";
+      // Create a roletype
+        $rt = TestUtil::createSampleRoleType("NAME");
+        $this->em->persist($rt);
 
-    // Create a user
-    $u = TestUtil::createSampleUser("Test", "Testing");
-    $identifier= TestUtil::createSampleUserIdentifier("X.509", "/c=test");
-    $u->addUserIdentifierDoJoin($identifier);
-    $this->em->persist($identifier);
-    $this->em->persist($u);
+      // Create a user
+        $u = TestUtil::createSampleUser("Test", "Testing");
+        $identifier = TestUtil::createSampleUserIdentifier("X.509", "/c=test");
+        $u->addUserIdentifierDoJoin($identifier);
+        $this->em->persist($identifier);
+        $this->em->persist($u);
 
-    // Create an NGI
-    $n = TestUtil::createSampleNGI("MYNGI");
-    $this->em->persist($n);
+      // Create an NGI
+        $n = TestUtil::createSampleNGI("MYNGI");
+        $this->em->persist($n);
 
-    // Create a role and link to the user, role type and ngi
-    $r = TestUtil::createSampleRole($u, $rt, $n, RoleStatus::GRANTED);
-    $this->em->persist($r);
-    $this->em->flush();
+      // Create a role and link to the user, role type and ngi
+        $r = TestUtil::createSampleRole($u, $rt, $n, RoleStatus::GRANTED);
+        $this->em->persist($r);
+        $this->em->flush();
 
-    // try to delete the role type before deleting
-    // the dependant role
-    $this->em->remove($rt);
-    $this->em->flush();
-  }
+      // try to delete the role type before deleting
+      // the dependant role
+        $this->em->remove($rt);
+        $this->em->flush();
+    }
 
   /**
    * Ensure no duplicate role types are inserted
    * @expectedException \Doctrine\DBAL\DBALException
    */
-  public function testDuplicateRoleTypes() {
-    print __METHOD__ . "\n";
-    // Should throw an expected exception because the role type Name value
-    // must be unique
-    $rt1 = TestUtil::createSampleRoleType("RoleName"/*, RoleTypeClass::SITE_USER*/);
-    $rt2 = TestUtil::createSampleRoleType("RoleName"/*, RoleTypeClass::REGIONAL_USER*/);
-    $this->em->persist($rt1);
-    $this->em->persist($rt2);
-    $this->em->flush();
-  }
+    public function testDuplicateRoleTypes()
+    {
+        print __METHOD__ . "\n";
+      // Should throw an expected exception because the role type Name value
+      // must be unique
+        $rt1 = TestUtil::createSampleRoleType("RoleName"/*, RoleTypeClass::SITE_USER*/);
+        $rt2 = TestUtil::createSampleRoleType("RoleName"/*, RoleTypeClass::REGIONAL_USER*/);
+        $this->em->persist($rt1);
+        $this->em->persist($rt2);
+        $this->em->flush();
+    }
 
-  public function testRoleConstants(){
-    print __METHOD__ . "\n";
+    public function testRoleConstants()
+    {
+        print __METHOD__ . "\n";
 
-    $roleNames = RoleTypeName::getAsArray();
-    $this->assertEquals(RoleTypeName::SITE_ADMIN, $roleNames['SITE_ADMIN'] );
-    $this->assertEquals(RoleTypeName::COD_ADMIN, $roleNames['COD_ADMIN'] );
+        $roleNames = RoleTypeName::getAsArray();
+        $this->assertEquals(RoleTypeName::SITE_ADMIN, $roleNames['SITE_ADMIN']);
+        $this->assertEquals(RoleTypeName::COD_ADMIN, $roleNames['COD_ADMIN']);
 
-    $roleStatusVals = RoleStatus::getAsArray();
-    $this->assertEquals(RoleStatus::GRANTED, $roleStatusVals['GRANTED']);
-    $this->assertEquals(RoleStatus::PENDING, $roleStatusVals['PENDING']);
-  }
-
+        $roleStatusVals = RoleStatus::getAsArray();
+        $this->assertEquals(RoleStatus::GRANTED, $roleStatusVals['GRANTED']);
+        $this->assertEquals(RoleStatus::PENDING, $roleStatusVals['PENDING']);
+    }
 }
-?>

--- a/tests/doctrine/Scoped_IPIQuery_Test1.php
+++ b/tests/doctrine/Scoped_IPIQuery_Test1.php
@@ -1,4 +1,5 @@
 <?php
+
 require_once dirname(__FILE__) . '/TestUtil.php';
 use Doctrine\ORM\EntityManager;
 require_once dirname(__FILE__) . '/bootstrap.php';
@@ -18,179 +19,198 @@ require_once dirname(__FILE__) . '/../../lib/Gocdb_Services/PI/QueryBuilders/Ext
 *
 * @author David Meredith
 */
-class Scoped_IPIQuery_Test1 extends PHPUnit_Extensions_Database_TestCase {
-
-  private $em;
+class Scoped_IPIQuery_Test1 extends PHPUnit_Extensions_Database_TestCase
+{
+    private $em;
 
   /**
   * Overridden.
   */
-  public static function setUpBeforeClass() {
-    parent::setUpBeforeClass();
-    echo "\n\n-------------------------------------------------\n";
-    echo "Executing Scoped_IPIQuery_Test1. . .\n";
-  }
+    public static function setUpBeforeClass()
+    {
+        parent::setUpBeforeClass();
+        echo "\n\n-------------------------------------------------\n";
+        echo "Executing Scoped_IPIQuery_Test1. . .\n";
+    }
 
   /**
   * Overridden. Returns the test database connection.
   * @return PHPUnit_Extensions_Database_DB_IDatabaseConnection
   */
-  protected function getConnection() {
-    require_once dirname(__FILE__) . '/bootstrap_pdo.php';
-    return getConnectionToTestDB();
-  }
+    protected function getConnection()
+    {
+        require_once dirname(__FILE__) . '/bootstrap_pdo.php';
+        return getConnectionToTestDB();
+    }
 
   /**
   * Overridden. Returns the test dataset.
   * Defines how the initial state of the database should look before each test is executed.
   * @return PHPUnit_Extensions_Database_DataSet_IDataSet
   */
-  protected function getDataSet() {
-    return $this->createFlatXMLDataSet(dirname(__FILE__) . '/truncateDataTables.xml');
-    // Use below to return an empty data set if we don't want to truncate and seed
-    //return new PHPUnit_Extensions_Database_DataSet_DefaultDataSet();
-  }
+    protected function getDataSet()
+    {
+        return $this->createFlatXMLDataSet(dirname(__FILE__) . '/truncateDataTables.xml');
+      // Use below to return an empty data set if we don't want to truncate and seed
+      //return new PHPUnit_Extensions_Database_DataSet_DefaultDataSet();
+    }
 
   /**
   * Overridden.
   */
-  protected function getSetUpOperation() {
-    // CLEAN_INSERT is default
-    //return PHPUnit_Extensions_Database_Operation_Factory::CLEAN_INSERT();
-    //return PHPUnit_Extensions_Database_Operation_Factory::UPDATE();
-    //return PHPUnit_Extensions_Database_Operation_Factory::NONE();
-    //
-    // Issue a DELETE from <table> which is more portable than a
-    // TRUNCATE table <table> (some DBs require high privileges for truncate statements
-    // and also do not allow truncates across tables with FK contstraints e.g. Oracle)
-    return PHPUnit_Extensions_Database_Operation_Factory::DELETE_ALL();
-  }
+    protected function getSetUpOperation()
+    {
+      // CLEAN_INSERT is default
+      //return PHPUnit_Extensions_Database_Operation_Factory::CLEAN_INSERT();
+      //return PHPUnit_Extensions_Database_Operation_Factory::UPDATE();
+      //return PHPUnit_Extensions_Database_Operation_Factory::NONE();
+      //
+      // Issue a DELETE from <table> which is more portable than a
+      // TRUNCATE table <table> (some DBs require high privileges for truncate statements
+      // and also do not allow truncates across tables with FK contstraints e.g. Oracle)
+        return PHPUnit_Extensions_Database_Operation_Factory::DELETE_ALL();
+    }
 
   /**
   * Overridden.
   */
-  protected function getTearDownOperation() {
-    // NONE is default
-    return PHPUnit_Extensions_Database_Operation_Factory::NONE();
-  }
+    protected function getTearDownOperation()
+    {
+      // NONE is default
+        return PHPUnit_Extensions_Database_Operation_Factory::NONE();
+    }
 
   /**
   * Sets up the fixture, e.g create a new entityManager for each test run
   * This method is called before each test method is executed.
   */
-  protected function setUp() {
-    parent::setUp();
-    $this->em = $this->createEntityManager();
-  }
-
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->em = $this->createEntityManager();
+    }
+  /**
+   * Run after each test function to prevent pile-up of database connections.
+   */
+    protected function tearDown()
+    {
+        parent::tearDown();
+        if (!is_null($this->em)) {
+            $this->em->getConnection()->close();
+        }
+    }
   /**
   * @return EntityManager
   */
-  private function createEntityManager() {
-    require dirname(__FILE__) . '/bootstrap_doctrine.php';
-    return $entityManager;
-  }
+    private function createEntityManager()
+    {
+        require dirname(__FILE__) . '/bootstrap_doctrine.php';
+        return $entityManager;
+    }
 
   /**
   * Called after setUp() and before each test. Used for common assertions
   * across all tests.
   */
-  protected function assertPreConditions() {
-    $con = $this->getConnection();
-    $fixture = dirname(__FILE__) . '/truncateDataTables.xml';
-    $tables = simplexml_load_file($fixture);
+    protected function assertPreConditions()
+    {
+        $con = $this->getConnection();
+        $fixture = dirname(__FILE__) . '/truncateDataTables.xml';
+        $tables = simplexml_load_file($fixture);
 
-    foreach ($tables as $tableName) {
-      //print $tableName->getName() . "\n";
-      $sql = "SELECT * FROM " . $tableName->getName();
-      $result = $con->createQueryTable('results_table', $sql);
-      //echo 'row count: '.$result->getRowCount() ;
-      if ($result->getRowCount() != 0) {
-        throw new RuntimeException("Invalid fixture. Table has rows: " . $tableName->getName());
-      }
+        foreach ($tables as $tableName) {
+          //print $tableName->getName() . "\n";
+            $sql = "SELECT * FROM " . $tableName->getName();
+            $result = $con->createQueryTable('results_table', $sql);
+          //echo 'row count: '.$result->getRowCount() ;
+            if ($result->getRowCount() != 0) {
+                throw new RuntimeException("Invalid fixture. Table has rows: " . $tableName->getName());
+            }
+        }
     }
-  }
 
   /**
   * See class doc.
   */
-  public function testGet_Scoped_IPIQuery() {
-    print __METHOD__ . "\n";
-    include __DIR__ . '/resources/sampleFixtureData2.php';
+    public function testGet_Scoped_IPIQuery()
+    {
+        print __METHOD__ . "\n";
+        include __DIR__ . '/resources/sampleFixtureData2.php';
 
-    // Initialise the factory config service.
-    \Factory::getConfigService()->setLocalInfoFileLocation(__DIR__ . '/resources/sample_local_info2.xml');
-
-
-    $query = new \org\gocdb\services\GetNGI($this->em);
-    $this->doScopedQueryCalls($query);
-
-    $query = new \org\gocdb\services\GetSite($this->em);
-    $this->doScopedQueryCalls($query);
-
-    $query = new \org\gocdb\services\GetService($this->em);
-    $this->doScopedQueryCalls($query);
-
-    $query = new \org\gocdb\services\GetServiceGroup($this->em);
-    $this->doScopedQueryCalls($query);
-
-    //$query = new \org\gocdb\services\GetDowntime($this->em);
-    //$this->doScopedQueryCalls($query);
-  }
+      // Initialise the factory config service.
+        \Factory::getConfigService()->setLocalInfoFileLocation(__DIR__ . '/resources/sample_local_info2.xml');
 
 
-  private function doScopedQueryCalls(\org\gocdb\services\IPIQuery $query) {
+        $query = new \org\gocdb\services\GetNGI($this->em);
+        $this->doScopedQueryCalls($query);
 
-    // empty scope string is a wildcard for 'any' value (i.e. scope can be any value)
-    $this->queryForIScopedEntity($query, array('scope' => '', 'scope_match' => 'all'), 5);
-    $this->queryForIScopedEntity($query, array('scope' => '', 'scope_match' => 'any'), 5);
-    try {
-      $this->queryForIScopedEntity($query, null, 5);
-      $this->fail("Expected and InvalidArgumentException");
-    } catch(InvalidArgumentException $ex){
-      // ok, we expected this so continue on below
+        $query = new \org\gocdb\services\GetSite($this->em);
+        $this->doScopedQueryCalls($query);
+
+        $query = new \org\gocdb\services\GetService($this->em);
+        $this->doScopedQueryCalls($query);
+
+        $query = new \org\gocdb\services\GetServiceGroup($this->em);
+        $this->doScopedQueryCalls($query);
+
+      //$query = new \org\gocdb\services\GetDowntime($this->em);
+      //$this->doScopedQueryCalls($query);
     }
-    // TODO - All Tests below involve missing/empty/null 'scope' and 'scope_match'
-    // values. This causes the IPIQuery object to invoke the Factory::getConfigService()
-    // to get the default 'scope' and 'scope_match' values.
-    // If we were being strict OO practitioners, then the IPIQuery
-    // objects shouldn't really depend on the Factory or ConfigService.
-    // Instead, these defaults could be injected from calling/client code
-    // (with an additional a hardwired fallback of 'scope_match = all' and
-    // 'no' default scope defined within the IPIQuery).
-    //
-    // 5 queries below use the default scope and default scope_match values
-    $this->queryForIScopedEntity($query, array('scope_match' => 'all'), 0); // no scope (uses default)
-    $this->queryForIScopedEntity($query, array('scope_match' => ''), 0); // no scope and empty scope_match
-    $this->queryForIScopedEntity($query, array(), 0); // no scope, no scope_match (uses defaults)
-    $this->queryForIScopedEntity($query, array('scope' => null, 'scope_match' => 'any'), 0); // no scope (uses default)
-    $this->queryForIScopedEntity($query, array('scope' => null, 'scope_match' => 'all'), 0);// no scope (uses default)
-
-    // Test with scope_match = all
-    $this->queryForIScopedEntity($query, array('scope' => 'Scope0', 'scope_match' => 'all'), 4);
-    $this->queryForIScopedEntity($query, array('scope' => 'Scope0,Scope1', 'scope_match' => 'all'), 3);
-    $this->queryForIScopedEntity($query, array('scope' => 'Scope2', 'scope_match' => 'all'), 2);
-    $this->queryForIScopedEntity($query, array('scope' => 'Scope3,Scope4,Scope5', 'scope_match' => 'all'), 1);
-    $this->queryForIScopedEntity($query, array('scope' => 'Scope0,Scope1,ScopeX', 'scope_match' => 'all'), 0);
-    // Test with scope_match = any
-    $this->queryForIScopedEntity($query, array('scope' => 'Scope0', 'scope_match' => 'any'), 4);
-    $this->queryForIScopedEntity($query, array('scope' => 'Scope1', 'scope_match' => 'any'), 3);
-    $this->queryForIScopedEntity($query, array('scope' => 'ScopeX0,ScopeX1,ScopeX1', 'scope_match' => 'any'), 0);
 
 
-    $this->queryForIScopedEntity($query, array('scope' => 'Scope0,Scope1,ScopeX', 'scope_match' => 'any'), 4);
-    $this->queryForIScopedEntity($query, array('scope' => 'Scope1,ScopeX,ScopeXX', 'scope_match' => 'any'), 3);
-    $this->queryForIScopedEntity($query, array('scope' => 'Scope1,Scope2', 'scope_match' => 'any'), 3);
-    $this->queryForIScopedEntity($query, array('scope' => 'Scope2,Scope3,Scope4', 'scope_match' => 'any'), 2);
-    $this->queryForIScopedEntity($query, array('scope' => 'Scope5,ScopeX,ScopeXX', 'scope_match' => 'any'), 1);
-  }
+    private function doScopedQueryCalls(\org\gocdb\services\IPIQuery $query)
+    {
 
-  private function queryForIScopedEntity(\org\gocdb\services\IPIQuery $query, $params, $expectedCount) {
-    $query->validateParameters($params);
-    $query->createQuery();
-    $results = $query->executeQuery();
-    $this->assertTrue($expectedCount == count($results));
-    return $results;
-  }
+      // empty scope string is a wildcard for 'any' value (i.e. scope can be any value)
+        $this->queryForIScopedEntity($query, array('scope' => '', 'scope_match' => 'all'), 5);
+        $this->queryForIScopedEntity($query, array('scope' => '', 'scope_match' => 'any'), 5);
+        try {
+            $this->queryForIScopedEntity($query, null, 5);
+            $this->fail("Expected and InvalidArgumentException");
+        } catch (InvalidArgumentException $ex) {
+          // ok, we expected this so continue on below
+        }
+      // TODO - All Tests below involve missing/empty/null 'scope' and 'scope_match'
+      // values. This causes the IPIQuery object to invoke the Factory::getConfigService()
+      // to get the default 'scope' and 'scope_match' values.
+      // If we were being strict OO practitioners, then the IPIQuery
+      // objects shouldn't really depend on the Factory or ConfigService.
+      // Instead, these defaults could be injected from calling/client code
+      // (with an additional a hardwired fallback of 'scope_match = all' and
+      // 'no' default scope defined within the IPIQuery).
+      //
+      // 5 queries below use the default scope and default scope_match values
+        $this->queryForIScopedEntity($query, array('scope_match' => 'all'), 0); // no scope (uses default)
+        $this->queryForIScopedEntity($query, array('scope_match' => ''), 0); // no scope and empty scope_match
+        $this->queryForIScopedEntity($query, array(), 0); // no scope, no scope_match (uses defaults)
+        $this->queryForIScopedEntity($query, array('scope' => null, 'scope_match' => 'any'), 0); // no scope (uses default)
+        $this->queryForIScopedEntity($query, array('scope' => null, 'scope_match' => 'all'), 0);// no scope (uses default)
+
+      // Test with scope_match = all
+        $this->queryForIScopedEntity($query, array('scope' => 'Scope0', 'scope_match' => 'all'), 4);
+        $this->queryForIScopedEntity($query, array('scope' => 'Scope0,Scope1', 'scope_match' => 'all'), 3);
+        $this->queryForIScopedEntity($query, array('scope' => 'Scope2', 'scope_match' => 'all'), 2);
+        $this->queryForIScopedEntity($query, array('scope' => 'Scope3,Scope4,Scope5', 'scope_match' => 'all'), 1);
+        $this->queryForIScopedEntity($query, array('scope' => 'Scope0,Scope1,ScopeX', 'scope_match' => 'all'), 0);
+      // Test with scope_match = any
+        $this->queryForIScopedEntity($query, array('scope' => 'Scope0', 'scope_match' => 'any'), 4);
+        $this->queryForIScopedEntity($query, array('scope' => 'Scope1', 'scope_match' => 'any'), 3);
+        $this->queryForIScopedEntity($query, array('scope' => 'ScopeX0,ScopeX1,ScopeX1', 'scope_match' => 'any'), 0);
+
+
+        $this->queryForIScopedEntity($query, array('scope' => 'Scope0,Scope1,ScopeX', 'scope_match' => 'any'), 4);
+        $this->queryForIScopedEntity($query, array('scope' => 'Scope1,ScopeX,ScopeXX', 'scope_match' => 'any'), 3);
+        $this->queryForIScopedEntity($query, array('scope' => 'Scope1,Scope2', 'scope_match' => 'any'), 3);
+        $this->queryForIScopedEntity($query, array('scope' => 'Scope2,Scope3,Scope4', 'scope_match' => 'any'), 2);
+        $this->queryForIScopedEntity($query, array('scope' => 'Scope5,ScopeX,ScopeXX', 'scope_match' => 'any'), 1);
+    }
+
+    private function queryForIScopedEntity(\org\gocdb\services\IPIQuery $query, $params, $expectedCount)
+    {
+        $query->validateParameters($params);
+        $query->createQuery();
+        $results = $query->executeQuery();
+        $this->assertTrue($expectedCount == count($results));
+        return $results;
+    }
 }
-?>

--- a/tests/doctrine/ServiceDAOTest.php
+++ b/tests/doctrine/ServiceDAOTest.php
@@ -1,4 +1,5 @@
 <?php
+
 require_once dirname(__FILE__) . '/TestUtil.php';
 use Doctrine\ORM\EntityManager;
 require_once dirname(__FILE__) . '/bootstrap.php';
@@ -13,99 +14,117 @@ require_once dirname(__FILE__) . '/../../lib/DAOs/ServiceDAO.php';
  *
  * @author David Meredith
  */
-class ServiceDAOTest extends PHPUnit_Extensions_Database_TestCase {
-  private $em;
+class ServiceDAOTest extends PHPUnit_Extensions_Database_TestCase
+{
+    private $em;
 
   /**
   * Overridden.
   */
-  public static function setUpBeforeClass() {
-    parent::setUpBeforeClass();
-    echo "\n\n-------------------------------------------------\n";
-    echo "Executing ServiceDAOTest. . .\n";
-  }
+    public static function setUpBeforeClass()
+    {
+        parent::setUpBeforeClass();
+        echo "\n\n-------------------------------------------------\n";
+        echo "Executing ServiceDAOTest. . .\n";
+    }
 
   /**
   * Overridden. Returns the test database connection.
   * @return PHPUnit_Extensions_Database_DB_IDatabaseConnection
   */
-  protected function getConnection() {
-    require_once dirname(__FILE__) . '/bootstrap_pdo.php';
-    return getConnectionToTestDB();
-  }
+    protected function getConnection()
+    {
+        require_once dirname(__FILE__) . '/bootstrap_pdo.php';
+        return getConnectionToTestDB();
+    }
 
   /**
   * Overridden. Returns the test dataset.
   * Defines how the initial state of the database should look before each test is executed.
   * @return PHPUnit_Extensions_Database_DataSet_IDataSet
   */
-  protected function getDataSet() {
-    return $this->createFlatXMLDataSet(dirname(__FILE__) . '/truncateDataTables.xml');
-    // Use below to return an empty data set if we don't want to truncate and seed
-    //return new PHPUnit_Extensions_Database_DataSet_DefaultDataSet();
-  }
+    protected function getDataSet()
+    {
+        return $this->createFlatXMLDataSet(dirname(__FILE__) . '/truncateDataTables.xml');
+      // Use below to return an empty data set if we don't want to truncate and seed
+      //return new PHPUnit_Extensions_Database_DataSet_DefaultDataSet();
+    }
 
   /**
   * Overridden.
   */
-  protected function getSetUpOperation() {
-    // CLEAN_INSERT is default
-    //return PHPUnit_Extensions_Database_Operation_Factory::CLEAN_INSERT();
-    //return PHPUnit_Extensions_Database_Operation_Factory::UPDATE();
-    //return PHPUnit_Extensions_Database_Operation_Factory::NONE();
-    //
-    // Issue a DELETE from <table> which is more portable than a
-    // TRUNCATE table <table> (some DBs require high privileges for truncate statements
-    // and also do not allow truncates across tables with FK contstraints e.g. Oracle)
-    return PHPUnit_Extensions_Database_Operation_Factory::DELETE_ALL();
-  }
+    protected function getSetUpOperation()
+    {
+      // CLEAN_INSERT is default
+      //return PHPUnit_Extensions_Database_Operation_Factory::CLEAN_INSERT();
+      //return PHPUnit_Extensions_Database_Operation_Factory::UPDATE();
+      //return PHPUnit_Extensions_Database_Operation_Factory::NONE();
+      //
+      // Issue a DELETE from <table> which is more portable than a
+      // TRUNCATE table <table> (some DBs require high privileges for truncate statements
+      // and also do not allow truncates across tables with FK contstraints e.g. Oracle)
+        return PHPUnit_Extensions_Database_Operation_Factory::DELETE_ALL();
+    }
 
   /**
   * Overridden.
   */
-  protected function getTearDownOperation() {
-    // NONE is default
-    return PHPUnit_Extensions_Database_Operation_Factory::NONE();
-  }
+    protected function getTearDownOperation()
+    {
+      // NONE is default
+        return PHPUnit_Extensions_Database_Operation_Factory::NONE();
+    }
 
   /**
   * Sets up the fixture, e.g create a new entityManager for each test run
   * This method is called before each test method is executed.
   */
-  protected function setUp() {
-    parent::setUp();
-    $this->em = $this->createEntityManager();
-  }
-
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->em = $this->createEntityManager();
+    }
+  /**
+   * Run after each test function to prevent pile-up of database connections.
+   */
+    protected function tearDown()
+    {
+        parent::tearDown();
+        if (!is_null($this->em)) {
+            $this->em->getConnection()->close();
+        }
+    }
   /**
   * @todo Still need to setup connection to different databases.
   * @return EntityManager
   */
-  private function createEntityManager() {
-    //require dirname(__FILE__).'/../lib/Doctrine/bootstrap.php';
-    require dirname(__FILE__) . '/bootstrap_doctrine.php';
-    return $entityManager;
-  }
+    private function createEntityManager()
+    {
+      //require dirname(__FILE__).'/../lib/Doctrine/bootstrap.php';
+        require dirname(__FILE__) . '/bootstrap_doctrine.php';
+        return $entityManager;
+    }
 
   /**
   * Called after setUp() and before each test. Used for common assertions
   * across all tests.
   */
-  protected function assertPreConditions() {
-    $con = $this->getConnection();
-    $fixture = dirname(__FILE__) . '/truncateDataTables.xml';
-    $tables = simplexml_load_file($fixture);
+    protected function assertPreConditions()
+    {
+        $con = $this->getConnection();
+        $fixture = dirname(__FILE__) . '/truncateDataTables.xml';
+        $tables = simplexml_load_file($fixture);
 
-    foreach ($tables as $tableName) {
-      //print $tableName->getName() . "\n";
-      $sql = "SELECT * FROM " . $tableName->getName();
-      $result = $con->createQueryTable('results_table', $sql);
-      //echo 'row count: '.$result->getRowCount() ;
-      if ($result->getRowCount() != 0){
-        throw new RuntimeException("Invalid fixture. Table has rows: " . $tableName->getName());
-      }
+        foreach ($tables as $tableName) {
+          //print $tableName->getName() . "\n";
+            $sql = "SELECT * FROM " . $tableName->getName();
+            $result = $con->createQueryTable('results_table', $sql);
+          //echo 'row count: '.$result->getRowCount() ;
+            if ($result->getRowCount() != 0) {
+                throw new RuntimeException("Invalid fixture. Table has rows: " . $tableName->getName());
+            }
+        }
     }
-  }
 
   /**
   * Test the ServiceDAO->removeService();
@@ -118,48 +137,48 @@ class ServiceDAOTest extends PHPUnit_Extensions_Database_TestCase {
   * want to delete those DTs that exclusively link to one EL only and which
   * would subsequently be orphaned). We do this managed deletion of DTs in ServiceDAO->removeService();
   */
-  public function testServiceDAO_removeService() {
-    print __METHOD__ . "\n";
-    include __DIR__ . '/resources/sampleFixtureData1.php';
+    public function testServiceDAO_removeService()
+    {
+        print __METHOD__ . "\n";
+        include __DIR__ . '/resources/sampleFixtureData1.php';
 
-    // Impt: When deleting a service, we can't rely solely on the
-    // 'onDelete=cascade' defined on the 'EndpointLocation->service'
-    // to correctly cascade-delete the EL. This is because downtimes can also be linked
-    // to the EL.  Therefore, if we don't invoke an $em->remove() on the EL
-    // (either via cascade="remove" or manually invoking em->remove() on each EL),
-    // Doctrine will not have flagged the EL as removed and so will not automatically delete the
-    // relevant row(s) in 'DOWNTIMES_ENDPOINTLOCATIONS' join table.
-    // This would cause a FK integrity/violation constraint exception
-    // on the 'DOWNTIMES_ENDPOINTLOCATIONS.ENDPOINTLOCATION_ID' FK column.
-    // This is why we need to do a managed delete using the ServiceDAO
-    $serviceDao = new ServiceDAO();
-    $serviceDao->setEntityManager($this->em);
-    $serviceDao->removeService($service1);
-    $this->em->flush();
+      // Impt: When deleting a service, we can't rely solely on the
+      // 'onDelete=cascade' defined on the 'EndpointLocation->service'
+      // to correctly cascade-delete the EL. This is because downtimes can also be linked
+      // to the EL.  Therefore, if we don't invoke an $em->remove() on the EL
+      // (either via cascade="remove" or manually invoking em->remove() on each EL),
+      // Doctrine will not have flagged the EL as removed and so will not automatically delete the
+      // relevant row(s) in 'DOWNTIMES_ENDPOINTLOCATIONS' join table.
+      // This would cause a FK integrity/violation constraint exception
+      // on the 'DOWNTIMES_ENDPOINTLOCATIONS.ENDPOINTLOCATION_ID' FK column.
+      // This is why we need to do a managed delete using the ServiceDAO
+        $serviceDao = new ServiceDAO();
+        $serviceDao->setEntityManager($this->em);
+        $serviceDao->removeService($service1);
+        $this->em->flush();
 
-    // use DB connection to check data has been deleted
-    $con = $this->getConnection();
-    $result = $con->createQueryTable('results_table', "SELECT * FROM EndpointLocations");
-    $this->assertTrue($result->getRowCount() == 0);
-    $result = $con->createQueryTable('results_table', "SELECT * FROM Downtimes");
-    $this->assertTrue($result->getRowCount() == 0);
-  }
+      // use DB connection to check data has been deleted
+        $con = $this->getConnection();
+        $result = $con->createQueryTable('results_table', "SELECT * FROM EndpointLocations");
+        $this->assertTrue($result->getRowCount() == 0);
+        $result = $con->createQueryTable('results_table', "SELECT * FROM Downtimes");
+        $this->assertTrue($result->getRowCount() == 0);
+    }
 
-  public function testNgiService_removeNgi() {
-    print __METHOD__ . "\n";
-    include __DIR__ . '/resources/sampleFixtureData1.php';
+    public function testNgiService_removeNgi()
+    {
+        print __METHOD__ . "\n";
+        include __DIR__ . '/resources/sampleFixtureData1.php';
 
-    $adminUser = TestUtil::createSampleUser('some', 'admin');
-    $identifier= TestUtil::createSampleUserIdentifier('X.509', '/some/admin');
-    $adminUser->addUserIdentifierDoJoin($identifier);
-    $this->em->persist($identifier);
-    $adminUser->setAdmin(TRUE);
-    $this->em->persist($adminUser);
+        $adminUser = TestUtil::createSampleUser('some', 'admin');
+        $identifier = TestUtil::createSampleUserIdentifier('X.509', '/some/admin');
+        $adminUser->addUserIdentifierDoJoin($identifier);
+        $this->em->persist($identifier);
+        $adminUser->setAdmin(true);
+        $this->em->persist($adminUser);
 
-    $ngiService = new org\gocdb\services\NGI();
-    $ngiService->setEntityManager($this->em);
-    $ngiService->deleteNgi($ngi, $adminUser, FALSE);
-  }
+        $ngiService = new org\gocdb\services\NGI();
+        $ngiService->setEntityManager($this->em);
+        $ngiService->deleteNgi($ngi, $adminUser, false);
+    }
 }
-
-?>

--- a/tests/doctrine/ServiceMoveTest.php
+++ b/tests/doctrine/ServiceMoveTest.php
@@ -1,9 +1,10 @@
 <?php
+
 require_once dirname(__FILE__) . '/TestUtil.php';
 use Doctrine\ORM\EntityManager;
 require_once dirname(__FILE__) . '/bootstrap.php';
-require_once dirname(__FILE__). '/../../lib/Gocdb_Services/Site.php';
-require_once dirname(__FILE__). '/../../lib/Gocdb_Services/ServiceService.php';
+require_once dirname(__FILE__) . '/../../lib/Gocdb_Services/Site.php';
+require_once dirname(__FILE__) . '/../../lib/Gocdb_Services/ServiceService.php';
 
 /**
 *
@@ -13,100 +14,118 @@ require_once dirname(__FILE__). '/../../lib/Gocdb_Services/ServiceService.php';
 * @author David Meredith
 * @author John Casson
 */
-class ServiceMoveTest extends PHPUnit_Extensions_Database_TestCase {
-  private $em;
-  private $egiScope;
-  private $localScope;
-  private $eudatScope;
+class ServiceMoveTest extends PHPUnit_Extensions_Database_TestCase
+{
+    private $em;
+    private $egiScope;
+    private $localScope;
+    private $eudatScope;
 
 
   /**
   * Overridden.
   */
-  public static function setUpBeforeClass() {
-    parent::setUpBeforeClass();
-    echo "\n\n-------------------------------------------------\n";
-    echo "Executing ServiceMoveTest. . .\n";
-  }
+    public static function setUpBeforeClass()
+    {
+        parent::setUpBeforeClass();
+        echo "\n\n-------------------------------------------------\n";
+        echo "Executing ServiceMoveTest. . .\n";
+    }
 
   /**
   * Overridden. Returns the test database connection.
   * @return PHPUnit_Extensions_Database_DB_IDatabaseConnection
   */
-  protected function getConnection() {
-    require_once dirname(__FILE__) . '/bootstrap_pdo.php';
-    return getConnectionToTestDB();
-  }
+    protected function getConnection()
+    {
+        require_once dirname(__FILE__) . '/bootstrap_pdo.php';
+        return getConnectionToTestDB();
+    }
 
   /**
   * Overridden. Returns the test dataset.
   * Defines how the initial state of the database should look before each test is executed.
   * @return PHPUnit_Extensions_Database_DataSet_IDataSet
   */
-  protected function getDataSet() {
-    return $this->createFlatXMLDataSet(dirname(__FILE__) . '/truncateDataTables.xml');
-    // Use below to return an empty data set if we don't want to truncate and seed
-    //return new PHPUnit_Extensions_Database_DataSet_DefaultDataSet();
-  }
+    protected function getDataSet()
+    {
+        return $this->createFlatXMLDataSet(dirname(__FILE__) . '/truncateDataTables.xml');
+      // Use below to return an empty data set if we don't want to truncate and seed
+      //return new PHPUnit_Extensions_Database_DataSet_DefaultDataSet();
+    }
 
   /**
   * Overridden.
   */
-  protected function getSetUpOperation() {
-    // CLEAN_INSERT is default
-    //return PHPUnit_Extensions_Database_Operation_Factory::CLEAN_INSERT();
-    //return PHPUnit_Extensions_Database_Operation_Factory::UPDATE();
-    //return PHPUnit_Extensions_Database_Operation_Factory::NONE();
-    //
-    // Issue a DELETE from <table> which is more portable than a
-    // TRUNCATE table <table> (some DBs require high privileges for truncate statements
-    // and also do not allow truncates across tables with FK contstraints e.g. Oracle)
-    return PHPUnit_Extensions_Database_Operation_Factory::DELETE_ALL();
-  }
+    protected function getSetUpOperation()
+    {
+      // CLEAN_INSERT is default
+      //return PHPUnit_Extensions_Database_Operation_Factory::CLEAN_INSERT();
+      //return PHPUnit_Extensions_Database_Operation_Factory::UPDATE();
+      //return PHPUnit_Extensions_Database_Operation_Factory::NONE();
+      //
+      // Issue a DELETE from <table> which is more portable than a
+      // TRUNCATE table <table> (some DBs require high privileges for truncate statements
+      // and also do not allow truncates across tables with FK contstraints e.g. Oracle)
+        return PHPUnit_Extensions_Database_Operation_Factory::DELETE_ALL();
+    }
 
   /**
   * Overridden.
   */
-  protected function getTearDownOperation() {
-    // NONE is default
-    return PHPUnit_Extensions_Database_Operation_Factory::NONE();
-  }
+    protected function getTearDownOperation()
+    {
+      // NONE is default
+        return PHPUnit_Extensions_Database_Operation_Factory::NONE();
+    }
 
   /**
   * Sets up the fixture, e.g create a new entityManager for each test run
   * This method is called before each test method is executed.
   */
-  protected function setUp() {
-    parent::setUp();
-    $this->em = $this->createEntityManager();
-  }
-
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->em = $this->createEntityManager();
+    }
+  /**
+   * Run after each test function to prevent pile-up of database connections.
+   */
+    protected function tearDown()
+    {
+        parent::tearDown();
+        if (!is_null($this->em)) {
+            $this->em->getConnection()->close();
+        }
+    }
   /**
   * @todo Still need to setup connection to different databases.
   * @return EntityManager
   */
-  private function createEntityManager(){
-    require dirname(__FILE__).'/bootstrap_doctrine.php';
-    return $entityManager;
-  }
+    private function createEntityManager()
+    {
+        require dirname(__FILE__) . '/bootstrap_doctrine.php';
+        return $entityManager;
+    }
 
   /**
   * Called after setUp() and before each test. Used for common assertions
   * across all tests.
   */
-  protected function assertPreConditions() {
-    $con = $this->getConnection();
-    $fixture = dirname(__FILE__) . '/truncateDataTables.xml';
-    $tables = simplexml_load_file($fixture);
+    protected function assertPreConditions()
+    {
+        $con = $this->getConnection();
+        $fixture = dirname(__FILE__) . '/truncateDataTables.xml';
+        $tables = simplexml_load_file($fixture);
 
-    foreach($tables as $tableName) {
-      $sql = "SELECT * FROM ".$tableName->getName();
-      $result = $con->createQueryTable('results_table', $sql);
-      if($result->getRowCount() != 0) {
-        throw new RuntimeException("Invalid fixture. Table has rows: ".$tableName->getName());
-      }
+        foreach ($tables as $tableName) {
+            $sql = "SELECT * FROM " . $tableName->getName();
+            $result = $con->createQueryTable('results_table', $sql);
+            if ($result->getRowCount() != 0) {
+                throw new RuntimeException("Invalid fixture. Table has rows: " . $tableName->getName());
+            }
+        }
     }
-  }
 
   /*
   * Inserts Two NGIs, three sites, and a service endpoint.
@@ -114,138 +133,137 @@ class ServiceMoveTest extends PHPUnit_Extensions_Database_TestCase {
   *  Moves two of the sites between NGIs.
   *  Checks the sites are under the right NGIs.
   */
-  public function testServiceMoves() {
-    print __METHOD__ . "\n";
+    public function testServiceMoves()
+    {
+        print __METHOD__ . "\n";
 
-    //Insert initial data
-    $S1 = TestUtil::createSamplesite("Site1");
-    $S2 = TestUtil::createSamplesite("Site2");
-    $SE1 = TestUtil::createSampleService("SEP1");
-    $SE2 = TestUtil::createSampleService("SEP2");
-    $SE3 = TestUtil::createSampleService("SEP3");
-    $dummy_user = TestUtil::createSampleUser('Test', 'User');
-    $identifier= TestUtil::createSampleUserIdentifier('X.509', '/Some/string');
-    $dummy_user->addUserIdentifierDoJoin($identifier);
-    $this->em->persist($identifier);
+      //Insert initial data
+        $S1 = TestUtil::createSamplesite("Site1");
+        $S2 = TestUtil::createSamplesite("Site2");
+        $SE1 = TestUtil::createSampleService("SEP1");
+        $SE2 = TestUtil::createSampleService("SEP2");
+        $SE3 = TestUtil::createSampleService("SEP3");
+        $dummy_user = TestUtil::createSampleUser('Test', 'User');
+        $identifier = TestUtil::createSampleUserIdentifier('X.509', '/Some/string');
+        $dummy_user->addUserIdentifierDoJoin($identifier);
+        $this->em->persist($identifier);
 
-    //Make dummy user a GOCDB admin so it can perfirm site moves etc.
-    $dummy_user->setAdmin(true);
+      //Make dummy user a GOCDB admin so it can perfirm site moves etc.
+        $dummy_user->setAdmin(true);
 
-    // Assign the service end points to the sites
-    $S1->addServiceDoJoin($SE1);
-    $S2->addServiceDoJoin($SE2);
-    $S2->addServiceDoJoin($SE3);
+      // Assign the service end points to the sites
+        $S1->addServiceDoJoin($SE1);
+        $S2->addServiceDoJoin($SE2);
+        $S2->addServiceDoJoin($SE3);
 
-    //Persist initial data
-    $this->em->persist($S1);
-    $this->em->persist($S2);
-    $this->em->persist($SE1);
-    $this->em->persist($SE2);
-    $this->em->persist($SE3);
-    $this->em->persist($dummy_user);
-    $this->em->flush();
+      //Persist initial data
+        $this->em->persist($S1);
+        $this->em->persist($S2);
+        $this->em->persist($SE1);
+        $this->em->persist($SE2);
+        $this->em->persist($SE3);
+        $this->em->persist($dummy_user);
+        $this->em->flush();
 
-    //Use DB connection to check data
-    $con = $this->getConnection();
+      //Use DB connection to check data
+        $con = $this->getConnection();
 
-    /*
-    * Check both that each Site is present and that the ID matches the doctrine one
-    */
-    $S1_ID = $S1->getId();
-    $sql = "SELECT 1 FROM Sites WHERE shortname = 'Site1' AND ID = '$S1_ID'";
-    $result = $con->createQueryTable('', $sql);
-    $this->assertEquals(1, $result->getRowCount());
+      /*
+      * Check both that each Site is present and that the ID matches the doctrine one
+      */
+        $S1_ID = $S1->getId();
+        $sql = "SELECT 1 FROM Sites WHERE shortname = 'Site1' AND ID = '$S1_ID'";
+        $result = $con->createQueryTable('', $sql);
+        $this->assertEquals(1, $result->getRowCount());
 
-    $S2_ID = $S2->getId();
-    $sql = "SELECT 1 FROM Sites WHERE shortname = 'Site2' AND ID = '$S2_ID'";
-    $result = $con->createQueryTable('', $sql);
-    $this->assertEquals(1, $result->getRowCount());
+        $S2_ID = $S2->getId();
+        $sql = "SELECT 1 FROM Sites WHERE shortname = 'Site2' AND ID = '$S2_ID'";
+        $result = $con->createQueryTable('', $sql);
+        $this->assertEquals(1, $result->getRowCount());
 
-    /*
-    * Check each service endpoint is: present, has the right ID & parent Site
-    */
-    $SE1_id= $SE1->getId();
-    $sql = "SELECT 1 FROM Services WHERE hostname = 'SEP1' AND ID = '$SE1_id' AND PARENTSITE_ID = '$S1_ID'";
-    $result = $con->createQueryTable('', $sql);
-    $this->assertEquals(1, $result->getRowCount());
+      /*
+      * Check each service endpoint is: present, has the right ID & parent Site
+      */
+        $SE1_id = $SE1->getId();
+        $sql = "SELECT 1 FROM Services WHERE hostname = 'SEP1' AND ID = '$SE1_id' AND PARENTSITE_ID = '$S1_ID'";
+        $result = $con->createQueryTable('', $sql);
+        $this->assertEquals(1, $result->getRowCount());
 
-    $SE2_id= $SE2->getId();
-    $sql = "SELECT 1 FROM Services WHERE hostname = 'SEP2' AND ID = '$SE2_id' AND PARENTSITE_ID = '$S2_ID'";
-    $result = $con->createQueryTable('', $sql);
-    $this->assertEquals(1, $result->getRowCount());
+        $SE2_id = $SE2->getId();
+        $sql = "SELECT 1 FROM Services WHERE hostname = 'SEP2' AND ID = '$SE2_id' AND PARENTSITE_ID = '$S2_ID'";
+        $result = $con->createQueryTable('', $sql);
+        $this->assertEquals(1, $result->getRowCount());
 
-    $SE3_id= $SE3->getId();
-    $sql = "SELECT 1 FROM Services WHERE hostname = 'SEP3' AND ID = '$SE3_id' AND PARENTSITE_ID = '$S2_ID'";
-    $result = $con->createQueryTable('', $sql);
-    $this->assertEquals(1, $result->getRowCount());
+        $SE3_id = $SE3->getId();
+        $sql = "SELECT 1 FROM Services WHERE hostname = 'SEP3' AND ID = '$SE3_id' AND PARENTSITE_ID = '$S2_ID'";
+        $result = $con->createQueryTable('', $sql);
+        $this->assertEquals(1, $result->getRowCount());
 
-    //Move service endpoints
-    $serv = new org\gocdb\services\ServiceService;
-    $serv->setEntityManager($this->em);
-    $serv->moveService($SE1, $S2, $dummy_user);
-    $serv->moveService($SE2, $S1, $dummy_user);
-    $serv->moveService($SE3, $S2, $dummy_user); //No change
+      //Move service endpoints
+        $serv = new org\gocdb\services\ServiceService();
+        $serv->setEntityManager($this->em);
+        $serv->moveService($SE1, $S2, $dummy_user);
+        $serv->moveService($SE2, $S1, $dummy_user);
+        $serv->moveService($SE3, $S2, $dummy_user); //No change
 
-    //flush movement
-    $this->em->flush();
+      //flush movement
+        $this->em->flush();
 
-    //Use doctrine to check movement
-    //Check correct Site for each service endpoint
-    $this->assertEquals($S2, $SE1->getParentSite());
-    $this->assertEquals($S1, $SE2->getParentSite());
-    $this->assertEquals($S2, $SE3->getParentSite());
+      //Use doctrine to check movement
+      //Check correct Site for each service endpoint
+        $this->assertEquals($S2, $SE1->getParentSite());
+        $this->assertEquals($S1, $SE2->getParentSite());
+        $this->assertEquals($S2, $SE3->getParentSite());
 
-    //Check correct service endpoints for each Site
-    //Site1
-    $SiteSEPs = $S1->getServices();
-    foreach ($SiteSEPs as $SEP){
-      $this->assertEquals($SE2, $SEP);
+      //Check correct service endpoints for each Site
+      //Site1
+        $SiteSEPs = $S1->getServices();
+        foreach ($SiteSEPs as $SEP) {
+            $this->assertEquals($SE2, $SEP);
+        }
+      //Site2
+        $SiteSEPs = $S2->getServices();
+        foreach ($SiteSEPs as $SEP) {
+            $this->assertTrue(($SEP == $SE1) or ($SEP == $SE3));
+        }
+
+      //Use database connection to check movememrnt
+        $con = $this->getConnection();
+
+      //Check Sites are still present and their ID is unchanged
+        $sql = "SELECT 1 FROM Sites WHERE shortname = 'Site1' AND ID = '$S1_ID'";
+        $result = $con->createQueryTable('', $sql);
+        $this->assertEquals(1, $result->getRowCount());
+
+        $sql = "SELECT 1 FROM Sites WHERE shortname = 'Site2' AND ID = '$S2_ID'";
+        $result = $con->createQueryTable('', $sql);
+        $this->assertEquals(1, $result->getRowCount());
+
+      //Check each Site has the correct number of service endpoints
+      //Site 1
+        $sql = "SELECT 1 FROM Services WHERE parentsite_id = '$S1_ID'";
+        $result = $con->createQueryTable('', $sql);
+        $this->assertEquals(1, $result->getRowCount());
+
+      //Site 2
+        $sql = "SELECT 1 FROM Services WHERE parentsite_id = '$S2_ID'";
+        $result = $con->createQueryTable('', $sql);
+        $this->assertEquals(2, $result->getRowCount());
+
+      //check Site IDs are unchanged and they are assigned to the correct NGI
+      //Site 1
+        $sql = "SELECT 1 FROM Services WHERE hostname = 'SEP1' AND id = '$SE1_id' AND parentsite_id = '$S2_ID'";
+        $result = $con->createQueryTable('', $sql);
+        $this->assertEquals(1, $result->getRowCount());
+
+      //Site 2
+        $sql = "SELECT 1 FROM Services WHERE hostname = 'SEP2' AND id = '$SE2_id' AND parentsite_id = '$S1_ID'";
+        $result = $con->createQueryTable('', $sql);
+        $this->assertEquals(1, $result->getRowCount());
+
+      //Site 3
+        $sql = "SELECT 1 FROM Services WHERE hostname = 'SEP3' AND id = '$SE3_id' AND parentsite_id = '$S2_ID'";
+        $result = $con->createQueryTable('', $sql);
+        $this->assertEquals(1, $result->getRowCount());
     }
-    //Site2
-    $SiteSEPs = $S2->getServices();
-    foreach ($SiteSEPs as $SEP){
-      $this->assertTrue(($SEP==$SE1) or ($SEP==$SE3));
-    }
-
-    //Use database connection to check movememrnt
-    $con = $this->getConnection();
-
-    //Check Sites are still present and their ID is unchanged
-    $sql = "SELECT 1 FROM Sites WHERE shortname = 'Site1' AND ID = '$S1_ID'";
-    $result = $con->createQueryTable('', $sql);
-    $this->assertEquals(1, $result->getRowCount());
-
-    $sql = "SELECT 1 FROM Sites WHERE shortname = 'Site2' AND ID = '$S2_ID'";
-    $result = $con->createQueryTable('', $sql);
-    $this->assertEquals(1, $result->getRowCount());
-
-    //Check each Site has the correct number of service endpoints
-    //Site 1
-    $sql = "SELECT 1 FROM Services WHERE parentsite_id = '$S1_ID'";
-    $result = $con->createQueryTable('', $sql);
-    $this->assertEquals(1, $result->getRowCount());
-
-    //Site 2
-    $sql = "SELECT 1 FROM Services WHERE parentsite_id = '$S2_ID'";
-    $result = $con->createQueryTable('', $sql);
-    $this->assertEquals(2, $result->getRowCount());
-
-    //check Site IDs are unchanged and they are assigned to the correct NGI
-    //Site 1
-    $sql = "SELECT 1 FROM Services WHERE hostname = 'SEP1' AND id = '$SE1_id' AND parentsite_id = '$S2_ID'";
-    $result = $con->createQueryTable('', $sql);
-    $this->assertEquals(1, $result->getRowCount());
-
-    //Site 2
-    $sql = "SELECT 1 FROM Services WHERE hostname = 'SEP2' AND id = '$SE2_id' AND parentsite_id = '$S1_ID'";
-    $result = $con->createQueryTable('', $sql);
-    $this->assertEquals(1, $result->getRowCount());
-
-    //Site 3
-    $sql = "SELECT 1 FROM Services WHERE hostname = 'SEP3' AND id = '$SE3_id' AND parentsite_id = '$S2_ID'";
-    $result = $con->createQueryTable('', $sql);
-    $this->assertEquals(1, $result->getRowCount());
-  }
-
 }
-?>

--- a/tests/doctrine/SiteMoveTest.php
+++ b/tests/doctrine/SiteMoveTest.php
@@ -1,4 +1,5 @@
 <?php
+
 //use org\gocdb\services\NGI;
 //use org\gocdb\services\Site;
 //require_once 'PHPUnit/Extensions/Database/TestCase.php';
@@ -19,17 +20,19 @@ require_once dirname(__FILE__) . '/../../lib/Gocdb_Services/ServiceService.php';
  * @author David Meredith
  * @author John Casson
  */
-class SiteMoveTest extends PHPUnit_Extensions_Database_TestCase {
-   private $em;
-   private $egiScope;
-   private $localScope;
-   private $eudatScope;
+class SiteMoveTest extends PHPUnit_Extensions_Database_TestCase
+{
+    private $em;
+    private $egiScope;
+    private $localScope;
+    private $eudatScope;
 
 
     /**
      * Overridden.
      */
-    public static function setUpBeforeClass() {
+    public static function setUpBeforeClass()
+    {
         parent::setUpBeforeClass();
         echo "\n\n-------------------------------------------------\n";
         echo "Executing SiteMoveTest. . .\n";
@@ -39,7 +42,8 @@ class SiteMoveTest extends PHPUnit_Extensions_Database_TestCase {
      * Overridden. Returns the test database connection.
      * @return PHPUnit_Extensions_Database_DB_IDatabaseConnection
      */
-    protected function getConnection() {
+    protected function getConnection()
+    {
         require_once dirname(__FILE__) . '/bootstrap_pdo.php';
         return getConnectionToTestDB();
     }
@@ -49,7 +53,8 @@ class SiteMoveTest extends PHPUnit_Extensions_Database_TestCase {
      * Defines how the initial state of the database should look before each test is executed.
      * @return PHPUnit_Extensions_Database_DataSet_IDataSet
      */
-    protected function getDataSet() {
+    protected function getDataSet()
+    {
         return $this->createFlatXMLDataSet(dirname(__FILE__) . '/truncateDataTables.xml');
         // Use below to return an empty data set if we don't want to truncate and seed
         //return new PHPUnit_Extensions_Database_DataSet_DefaultDataSet();
@@ -58,7 +63,8 @@ class SiteMoveTest extends PHPUnit_Extensions_Database_TestCase {
     /**
      * Overridden.
      */
-    protected function getSetUpOperation() {
+    protected function getSetUpOperation()
+    {
         // CLEAN_INSERT is default
         //return PHPUnit_Extensions_Database_Operation_Factory::CLEAN_INSERT();
         //return PHPUnit_Extensions_Database_Operation_Factory::UPDATE();
@@ -73,7 +79,8 @@ class SiteMoveTest extends PHPUnit_Extensions_Database_TestCase {
     /**
      * Overridden.
      */
-    protected function getTearDownOperation() {
+    protected function getTearDownOperation()
+    {
         // NONE is default
         return PHPUnit_Extensions_Database_Operation_Factory::NONE();
     }
@@ -82,18 +89,29 @@ class SiteMoveTest extends PHPUnit_Extensions_Database_TestCase {
      * Sets up the fixture, e.g create a new entityManager for each test run
      * This method is called before each test method is executed.
      */
-    protected function setUp() {
+    protected function setUp()
+    {
         parent::setUp();
         $this->em = $this->createEntityManager();
     }
-
+  /**
+   * Run after each test function to prevent pile-up of database connections.
+   */
+    protected function tearDown()
+    {
+        parent::tearDown();
+        if (!is_null($this->em)) {
+            $this->em->getConnection()->close();
+        }
+    }
     /**
      * @todo Still need to setup connection to different databases.
      * @return EntityManager
      */
-    private function createEntityManager(){
+    private function createEntityManager()
+    {
         //require dirname(__FILE__).'/../lib/Doctrine/bootstrap.php';
-        require dirname(__FILE__).'/bootstrap_doctrine.php';
+        require dirname(__FILE__) . '/bootstrap_doctrine.php';
         return $entityManager;
     }
 
@@ -101,18 +119,20 @@ class SiteMoveTest extends PHPUnit_Extensions_Database_TestCase {
      * Called after setUp() and before each test. Used for common assertions
      * across all tests.
      */
-    protected function assertPreConditions() {
+    protected function assertPreConditions()
+    {
         $con = $this->getConnection();
         $fixture = dirname(__FILE__) . '/truncateDataTables.xml';
         $tables = simplexml_load_file($fixture);
 
-        foreach($tables as $tableName) {
+        foreach ($tables as $tableName) {
             //print $tableName->getName() . "\n";
-            $sql = "SELECT * FROM ".$tableName->getName();
+            $sql = "SELECT * FROM " . $tableName->getName();
             $result = $con->createQueryTable('results_table', $sql);
             //echo 'row count: '.$result->getRowCount() ;
-            if($result->getRowCount() != 0)
-                throw new RuntimeException("Invalid fixture. Table has rows: ".$tableName->getName());
+            if ($result->getRowCount() != 0) {
+                throw new RuntimeException("Invalid fixture. Table has rows: " . $tableName->getName());
+            }
         }
     }
 
@@ -122,7 +142,8 @@ class SiteMoveTest extends PHPUnit_Extensions_Database_TestCase {
      *  Moves two of the sites between NGIs.
      *  Checks the sites are under the right NGIs.
      */
-    public function testSiteMoves() {
+    public function testSiteMoves()
+    {
 
         print __METHOD__ . "\n";
 
@@ -132,9 +153,9 @@ class SiteMoveTest extends PHPUnit_Extensions_Database_TestCase {
         $S1 = TestUtil::createSampleSite("Site1");
         $S2 = TestUtil::createSampleSite("Site2");
         $S3 = TestUtil::createSampleSite("Site3");
-        $SE1= TestUtil::createSampleService("SEP1");
+        $SE1 = TestUtil::createSampleService("SEP1");
         $dummy_user = TestUtil::createSampleUser('Test', 'User');
-        $identifier= TestUtil::createSampleUserIdentifier('X.509', '/Some/string');
+        $identifier = TestUtil::createSampleUserIdentifier('X.509', '/Some/string');
         $dummy_user->addUserIdentifierDoJoin($identifier);
         $this->em->persist($identifier);
 
@@ -181,17 +202,17 @@ class SiteMoveTest extends PHPUnit_Extensions_Database_TestCase {
             /*
              * Check each site is: present, has the right ID & parent NGI
              */
-            $S1_id= $S1->getId();
+            $S1_id = $S1->getId();
             $sql = "SELECT 1 FROM Sites WHERE shortname = 'Site1' AND ID = '$S1_id' AND NGI_ID = '$N1_ID'";
             $result = $con->createQueryTable('', $sql);
             $this->assertEquals(1, $result->getRowCount());
 
-            $S2_id= $S2->getId();
+            $S2_id = $S2->getId();
             $sql = "SELECT 1 FROM Sites WHERE shortname = 'Site2' AND ID = '$S2_id' AND NGI_ID = '$N2_ID'";
             $result = $con->createQueryTable('', $sql);
             $this->assertEquals(1, $result->getRowCount());
 
-            $S3_id= $S3->getId();
+            $S3_id = $S3->getId();
             $sql = "SELECT 1 FROM Sites WHERE shortname = 'Site3' AND ID = '$S3_id' AND NGI_ID = '$N2_ID'";
             $result = $con->createQueryTable('', $sql);
             $this->assertEquals(1, $result->getRowCount());
@@ -204,9 +225,9 @@ class SiteMoveTest extends PHPUnit_Extensions_Database_TestCase {
         //Move sites
         $serv =  new org\gocdb\services\Site();
         $serv->setEntityManager($this->em);
-        $serv->moveSite($S1,$N2, $dummy_user);
-        $serv->moveSite($S2,$N1, $dummy_user);
-        $serv->moveSite($S3,$N2, $dummy_user); //No change
+        $serv->moveSite($S1, $N2, $dummy_user);
+        $serv->moveSite($S2, $N1, $dummy_user);
+        $serv->moveSite($S3, $N2, $dummy_user); //No change
 
 
         //flush movement
@@ -221,17 +242,17 @@ class SiteMoveTest extends PHPUnit_Extensions_Database_TestCase {
             //Check correct sites for each NGI
                 //NGI1
                 $ngisites = $N1->getSites();
-                foreach ($ngisites as $site){
-                    $this->assertEquals($S2, $site);
-                }
+        foreach ($ngisites as $site) {
+            $this->assertEquals($S2, $site);
+        }
                 //NGI2
                 $ngisites = $N2->getSites();
-                foreach ($ngisites as $site){
-                    $this->assertTrue(($site==$S1) or ($site==$S3));
-                }
+        foreach ($ngisites as $site) {
+            $this->assertTrue(($site == $S1) or ($site == $S3));
+        }
 
             //check Service End Point
-            $this->assertEquals($S1,$SE1->getParentSite());
+            $this->assertEquals($S1, $SE1->getParentSite());
 
 
         //Use database connection to check movememrnt
@@ -273,8 +294,5 @@ class SiteMoveTest extends PHPUnit_Extensions_Database_TestCase {
                 $sql = "SELECT 1 FROM Sites WHERE shortname = 'Site3' AND ID = '$S3_id' AND NGI_ID = '$N2_ID'";
                 $result = $con->createQueryTable('', $sql);
                 $this->assertEquals(1, $result->getRowCount());
-
     }//close function
 }//close class
-
-?>

--- a/tests/doctrine/Site_CertStatusLogCascadeDeletionsTest.php
+++ b/tests/doctrine/Site_CertStatusLogCascadeDeletionsTest.php
@@ -22,8 +22,8 @@ require_once dirname(__FILE__) . '/bootstrap.php';
  *
  * @author David Meredith
  */
-class Site_CertStatusLogCascadeDeletionsTest extends PHPUnit_Extensions_Database_TestCase {
-
+class Site_CertStatusLogCascadeDeletionsTest extends PHPUnit_Extensions_Database_TestCase
+{
     private $em;
 
     //private $egiScope;
@@ -33,7 +33,8 @@ class Site_CertStatusLogCascadeDeletionsTest extends PHPUnit_Extensions_Database
     /**
      * Overridden.
      */
-    public static function setUpBeforeClass() {
+    public static function setUpBeforeClass()
+    {
         parent::setUpBeforeClass();
         echo "\n\n-------------------------------------------------\n";
         echo "Executing Site_CertStatusLogCascadeDeletionsTest. . .\n";
@@ -43,7 +44,8 @@ class Site_CertStatusLogCascadeDeletionsTest extends PHPUnit_Extensions_Database
      * Overridden. Returns the test database connection.
      * @return PHPUnit_Extensions_Database_DB_IDatabaseConnection
      */
-    protected function getConnection() {
+    protected function getConnection()
+    {
         require_once dirname(__FILE__) . '/bootstrap_pdo.php';
         return getConnectionToTestDB();
     }
@@ -53,7 +55,8 @@ class Site_CertStatusLogCascadeDeletionsTest extends PHPUnit_Extensions_Database
      * Defines how the initial state of the database should look before each test is executed.
      * @return PHPUnit_Extensions_Database_DataSet_IDataSet
      */
-    protected function getDataSet() {
+    protected function getDataSet()
+    {
         return $this->createFlatXMLDataSet(dirname(__FILE__) . '/truncateDataTables.xml');
         // Use below to return an empty data set if we don't want to truncate and seed
         //return new PHPUnit_Extensions_Database_DataSet_DefaultDataSet();
@@ -62,7 +65,8 @@ class Site_CertStatusLogCascadeDeletionsTest extends PHPUnit_Extensions_Database
     /**
      * Overridden.
      */
-    protected function getSetUpOperation() {
+    protected function getSetUpOperation()
+    {
         // CLEAN_INSERT is default
         //return PHPUnit_Extensions_Database_Operation_Factory::CLEAN_INSERT();
         //return PHPUnit_Extensions_Database_Operation_Factory::UPDATE();
@@ -77,7 +81,8 @@ class Site_CertStatusLogCascadeDeletionsTest extends PHPUnit_Extensions_Database
     /**
      * Overridden.
      */
-    protected function getTearDownOperation() {
+    protected function getTearDownOperation()
+    {
         // NONE is default
         return PHPUnit_Extensions_Database_Operation_Factory::NONE();
     }
@@ -86,16 +91,27 @@ class Site_CertStatusLogCascadeDeletionsTest extends PHPUnit_Extensions_Database
      * Sets up the fixture, e.g create a new entityManager for each test run
      * This method is called before each test method is executed.
      */
-    protected function setUp() {
+    protected function setUp()
+    {
         parent::setUp();
         $this->em = $this->createEntityManager();
     }
-
+  /**
+   * Run after each test function to prevent pile-up of database connections.
+   */
+    protected function tearDown()
+    {
+        parent::tearDown();
+        if (!is_null($this->em)) {
+            $this->em->getConnection()->close();
+        }
+    }
     /**
      * @todo Still need to setup connection to different databases.
      * @return EntityManager
      */
-    private function createEntityManager() {
+    private function createEntityManager()
+    {
         //require dirname(__FILE__).'/../lib/Doctrine/bootstrap.php';
         require dirname(__FILE__) . '/bootstrap_doctrine.php';
         return $entityManager;
@@ -105,7 +121,8 @@ class Site_CertStatusLogCascadeDeletionsTest extends PHPUnit_Extensions_Database
      * Called after setUp() and before each test. Used for common assertions
      * across all tests.
      */
-    protected function assertPreConditions() {
+    protected function assertPreConditions()
+    {
         $con = $this->getConnection();
         $fixture = dirname(__FILE__) . '/truncateDataTables.xml';
         $tables = simplexml_load_file($fixture);
@@ -115,13 +132,15 @@ class Site_CertStatusLogCascadeDeletionsTest extends PHPUnit_Extensions_Database
             $sql = "SELECT * FROM " . $tableName->getName();
             $result = $con->createQueryTable('results_table', $sql);
             //echo 'row count: '.$result->getRowCount() ;
-            if ($result->getRowCount() != 0)
+            if ($result->getRowCount() != 0) {
                 throw new RuntimeException("Invalid fixture. Table has rows: " . $tableName->getName());
+            }
         }
     }
 
 
-     public function testCertStatusLogDeleted_OnSiteDeletion() {
+    public function testCertStatusLogDeleted_OnSiteDeletion()
+    {
         print __METHOD__ . "\n";
         include __DIR__ . '/resources/sampleFixtureData1.php';
 
@@ -140,10 +159,5 @@ class Site_CertStatusLogCascadeDeletionsTest extends PHPUnit_Extensions_Database
         $this->assertTrue($result->getRowCount() == 1); // site1 not deleted
         $result = $testConn->createQueryTable('results_table', "SELECT * FROM CertificationStatusLogs");
         $this->assertTrue($result->getRowCount() == 0);
-
     }
-
-
 }
-
-?>

--- a/tests/unit/lib/Gocdb_Services/APIAuthenticationServiceTest.php
+++ b/tests/unit/lib/Gocdb_Services/APIAuthenticationServiceTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright (C) 2015 STFC
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -21,149 +22,179 @@ use Doctrine\ORM\EntityManager;
  *
  * @author Ian Neilson (after David Meredith)
  */
-class APIAuthEnticationServiceTest extends PHPUnit_Extensions_Database_TestCase {
-  private $entityManager;
-  private $dbOpsFactory;
+class APIAuthEnticationServiceTest extends PHPUnit_Extensions_Database_TestCase
+{
+    private $entityManager;
+    private $dbOpsFactory;
 
-  function __construct() {
-    parent::__construct();
-    // Use a local instance to avoid Mess Detector's whinging about avoiding
-    // static access.
-    $this->dbOpsFactory = new PHPUnit_Extensions_Database_Operation_Factory();
-  }
+    function __construct()
+    {
+        parent::__construct();
+      // Use a local instance to avoid Mess Detector's whinging about avoiding
+      // static access.
+        $this->dbOpsFactory = new PHPUnit_Extensions_Database_Operation_Factory();
+    }
   /**
   * Overridden.
   */
-  public static function setUpBeforeClass() {
-    parent::setUpBeforeClass();
-    echo "\n\n-------------------------------------------------\n";
-    echo "Executing APIAuthEntServiceTest. . .\n";
-  }
+    public static function setUpBeforeClass()
+    {
+        parent::setUpBeforeClass();
+        echo "\n\n-------------------------------------------------\n";
+        echo "Executing APIAuthEntServiceTest. . .\n";
+    }
 
   /**
   * Overridden. Returns the test database connection.
   * @return PHPUnit_Extensions_Database_DB_IDatabaseConnection
   */
-  protected function getConnection() {
-    require_once __DIR__ . '/../../../doctrine/bootstrap_pdo.php';
-    return getConnectionToTestDB();
-  }
+    protected function getConnection()
+    {
+        require_once __DIR__ . '/../../../doctrine/bootstrap_pdo.php';
+        return getConnectionToTestDB();
+    }
 
   /**
   * Overridden. Returns the test dataset.
   * Defines how the initial state of the database should look before each test is executed.
   * @return PHPUnit_Extensions_Database_DataSet_IDataSet
   */
-  protected function getDataSet() {
-    $dataset = $this->createFlatXMLDataSet(__DIR__ . '/../../../doctrine/truncateDataTables.xml');
-    return $dataset;
-    // Use below to return an empty data set if we don't want to truncate and seed
-    //return new PHPUnit_Extensions_Database_DataSet_DefaultDataSet();
-  }
+    protected function getDataSet()
+    {
+        $dataset = $this->createFlatXMLDataSet(__DIR__ . '/../../../doctrine/truncateDataTables.xml');
+        return $dataset;
+      // Use below to return an empty data set if we don't want to truncate and seed
+      //return new PHPUnit_Extensions_Database_DataSet_DefaultDataSet();
+    }
 
   /**
   * Overridden.
   */
-  protected function getSetUpOperation() {
-    // CLEAN_INSERT is default
-    //return PHPUnit_Extensions_Database_Operation_Factory::CLEAN_INSERT();
-    //return PHPUnit_Extensions_Database_Operation_Factory::UPDATE();
-    //return PHPUnit_Extensions_Database_Operation_Factory::NONE();
-    //
-    // Issue a DELETE from <table> which is more portable than a
-    // TRUNCATE table <table> (some DBs require high privileges for truncate statements
-    // and also do not allow truncates across tables with FK contstraints e.g. Oracle)
-    return $this->dbOpsFactory->DELETE_ALL();
-  }
+    protected function getSetUpOperation()
+    {
+      // CLEAN_INSERT is default
+      //return PHPUnit_Extensions_Database_Operation_Factory::CLEAN_INSERT();
+      //return PHPUnit_Extensions_Database_Operation_Factory::UPDATE();
+      //return PHPUnit_Extensions_Database_Operation_Factory::NONE();
+      //
+      // Issue a DELETE from <table> which is more portable than a
+      // TRUNCATE table <table> (some DBs require high privileges for truncate statements
+      // and also do not allow truncates across tables with FK contstraints e.g. Oracle)
+        return $this->dbOpsFactory->DELETE_ALL();
+    }
 
   /**
   * Overridden.
   */
-  protected function getTearDownOperation() {
-    // NONE is default
-    return $this->dbOpsFactory->NONE();
-  }
+    protected function getTearDownOperation()
+    {
+      // NONE is default
+        return $this->dbOpsFactory->NONE();
+    }
 
   /**
   * Sets up the fixture, e.g create a new entityManager for each test run
   * This method is called before each test method is executed.
   */
-  protected function setUp() {
-    parent::setUp();
-    $this->entityManager = $this->createEntityManager();
-    // Pass the Entity Manager into the Factory to allow Gocdb_Services
-    // to use other Gocdb_Services.
-    \Factory::setEntityManager($this->entityManager);
-  }
-
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->entityManager = $this->createEntityManager();
+      // Pass the Entity Manager into the Factory to allow Gocdb_Services
+      // to use other Gocdb_Services.
+        \Factory::setEntityManager($this->entityManager);
+    }
+  /**
+   * Run after each test function to prevent pile-up of database connections.
+   */
+    protected function tearDown()
+    {
+        parent::tearDown();
+        if (!is_null($this->entityManager)) {
+            $this->entityManager->getConnection()->close();
+        }
+    }
   /**
   * @return EntityManager
   */
-  private function createEntityManager(){
-    $entityManager = null; // Initialise in local scope to avoid unused variable warnings
-    require __DIR__ . '/../../../doctrine/bootstrap_doctrine.php';
-    return $entityManager;
-  }
+    private function createEntityManager()
+    {
+        $entityManager = null; // Initialise in local scope to avoid unused variable warnings
+        require __DIR__ . '/../../../doctrine/bootstrap_doctrine.php';
+        return $entityManager;
+    }
 
   /**
   * Called after setUp() and before each test. Used for common assertions
   * across all tests.
   */
-  protected function assertPreConditions() {
-    $con = $this->getConnection();
-    $fixture = __DIR__ . '/../../../doctrine/truncateDataTables.xml';
-    $tables = simplexml_load_file($fixture);
+    protected function assertPreConditions()
+    {
+        $con = $this->getConnection();
+        $fixture = __DIR__ . '/../../../doctrine/truncateDataTables.xml';
+        $tables = simplexml_load_file($fixture);
 
-    foreach($tables as $tableName) {
-      $sql = "SELECT * FROM ".$tableName->getName();
-      $result = $con->createQueryTable('results_table', $sql);
-      if($result->getRowCount() != 0){
-        throw new RuntimeException("Invalid fixture. Table has rows: ".$tableName->getName());
-      }
+        foreach ($tables as $tableName) {
+            $sql = "SELECT * FROM " . $tableName->getName();
+            $result = $con->createQueryTable('results_table', $sql);
+            if ($result->getRowCount() != 0) {
+                throw new RuntimeException("Invalid fixture. Table has rows: " . $tableName->getName());
+            }
+        }
     }
-  }
-  public function testGetAPIAuthentication () {
-    print __METHOD__ . "\n";
+    public function testGetAPIAuthentication()
+    {
+        print __METHOD__ . "\n";
 
-    $siteData = ServiceTestUtil::getSiteData($this->entityManager);
-    $siteService = ServiceTestUtil::getSiteService($this->entityManager);
-    $site = ServiceTestUtil::createAndAddSite($this->entityManager, $siteData);
+        $siteData = ServiceTestUtil::getSiteData($this->entityManager);
+        $siteService = ServiceTestUtil::getSiteService($this->entityManager);
+        $site = ServiceTestUtil::createAndAddSite($this->entityManager, $siteData);
 
-    $user = TestUtil::createSampleUser('Beta','User');
-    $user->setAdmin(true);
+        $user = TestUtil::createSampleUser('Beta', 'User');
+        $user->setAdmin(true);
 
-    $identifier = TestUtil::createSampleUserIdentifier('X.509','/Beta.User');
-    ServiceTestUtil::persistAndFlush($this->entityManager, $identifier);
+        $identifier = TestUtil::createSampleUserIdentifier('X.509', '/Beta.User');
+        ServiceTestUtil::persistAndFlush($this->entityManager, $identifier);
 
-    $user->addUserIdentifierDoJoin($identifier);
+        $user->addUserIdentifierDoJoin($identifier);
 
-    ServiceTestUtil::persistAndFlush($this->entityManager, $user);
+        ServiceTestUtil::persistAndFlush($this->entityManager, $user);
 
-    $authEntServ = new org\gocdb\services\APIAuthenticationService();
-    $authEntServ->setEntityManager($this->entityManager);
+        $authEntServ = new org\gocdb\services\APIAuthenticationService();
+        $authEntServ->setEntityManager($this->entityManager);
 
-    $this->assertTrue($authEntServ instanceof org\gocdb\services\APIAuthenticationService,
-                        'Failed to create APIAuthenticationService');
+        $this->assertTrue(
+            $authEntServ instanceof org\gocdb\services\APIAuthenticationService,
+            'Failed to create APIAuthenticationService'
+        );
 
-    $ident = '/CN=A Dummy Subject';
-    $type = 'X509';
-    // Start with no APIAuthentication entities to be found
-    $this->assertNull($authEntServ->getAPIAuthentication($ident, $type),
-                        "Non-null value returned when searching for APIAuthentication entity " .
-                        "for id:{$ident} with type:{$type} when expected none.");
+        $ident = '/CN=A Dummy Subject';
+        $type = 'X509';
+      // Start with no APIAuthentication entities to be found
+        $this->assertNull(
+            $authEntServ->getAPIAuthentication($ident, $type),
+            "Non-null value returned when searching for APIAuthentication entity " .
+            "for id:{$ident} with type:{$type} when expected none."
+        );
 
-    $authEnt = $siteService->addAPIAuthEntity($site, $user,
-                              array('IDENTIFIER' =>  $ident,
+        $authEnt = $siteService->addAPIAuthEntity(
+            $site,
+            $user,
+            array('IDENTIFIER' =>  $ident,
                               'TYPE' => $type,
-                              'ALLOW_WRITE' => false));
+            'ALLOW_WRITE' => false)
+        );
 
-    $this->assertTrue($authEnt instanceof \APIAuthentication,
-                      "Failed to add APIAuthentication entity for id:{$ident} with type:{$type}.");
+        $this->assertTrue(
+            $authEnt instanceof \APIAuthentication,
+            "Failed to add APIAuthentication entity for id:{$ident} with type:{$type}."
+        );
 
-    $authEntMatched = $authEntServ->getAPIAuthentication($ident, $type);
+        $authEntMatched = $authEntServ->getAPIAuthentication($ident, $type);
 
-    $this->assertTrue($authEnt === $authEntMatched,
-                      "Failed to return APIAuthentication entity for id:{$ident} with type:{$type}.");
-
-  }
+        $this->assertTrue(
+            $authEnt === $authEntMatched,
+            "Failed to return APIAuthentication entity for id:{$ident} with type:{$type}."
+        );
+    }
 }

--- a/tests/unit/lib/Gocdb_Services/RoleActionAuthorisationServiceTest.php
+++ b/tests/unit/lib/Gocdb_Services/RoleActionAuthorisationServiceTest.php
@@ -24,657 +24,677 @@ require_once __DIR__ . '/../../../doctrine/bootstrap.php';
 *
 * @author djm76
 */
-class RoleActionAuthorisationServiceTest  extends PHPUnit_Extensions_Database_TestCase{
-  private $em;
+class RoleActionAuthorisationServiceTest extends PHPUnit_Extensions_Database_TestCase
+{
+    private $em;
 
   /**
    * Overridden.
    */
-  public static function setUpBeforeClass() {
-    parent::setUpBeforeClass();
-    echo "\n\n-------------------------------------------------\n";
-    echo "Executing RoleServiceTest. . .\n";
-  }
+    public static function setUpBeforeClass()
+    {
+        parent::setUpBeforeClass();
+        echo "\n\n-------------------------------------------------\n";
+        echo "Executing RoleServiceTest. . .\n";
+    }
 
   /**
   * Overridden. Returns the test database connection.
   * @return PHPUnit_Extensions_Database_DB_IDatabaseConnection
   */
-  protected function getConnection() {
-    require_once __DIR__ . '/../../../doctrine/bootstrap_pdo.php';
-    return getConnectionToTestDB();
-  }
+    protected function getConnection()
+    {
+        require_once __DIR__ . '/../../../doctrine/bootstrap_pdo.php';
+        return getConnectionToTestDB();
+    }
 
   /**
   * Overridden. Returns the test dataset.
   * Defines how the initial state of the database should look before each test is executed.
   * @return PHPUnit_Extensions_Database_DataSet_IDataSet
   */
-  protected function getDataSet() {
-    return $this->createFlatXMLDataSet(__DIR__ . '/../../../doctrine/truncateDataTables.xml');
-    // Use below to return an empty data set if we don't want to truncate and seed
-    //return new PHPUnit_Extensions_Database_DataSet_DefaultDataSet();
-  }
+    protected function getDataSet()
+    {
+        return $this->createFlatXMLDataSet(__DIR__ . '/../../../doctrine/truncateDataTables.xml');
+      // Use below to return an empty data set if we don't want to truncate and seed
+      //return new PHPUnit_Extensions_Database_DataSet_DefaultDataSet();
+    }
 
   /**
   * Overridden.
   */
-  protected function getSetUpOperation() {
-    // CLEAN_INSERT is default
-    //return PHPUnit_Extensions_Database_Operation_Factory::CLEAN_INSERT();
-    //return PHPUnit_Extensions_Database_Operation_Factory::UPDATE();
-    //return PHPUnit_Extensions_Database_Operation_Factory::NONE();
-    //
-    // Issue a DELETE from <table> which is more portable than a
-    // TRUNCATE table <table> (some DBs require high privileges for truncate statements
-    // and also do not allow truncates across tables with FK contstraints e.g. Oracle)
-    return PHPUnit_Extensions_Database_Operation_Factory::DELETE_ALL();
-  }
+    protected function getSetUpOperation()
+    {
+      // CLEAN_INSERT is default
+      //return PHPUnit_Extensions_Database_Operation_Factory::CLEAN_INSERT();
+      //return PHPUnit_Extensions_Database_Operation_Factory::UPDATE();
+      //return PHPUnit_Extensions_Database_Operation_Factory::NONE();
+      //
+      // Issue a DELETE from <table> which is more portable than a
+      // TRUNCATE table <table> (some DBs require high privileges for truncate statements
+      // and also do not allow truncates across tables with FK contstraints e.g. Oracle)
+        return PHPUnit_Extensions_Database_Operation_Factory::DELETE_ALL();
+    }
 
   /**
   * Overridden.
   */
-  protected function getTearDownOperation() {
-    // NONE is default
-    return PHPUnit_Extensions_Database_Operation_Factory::NONE();
-  }
+    protected function getTearDownOperation()
+    {
+      // NONE is default
+        return PHPUnit_Extensions_Database_Operation_Factory::NONE();
+    }
 
   /**
   * Sets up the fixture, e.g create a new entityManager for each test run
   * This method is called before each test method is executed.
   */
-  protected function setUp() {
-    parent::setUp();
-    $this->em = $this->createEntityManager();
-  }
-
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->em = $this->createEntityManager();
+    }
+  /**
+   * Run after each test function to prevent pile-up of database connections.
+   */
+    protected function tearDown()
+    {
+        parent::tearDown();
+        if (!is_null($this->em)) {
+            $this->em->getConnection()->close();
+        }
+    }
   /**
   * @todo Still need to setup connection to different databases.
   * @return EntityManager
   */
-  private function createEntityManager(){
-    require __DIR__ . '/../../../doctrine/bootstrap_doctrine.php';
-    return $entityManager;
-  }
+    private function createEntityManager()
+    {
+        require __DIR__ . '/../../../doctrine/bootstrap_doctrine.php';
+        return $entityManager;
+    }
 
   /**
   * Called after setUp() and before each test. Used for common assertions
   * across all tests.
   */
-  protected function assertPreConditions() {
-    $con = $this->getConnection();
-    $fixture = __DIR__ . '/../../../doctrine/truncateDataTables.xml';
-    $tables = simplexml_load_file($fixture);
+    protected function assertPreConditions()
+    {
+        $con = $this->getConnection();
+        $fixture = __DIR__ . '/../../../doctrine/truncateDataTables.xml';
+        $tables = simplexml_load_file($fixture);
 
-    foreach($tables as $tableName) {
-      //print $tableName->getName() . "\n";
-      $sql = "SELECT * FROM ".$tableName->getName();
-      $result = $con->createQueryTable('results_table', $sql);
-      //echo 'row count: '.$result->getRowCount() ;
-      if($result->getRowCount() != 0){
-        throw new RuntimeException("Invalid fixture. Table has rows: ".$tableName->getName());
-      }
+        foreach ($tables as $tableName) {
+          //print $tableName->getName() . "\n";
+            $sql = "SELECT * FROM " . $tableName->getName();
+            $result = $con->createQueryTable('results_table', $sql);
+          //echo 'row count: '.$result->getRowCount() ;
+            if ($result->getRowCount() != 0) {
+                throw new RuntimeException("Invalid fixture. Table has rows: " . $tableName->getName());
+            }
+        }
     }
-  }
-
-  public function NOT_RUN_test_authoriseActionBug(){
-    print __METHOD__ . "\n";
-    $codRT = TestUtil::createSampleRoleType(TestRoleTypeName::COD_ADMIN);
-    $this->em->persist($codRT);  // edit all sites cert status only
-
-    // Create a user
-    $u = TestUtil::createSampleUser("Test", "Testing");
-    $identifier= TestUtil::createSampleUserIdentifier("X.509", "/c=test");
-    $u->addUserIdentifierDoJoin($identifier);
-    $this->em->persist($identifier);
-    $this->em->persist($u);
-
-    /*
-     * Create test data with the following structure
-     *
-     *   p1  EGI
-     *    \  /
-     *     n1
-     */
-    $p1 = new \Project("p1");
-    $p2 = new \Project("EGI");
-    $n1 = TestUtil::createSampleNGI("n1");
-    $this->em->persist($p1);
-    $this->em->persist($p2);
-    $this->em->persist($n1);
-    $p1->addNgi($n1);
-    $p2->addNgi($n1);
-
-    // Build dependencies and inject business objects:
-    // start a new connection to test transactional isolation of RoleService methods.
-    //$em2 = $this->createEntityManager();
-    $em2 = $this->em;
-
-    // Create RoleActionMappingService with non-default roleActionMappings file
-    $roleActionMappingService = new org\gocdb\services\RoleActionMappingService();
-    $roleActionMappingService->setRoleActionMappingsXmlPath(
-      __DIR__."/../../resources/roleActionMappingSamples/TestRoleActionMappings7.xml"
-    );
-
-    // Create RoleActionAuthorisationService with dependencies
-    $roleAuthServ = new org\gocdb\services\RoleActionAuthorisationService($roleActionMappingService);
-    $roleAuthServ->setEntityManager($em2);
-
-    // Create role and link user and owned entities (user link not shown)
-    /*
-     * r1->p1  EGI
-     *      \  /
-     *       n1
-     */
-    $r1 = TestUtil::createSampleRole($u, $codRT, $p1, RoleStatus::GRANTED);
-    $this->em->persist($r1);
-    $this->em->flush();
-
-    // Assert user has no authorising roles over n1 BECAUSE p1 is not
-    // mapped in XML file and there is no default mapping!
-    $enablingRoles = $roleAuthServ->authoriseAction(\Action::REVOKE_ROLE, $n1, $u)->getGrantingRoles();
-    $this->assertEquals(0, count($enablingRoles));
-  }
-
-  public function test_authoriseAction(){
-    print __METHOD__ . "\n";
-    // Create roletypes
-    $siteAdminRT = TestUtil::createSampleRoleType(TestRoleTypeName::SITE_ADMIN);
-    $siteDepManAdminRT = TestUtil::createSampleRoleType(TestRoleTypeName::SITE_OPS_DEP_MAN);
-    $ngiManRT = TestUtil::createSampleRoleType(TestRoleTypeName::NGI_OPS_MAN);
-    $rodRT = TestUtil::createSampleRoleType(TestRoleTypeName::REG_STAFF_ROD);
-    $codRT = TestUtil::createSampleRoleType(TestRoleTypeName::COD_ADMIN);
-    $cooRT = TestUtil::createSampleRoleType(TestRoleTypeName::COO);
-    $this->em->persist($siteAdminRT); // edit site1 (but not cert status)
-    $this->em->persist($ngiManRT); // edit owned site1/site2 and cert status
-    $this->em->persist($rodRT);  // edit owned sites 1and2 (but not cert status)
-    $this->em->persist($codRT);  // edit all sites cert status only
-    $this->em->persist($cooRT);  // edit all sites cert status only
-    $this->em->persist($siteDepManAdminRT);  // edit all sites cert status only
-
-    // Create a user
-    $u = TestUtil::createSampleUser("Test", "Testing");
-    $identifier= TestUtil::createSampleUserIdentifier("X.509", "/c=test");
-    $u->addUserIdentifierDoJoin($identifier);
-    $this->em->persist($identifier);
-    $this->em->persist($u);
-
-    /*
-     * Create test data with the following structure (note p3 has two ngis)
-     *
-     * p1  p2  p3
-     * |   |  /|
-     * n1  n2  n3
-     * |   |   |
-     * s1  s2  s3
-     */
-    include __DIR__ . '/../../resources/sampleFixtureData6.php';
-
-    // Build dependencies and inject business objects:
-    // start a new connection to test transactional isolation of RoleService methods.
-    //$em2 = $this->createEntityManager();
-    $em2 = $this->em;
-
-    // Create RoleActionMappingService with non-default roleActionMappings file
-    $roleActionMappingService = new org\gocdb\services\RoleActionMappingService();
-    $roleActionMappingService->setRoleActionMappingsXmlPath(
-      __DIR__."/../../resources/roleActionMappingSamples/TestRoleActionMappings6.xml"
-    );
-
-    // Create RoleActionAuthorisationService with dependencies
-    $roleAuthServ = new org\gocdb\services\RoleActionAuthorisationService($roleActionMappingService);
-    $roleAuthServ->setEntityManager($em2);
-
-    // Create role and link user and owned entities (user link not shown)
-    /*
-     *    p1  p2  p3
-     *    |    |  /|
-     * r1-n1  n2  n3
-     *    |   |   |
-     *    s1  s2  s3
-     */
-    $r1 = TestUtil::createSampleRole($u, $ngiManRT, $n1, RoleStatus::GRANTED);
-    $this->em->persist($r1);
-    $this->em->flush();
-
-    // Assert user can edit s1 using r1
-    $enablingRoles = $roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $s1, $u)->getGrantingRoles();
-    $this->assertEquals(1, count($enablingRoles));
-    $this->assertTrue(in_array($r1, $enablingRoles));
-    $this->assertEquals(TestRoleTypeName::NGI_OPS_MAN, $enablingRoles[0]->getRoleType()->getName());
-
-    // Assert user can edit n1 using r1
-    $enablingRoles = $roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $n1, $u)->getGrantingRoles();
-    $this->assertEquals(1, count($enablingRoles));
-    $this->assertTrue(in_array($r1, $enablingRoles));
-    $this->assertEquals(TestRoleTypeName::NGI_OPS_MAN, $enablingRoles[0]->getRoleType()->getName());
-
-    // Assert user can change s1 cert status with r1
-    $this->assertTrue(in_array($r1, $roleAuthServ->authoriseAction(\Action::SITE_EDIT_CERT_STATUS, $s1, $u)->getGrantingRoles()) );
-
-    // Assert user can't edit other sites/ngis/projects
-    $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $s2, $u)->getGrantingRoles()));
-    $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $s3, $u)->getGrantingRoles()));
-    $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $n2, $u)->getGrantingRoles()));
-    $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $n3, $u)->getGrantingRoles()));
-    $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $p1, $u)->getGrantingRoles()));
-    $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $p2, $u)->getGrantingRoles()));
-    $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $p3, $u)->getGrantingRoles()));
-
-     /*
-     *    p1  p2  p3
-     *    |    |  /|
-     * r1-n1  n2  n3
-     *    |   |   |
-     * r2-s1  s2  s3
-     */
-    $r2 = TestUtil::createSampleRole($u, $siteAdminRT, $s1, RoleStatus::GRANTED) ;
-    $this->em->persist($r2);
-    $this->em->flush();
-
-    // Assert user can edit s1 using r1 + r2
-    $enablingRoles = $roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $s1, $u)->getGrantingRoles();
-    $this->assertEquals(2, count($enablingRoles));
-    $this->assertTrue(in_array($r1, $enablingRoles));
-    $this->assertTrue(in_array($r2, $enablingRoles));
-    //$enablingRoleNames = $this->getRoleTypeNames($enablingRoles);
-    //$this->assertTrue(in_array(TestRoleTypeName::NGI_OPS_MAN, $enablingRoleNames));
-    //$this->assertTrue(in_array(TestRoleTypeName::SITE_ADMIN, $enablingRoleNames));
-
-    // Assert user can change site cert status with r1
-    $enablingRoles = $roleAuthServ->authoriseAction(\Action::SITE_EDIT_CERT_STATUS, $s1, $u)->getGrantingRoles();
-    $this->assertEquals(1, count($enablingRoles));
-    $this->assertTrue(in_array($r1, $enablingRoles));
-
-    // Assert user can't edit other sites/ngis/projects
-    $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $s2, $u)->getGrantingRoles()));
-    $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $s3, $u)->getGrantingRoles()));
-    $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $n2, $u)->getGrantingRoles()));
-    $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $n3, $u)->getGrantingRoles()));
-    $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $p1, $u)->getGrantingRoles()));
-    $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $p2, $u)->getGrantingRoles()));
-    $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $p3, $u)->getGrantingRoles()));
-
-    /*
-     *    p1     p2  p3
-     *    |      |  /|
-     * r1-n1     n2  n3
-     *    |      |   |
-     * r2-s1  r3-s2  s3
-     */
-    $r3 = TestUtil::createSampleRole($u, $siteAdminRT, $s2, RoleStatus::GRANTED) ;
-    $this->em->persist($r3);
-    $this->em->flush();
-
-    // Assert user can edit s1 via r1 + r2
-    $enablingRoles = $roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $s1, $u)->getGrantingRoles();
-    $this->assertEquals(2, count($enablingRoles));
-    $this->assertTrue(in_array($r1, $enablingRoles));
-    $this->assertTrue(in_array($r2, $enablingRoles));
-
-    // Assert user can edit s2 via r3
-    $enablingRoles = $roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $s2, $u)->getGrantingRoles();
-    $this->assertEquals(1, count($enablingRoles));
-    $this->assertTrue(in_array($r3, $enablingRoles));
-
-    // Assert user can change s1 cert status via r1
-    $enablingRoles = $roleAuthServ->authoriseAction(\Action::SITE_EDIT_CERT_STATUS, $s1, $u)->getGrantingRoles();
-    $this->assertEquals(1, count($enablingRoles));
-    $this->assertTrue(in_array($r1, $enablingRoles));
-
-    // Assert user cant change s2 cert status
-    $enablingRoles = $roleAuthServ->authoriseAction(\Action::SITE_EDIT_CERT_STATUS, $s2, $u)->getGrantingRoles();
-    $this->assertEquals(0, count($enablingRoles));
-
-    // Assert user can't edit other sites/ngis/projects
-    $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $s3, $u)->getGrantingRoles()));
-    $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $n2, $u)->getGrantingRoles()));
-    $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $n3, $u)->getGrantingRoles()));
-    $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $p1, $u)->getGrantingRoles()));
-    $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $p2, $u)->getGrantingRoles()));
-    $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $p3, $u)->getGrantingRoles()));
-
-
-    /*
-     *    p1  r4-p2  p3
-     *    |      |  /|
-     * r1-n1     n2  n3
-     *    |      |   |
-     * r2-s1  r3-s2  s3
-     */
-    $r4 = TestUtil::createSampleRole($u, $cooRT, $p2, RoleStatus::GRANTED);
-    $this->em->persist($r4);
-    $this->em->flush();
-
-    // Assert user can edit p2 via r4
-    $enablingRoles = $roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $p2, $u)->getGrantingRoles();
-    $this->assertEquals(1, count($enablingRoles));
-    $this->assertTrue(in_array($r4, $enablingRoles));
-
-    // Assert user can grantRole on p2 via r4
-    $enablingRoles = $roleAuthServ->authoriseAction(\Action::GRANT_ROLE, $p2, $u)->getGrantingRoles();
-    $this->assertEquals(1, count($enablingRoles));
-    $this->assertTrue(in_array($r4, $enablingRoles));
-
-    // Assert user can grantRole on n2 via r4
-    $enablingRoles = $roleAuthServ->authoriseAction(\Action::GRANT_ROLE, $n2, $u)->getGrantingRoles();
-    $this->assertEquals(1, count($enablingRoles));
-    $this->assertTrue(in_array($r4, $enablingRoles));
-
-    // Assert user can't edit other sites/ngis/projects
-    $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $n2, $u)->getGrantingRoles()));
-    $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $s3, $u)->getGrantingRoles()));
-    $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $n3, $u)->getGrantingRoles()));
-    $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $p3, $u)->getGrantingRoles()));
-
-    /*
-     *    p1  r4-p2  p3-r5
-     *    |      |  /|
-     * r1-n1     n2  n3
-     *    |      |   |
-     * r2-s1  r3-s2  s3
-     */
-    $r5 = TestUtil::createSampleRole($u, $codRT, $p3, RoleStatus::GRANTED);
-    $this->em->persist($r5);
-    $this->em->flush();
-
-    // Assert user can edit p3 with r5
-    $enablingRoles = $roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $p3, $u)->getGrantingRoles();
-    $this->assertEquals(1, count($enablingRoles));
-    $this->assertTrue(in_array($r5, $enablingRoles));
-
-    // Assert user can grant role on n2 + n3 via r5
-    $enablingRoles = $roleAuthServ->authoriseAction(\Action::GRANT_ROLE, $n2, $u)->getGrantingRoles();
-    $this->assertEquals(2, count($enablingRoles));
-    $this->assertTrue(in_array($r5, $enablingRoles));
-    $this->assertTrue(in_array($r4, $enablingRoles));
-
-    // Assert user can't edit other sites/ngis/projects
-    $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $n2, $u)->getGrantingRoles()));
-    $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $s3, $u)->getGrantingRoles()));
-    $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $n3, $u)->getGrantingRoles()));
-
-    /*
-     *    p1  r4-p2  p3-r5
-     *    |      |  /|
-     * r1-n1     n2  n3-r6
-     *    |      |   |
-     * r2-s1  r3-s2  s3
-     */
-    $r6 = TestUtil::createSampleRole($u, $ngiManRT, $n3, RoleStatus::GRANTED);
-    $this->em->persist($r6);
-    $this->em->flush();
-
-    /*
-     *    p1  r4-p2  p3-r5
-     *    |      |  /|
-     * r1-n1     n2  n3-r6
-     *    |      |   |
-     * r2-s1  r3-s2  s3-r7
-     */
-    $r7 = TestUtil::createSampleRole($u, $siteAdminRT, $s3, RoleStatus::GRANTED);
-    $this->em->persist($r7);
-    $this->em->flush();
-
-    // Assert user can edit s3 with r6 + r7
-    $enablingRoles = $roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $s3, $u)->getGrantingRoles();
-    $this->assertEquals(2, count($enablingRoles));
-    $this->assertTrue(in_array($r7, $enablingRoles));
-    $this->assertTrue(in_array($r6, $enablingRoles));
-
-    /*
-     *    p1  r4-p2  p3-r5
-     *    |      |  /|
-     * r1-n1  r8-n2  n3-r6
-     *    |      |   |
-     * r2-s1  r3-s2  s3-r7
-     */
-    $r8 = TestUtil::createSampleRole($u, $ngiManRT, $n2, RoleStatus::GRANTED);
-    $this->em->persist($r8);
-    $this->em->flush();
-
-    $enablingRoles = $roleAuthServ->authoriseAction(\Action::SITE_EDIT_CERT_STATUS, $s2, $u)->getGrantingRoles();
-    $this->assertEquals(3, count($enablingRoles));
-    $this->assertTrue(in_array($r8, $enablingRoles));
-    $this->assertTrue(in_array($r4, $enablingRoles));
-    $this->assertTrue(in_array($r5, $enablingRoles));
-
-    $enablingRoles = $roleAuthServ->authoriseAction(\Action::SITE_EDIT_CERT_STATUS, $s3, $u)->getGrantingRoles();
-    $this->assertEquals(2, count($enablingRoles));
-    $this->assertTrue(in_array($r6, $enablingRoles));
-    $this->assertTrue(in_array($r5, $enablingRoles));
-
-    /*
-     *    p1  r4-p2  p3-r5
-     *    |      |  /|
-     * r1-n1  r8-n2  n3-r6
-     *    |      |   |
-     * r2-s1  r3-s2  s3-r7,r9
-     */
-    $r9 = TestUtil::createSampleRole($u, $siteDepManAdminRT, $s3, RoleStatus::GRANTED);
-    $this->em->persist($r9);
-    $this->em->flush();
-
-    // Assert user can edit s3 with r7, r9, r6
-    $enablingRoles = $roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $s3, $u)->getGrantingRoles();
-    $this->assertEquals(3, count($enablingRoles));
-    $this->assertTrue(in_array($r7, $enablingRoles));
-    $this->assertTrue(in_array($r9, $enablingRoles));
-    $this->assertTrue(in_array($r6, $enablingRoles));
-
-    // Assert user can change s3 cert status with r6 + r5
-    $enablingRoles = $roleAuthServ->authoriseAction(\Action::SITE_EDIT_CERT_STATUS, $s3, $u)->getGrantingRoles();
-    $this->assertEquals(2, count($enablingRoles));
-    $this->assertTrue(in_array($r6, $enablingRoles));
-    $this->assertTrue(in_array($r5, $enablingRoles));
-
-    /*
-     *    p1  r4-p2  p3-r5
-     *    |      |  /|
-     * r1-n1  r8-n2  n3-r6,r10
-     *    |      |   |
-     * r2-s1  r3-s2  s3-r7,r9
-     */
-    $r10 = TestUtil::createSampleRole($u, $rodRT, $n3, RoleStatus::GRANTED);
-    $this->em->persist($r10);
-    $this->em->flush();
-
-    $enablingRoles = $roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $s3, $u)->getGrantingRoles();
-    $this->assertEquals(4, count($enablingRoles));
-    $this->assertTrue(in_array($r6, $enablingRoles));
-    $this->assertTrue(in_array($r10, $enablingRoles));
-    $this->assertTrue(in_array($r7, $enablingRoles));
-    $this->assertTrue(in_array($r9, $enablingRoles));
-
-    $enablingRoles = $roleAuthServ->authoriseAction(\Action::NGI_ADD_SITE, $n3, $u)->getGrantingRoles();
-    $this->assertEquals(1, count($enablingRoles));
-    $this->assertTrue(in_array($r6, $enablingRoles));
-  }
-
-  public function test_getUserRolesOnAndAboveEntity(){
-    print __METHOD__ . "\n";
-    include __DIR__ . '/../../resources/sampleFixtureData5.php';
-
-    // create a user
-    $u = TestUtil::createSampleUser("dave", "meredith");
-    $identifier= TestUtil::createSampleUserIdentifier("X.509", "idSTring");
-    $u->addUserIdentifierDoJoin($identifier);
-    $this->em->persist($identifier);
-    $this->em->persist($u);
-
-    // add some roles to domain model
-    $ngiRoleType = TestUtil::createSampleRoleType("NGI_RT");
-    $siteRoleType = TestUtil::createSampleRoleType("SITE_RT");
-    $siteRoleType2 = TestUtil::createSampleRoleType("SITE_RT2");
-    $projRoleType = TestUtil::createSampleRoleType("PROJ_RT");
-    $this->em->persist($ngiRoleType);
-    $this->em->persist($siteRoleType);
-    $this->em->persist($siteRoleType2);
-    $this->em->persist($projRoleType);
-
-    $this->em->flush();
-
-    $roleActionMappingService = new org\gocdb\services\RoleActionMappingService();
-    // Create RoleActionAuthorisationService with dependencies
-    $roleAuthServ = new org\gocdb\services\RoleActionAuthorisationService($roleActionMappingService);
-
-    // We could create/inject a new em connection into the roleService
-    // to test the transactional isolation of its methods (rather than injecting
-    // $this->em instance), e.g.:
-    //   $em = $this->createEntityManager();
-    //   $roleService->setEntityManager($em);
-    //
-    // However, this is problematic for this test which
-    // needs to use the in_array() method to assert that the tested methods return
-    // the expected roles - in_array() uses object-instance-equality to deterine
-    // if the role exists in the array, and using a different $em instance
-    // means the returned roles will be considered different
-    // instances. We could get round this by comparing the Ids, but this makes
-    // checking more of hassle as we need to extract all the Ids from the roles
-    // into another array to assert the ids are expected, as in:
-    //   $roleIds = array();
-    //   foreach($roles as $r){ $roleIds[] = $r->getId(); }
-    //   $this->assertTrue(in_array($r1->getId(), $roleIds));
-    //   $this->assertTrue(in_array($r2->getId(), $roleIds));
-    //
-    // For this test, we will therefore re-use $this->em to ensure
-    // object-equality:
-    $roleAuthServ->setEntityManager($this->em);
-
-    $roles = $roleAuthServ->getUserRolesReachableFromEntityASC($u, $p1);
-    $this->assertEmpty($roles);
-
-    // Create a Role and link to the User, ngiRoleType and ngi
-    /*
-     * p1     p2     p3
-     * |      |     /|
-     * n1     n2-r1  n3
-     * |      |      |
-     * s1     s2     s3
-     */
-    $r1 = TestUtil::createSampleRole($u, $ngiRoleType, $n2, RoleStatus::GRANTED);
-    $this->em->persist($r1);
-    $this->em->flush();
-
-    $rolesDirect = $u->getRoles();
-    $this->assertEquals(1, count($rolesDirect));
-
-    $roles = $roleAuthServ->getUserRolesReachableFromEntityASC($u, $s1);
-    $this->assertEmpty($roles);
-
-    $roles = $roleAuthServ->getUserRolesReachableFromEntityASC($u, $s2);
-    $this->assertEquals(1, count($roles));
-    $this->assertTrue(in_array($r1, $roles));
-
-    /*
-     * p1     p2     p3
-     * |      |     /|
-     * n1     n2-r1  n3-r2
-     * |      |      |
-     * s1     s2     s3
-     */
-    $r2 = TestUtil::createSampleRole($u, $ngiRoleType, $n3, RoleStatus::GRANTED);
-    $this->em->persist($r2);
-    $this->em->flush();
-
-    $roles = $roleAuthServ->getUserRolesReachableFromEntityASC($u, $s2);
-    $this->assertEquals(1, count($roles));
-    $this->assertTrue(in_array($r1, $roles));
-
-    $roles = $roleAuthServ->getUserRolesReachableFromEntityASC($u, $s3);
-    $this->assertEquals(1, count($roles));
-    $this->assertTrue(in_array($r2, $roles));
-
-     /*
-     * p1     p2     p3
-     * |      |     /|
-     * n1     n2-r1  n3-r2
-     * |      |      |
-     * s1     s2     s3-r3
-     */
-    $r3 = TestUtil::createSampleRole($u, $siteRoleType, $s3, RoleStatus::GRANTED);
-    $this->em->persist($r3);
-    $this->em->flush();
-
-    $roles = $roleAuthServ->getUserRolesReachableFromEntityASC($u, $s3);
-    $this->assertEquals(2, count($roles));
-    $this->assertTrue(in_array($r2, $roles));
-    $this->assertTrue(in_array($r3, $roles));
-
-    /*
-     * p1     p2     p3-r4
-     * |      |     /|
-     * n1     n2-r1  n3-r2
-     * |      |      |
-     * s1     s2     s3-r3
-     */
-    $r4 = TestUtil::createSampleRole($u, $projRoleType, $p3, RoleStatus::GRANTED);
-    $this->em->persist($r4);
-    $this->em->flush();
-
-     /*
-     * p1     p2     p3-r4
-     * |      |     /|
-     * n1     n2-r1  n3-r2
-     * |      |      |
-     * s1     s2-r5  s3-r3
-     */
-    $r5 = TestUtil::createSampleRole($u, $siteRoleType, $s2, RoleStatus::GRANTED);
-    $this->em->persist($r5);
-    $this->em->flush();
-
-    /*
-     * p1     p2     p3-r4
-     * |      |     /|
-     * n1     n2-r1  n3-r2
-     * |      |      |
-     * s1-r6  s2-r5  s3-r3
-     */
-    $r6 = TestUtil::createSampleRole($u, $siteRoleType, $s1, RoleStatus::GRANTED);
-    $this->em->persist($r6);
-    $this->em->flush();
-
-    /*
-     * p1     p2     p3-r4
-     * |      |     /|
-     * n1     n2-r1  n3-r2
-     * |      |      |
-     * s1-r6  s2-r5  s3-r3,r7
-     */
-    $r7 = TestUtil::createSampleRole($u, $siteRoleType2, $s3, RoleStatus::GRANTED);
-    $this->em->persist($r7);
-    $this->em->flush();
-
-    /*
-     * p1     p2-r8  p3-r4
-     * |      |     /|
-     * n1     n2-r1  n3-r2
-     * |      |      |
-     * s1-r6  s2-r5  s3-r3,r7
-     */
-    $r8 = TestUtil::createSampleRole($u, $projRoleType, $p2, RoleStatus::GRANTED);
-    $this->em->persist($r8);
-    $this->em->flush();
-
-    $roles = $roleAuthServ->getUserRolesReachableFromEntityASC($u, $s1);
-    $this->assertEquals(1, count($roles));
-    $this->assertTrue(in_array($r6, $roles));
-
-    $roles = $roleAuthServ->getUserRolesReachableFromEntityASC($u, $s2);
-    $this->assertEquals(4, count($roles));
-    $this->assertTrue(in_array($r5, $roles));
-    $this->assertTrue(in_array($r1, $roles));
-    $this->assertTrue(in_array($r8, $roles));
-    $this->assertTrue(in_array($r4, $roles));
-
-    $roles = $roleAuthServ->getUserRolesReachableFromEntityASC($u, $s3);
-    $this->assertEquals(4, count($roles));
-    $this->assertTrue(in_array($r2, $roles));
-    $this->assertTrue(in_array($r3, $roles));
-    $this->assertTrue(in_array($r4, $roles));
-    $this->assertTrue(in_array($r7, $roles));
-
-  }
+
+    public function NOT_RUN_test_authoriseActionBug()
+    {
+        print __METHOD__ . "\n";
+        $codRT = TestUtil::createSampleRoleType(TestRoleTypeName::COD_ADMIN);
+        $this->em->persist($codRT);  // edit all sites cert status only
+
+      // Create a user
+        $u = TestUtil::createSampleUser("Test", "Testing");
+        $identifier = TestUtil::createSampleUserIdentifier("X.509", "/c=test");
+        $u->addUserIdentifierDoJoin($identifier);
+        $this->em->persist($identifier);
+        $this->em->persist($u);
+
+      /*
+       * Create test data with the following structure
+       *
+       *   p1  EGI
+       *    \  /
+       *     n1
+       */
+        $p1 = new \Project("p1");
+        $p2 = new \Project("EGI");
+        $n1 = TestUtil::createSampleNGI("n1");
+        $this->em->persist($p1);
+        $this->em->persist($p2);
+        $this->em->persist($n1);
+        $p1->addNgi($n1);
+        $p2->addNgi($n1);
+
+      // Build dependencies and inject business objects:
+      // start a new connection to test transactional isolation of RoleService methods.
+      //$em2 = $this->createEntityManager();
+        $em2 = $this->em;
+
+      // Create RoleActionMappingService with non-default roleActionMappings file
+        $roleActionMappingService = new org\gocdb\services\RoleActionMappingService();
+        $roleActionMappingService->setRoleActionMappingsXmlPath(
+            __DIR__ . "/../../resources/roleActionMappingSamples/TestRoleActionMappings7.xml"
+        );
+
+      // Create RoleActionAuthorisationService with dependencies
+        $roleAuthServ = new org\gocdb\services\RoleActionAuthorisationService($roleActionMappingService);
+        $roleAuthServ->setEntityManager($em2);
+
+      // Create role and link user and owned entities (user link not shown)
+      /*
+       * r1->p1  EGI
+       *      \  /
+       *       n1
+       */
+        $r1 = TestUtil::createSampleRole($u, $codRT, $p1, RoleStatus::GRANTED);
+        $this->em->persist($r1);
+        $this->em->flush();
+
+      // Assert user has no authorising roles over n1 BECAUSE p1 is not
+      // mapped in XML file and there is no default mapping!
+        $enablingRoles = $roleAuthServ->authoriseAction(\Action::REVOKE_ROLE, $n1, $u)->getGrantingRoles();
+        $this->assertEquals(0, count($enablingRoles));
+    }
+
+    public function test_authoriseAction()
+    {
+        print __METHOD__ . "\n";
+      // Create roletypes
+        $siteAdminRT = TestUtil::createSampleRoleType(TestRoleTypeName::SITE_ADMIN);
+        $siteDepManAdminRT = TestUtil::createSampleRoleType(TestRoleTypeName::SITE_OPS_DEP_MAN);
+        $ngiManRT = TestUtil::createSampleRoleType(TestRoleTypeName::NGI_OPS_MAN);
+        $rodRT = TestUtil::createSampleRoleType(TestRoleTypeName::REG_STAFF_ROD);
+        $codRT = TestUtil::createSampleRoleType(TestRoleTypeName::COD_ADMIN);
+        $cooRT = TestUtil::createSampleRoleType(TestRoleTypeName::COO);
+        $this->em->persist($siteAdminRT); // edit site1 (but not cert status)
+        $this->em->persist($ngiManRT); // edit owned site1/site2 and cert status
+        $this->em->persist($rodRT);  // edit owned sites 1and2 (but not cert status)
+        $this->em->persist($codRT);  // edit all sites cert status only
+        $this->em->persist($cooRT);  // edit all sites cert status only
+        $this->em->persist($siteDepManAdminRT);  // edit all sites cert status only
+
+      // Create a user
+        $u = TestUtil::createSampleUser("Test", "Testing");
+        $identifier = TestUtil::createSampleUserIdentifier("X.509", "/c=test");
+        $u->addUserIdentifierDoJoin($identifier);
+        $this->em->persist($identifier);
+        $this->em->persist($u);
+
+      /*
+       * Create test data with the following structure (note p3 has two ngis)
+       *
+       * p1  p2  p3
+       * |   |  /|
+       * n1  n2  n3
+       * |   |   |
+       * s1  s2  s3
+       */
+        include __DIR__ . '/../../resources/sampleFixtureData6.php';
+
+      // Build dependencies and inject business objects:
+      // start a new connection to test transactional isolation of RoleService methods.
+      //$em2 = $this->createEntityManager();
+        $em2 = $this->em;
+
+      // Create RoleActionMappingService with non-default roleActionMappings file
+        $roleActionMappingService = new org\gocdb\services\RoleActionMappingService();
+        $roleActionMappingService->setRoleActionMappingsXmlPath(
+            __DIR__ . "/../../resources/roleActionMappingSamples/TestRoleActionMappings6.xml"
+        );
+
+      // Create RoleActionAuthorisationService with dependencies
+        $roleAuthServ = new org\gocdb\services\RoleActionAuthorisationService($roleActionMappingService);
+        $roleAuthServ->setEntityManager($em2);
+
+      // Create role and link user and owned entities (user link not shown)
+      /*
+       *    p1  p2  p3
+       *    |    |  /|
+       * r1-n1  n2  n3
+       *    |   |   |
+       *    s1  s2  s3
+       */
+        $r1 = TestUtil::createSampleRole($u, $ngiManRT, $n1, RoleStatus::GRANTED);
+        $this->em->persist($r1);
+        $this->em->flush();
+
+      // Assert user can edit s1 using r1
+        $enablingRoles = $roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $s1, $u)->getGrantingRoles();
+        $this->assertEquals(1, count($enablingRoles));
+        $this->assertTrue(in_array($r1, $enablingRoles));
+        $this->assertEquals(TestRoleTypeName::NGI_OPS_MAN, $enablingRoles[0]->getRoleType()->getName());
+
+      // Assert user can edit n1 using r1
+        $enablingRoles = $roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $n1, $u)->getGrantingRoles();
+        $this->assertEquals(1, count($enablingRoles));
+        $this->assertTrue(in_array($r1, $enablingRoles));
+        $this->assertEquals(TestRoleTypeName::NGI_OPS_MAN, $enablingRoles[0]->getRoleType()->getName());
+
+      // Assert user can change s1 cert status with r1
+        $this->assertTrue(in_array($r1, $roleAuthServ->authoriseAction(\Action::SITE_EDIT_CERT_STATUS, $s1, $u)->getGrantingRoles()));
+
+      // Assert user can't edit other sites/ngis/projects
+        $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $s2, $u)->getGrantingRoles()));
+        $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $s3, $u)->getGrantingRoles()));
+        $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $n2, $u)->getGrantingRoles()));
+        $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $n3, $u)->getGrantingRoles()));
+        $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $p1, $u)->getGrantingRoles()));
+        $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $p2, $u)->getGrantingRoles()));
+        $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $p3, $u)->getGrantingRoles()));
+
+       /*
+       *    p1  p2  p3
+       *    |    |  /|
+       * r1-n1  n2  n3
+       *    |   |   |
+       * r2-s1  s2  s3
+       */
+        $r2 = TestUtil::createSampleRole($u, $siteAdminRT, $s1, RoleStatus::GRANTED) ;
+        $this->em->persist($r2);
+        $this->em->flush();
+
+      // Assert user can edit s1 using r1 + r2
+        $enablingRoles = $roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $s1, $u)->getGrantingRoles();
+        $this->assertEquals(2, count($enablingRoles));
+        $this->assertTrue(in_array($r1, $enablingRoles));
+        $this->assertTrue(in_array($r2, $enablingRoles));
+      //$enablingRoleNames = $this->getRoleTypeNames($enablingRoles);
+      //$this->assertTrue(in_array(TestRoleTypeName::NGI_OPS_MAN, $enablingRoleNames));
+      //$this->assertTrue(in_array(TestRoleTypeName::SITE_ADMIN, $enablingRoleNames));
+
+      // Assert user can change site cert status with r1
+        $enablingRoles = $roleAuthServ->authoriseAction(\Action::SITE_EDIT_CERT_STATUS, $s1, $u)->getGrantingRoles();
+        $this->assertEquals(1, count($enablingRoles));
+        $this->assertTrue(in_array($r1, $enablingRoles));
+
+      // Assert user can't edit other sites/ngis/projects
+        $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $s2, $u)->getGrantingRoles()));
+        $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $s3, $u)->getGrantingRoles()));
+        $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $n2, $u)->getGrantingRoles()));
+        $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $n3, $u)->getGrantingRoles()));
+        $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $p1, $u)->getGrantingRoles()));
+        $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $p2, $u)->getGrantingRoles()));
+        $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $p3, $u)->getGrantingRoles()));
+
+      /*
+       *    p1     p2  p3
+       *    |      |  /|
+       * r1-n1     n2  n3
+       *    |      |   |
+       * r2-s1  r3-s2  s3
+       */
+        $r3 = TestUtil::createSampleRole($u, $siteAdminRT, $s2, RoleStatus::GRANTED) ;
+        $this->em->persist($r3);
+        $this->em->flush();
+
+      // Assert user can edit s1 via r1 + r2
+        $enablingRoles = $roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $s1, $u)->getGrantingRoles();
+        $this->assertEquals(2, count($enablingRoles));
+        $this->assertTrue(in_array($r1, $enablingRoles));
+        $this->assertTrue(in_array($r2, $enablingRoles));
+
+      // Assert user can edit s2 via r3
+        $enablingRoles = $roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $s2, $u)->getGrantingRoles();
+        $this->assertEquals(1, count($enablingRoles));
+        $this->assertTrue(in_array($r3, $enablingRoles));
+
+      // Assert user can change s1 cert status via r1
+        $enablingRoles = $roleAuthServ->authoriseAction(\Action::SITE_EDIT_CERT_STATUS, $s1, $u)->getGrantingRoles();
+        $this->assertEquals(1, count($enablingRoles));
+        $this->assertTrue(in_array($r1, $enablingRoles));
+
+      // Assert user cant change s2 cert status
+        $enablingRoles = $roleAuthServ->authoriseAction(\Action::SITE_EDIT_CERT_STATUS, $s2, $u)->getGrantingRoles();
+        $this->assertEquals(0, count($enablingRoles));
+
+      // Assert user can't edit other sites/ngis/projects
+        $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $s3, $u)->getGrantingRoles()));
+        $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $n2, $u)->getGrantingRoles()));
+        $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $n3, $u)->getGrantingRoles()));
+        $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $p1, $u)->getGrantingRoles()));
+        $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $p2, $u)->getGrantingRoles()));
+        $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $p3, $u)->getGrantingRoles()));
+
+
+      /*
+       *    p1  r4-p2  p3
+       *    |      |  /|
+       * r1-n1     n2  n3
+       *    |      |   |
+       * r2-s1  r3-s2  s3
+       */
+        $r4 = TestUtil::createSampleRole($u, $cooRT, $p2, RoleStatus::GRANTED);
+        $this->em->persist($r4);
+        $this->em->flush();
+
+      // Assert user can edit p2 via r4
+        $enablingRoles = $roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $p2, $u)->getGrantingRoles();
+        $this->assertEquals(1, count($enablingRoles));
+        $this->assertTrue(in_array($r4, $enablingRoles));
+
+      // Assert user can grantRole on p2 via r4
+        $enablingRoles = $roleAuthServ->authoriseAction(\Action::GRANT_ROLE, $p2, $u)->getGrantingRoles();
+        $this->assertEquals(1, count($enablingRoles));
+        $this->assertTrue(in_array($r4, $enablingRoles));
+
+      // Assert user can grantRole on n2 via r4
+        $enablingRoles = $roleAuthServ->authoriseAction(\Action::GRANT_ROLE, $n2, $u)->getGrantingRoles();
+        $this->assertEquals(1, count($enablingRoles));
+        $this->assertTrue(in_array($r4, $enablingRoles));
+
+      // Assert user can't edit other sites/ngis/projects
+        $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $n2, $u)->getGrantingRoles()));
+        $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $s3, $u)->getGrantingRoles()));
+        $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $n3, $u)->getGrantingRoles()));
+        $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $p3, $u)->getGrantingRoles()));
+
+      /*
+       *    p1  r4-p2  p3-r5
+       *    |      |  /|
+       * r1-n1     n2  n3
+       *    |      |   |
+       * r2-s1  r3-s2  s3
+       */
+        $r5 = TestUtil::createSampleRole($u, $codRT, $p3, RoleStatus::GRANTED);
+        $this->em->persist($r5);
+        $this->em->flush();
+
+      // Assert user can edit p3 with r5
+        $enablingRoles = $roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $p3, $u)->getGrantingRoles();
+        $this->assertEquals(1, count($enablingRoles));
+        $this->assertTrue(in_array($r5, $enablingRoles));
+
+      // Assert user can grant role on n2 + n3 via r5
+        $enablingRoles = $roleAuthServ->authoriseAction(\Action::GRANT_ROLE, $n2, $u)->getGrantingRoles();
+        $this->assertEquals(2, count($enablingRoles));
+        $this->assertTrue(in_array($r5, $enablingRoles));
+        $this->assertTrue(in_array($r4, $enablingRoles));
+
+      // Assert user can't edit other sites/ngis/projects
+        $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $n2, $u)->getGrantingRoles()));
+        $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $s3, $u)->getGrantingRoles()));
+        $this->assertEquals(0, count($roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $n3, $u)->getGrantingRoles()));
+
+      /*
+       *    p1  r4-p2  p3-r5
+       *    |      |  /|
+       * r1-n1     n2  n3-r6
+       *    |      |   |
+       * r2-s1  r3-s2  s3
+       */
+        $r6 = TestUtil::createSampleRole($u, $ngiManRT, $n3, RoleStatus::GRANTED);
+        $this->em->persist($r6);
+        $this->em->flush();
+
+      /*
+       *    p1  r4-p2  p3-r5
+       *    |      |  /|
+       * r1-n1     n2  n3-r6
+       *    |      |   |
+       * r2-s1  r3-s2  s3-r7
+       */
+        $r7 = TestUtil::createSampleRole($u, $siteAdminRT, $s3, RoleStatus::GRANTED);
+        $this->em->persist($r7);
+        $this->em->flush();
+
+      // Assert user can edit s3 with r6 + r7
+        $enablingRoles = $roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $s3, $u)->getGrantingRoles();
+        $this->assertEquals(2, count($enablingRoles));
+        $this->assertTrue(in_array($r7, $enablingRoles));
+        $this->assertTrue(in_array($r6, $enablingRoles));
+
+      /*
+       *    p1  r4-p2  p3-r5
+       *    |      |  /|
+       * r1-n1  r8-n2  n3-r6
+       *    |      |   |
+       * r2-s1  r3-s2  s3-r7
+       */
+        $r8 = TestUtil::createSampleRole($u, $ngiManRT, $n2, RoleStatus::GRANTED);
+        $this->em->persist($r8);
+        $this->em->flush();
+
+        $enablingRoles = $roleAuthServ->authoriseAction(\Action::SITE_EDIT_CERT_STATUS, $s2, $u)->getGrantingRoles();
+        $this->assertEquals(3, count($enablingRoles));
+        $this->assertTrue(in_array($r8, $enablingRoles));
+        $this->assertTrue(in_array($r4, $enablingRoles));
+        $this->assertTrue(in_array($r5, $enablingRoles));
+
+        $enablingRoles = $roleAuthServ->authoriseAction(\Action::SITE_EDIT_CERT_STATUS, $s3, $u)->getGrantingRoles();
+        $this->assertEquals(2, count($enablingRoles));
+        $this->assertTrue(in_array($r6, $enablingRoles));
+        $this->assertTrue(in_array($r5, $enablingRoles));
+
+      /*
+       *    p1  r4-p2  p3-r5
+       *    |      |  /|
+       * r1-n1  r8-n2  n3-r6
+       *    |      |   |
+       * r2-s1  r3-s2  s3-r7,r9
+       */
+        $r9 = TestUtil::createSampleRole($u, $siteDepManAdminRT, $s3, RoleStatus::GRANTED);
+        $this->em->persist($r9);
+        $this->em->flush();
+
+      // Assert user can edit s3 with r7, r9, r6
+        $enablingRoles = $roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $s3, $u)->getGrantingRoles();
+        $this->assertEquals(3, count($enablingRoles));
+        $this->assertTrue(in_array($r7, $enablingRoles));
+        $this->assertTrue(in_array($r9, $enablingRoles));
+        $this->assertTrue(in_array($r6, $enablingRoles));
+
+      // Assert user can change s3 cert status with r6 + r5
+        $enablingRoles = $roleAuthServ->authoriseAction(\Action::SITE_EDIT_CERT_STATUS, $s3, $u)->getGrantingRoles();
+        $this->assertEquals(2, count($enablingRoles));
+        $this->assertTrue(in_array($r6, $enablingRoles));
+        $this->assertTrue(in_array($r5, $enablingRoles));
+
+      /*
+       *    p1  r4-p2  p3-r5
+       *    |      |  /|
+       * r1-n1  r8-n2  n3-r6,r10
+       *    |      |   |
+       * r2-s1  r3-s2  s3-r7,r9
+       */
+        $r10 = TestUtil::createSampleRole($u, $rodRT, $n3, RoleStatus::GRANTED);
+        $this->em->persist($r10);
+        $this->em->flush();
+
+        $enablingRoles = $roleAuthServ->authoriseAction(\Action::EDIT_OBJECT, $s3, $u)->getGrantingRoles();
+        $this->assertEquals(4, count($enablingRoles));
+        $this->assertTrue(in_array($r6, $enablingRoles));
+        $this->assertTrue(in_array($r10, $enablingRoles));
+        $this->assertTrue(in_array($r7, $enablingRoles));
+        $this->assertTrue(in_array($r9, $enablingRoles));
+
+        $enablingRoles = $roleAuthServ->authoriseAction(\Action::NGI_ADD_SITE, $n3, $u)->getGrantingRoles();
+        $this->assertEquals(1, count($enablingRoles));
+        $this->assertTrue(in_array($r6, $enablingRoles));
+    }
+
+    public function test_getUserRolesOnAndAboveEntity()
+    {
+        print __METHOD__ . "\n";
+        include __DIR__ . '/../../resources/sampleFixtureData5.php';
+
+      // create a user
+        $u = TestUtil::createSampleUser("dave", "meredith");
+        $identifier = TestUtil::createSampleUserIdentifier("X.509", "idSTring");
+        $u->addUserIdentifierDoJoin($identifier);
+        $this->em->persist($identifier);
+        $this->em->persist($u);
+
+      // add some roles to domain model
+        $ngiRoleType = TestUtil::createSampleRoleType("NGI_RT");
+        $siteRoleType = TestUtil::createSampleRoleType("SITE_RT");
+        $siteRoleType2 = TestUtil::createSampleRoleType("SITE_RT2");
+        $projRoleType = TestUtil::createSampleRoleType("PROJ_RT");
+        $this->em->persist($ngiRoleType);
+        $this->em->persist($siteRoleType);
+        $this->em->persist($siteRoleType2);
+        $this->em->persist($projRoleType);
+
+        $this->em->flush();
+
+        $roleActionMappingService = new org\gocdb\services\RoleActionMappingService();
+      // Create RoleActionAuthorisationService with dependencies
+        $roleAuthServ = new org\gocdb\services\RoleActionAuthorisationService($roleActionMappingService);
+
+      // We could create/inject a new em connection into the roleService
+      // to test the transactional isolation of its methods (rather than injecting
+      // $this->em instance), e.g.:
+      //   $em = $this->createEntityManager();
+      //   $roleService->setEntityManager($em);
+      //
+      // However, this is problematic for this test which
+      // needs to use the in_array() method to assert that the tested methods return
+      // the expected roles - in_array() uses object-instance-equality to deterine
+      // if the role exists in the array, and using a different $em instance
+      // means the returned roles will be considered different
+      // instances. We could get round this by comparing the Ids, but this makes
+      // checking more of hassle as we need to extract all the Ids from the roles
+      // into another array to assert the ids are expected, as in:
+      //   $roleIds = array();
+      //   foreach($roles as $r){ $roleIds[] = $r->getId(); }
+      //   $this->assertTrue(in_array($r1->getId(), $roleIds));
+      //   $this->assertTrue(in_array($r2->getId(), $roleIds));
+      //
+      // For this test, we will therefore re-use $this->em to ensure
+      // object-equality:
+        $roleAuthServ->setEntityManager($this->em);
+
+        $roles = $roleAuthServ->getUserRolesReachableFromEntityASC($u, $p1);
+        $this->assertEmpty($roles);
+
+      // Create a Role and link to the User, ngiRoleType and ngi
+      /*
+       * p1     p2     p3
+       * |      |     /|
+       * n1     n2-r1  n3
+       * |      |      |
+       * s1     s2     s3
+       */
+        $r1 = TestUtil::createSampleRole($u, $ngiRoleType, $n2, RoleStatus::GRANTED);
+        $this->em->persist($r1);
+        $this->em->flush();
+
+        $rolesDirect = $u->getRoles();
+        $this->assertEquals(1, count($rolesDirect));
+
+        $roles = $roleAuthServ->getUserRolesReachableFromEntityASC($u, $s1);
+        $this->assertEmpty($roles);
+
+        $roles = $roleAuthServ->getUserRolesReachableFromEntityASC($u, $s2);
+        $this->assertEquals(1, count($roles));
+        $this->assertTrue(in_array($r1, $roles));
+
+      /*
+       * p1     p2     p3
+       * |      |     /|
+       * n1     n2-r1  n3-r2
+       * |      |      |
+       * s1     s2     s3
+       */
+        $r2 = TestUtil::createSampleRole($u, $ngiRoleType, $n3, RoleStatus::GRANTED);
+        $this->em->persist($r2);
+        $this->em->flush();
+
+        $roles = $roleAuthServ->getUserRolesReachableFromEntityASC($u, $s2);
+        $this->assertEquals(1, count($roles));
+        $this->assertTrue(in_array($r1, $roles));
+
+        $roles = $roleAuthServ->getUserRolesReachableFromEntityASC($u, $s3);
+        $this->assertEquals(1, count($roles));
+        $this->assertTrue(in_array($r2, $roles));
+
+       /*
+       * p1     p2     p3
+       * |      |     /|
+       * n1     n2-r1  n3-r2
+       * |      |      |
+       * s1     s2     s3-r3
+       */
+        $r3 = TestUtil::createSampleRole($u, $siteRoleType, $s3, RoleStatus::GRANTED);
+        $this->em->persist($r3);
+        $this->em->flush();
+
+        $roles = $roleAuthServ->getUserRolesReachableFromEntityASC($u, $s3);
+        $this->assertEquals(2, count($roles));
+        $this->assertTrue(in_array($r2, $roles));
+        $this->assertTrue(in_array($r3, $roles));
+
+      /*
+       * p1     p2     p3-r4
+       * |      |     /|
+       * n1     n2-r1  n3-r2
+       * |      |      |
+       * s1     s2     s3-r3
+       */
+        $r4 = TestUtil::createSampleRole($u, $projRoleType, $p3, RoleStatus::GRANTED);
+        $this->em->persist($r4);
+        $this->em->flush();
+
+       /*
+       * p1     p2     p3-r4
+       * |      |     /|
+       * n1     n2-r1  n3-r2
+       * |      |      |
+       * s1     s2-r5  s3-r3
+       */
+        $r5 = TestUtil::createSampleRole($u, $siteRoleType, $s2, RoleStatus::GRANTED);
+        $this->em->persist($r5);
+        $this->em->flush();
+
+      /*
+       * p1     p2     p3-r4
+       * |      |     /|
+       * n1     n2-r1  n3-r2
+       * |      |      |
+       * s1-r6  s2-r5  s3-r3
+       */
+        $r6 = TestUtil::createSampleRole($u, $siteRoleType, $s1, RoleStatus::GRANTED);
+        $this->em->persist($r6);
+        $this->em->flush();
+
+      /*
+       * p1     p2     p3-r4
+       * |      |     /|
+       * n1     n2-r1  n3-r2
+       * |      |      |
+       * s1-r6  s2-r5  s3-r3,r7
+       */
+        $r7 = TestUtil::createSampleRole($u, $siteRoleType2, $s3, RoleStatus::GRANTED);
+        $this->em->persist($r7);
+        $this->em->flush();
+
+      /*
+       * p1     p2-r8  p3-r4
+       * |      |     /|
+       * n1     n2-r1  n3-r2
+       * |      |      |
+       * s1-r6  s2-r5  s3-r3,r7
+       */
+        $r8 = TestUtil::createSampleRole($u, $projRoleType, $p2, RoleStatus::GRANTED);
+        $this->em->persist($r8);
+        $this->em->flush();
+
+        $roles = $roleAuthServ->getUserRolesReachableFromEntityASC($u, $s1);
+        $this->assertEquals(1, count($roles));
+        $this->assertTrue(in_array($r6, $roles));
+
+        $roles = $roleAuthServ->getUserRolesReachableFromEntityASC($u, $s2);
+        $this->assertEquals(4, count($roles));
+        $this->assertTrue(in_array($r5, $roles));
+        $this->assertTrue(in_array($r1, $roles));
+        $this->assertTrue(in_array($r8, $roles));
+        $this->assertTrue(in_array($r4, $roles));
+
+        $roles = $roleAuthServ->getUserRolesReachableFromEntityASC($u, $s3);
+        $this->assertEquals(4, count($roles));
+        $this->assertTrue(in_array($r2, $roles));
+        $this->assertTrue(in_array($r3, $roles));
+        $this->assertTrue(in_array($r4, $roles));
+        $this->assertTrue(in_array($r7, $roles));
+    }
 
   /**
    * Persist some seed data - roletypes, user, Project, NGI, sites and SEs and
@@ -683,256 +703,257 @@ class RoleActionAuthorisationServiceTest  extends PHPUnit_Extensions_Database_Te
    * number of roles that allow a particular site to be edited, or 'n' number
    * of roles that allow an NGI certification status change.
    */
-  public function testAuthoriseAction2(){
-    print __METHOD__ . "\n";
-    // Create roletypes
-    $siteAdminRT = TestUtil::createSampleRoleType(RoleTypeName::SITE_ADMIN/*, RoleTypeClass::SITE_USER*/);
-    $ngiManRT = TestUtil::createSampleRoleType(RoleTypeName::NGI_OPS_MAN/*, RoleTypeClass::REGIONAL_MANAGER*/);
-    $rodRT = TestUtil::createSampleRoleType(RoleTypeName::REG_STAFF_ROD/*, RoleTypeClass::REGIONAL_USER*/);
-    $codRT = TestUtil::createSampleRoleType(RoleTypeName::COD_ADMIN/*, RoleTypeClass::PROJECT*/);
-    $this->em->persist($siteAdminRT); // edit site1 (but not cert status)
-    $this->em->persist($ngiManRT); // edit owned site1/site2 and cert status
-    $this->em->persist($rodRT);  // edit owned sites 1and2 (but not cert status)
-    $this->em->persist($codRT);  // edit all sites cert status only
+    public function testAuthoriseAction2()
+    {
+        print __METHOD__ . "\n";
+      // Create roletypes
+        $siteAdminRT = TestUtil::createSampleRoleType(RoleTypeName::SITE_ADMIN/*, RoleTypeClass::SITE_USER*/);
+        $ngiManRT = TestUtil::createSampleRoleType(RoleTypeName::NGI_OPS_MAN/*, RoleTypeClass::REGIONAL_MANAGER*/);
+        $rodRT = TestUtil::createSampleRoleType(RoleTypeName::REG_STAFF_ROD/*, RoleTypeClass::REGIONAL_USER*/);
+        $codRT = TestUtil::createSampleRoleType(RoleTypeName::COD_ADMIN/*, RoleTypeClass::PROJECT*/);
+        $this->em->persist($siteAdminRT); // edit site1 (but not cert status)
+        $this->em->persist($ngiManRT); // edit owned site1/site2 and cert status
+        $this->em->persist($rodRT);  // edit owned sites 1and2 (but not cert status)
+        $this->em->persist($codRT);  // edit all sites cert status only
 
-    // Create a user
-    $u = TestUtil::createSampleUser("Test", "Testing");
-    $identifier= TestUtil::createSampleUserIdentifier("X.509", "/c=test");
-    $u->addUserIdentifierDoJoin($identifier);
-    $this->em->persist($identifier);
-    $this->em->persist($u);
+      // Create a user
+        $u = TestUtil::createSampleUser("Test", "Testing");
+        $identifier = TestUtil::createSampleUserIdentifier("X.509", "/c=test");
+        $u->addUserIdentifierDoJoin($identifier);
+        $this->em->persist($identifier);
+        $this->em->persist($u);
 
-    /*
-    * Create a linked object graph
-    *
-    *                         p1
-    *                         |
-    *                        ngi      <- ngiManRT, rodRT,
-    *                      |    \
-    * siteAdminRT  ->   site1   site2
-    *                     |
-    *                   se1
-    *
-    */
-    $ngi = TestUtil::createSampleNGI("MYNGI");
-    $this->em->persist($ngi);
-    $site1 = TestUtil::createSampleSite("SITENAME"/*, "PK01"*/);
-    //$site1->setNgiDoJoin($ngi);
-    $ngi->addSiteDoJoin($site1);
-    $this->em->persist($site1);
-    $se1 = TestUtil::createSampleService('somelabel');
-    $site1->addServiceDoJoin($se1);
-    $this->em->persist($se1);
-    $site2_userHasNoDirectRole = TestUtil::createSampleSite("SITENAME_2"/*, "PK01"*/);
-    $ngi->addSiteDoJoin($site2_userHasNoDirectRole);
-    //$site2_userHasNoDirectRole->setNgiDoJoin($ngi);
-    $this->em->persist($site2_userHasNoDirectRole);
+      /*
+      * Create a linked object graph
+      *
+      *                         p1
+      *                         |
+      *                        ngi      <- ngiManRT, rodRT,
+      *                      |    \
+      * siteAdminRT  ->   site1   site2
+      *                     |
+      *                   se1
+      *
+      */
+        $ngi = TestUtil::createSampleNGI("MYNGI");
+        $this->em->persist($ngi);
+        $site1 = TestUtil::createSampleSite("SITENAME"/*, "PK01"*/);
+      //$site1->setNgiDoJoin($ngi);
+        $ngi->addSiteDoJoin($site1);
+        $this->em->persist($site1);
+        $se1 = TestUtil::createSampleService('somelabel');
+        $site1->addServiceDoJoin($se1);
+        $this->em->persist($se1);
+        $site2_userHasNoDirectRole = TestUtil::createSampleSite("SITENAME_2"/*, "PK01"*/);
+        $ngi->addSiteDoJoin($site2_userHasNoDirectRole);
+      //$site2_userHasNoDirectRole->setNgiDoJoin($ngi);
+        $this->em->persist($site2_userHasNoDirectRole);
 
-    $p1 = new \Project("EGI");
-    $this->em->persist($p1);
-    $p1->addNgi($ngi);
+        $p1 = new \Project("EGI");
+        $this->em->persist($p1);
+        $p1->addNgi($ngi);
 
-    // Create ngiManagerRole, ngiUserRole, siteAdminRole and link user and owned entities
-    $ngiManagerRole = TestUtil::createSampleRole($u, $ngiManRT, $ngi, RoleStatus::GRANTED);
-    $this->em->persist($ngiManagerRole);
-    $rodUserRole = TestUtil::createSampleRole($u, $rodRT, $ngi, RoleStatus::GRANTED);
-    $this->em->persist($rodUserRole);
-    $siteAdminRole = TestUtil::createSampleRole($u, $siteAdminRT, $site1, RoleStatus::GRANTED) ;
-    $this->em->persist($siteAdminRole);
-    $this->em->flush();
+      // Create ngiManagerRole, ngiUserRole, siteAdminRole and link user and owned entities
+        $ngiManagerRole = TestUtil::createSampleRole($u, $ngiManRT, $ngi, RoleStatus::GRANTED);
+        $this->em->persist($ngiManagerRole);
+        $rodUserRole = TestUtil::createSampleRole($u, $rodRT, $ngi, RoleStatus::GRANTED);
+        $this->em->persist($rodUserRole);
+        $siteAdminRole = TestUtil::createSampleRole($u, $siteAdminRT, $site1, RoleStatus::GRANTED) ;
+        $this->em->persist($siteAdminRole);
+        $this->em->flush();
 
-    // ********MUST******** start a new connection to test transactional
-    // isolation of RoleService methods.
-    //$em = $this->createEntityManager();
-    //$siteService = new org\gocdb\services\Site();
-    //$siteService->setEntityManager($em);
-    $roleActionMappingService = new org\gocdb\services\RoleActionMappingService();
-    $roleActionAuthService = new org\gocdb\services\RoleActionAuthorisationService($roleActionMappingService);
-    $roleActionAuthService->setEntityManager($this->em);
+      // ********MUST******** start a new connection to test transactional
+      // isolation of RoleService methods.
+      //$em = $this->createEntityManager();
+      //$siteService = new org\gocdb\services\Site();
+      //$siteService->setEntityManager($em);
+        $roleActionMappingService = new org\gocdb\services\RoleActionMappingService();
+        $roleActionAuthService = new org\gocdb\services\RoleActionAuthorisationService($roleActionMappingService);
+        $roleActionAuthService->setEntityManager($this->em);
 
-    // Assert user can edit site using 3 enabling roles
-    $enablingRoles = $roleActionAuthService->authoriseAction(\Action::EDIT_OBJECT, $site1, $u)->getGrantingRoles();
-    $this->assertEquals(3, count($enablingRoles));
-    $this->assertTrue(in_array($siteAdminRole, $enablingRoles));
-    $this->assertTrue(in_array($rodUserRole, $enablingRoles));
-    $this->assertTrue(in_array($ngiManagerRole, $enablingRoles));
+      // Assert user can edit site using 3 enabling roles
+        $enablingRoles = $roleActionAuthService->authoriseAction(\Action::EDIT_OBJECT, $site1, $u)->getGrantingRoles();
+        $this->assertEquals(3, count($enablingRoles));
+        $this->assertTrue(in_array($siteAdminRole, $enablingRoles));
+        $this->assertTrue(in_array($rodUserRole, $enablingRoles));
+        $this->assertTrue(in_array($ngiManagerRole, $enablingRoles));
 
-    // Assert user can only edit cert status through his NGI_OPS_MAN role
-    $enablingRoles = $roleActionAuthService->authoriseAction(\Action::SITE_EDIT_CERT_STATUS, $site1, $u)->getGrantingRoles();
-    $this->assertEquals(1, count($enablingRoles));
-    $this->assertTrue(in_array($ngiManagerRole, $enablingRoles));
+      // Assert user can only edit cert status through his NGI_OPS_MAN role
+        $enablingRoles = $roleActionAuthService->authoriseAction(\Action::SITE_EDIT_CERT_STATUS, $site1, $u)->getGrantingRoles();
+        $this->assertEquals(1, count($enablingRoles));
+        $this->assertTrue(in_array($ngiManagerRole, $enablingRoles));
 
-    // Add a new project role and link ngi and give user COD_ADMIN Project role (use $this->em to isolate)
-    $codRole = TestUtil::createSampleRole($u, $codRT, $p1, RoleStatus::GRANTED);
-    $this->em->persist($codRole);
-    $this->em->flush();
+      // Add a new project role and link ngi and give user COD_ADMIN Project role (use $this->em to isolate)
+        $codRole = TestUtil::createSampleRole($u, $codRT, $p1, RoleStatus::GRANTED);
+        $this->em->persist($codRole);
+        $this->em->flush();
 
-    /*
-    *                                 p1      <- codRT
-    *                                |
-    *                               ngi      <- ngiManRT, rodRT,
-    *                             |    \
-    *         siteAdminRT  ->   site1   site2
-    *                            |
-    *                           se1
-    *
-    */
+      /*
+      *                                 p1      <- codRT
+      *                                |
+      *                               ngi      <- ngiManRT, rodRT,
+      *                             |    \
+      *         siteAdminRT  ->   site1   site2
+      *                            |
+      *                           se1
+      *
+      */
 
-    // Assert user now has 2 roles that enable SITE_EDIT_CERT_STATUS change action
-    $enablingRoles = $roleActionAuthService->authoriseAction(\Action::SITE_EDIT_CERT_STATUS, $site1, $u)->getGrantingRoles();
-    $this->assertEquals(2, count($enablingRoles));
-    $this->assertTrue(in_array($ngiManagerRole, $enablingRoles));
-    $this->assertTrue(in_array($codRole, $enablingRoles));
+      // Assert user now has 2 roles that enable SITE_EDIT_CERT_STATUS change action
+        $enablingRoles = $roleActionAuthService->authoriseAction(\Action::SITE_EDIT_CERT_STATUS, $site1, $u)->getGrantingRoles();
+        $this->assertEquals(2, count($enablingRoles));
+        $this->assertTrue(in_array($ngiManagerRole, $enablingRoles));
+        $this->assertTrue(in_array($codRole, $enablingRoles));
 
-    // Assert user can edit SE using SITE_ADMIN, NGI_OPS_MAN, REG_STAFF_ROD roles (but not COD role)
-    $enablingRoles = $roleActionAuthService->authoriseAction(\Action::EDIT_OBJECT, $se1->getParentSite(), $u)->getGrantingRoles();
-    $this->assertEquals(3, count($enablingRoles));
-    $this->assertTrue(in_array($siteAdminRole, $enablingRoles));
-    $this->assertTrue(in_array($ngiManagerRole, $enablingRoles));
-    $this->assertTrue(in_array($rodUserRole, $enablingRoles));
+      // Assert user can edit SE using SITE_ADMIN, NGI_OPS_MAN, REG_STAFF_ROD roles (but not COD role)
+        $enablingRoles = $roleActionAuthService->authoriseAction(\Action::EDIT_OBJECT, $se1->getParentSite(), $u)->getGrantingRoles();
+        $this->assertEquals(3, count($enablingRoles));
+        $this->assertTrue(in_array($siteAdminRole, $enablingRoles));
+        $this->assertTrue(in_array($ngiManagerRole, $enablingRoles));
+        $this->assertTrue(in_array($rodUserRole, $enablingRoles));
 
-    // Assert User can only edit Site2 through his 2 indirect ngi roles
-    // (user don't have any direct site level roles on this site and COD don't give edit perm)
-    $enablingRoles = $roleActionAuthService->authoriseAction(\Action::EDIT_OBJECT, $site2_userHasNoDirectRole, $u)->getGrantingRoles();
-    $this->assertEquals(2, count($enablingRoles));
-    $this->assertTrue(in_array($ngiManagerRole, $enablingRoles));
-    $this->assertTrue(in_array($rodUserRole, $enablingRoles));
+      // Assert User can only edit Site2 through his 2 indirect ngi roles
+      // (user don't have any direct site level roles on this site and COD don't give edit perm)
+        $enablingRoles = $roleActionAuthService->authoriseAction(\Action::EDIT_OBJECT, $site2_userHasNoDirectRole, $u)->getGrantingRoles();
+        $this->assertEquals(2, count($enablingRoles));
+        $this->assertTrue(in_array($ngiManagerRole, $enablingRoles));
+        $this->assertTrue(in_array($rodUserRole, $enablingRoles));
 
-    // Delete the user's Project COD role
-    $this->em->remove($codRole);
-    $this->em->flush();
-    /*
-    *                               p1
-    *                                |
-    *                             ngi      <- ngiManRT, rodRT,
-    *                             |    \
-    *         siteAdminRT  ->   site1   site2
-    *                             |
-    *                            se1
-    *
-    */
+      // Delete the user's Project COD role
+        $this->em->remove($codRole);
+        $this->em->flush();
+      /*
+      *                               p1
+      *                                |
+      *                             ngi      <- ngiManRT, rodRT,
+      *                             |    \
+      *         siteAdminRT  ->   site1   site2
+      *                             |
+      *                            se1
+      *
+      */
 
-    // Assert user can only SITE_EDIT_CERT_STATUS through 1 role for both sites
-    $enablingRoles =  $roleActionAuthService->authoriseAction(\Action::SITE_EDIT_CERT_STATUS, $site2_userHasNoDirectRole, $u)->getGrantingRoles();
-    $this->assertEquals(1, count($enablingRoles));
-    $this->assertTrue(in_array($ngiManagerRole, $enablingRoles));
-    $enablingRoles =  $roleActionAuthService->authoriseAction(\Action::SITE_EDIT_CERT_STATUS, $site1, $u)->getGrantingRoles();
-    $this->assertEquals(1, count($enablingRoles));
-    $this->assertTrue(in_array($ngiManagerRole, $enablingRoles));
+      // Assert user can only SITE_EDIT_CERT_STATUS through 1 role for both sites
+        $enablingRoles =  $roleActionAuthService->authoriseAction(\Action::SITE_EDIT_CERT_STATUS, $site2_userHasNoDirectRole, $u)->getGrantingRoles();
+        $this->assertEquals(1, count($enablingRoles));
+        $this->assertTrue(in_array($ngiManagerRole, $enablingRoles));
+        $enablingRoles =  $roleActionAuthService->authoriseAction(\Action::SITE_EDIT_CERT_STATUS, $site1, $u)->getGrantingRoles();
+        $this->assertEquals(1, count($enablingRoles));
+        $this->assertTrue(in_array($ngiManagerRole, $enablingRoles));
 
-    // Delete the user's NGI manager role
-    $this->em->remove($ngiManagerRole);
-    $this->em->flush();
+      // Delete the user's NGI manager role
+        $this->em->remove($ngiManagerRole);
+        $this->em->flush();
 
-    /*
-    *                         p1
-    *                         |
-    *                        ngi      <- rodRT,
-    *                      |    \
-    *  siteAdminRT  ->   site1   site2
-    *                     |
-    *                    se1
-    */
+      /*
+      *                         p1
+      *                         |
+      *                        ngi      <- rodRT,
+      *                      |    \
+      *  siteAdminRT  ->   site1   site2
+      *                     |
+      *                    se1
+      */
 
-    // Assert user can't edit site2 cert status
-    $enablingRoles = $roleActionAuthService->authoriseAction(\Action::SITE_EDIT_CERT_STATUS, $site2_userHasNoDirectRole, $u)->getGrantingRoles();
-    $this->assertEquals(0, count($enablingRoles));
-    // Assert user can still edit site via his ROD role
-    $enablingRoles = $roleActionAuthService->authoriseAction(\Action::EDIT_OBJECT, $site2_userHasNoDirectRole, $u)->getGrantingRoles();
-    $this->assertEquals(1, count($enablingRoles));
-    $this->assertTrue(in_array($rodUserRole, $enablingRoles));
+      // Assert user can't edit site2 cert status
+        $enablingRoles = $roleActionAuthService->authoriseAction(\Action::SITE_EDIT_CERT_STATUS, $site2_userHasNoDirectRole, $u)->getGrantingRoles();
+        $this->assertEquals(0, count($enablingRoles));
+      // Assert user can still edit site via his ROD role
+        $enablingRoles = $roleActionAuthService->authoriseAction(\Action::EDIT_OBJECT, $site2_userHasNoDirectRole, $u)->getGrantingRoles();
+        $this->assertEquals(1, count($enablingRoles));
+        $this->assertTrue(in_array($rodUserRole, $enablingRoles));
 
-    // Delete the user's NGI ROD role
-    $this->em->remove($rodUserRole);
-    $this->em->flush();
+      // Delete the user's NGI ROD role
+        $this->em->remove($rodUserRole);
+        $this->em->flush();
 
-    /*
-    *                         p1
-    *                         |
-    *                         ngi
-    *                       |    \
-    *  siteAdminRT  ->   site1   site2
-    *                      |
-    *                     se1
-    */
+      /*
+      *                         p1
+      *                         |
+      *                         ngi
+      *                       |    \
+      *  siteAdminRT  ->   site1   site2
+      *                      |
+      *                     se1
+      */
 
-    // User can't edit site2
-    $enablingRoles = $roleActionAuthService->authoriseAction(\Action::EDIT_OBJECT, $site2_userHasNoDirectRole, $u)->getGrantingRoles();
-    $this->assertEquals(0, count($enablingRoles));
+      // User can't edit site2
+        $enablingRoles = $roleActionAuthService->authoriseAction(\Action::EDIT_OBJECT, $site2_userHasNoDirectRole, $u)->getGrantingRoles();
+        $this->assertEquals(0, count($enablingRoles));
 
-    // Assert user can still edit SITE1 through his direct site level role (this role has not been deleted)
-    $enablingRoles = $roleActionAuthService->authoriseAction(\Action::EDIT_OBJECT, $site1, $u)->getGrantingRoles();
-    $this->assertEquals(1, count($enablingRoles));
-    $this->assertTrue(in_array($siteAdminRole, $enablingRoles));
+      // Assert user can still edit SITE1 through his direct site level role (this role has not been deleted)
+        $enablingRoles = $roleActionAuthService->authoriseAction(\Action::EDIT_OBJECT, $site1, $u)->getGrantingRoles();
+        $this->assertEquals(1, count($enablingRoles));
+        $this->assertTrue(in_array($siteAdminRole, $enablingRoles));
 
-    // Delete user's remaining Site role
-    $this->em->remove($siteAdminRole);
-    $this->em->flush();
+      // Delete user's remaining Site role
+        $this->em->remove($siteAdminRole);
+        $this->em->flush();
 
-    /*
-    *                         p1
-    *                         |
-    *                         ngi
-    *                       |    \
-    *                     site1   site2
-    *                      |
-    *                     se1
-    */
+      /*
+      *                         p1
+      *                         |
+      *                         ngi
+      *                       |    \
+      *                     site1   site2
+      *                      |
+      *                     se1
+      */
 
-    // User can't edit site1
-    $enablingRoles = $roleActionAuthService->authoriseAction(\Action::EDIT_OBJECT, $site1, $u)->getGrantingRoles();
-    $this->assertEquals(0, count($enablingRoles));
-  }
-
+      // User can't edit site1
+        $enablingRoles = $roleActionAuthService->authoriseAction(\Action::EDIT_OBJECT, $site1, $u)->getGrantingRoles();
+        $this->assertEquals(0, count($enablingRoles));
+    }
 }
 
-class TestRoleTypeName {
-
-  const GOCDB_ADMIN = 'GOCDB_ADMIN';
+class TestRoleTypeName
+{
+    const GOCDB_ADMIN = 'GOCDB_ADMIN';
 
   // Roles for Sites
-  const SITE_ADMIN = 'Site Administrator'; // C
+    const SITE_ADMIN = 'Site Administrator'; // C
 
-  const SITE_SECOFFICER = 'Site Security Officer'; // C'
-  const SITE_OPS_DEP_MAN = 'Site Operations Deputy Manager'; // C'
-  const SITE_OPS_MAN = 'Site Operations Manager'; // C'
+    const SITE_SECOFFICER = 'Site Security Officer'; // C'
+    const SITE_OPS_DEP_MAN = 'Site Operations Deputy Manager'; // C'
+    const SITE_OPS_MAN = 'Site Operations Manager'; // C'
 
   // Roles for NGIs
-  const REG_FIRST_LINE_SUPPORT = 'Regional First Line Support'; // D
-  const REG_STAFF_ROD = 'Regional Staff (ROD)'; // D
+    const REG_FIRST_LINE_SUPPORT = 'Regional First Line Support'; // D
+    const REG_STAFF_ROD = 'Regional Staff (ROD)'; // D
 
-  const NGI_SEC_OFFICER = 'NGI Security Officer'; // D'
-  const NGI_OPS_DEP_MAN = 'NGI Operations Deputy Manager'; // D'
-  const NGI_OPS_MAN = 'NGI Operations Manager'; // D'
+    const NGI_SEC_OFFICER = 'NGI Security Officer'; // D'
+    const NGI_OPS_DEP_MAN = 'NGI Operations Deputy Manager'; // D'
+    const NGI_OPS_MAN = 'NGI Operations Manager'; // D'
 
   // Roles for Projects
-  const COD_STAFF = 'COD Staff'; // E
-  const COD_ADMIN = 'COD Administrator'; // E
-  const EGI_CSIRT_OFFICER = 'EGI CSIRT Officer'; // E
-  const COO = 'Chief Operations Officer'; // E
+    const COD_STAFF = 'COD Staff'; // E
+    const COD_ADMIN = 'COD Administrator'; // E
+    const EGI_CSIRT_OFFICER = 'EGI CSIRT Officer'; // E
+    const COO = 'Chief Operations Officer'; // E
 
   // Roles for ServiceGroups
-  const SERVICEGROUP_ADMIN = 'Service Group Administrator'; // ServiceGroupC'
+    const SERVICEGROUP_ADMIN = 'Service Group Administrator'; // ServiceGroupC'
 
   // "Other" roles that have slipped by us (see AddRoleTypes.php)
-  const CIC_STAFF = 'CIC Staff'; // Pretty sure this role is not required anymore: https://rt.egi.eu/rt/Ticket/Display.html?id=931
-  const REG_STAFF = 'Regional Staff';
+    const CIC_STAFF = 'CIC Staff'; // Pretty sure this role is not required anymore: https://rt.egi.eu/rt/Ticket/Display.html?id=931
+    const REG_STAFF = 'Regional Staff';
 
   /**
   * private constructor to limit instantiation
   */
-  private function __construct() {
-  }
+    private function __construct()
+    {
+    }
 
   /**
   * Get an associative array of the class constants. Array keys are the constant
   * names, array values are the constant values.
   * @return array
   */
-  public static function getAsArray() {
-    $tmp = new ReflectionClass(get_called_class());
-    $a = $tmp->getConstants();        //$b = array_flip($a)
-    return $a;
-  }
-
+    public static function getAsArray()
+    {
+        $tmp = new ReflectionClass(get_called_class());
+        $a = $tmp->getConstants();        //$b = array_flip($a)
+        return $a;
+    }
 }

--- a/tests/unit/lib/Gocdb_Services/RoleServiceTest2.php
+++ b/tests/unit/lib/Gocdb_Services/RoleServiceTest2.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright (C) 2015 STFC
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -28,196 +29,218 @@ use org\gocdb\services\RoleActionAuthorisationService;
  *
  * @author Ian Neilson (after David Meredith)
  */
-class RoleServiceTest2 extends PHPUnit_Extensions_Database_TestCase {
-  private $entityManager;
-  private $dbOpsFactory;
-  private $user;
-  private $site;
+class RoleServiceTest2 extends PHPUnit_Extensions_Database_TestCase
+{
+    private $entityManager;
+    private $dbOpsFactory;
+    private $user;
+    private $site;
 
-  function __construct() {
-    parent::__construct();
-    // Use a local instance to avoid Mess Detector's whinging about avoiding
-    // static access.
-    $this->dbOpsFactory = new PHPUnit_Extensions_Database_Operation_Factory();
-  }
+    function __construct()
+    {
+        parent::__construct();
+      // Use a local instance to avoid Mess Detector's whinging about avoiding
+      // static access.
+        $this->dbOpsFactory = new PHPUnit_Extensions_Database_Operation_Factory();
+    }
   /**
   * Overridden.
   */
-  public static function setUpBeforeClass() {
-    parent::setUpBeforeClass();
-    echo "\n\n-------------------------------------------------\n";
-    echo "Executing RoleServiceTest. . .\n";
-  }
+    public static function setUpBeforeClass()
+    {
+        parent::setUpBeforeClass();
+        echo "\n\n-------------------------------------------------\n";
+        echo "Executing RoleServiceTest. . .\n";
+    }
 
   /**
   * Overridden. Returns the test database connection.
   * @return PHPUnit_Extensions_Database_DB_IDatabaseConnection
   */
-  protected function getConnection() {
-    require_once __DIR__ . '/../../../doctrine/bootstrap_pdo.php';
-    return getConnectionToTestDB();
-  }
+    protected function getConnection()
+    {
+        require_once __DIR__ . '/../../../doctrine/bootstrap_pdo.php';
+        return getConnectionToTestDB();
+    }
 
   /**
   * Overridden. Returns the test dataset.
   * Defines how the initial state of the database should look before each test is executed.
   * @return PHPUnit_Extensions_Database_DataSet_IDataSet
   */
-  protected function getDataSet() {
-    return $this->createFlatXMLDataSet(__DIR__ . '/../../../doctrine/truncateDataTables.xml');
-    // Use below to return an empty data set if we don't want to truncate and seed
-    //return new PHPUnit_Extensions_Database_DataSet_DefaultDataSet();
-  }
+    protected function getDataSet()
+    {
+        return $this->createFlatXMLDataSet(__DIR__ . '/../../../doctrine/truncateDataTables.xml');
+      // Use below to return an empty data set if we don't want to truncate and seed
+      //return new PHPUnit_Extensions_Database_DataSet_DefaultDataSet();
+    }
 
   /**
   * Overridden.
   */
-  protected function getSetUpOperation() {
-    // CLEAN_INSERT is default
-    //return PHPUnit_Extensions_Database_Operation_Factory::CLEAN_INSERT();
-    //return PHPUnit_Extensions_Database_Operation_Factory::UPDATE();
-    //return PHPUnit_Extensions_Database_Operation_Factory::NONE();
-    //
-    // Issue a DELETE from <table> which is more portable than a
-    // TRUNCATE table <table> (some DBs require high privileges for truncate statements
-    // and also do not allow truncates across tables with FK contstraints e.g. Oracle)
-    return $this->dbOpsFactory->DELETE_ALL();
-  }
+    protected function getSetUpOperation()
+    {
+      // CLEAN_INSERT is default
+      //return PHPUnit_Extensions_Database_Operation_Factory::CLEAN_INSERT();
+      //return PHPUnit_Extensions_Database_Operation_Factory::UPDATE();
+      //return PHPUnit_Extensions_Database_Operation_Factory::NONE();
+      //
+      // Issue a DELETE from <table> which is more portable than a
+      // TRUNCATE table <table> (some DBs require high privileges for truncate statements
+      // and also do not allow truncates across tables with FK contstraints e.g. Oracle)
+        return $this->dbOpsFactory->DELETE_ALL();
+    }
 
   /**
   * Overridden.
   */
-  protected function getTearDownOperation() {
-    // NONE is default
-    return $this->dbOpsFactory->NONE();
-  }
+    protected function getTearDownOperation()
+    {
+      // NONE is default
+        return $this->dbOpsFactory->NONE();
+    }
 
   /**
   * Sets up the fixture, e.g create a new entityManager for each test run
   * This method is called before each test method is executed.
   */
-  protected function setUp() {
-    parent::setUp();
-    $this->entityManager = $this->createEntityManager();
-    $this->util = new TestUtil();
-    $this->user = $this->util->createSampleUser("Alpha", "Beta");
-    $this->user->setAdmin(true);
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->entityManager = $this->createEntityManager();
+        $this->util = new TestUtil();
+        $this->user = $this->util->createSampleUser("Alpha", "Beta");
+        $this->user->setAdmin(true);
 
-    $identifier = $this->util->createSampleUserIdentifier('X.509',"/CN=Alpha Beta");
-    $this->entityManager->persist($identifier);
+        $identifier = $this->util->createSampleUserIdentifier('X.509', "/CN=Alpha Beta");
+        $this->entityManager->persist($identifier);
 
-    $this->user->addUserIdentifierDoJoin($identifier);
-    $this->entityManager->persist($this->user);
+        $this->user->addUserIdentifierDoJoin($identifier);
+        $this->entityManager->persist($this->user);
 
-    $this->site = $this->util->createSampleSite("Site1");
-    $this->entityManager->persist($this->site);
+        $this->site = $this->util->createSampleSite("Site1");
+        $this->entityManager->persist($this->site);
 
-    $this->roleServ = new \org\gocdb\services\Role();
-    $this->roleServ->setEntityManager($this->entityManager);
-  }
-
+        $this->roleServ = new \org\gocdb\services\Role();
+        $this->roleServ->setEntityManager($this->entityManager);
+    }
+  /**
+   * Run after each test function to prevent pile-up of database connections.
+   */
+    protected function tearDown()
+    {
+        parent::tearDown();
+        if (!is_null($this->entityManager)) {
+            $this->entityManager->getConnection()->close();
+        }
+    }
   /**
   * @return EntityManager
   */
-  private function createEntityManager(){
-    $entityManager = null; // Initialise in local scope to avoid unused variable warnings
-    require __DIR__ . '/../../../doctrine/bootstrap_doctrine.php';
-    return $entityManager;
-  }
+    private function createEntityManager()
+    {
+        $entityManager = null; // Initialise in local scope to avoid unused variable warnings
+        require __DIR__ . '/../../../doctrine/bootstrap_doctrine.php';
+        return $entityManager;
+    }
 
   /**
   * Called after setUp() and before each test. Used for common assertions
   * across all tests.
   */
-  protected function assertPreConditions() {
-    $con = $this->getConnection();
-    $fixture = __DIR__ . '/../../../doctrine/truncateDataTables.xml';
-    $tables = simplexml_load_file($fixture);
+    protected function assertPreConditions()
+    {
+        $con = $this->getConnection();
+        $fixture = __DIR__ . '/../../../doctrine/truncateDataTables.xml';
+        $tables = simplexml_load_file($fixture);
 
-    foreach($tables as $tableName) {
-      $sql = "SELECT * FROM ".$tableName->getName();
-      $result = $con->createQueryTable('results_table', $sql);
-      if($result->getRowCount() != 0){
-        throw new RuntimeException("Invalid fixture. Table has rows: ".$tableName->getName());
-      }
+        foreach ($tables as $tableName) {
+            $sql = "SELECT * FROM " . $tableName->getName();
+            $result = $con->createQueryTable('results_table', $sql);
+            if ($result->getRowCount() != 0) {
+                throw new RuntimeException("Invalid fixture. Table has rows: " . $tableName->getName());
+            }
+        }
     }
-  }
   /**
    * Create some roles
    */
-  private function createTestRoles (array $roleNames) {
+    private function createTestRoles(array $roleNames)
+    {
 
-    foreach ($roleNames as $type) {
-      $roleType = $this->util->createSampleRoleType($type);
-      $role = $this->util->createSampleRole($this->user, $roleType, $this->site, \RoleStatus::GRANTED);
-      $this->entityManager->persist($roleType);
-      $this->entityManager->persist($role);
-      $roles[] = $role;
-    };
+        foreach ($roleNames as $type) {
+            $roleType = $this->util->createSampleRoleType($type);
+            $role = $this->util->createSampleRole($this->user, $roleType, $this->site, \RoleStatus::GRANTED);
+            $this->entityManager->persist($roleType);
+            $this->entityManager->persist($role);
+            $roles[] = $role;
+        };
 
-    $this->entityManager->flush();
+        $this->entityManager->flush();
 
-    return $roles;
-  }
+        return $roles;
+    }
   /**
    * Attach an APIAuthentication credential to user and site
    */
-  private function addAPIAuthEntity() {
-    // The only way to add an APIAuthentication credential is by creating
-    // a site service ...
+    private function addAPIAuthEntity()
+    {
+      // The only way to add an APIAuthentication credential is by creating
+      // a site service ...
 
-    $siteServ = new \org\gocdb\services\Site();
-    $siteServ->setEntityManager($this->entityManager);
+        $siteServ = new \org\gocdb\services\Site();
+        $siteServ->setEntityManager($this->entityManager);
 
-    // No role mappings are created or tested - we rely in user being an admin
-    $ram = new \org\gocdb\services\RoleActionMappingService();
-    $ras = new \org\gocdb\services\RoleActionAuthorisationService($ram);
+      // No role mappings are created or tested - we rely in user being an admin
+        $ram = new \org\gocdb\services\RoleActionMappingService();
+        $ras = new \org\gocdb\services\RoleActionAuthorisationService($ram);
 
-    $ras->setEntityManager($this->entityManager);
+        $ras->setEntityManager($this->entityManager);
 
-    $siteServ->setRoleActionAuthorisationService($ras);
+        $siteServ->setRoleActionAuthorisationService($ras);
 
-    $siteServ->addAPIAuthEntity(
-      $this->site,
-      $this->user,
-      array(
-        "IDENTIFIER" => $this->user->getUserIdentifiers()[0]->getKeyValue(),
-        "TYPE" => "X509",
-        "ALLOW_WRITE" => false
-      )
-    );
-    return;
-  }
+        $siteServ->addAPIAuthEntity(
+            $this->site,
+            $this->user,
+            array(
+            "IDENTIFIER" => $this->user->getUserIdentifiers()[0]->getKeyValue(),
+            "TYPE" => "X509",
+            "ALLOW_WRITE" => false
+            )
+        );
+        return;
+    }
   /**
    * Tests begin here
    */
-  public function testNullCheckOrphanAPIAuth () {
-    print __METHOD__ . "\n";
+    public function testNullCheckOrphanAPIAuth()
+    {
+        print __METHOD__ . "\n";
 
-    $roles = $this->createTestRoles(array("Manager","Administrator"));
+        $roles = $this->createTestRoles(array("Manager","Administrator"));
 
-    // No APIAuthentication credentials are yet assigned so the
-    // check should pass.
-    $this->assertNull($this->roleServ->checkOrphanAPIAuth($roles[0]));
+      // No APIAuthentication credentials are yet assigned so the
+      // check should pass.
+        $this->assertNull($this->roleServ->checkOrphanAPIAuth($roles[0]));
 
-    $this->addAPIAuthEntity();
+        $this->addAPIAuthEntity();
 
-    // User has two roles so the check should pass.
-    $this->assertNull($this->roleServ->checkOrphanAPIAuth($roles[0]));
-
-  }
+      // User has two roles so the check should pass.
+        $this->assertNull($this->roleServ->checkOrphanAPIAuth($roles[0]));
+    }
   /**
    * @depends testNullCheckOrphanAPIAuth
    * @expectedException Exception
    */
-  public function testFailCheckOrphanAPIAuth () {
-    print __METHOD__ . "\n";
+    public function testFailCheckOrphanAPIAuth()
+    {
+        print __METHOD__ . "\n";
 
-    $roles = $this->createTestRoles(array("Manager"));
+        $roles = $this->createTestRoles(array("Manager"));
 
-    $this->addAPIAuthEntity();
+        $this->addAPIAuthEntity();
 
-    // Should fail because there is only one role.
-    $this->roleServ->checkOrphanAPIAuth($roles[0]);
-  }
+      // Should fail because there is only one role.
+        $this->roleServ->checkOrphanAPIAuth($roles[0]);
+    }
 }

--- a/tests/unit/lib/Gocdb_Services/ScopeServiceTest.php
+++ b/tests/unit/lib/Gocdb_Services/ScopeServiceTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright (C) 2015 STFC
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -24,279 +25,304 @@ require_once __DIR__ . '/../../../doctrine/bootstrap.php';
  *
  * @author David Meredith
  */
-class ScopeServiceTest extends PHPUnit_Extensions_Database_TestCase{
-  private $em;
+class ScopeServiceTest extends PHPUnit_Extensions_Database_TestCase
+{
+    private $em;
 
   /**
   * Overridden.
   */
-  public static function setUpBeforeClass() {
-    parent::setUpBeforeClass();
-    echo "\n\n-------------------------------------------------\n";
-    echo "Executing ScopeServiceTest. . .\n";
-  }
+    public static function setUpBeforeClass()
+    {
+        parent::setUpBeforeClass();
+        echo "\n\n-------------------------------------------------\n";
+        echo "Executing ScopeServiceTest. . .\n";
+    }
 
   /**
   * Overridden. Returns the test database connection.
   * @return PHPUnit_Extensions_Database_DB_IDatabaseConnection
   */
-  protected function getConnection() {
-    require_once __DIR__ . '/../../../doctrine/bootstrap_pdo.php';
-    return getConnectionToTestDB();
-  }
+    protected function getConnection()
+    {
+        require_once __DIR__ . '/../../../doctrine/bootstrap_pdo.php';
+        return getConnectionToTestDB();
+    }
 
   /**
   * Overridden. Returns the test dataset.
   * Defines how the initial state of the database should look before each test is executed.
   * @return PHPUnit_Extensions_Database_DataSet_IDataSet
   */
-  protected function getDataSet() {
-    return $this->createFlatXMLDataSet(__DIR__ . '/../../../doctrine/truncateDataTables.xml');
-    // Use below to return an empty data set if we don't want to truncate and seed
-    //return new PHPUnit_Extensions_Database_DataSet_DefaultDataSet();
-  }
+    protected function getDataSet()
+    {
+        return $this->createFlatXMLDataSet(__DIR__ . '/../../../doctrine/truncateDataTables.xml');
+      // Use below to return an empty data set if we don't want to truncate and seed
+      //return new PHPUnit_Extensions_Database_DataSet_DefaultDataSet();
+    }
 
   /**
   * Overridden.
   */
-  protected function getSetUpOperation() {
-    // CLEAN_INSERT is default
-    //return PHPUnit_Extensions_Database_Operation_Factory::CLEAN_INSERT();
-    //return PHPUnit_Extensions_Database_Operation_Factory::UPDATE();
-    //return PHPUnit_Extensions_Database_Operation_Factory::NONE();
-    //
-    // Issue a DELETE from <table> which is more portable than a
-    // TRUNCATE table <table> (some DBs require high privileges for truncate statements
-    // and also do not allow truncates across tables with FK contstraints e.g. Oracle)
-    return PHPUnit_Extensions_Database_Operation_Factory::DELETE_ALL();
-  }
+    protected function getSetUpOperation()
+    {
+      // CLEAN_INSERT is default
+      //return PHPUnit_Extensions_Database_Operation_Factory::CLEAN_INSERT();
+      //return PHPUnit_Extensions_Database_Operation_Factory::UPDATE();
+      //return PHPUnit_Extensions_Database_Operation_Factory::NONE();
+      //
+      // Issue a DELETE from <table> which is more portable than a
+      // TRUNCATE table <table> (some DBs require high privileges for truncate statements
+      // and also do not allow truncates across tables with FK contstraints e.g. Oracle)
+        return PHPUnit_Extensions_Database_Operation_Factory::DELETE_ALL();
+    }
 
   /**
   * Overridden.
   */
-  protected function getTearDownOperation() {
-    // NONE is default
-    return PHPUnit_Extensions_Database_Operation_Factory::NONE();
-  }
+    protected function getTearDownOperation()
+    {
+      // NONE is default
+        return PHPUnit_Extensions_Database_Operation_Factory::NONE();
+    }
 
   /**
   * Sets up the fixture, e.g create a new entityManager for each test run
   * This method is called before each test method is executed.
   */
-  protected function setUp() {
-    parent::setUp();
-    $this->em = $this->createEntityManager();
-  }
-
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->em = $this->createEntityManager();
+    }
+  /**
+   * Run after each test function to prevent pile-up of database connections.
+   */
+    protected function tearDown()
+    {
+        parent::tearDown();
+        if (!is_null($this->em)) {
+            $this->em->getConnection()->close();
+        }
+    }
   /**
   * @todo Still need to setup connection to different databases.
   * @return EntityManager
   */
-  private function createEntityManager(){
-    require __DIR__ . '/../../../doctrine/bootstrap_doctrine.php';
-    return $entityManager;
-  }
+    private function createEntityManager()
+    {
+        require __DIR__ . '/../../../doctrine/bootstrap_doctrine.php';
+        return $entityManager;
+    }
 
   /**
   * Called after setUp() and before each test. Used for common assertions
   * across all tests.
   */
-  protected function assertPreConditions() {
-    $con = $this->getConnection();
-    $fixture = __DIR__ . '/../../../doctrine/truncateDataTables.xml';
-    $tables = simplexml_load_file($fixture);
+    protected function assertPreConditions()
+    {
+        $con = $this->getConnection();
+        $fixture = __DIR__ . '/../../../doctrine/truncateDataTables.xml';
+        $tables = simplexml_load_file($fixture);
 
-    foreach($tables as $tableName) {
-      $sql = "SELECT * FROM ".$tableName->getName();
-      $result = $con->createQueryTable('results_table', $sql);
-      if($result->getRowCount() != 0){
-        throw new RuntimeException("Invalid fixture. Table has rows: ".$tableName->getName());
-      }
+        foreach ($tables as $tableName) {
+            $sql = "SELECT * FROM " . $tableName->getName();
+            $result = $con->createQueryTable('results_table', $sql);
+            if ($result->getRowCount() != 0) {
+                throw new RuntimeException("Invalid fixture. Table has rows: " . $tableName->getName());
+            }
+        }
     }
-  }
 
-  private function insertTestScopes(){
-    $scopeCount = 10;
-    $scopes = array();
-    // create scopes and persist
-    for($i=0; $i<$scopeCount; $i++){
-      $scopes[] = TestUtil::createSampleScope("scope ".$i, "Scope".$i);
-      $this->em->persist($scopes[$i]);
+    private function insertTestScopes()
+    {
+        $scopeCount = 10;
+        $scopes = array();
+      // create scopes and persist
+        for ($i = 0; $i < $scopeCount; $i++) {
+            $scopes[] = TestUtil::createSampleScope("scope " . $i, "Scope" . $i);
+            $this->em->persist($scopes[$i]);
+        }
     }
-  }
 
-  public function testGetScopes(){
-    print __METHOD__ . "\n";
-    $this->insertTestScopes();
-    $this->em->flush();
+    public function testGetScopes()
+    {
+        print __METHOD__ . "\n";
+        $this->insertTestScopes();
+        $this->em->flush();
 
-    $scopeService = new \org\gocdb\services\Scope();
-    $scopeService->setEntityManager($this->em);
+        $scopeService = new \org\gocdb\services\Scope();
+        $scopeService->setEntityManager($this->em);
 
-    $scopes = $scopeService->getScopes();
-    $this->assertEquals(10, count($scopes));
-    $scopeIds = array();
-    foreach($scopes as $scope){
-      $scopeIds[] = $scope->getId();
+        $scopes = $scopeService->getScopes();
+        $this->assertEquals(10, count($scopes));
+        $scopeIds = array();
+        foreach ($scopes as $scope) {
+            $scopeIds[] = $scope->getId();
+        }
+        $scopes = $scopeService->getScopes($scopeIds);
+        $this->assertEquals(10, count($scopes));
     }
-    $scopes = $scopeService->getScopes($scopeIds);
-    $this->assertEquals(10, count($scopes));
-  }
 
-  public function testGetScopesFilterByParams1() {
-    print __METHOD__ . "\n";
-    $this->insertTestScopes();
-    $this->em->flush();
+    public function testGetScopesFilterByParams1()
+    {
+        print __METHOD__ . "\n";
+        $this->insertTestScopes();
+        $this->em->flush();
 
-    $scopeService = new \org\gocdb\services\Scope();
-    $scopeService->setEntityManager($this->em);
-    $configService = \Factory::getConfigService();
-    $configService->setLocalInfoFileLocation(__DIR__ . '/../../resources/sample_local_info1.xml');
-    $scopeService->setConfigService($configService);
+        $scopeService = new \org\gocdb\services\Scope();
+        $scopeService->setEntityManager($this->em);
+        $configService = \Factory::getConfigService();
+        $configService->setLocalInfoFileLocation(__DIR__ . '/../../resources/sample_local_info1.xml');
+        $scopeService->setConfigService($configService);
 
-    // exclude all the 'Reserved' scopes
-    $filterParams = array('excludeReserved' => true);
-    $excludedScopeNames = $configService->getReservedScopeList();//'Scope0', 'Scope1', 'Scope2', 'Scope3'
-    $filteredScopes = $scopeService->getScopesFilterByParams($filterParams, null);
-    foreach($filteredScopes as $scope){
-      if(in_array($scope->getName(), $excludedScopeNames)){
-       $this->fail("Reserved scope returned");
-      }
+      // exclude all the 'Reserved' scopes
+        $filterParams = array('excludeReserved' => true);
+        $excludedScopeNames = $configService->getReservedScopeList();//'Scope0', 'Scope1', 'Scope2', 'Scope3'
+        $filteredScopes = $scopeService->getScopesFilterByParams($filterParams, null);
+        foreach ($filteredScopes as $scope) {
+            if (in_array($scope->getName(), $excludedScopeNames)) {
+                $this->fail("Reserved scope returned");
+            }
+        }
+        $this->assertEquals(6, count($filteredScopes));
+
+      // excluding all the 'Normal/Non-Reserved' scopes should leave 0
+        $filterParams = array('excludeNonReserved' => true);
+        $filteredScopes = $scopeService->getScopesFilterByParams($filterParams, $filteredScopes);
+        $this->assertEquals(0, count($filteredScopes));
     }
-    $this->assertEquals(6, count($filteredScopes));
-
-    // excluding all the 'Normal/Non-Reserved' scopes should leave 0
-    $filterParams = array('excludeNonReserved' => true);
-    $filteredScopes = $scopeService->getScopesFilterByParams($filterParams, $filteredScopes);
-    $this->assertEquals(0, count($filteredScopes));
-  }
 
 
 
-  public function testGetScopesFilterByParams2() {
-    print __METHOD__ . "\n";
-    $this->insertTestScopes();
-    $this->em->flush();
+    public function testGetScopesFilterByParams2()
+    {
+        print __METHOD__ . "\n";
+        $this->insertTestScopes();
+        $this->em->flush();
 
-    $scopeService = new \org\gocdb\services\Scope();
-    $scopeService->setEntityManager($this->em);
-    $configService = \Factory::getConfigService();
-    $configService->setLocalInfoFileLocation(__DIR__ . '/../../resources/sample_local_info1.xml');
-    $scopeService->setConfigService($configService);
+        $scopeService = new \org\gocdb\services\Scope();
+        $scopeService->setEntityManager($this->em);
+        $configService = \Factory::getConfigService();
+        $configService->setLocalInfoFileLocation(__DIR__ . '/../../resources/sample_local_info1.xml');
+        $scopeService->setConfigService($configService);
 
-    // exclude all the 'Normal/Non-Reserved' scopes:
-    $filterParams = array('excludeNonReserved' => true);
-    $excludedScopeNames = array('Scope4', 'Scope5', 'Scope6', 'Scope7', 'Scope8', 'Scope9');
-    $filteredScopes = $scopeService->getScopesFilterByParams($filterParams, null);
-    foreach($filteredScopes as $scope){
-      if(in_array($scope->getName(), $excludedScopeNames)){
-       $this->fail("Normal/Non-Reserved scope returned");
-      }
+      // exclude all the 'Normal/Non-Reserved' scopes:
+        $filterParams = array('excludeNonReserved' => true);
+        $excludedScopeNames = array('Scope4', 'Scope5', 'Scope6', 'Scope7', 'Scope8', 'Scope9');
+        $filteredScopes = $scopeService->getScopesFilterByParams($filterParams, null);
+        foreach ($filteredScopes as $scope) {
+            if (in_array($scope->getName(), $excludedScopeNames)) {
+                $this->fail("Normal/Non-Reserved scope returned");
+            }
+        }
+        $this->assertEquals(4, count($filteredScopes));
+
+      // excluding all the 'Reserved' scopes should leave 0
+        $filterParams = array('excludeReserved' => true);
+        $filteredScopes = $scopeService->getScopesFilterByParams($filterParams, $filteredScopes);
+        $this->assertEquals(0, count($filteredScopes));
     }
-    $this->assertEquals(4, count($filteredScopes));
-
-    // excluding all the 'Reserved' scopes should leave 0
-    $filterParams = array('excludeReserved' => true);
-    $filteredScopes = $scopeService->getScopesFilterByParams($filterParams, $filteredScopes);
-    $this->assertEquals(0, count($filteredScopes));
-  }
 
 
-  public function testGetScopesFilterByParams3() {
-    print __METHOD__ . "\n";
-    $this->insertTestScopes();
-    $this->em->flush();
+    public function testGetScopesFilterByParams3()
+    {
+        print __METHOD__ . "\n";
+        $this->insertTestScopes();
+        $this->em->flush();
 
-    $scopeService = new \org\gocdb\services\Scope();
-    $scopeService->setEntityManager($this->em);
-    $configService = \Factory::getConfigService();
-    $configService->setLocalInfoFileLocation(__DIR__ . '/../../resources/sample_local_info1.xml');
-    $scopeService->setConfigService($configService);
+        $scopeService = new \org\gocdb\services\Scope();
+        $scopeService->setEntityManager($this->em);
+        $configService = \Factory::getConfigService();
+        $configService->setLocalInfoFileLocation(__DIR__ . '/../../resources/sample_local_info1.xml');
+        $scopeService->setConfigService($configService);
 
-    // exclude all the 'Default' scopes:
-    $filterParams = array('excludeDefault' => true);
-    $excludedScopeNames = array('Scope0');
-    $filteredScopes = $scopeService->getScopesFilterByParams($filterParams, null);
-    foreach($filteredScopes as $scope){
-      //echo $scope->getName()."\n";
-      if(in_array($scope->getName(), $excludedScopeNames)){
-        $this->fail("Default scope returned");
-      }
+      // exclude all the 'Default' scopes:
+        $filterParams = array('excludeDefault' => true);
+        $excludedScopeNames = array('Scope0');
+        $filteredScopes = $scopeService->getScopesFilterByParams($filterParams, null);
+        foreach ($filteredScopes as $scope) {
+          //echo $scope->getName()."\n";
+            if (in_array($scope->getName(), $excludedScopeNames)) {
+                $this->fail("Default scope returned");
+            }
+        }
+        $this->assertEquals(9, count($filteredScopes));
+
+      // excluding all the 'Non Default' scopes should leave 0
+        $filterParams = array('excludeNonDefault' => true);
+        $filteredScopes = $scopeService->getScopesFilterByParams($filterParams, $filteredScopes);
+        $this->assertEquals(0, count($filteredScopes));
     }
-    $this->assertEquals(9, count($filteredScopes));
 
-    // excluding all the 'Non Default' scopes should leave 0
-    $filterParams = array('excludeNonDefault' => true);
-    $filteredScopes = $scopeService->getScopesFilterByParams($filterParams, $filteredScopes);
-    $this->assertEquals(0, count($filteredScopes));
-  }
+    public function testGetScopesFilterByParams4()
+    {
+        print __METHOD__ . "\n";
+        $this->insertTestScopes();
+        $this->em->flush();
 
-  public function testGetScopesFilterByParams4() {
-    print __METHOD__ . "\n";
-    $this->insertTestScopes();
-    $this->em->flush();
+        $scopeService = new \org\gocdb\services\Scope();
+        $scopeService->setEntityManager($this->em);
+        $configService = \Factory::getConfigService();
+        $configService->setLocalInfoFileLocation(__DIR__ . '/../../resources/sample_local_info1.xml');
+        $scopeService->setConfigService($configService);
 
-    $scopeService = new \org\gocdb\services\Scope();
-    $scopeService->setEntityManager($this->em);
-    $configService = \Factory::getConfigService();
-    $configService->setLocalInfoFileLocation(__DIR__ . '/../../resources/sample_local_info1.xml');
-    $scopeService->setConfigService($configService);
+      // exclude all the 'Non Default' scopes:
+        $filterParams = array('excludeNonDefault' => true);
+        $excludedScopeNames = array('Scope1','Scope2','Scope3','Scope4','Scope5','Scope6','Scope7','Scope8','Scope9');
+        $filteredScopes = $scopeService->getScopesFilterByParams($filterParams, null);
+        foreach ($filteredScopes as $scope) {
+            if (in_array($scope->getName(), $excludedScopeNames)) {
+                $this->fail("Default scope returned");
+            }
+        }
+        $this->assertEquals(1, count($filteredScopes));
 
-    // exclude all the 'Non Default' scopes:
-    $filterParams = array('excludeNonDefault' => true);
-    $excludedScopeNames = array('Scope1','Scope2','Scope3','Scope4','Scope5','Scope6','Scope7','Scope8','Scope9');
-    $filteredScopes = $scopeService->getScopesFilterByParams($filterParams, null);
-    foreach($filteredScopes as $scope){
-      if(in_array($scope->getName(), $excludedScopeNames)){
-        $this->fail("Default scope returned");
-      }
+      // excluding all the 'Default' scopes should leave 0
+        $filterParams = array('excludeDefault' => true);
+        $filteredScopes = $scopeService->getScopesFilterByParams($filterParams, $filteredScopes);
+        $this->assertEquals(0, count($filteredScopes));
     }
-    $this->assertEquals(1, count($filteredScopes));
 
-    // excluding all the 'Default' scopes should leave 0
-    $filterParams = array('excludeDefault' => true);
-    $filteredScopes = $scopeService->getScopesFilterByParams($filterParams, $filteredScopes);
-    $this->assertEquals(0, count($filteredScopes));
-  }
+    public function testGetScopesFilterByParams5()
+    {
+        print __METHOD__ . "\n";
+        $this->insertTestScopes();
+        $this->em->flush();
 
-  public function testGetScopesFilterByParams5() {
-    print __METHOD__ . "\n";
-    $this->insertTestScopes();
-    $this->em->flush();
+        $scopeService = new \org\gocdb\services\Scope();
+        $scopeService->setEntityManager($this->em);
+        $configService = \Factory::getConfigService();
+        $configService->setLocalInfoFileLocation(__DIR__ . '/../../resources/sample_local_info1.xml');
+        $scopeService->setConfigService($configService);
 
-    $scopeService = new \org\gocdb\services\Scope();
-    $scopeService->setEntityManager($this->em);
-    $configService = \Factory::getConfigService();
-    $configService->setLocalInfoFileLocation(__DIR__ . '/../../resources/sample_local_info1.xml');
-    $scopeService->setConfigService($configService);
-
-    $filterParams = array('excludeDefault' => true, 'excludeNonReserved' => true);
-    $excludedScopeNames = array('Scope0', 'Scope4','Scope5','Scope6','Scope7','Scope8','Scope9');
-    // $expectedScopeNames=array('Scope1','Scope2','Scope3');
-    $filteredScopes = $scopeService->getScopesFilterByParams($filterParams, null);
-    foreach($filteredScopes as $scope){
-      //echo $scope->getName()."\n";
-      if(in_array($scope->getName(), $excludedScopeNames)){
-        $this->fail("Default scope returned");
-      }
+        $filterParams = array('excludeDefault' => true, 'excludeNonReserved' => true);
+        $excludedScopeNames = array('Scope0', 'Scope4','Scope5','Scope6','Scope7','Scope8','Scope9');
+      // $expectedScopeNames=array('Scope1','Scope2','Scope3');
+        $filteredScopes = $scopeService->getScopesFilterByParams($filterParams, null);
+        foreach ($filteredScopes as $scope) {
+          //echo $scope->getName()."\n";
+            if (in_array($scope->getName(), $excludedScopeNames)) {
+                $this->fail("Default scope returned");
+            }
+        }
+        $this->assertEquals(3, count($filteredScopes));
     }
-    $this->assertEquals(3, count($filteredScopes));
-  }
 
 
   /**
   * @expectedException InvalidArgumentException
   */
-  public function testGetScopesFilterByParamsUnsupportedParam() {
-    print __METHOD__ . "\n";
-    $scopeService = new \org\gocdb\services\Scope();
-    $scopeService->setEntityManager($this->em);
-    $configService = \Factory::getConfigService();
-    $configService->setLocalInfoFileLocation(__DIR__ . '/../../resources/sample_local_info1.xml');
-    $scopeService->setConfigService($configService);
+    public function testGetScopesFilterByParamsUnsupportedParam()
+    {
+        print __METHOD__ . "\n";
+        $scopeService = new \org\gocdb\services\Scope();
+        $scopeService->setEntityManager($this->em);
+        $configService = \Factory::getConfigService();
+        $configService->setLocalInfoFileLocation(__DIR__ . '/../../resources/sample_local_info1.xml');
+        $scopeService->setConfigService($configService);
 
-    $filterParams = array('_excludeNonDefault' => true);
-    $filteredScopes = $scopeService->getScopesFilterByParams($filterParams, null);
-  }
-
+        $filterParams = array('_excludeNonDefault' => true);
+        $filteredScopes = $scopeService->getScopesFilterByParams($filterParams, null);
+    }
 }

--- a/tests/unit/lib/Gocdb_Services/ServiceServiceTest.php
+++ b/tests/unit/lib/Gocdb_Services/ServiceServiceTest.php
@@ -84,7 +84,16 @@ class ServiceServiceTest extends PHPUnit_Extensions_Database_TestCase{
     parent::setUp();
     $this->eMan = $this->createEntityManager();
   }
-
+  /**
+   * Run after each test function to prevent pile-up of database connections.
+   */
+  protected function tearDown()
+  {
+      parent::tearDown();
+      if (!is_null($this->eMan)) {
+          $this->eMan->getConnection()->close();
+      }
+  }
   /**
   * @todo Still need to setup connection to different databases.
   * @return EntityManager

--- a/tests/unit/lib/Gocdb_Services/SiteServiceTest.php
+++ b/tests/unit/lib/Gocdb_Services/SiteServiceTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright (C) 2015 STFC
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -26,182 +27,219 @@ use Doctrine\ORM\EntityManager;
  *
  * @author Ian Neilson (after David Meredith)
  */
-class siteServiceTest extends PHPUnit_Extensions_Database_TestCase {
-  private $entityManager;
-  private $dbOpsFactory;
+class siteServiceTest extends PHPUnit_Extensions_Database_TestCase
+{
+    private $entityManager;
+    private $dbOpsFactory;
   /** @var TestUtil $testUtil */
-  private $testUtil;
+    private $testUtil;
 
-  function __construct() {
-    parent::__construct();
-    // Use a local instance to avoid Mess Detector's whinging about avoiding
-    // static access.
-    $this->dbOpsFactory = new PHPUnit_Extensions_Database_Operation_Factory();
-  }
+    function __construct()
+    {
+        parent::__construct();
+      // Use a local instance to avoid Mess Detector's whinging about avoiding
+      // static access.
+        $this->dbOpsFactory = new PHPUnit_Extensions_Database_Operation_Factory();
+    }
   /**
   * Overridden.
   */
-  public static function setUpBeforeClass() {
-    parent::setUpBeforeClass();
-    echo "\n\n-------------------------------------------------\n";
-    echo "Executing SiteServiceTest. . .\n";
-  }
+    public static function setUpBeforeClass()
+    {
+        parent::setUpBeforeClass();
+        echo "\n\n-------------------------------------------------\n";
+        echo "Executing SiteServiceTest. . .\n";
+    }
 
   /**
   * Overridden. Returns the test database connection.
   * @return PHPUnit_Extensions_Database_DB_IDatabaseConnection
   */
-  protected function getConnection() {
-    require_once __DIR__ . '/../../../doctrine/bootstrap_pdo.php';
-    return getConnectionToTestDB();
-  }
+    protected function getConnection()
+    {
+        require_once __DIR__ . '/../../../doctrine/bootstrap_pdo.php';
+        return getConnectionToTestDB();
+    }
 
   /**
   * Overridden. Returns the test dataset.
   * Defines how the initial state of the database should look before each test is executed.
   * @return PHPUnit_Extensions_Database_DataSet_IDataSet
   */
-  protected function getDataSet() {
-    $dataset = $this->createFlatXMLDataSet(__DIR__ . '/../../../doctrine/truncateDataTables.xml');
-    return $dataset;
-    // Use below to return an empty data set if we don't want to truncate and seed
-    //return new PHPUnit_Extensions_Database_DataSet_DefaultDataSet();
-  }
+    protected function getDataSet()
+    {
+        $dataset = $this->createFlatXMLDataSet(__DIR__ . '/../../../doctrine/truncateDataTables.xml');
+        return $dataset;
+      // Use below to return an empty data set if we don't want to truncate and seed
+      //return new PHPUnit_Extensions_Database_DataSet_DefaultDataSet();
+    }
 
   /**
   * Overridden.
   */
-  protected function getSetUpOperation() {
-    // CLEAN_INSERT is default
-    //return PHPUnit_Extensions_Database_Operation_Factory::CLEAN_INSERT();
-    //return PHPUnit_Extensions_Database_Operation_Factory::UPDATE();
-    //return PHPUnit_Extensions_Database_Operation_Factory::NONE();
-    //
-    // Issue a DELETE from <table> which is more portable than a
-    // TRUNCATE table <table> (some DBs require high privileges for truncate statements
-    // and also do not allow truncates across tables with FK contstraints e.g. Oracle)
-    return $this->dbOpsFactory->DELETE_ALL();
-  }
+    protected function getSetUpOperation()
+    {
+      // CLEAN_INSERT is default
+      //return PHPUnit_Extensions_Database_Operation_Factory::CLEAN_INSERT();
+      //return PHPUnit_Extensions_Database_Operation_Factory::UPDATE();
+      //return PHPUnit_Extensions_Database_Operation_Factory::NONE();
+      //
+      // Issue a DELETE from <table> which is more portable than a
+      // TRUNCATE table <table> (some DBs require high privileges for truncate statements
+      // and also do not allow truncates across tables with FK contstraints e.g. Oracle)
+        return $this->dbOpsFactory->DELETE_ALL();
+    }
 
   /**
   * Overridden.
   */
-  protected function getTearDownOperation() {
-    // NONE is default
-    return $this->dbOpsFactory->NONE();
-  }
+    protected function getTearDownOperation()
+    {
+      // NONE is default
+        return $this->dbOpsFactory->NONE();
+    }
 
   /**
   * Sets up the fixture, e.g create a new entityManager for each test run
   * This method is called before each test method is executed.
   */
-  protected function setUp() {
-    parent::setUp();
-    $this->entityManager = $this->createEntityManager();
-    $this->testUtil = new TestUtil();
-    // Pass the Entity Manager into the Factory to allow Gocdb_Services
-    // to use other Gocdb_Service.
-    \Factory::setEntityManager($this->entityManager);
-  }
-
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->entityManager = $this->createEntityManager();
+        $this->testUtil = new TestUtil();
+      // Pass the Entity Manager into the Factory to allow Gocdb_Services
+      // to use other Gocdb_Service.
+        \Factory::setEntityManager($this->entityManager);
+    }
+  /**
+   * Run after each test function to prevent pile-up of database connections.
+   */
+    protected function tearDown()
+    {
+        parent::tearDown();
+        if (!is_null($this->entityManager)) {
+            $this->entityManager->getConnection()->close();
+        }
+    }
   /**
   * @return EntityManager
   */
-  private function createEntityManager(){
-    $entityManager = null; // Initialise in local scope to avoid unused variable warnings
-    require __DIR__ . '/../../../doctrine/bootstrap_doctrine.php';
-    return $entityManager;
-  }
+    private function createEntityManager()
+    {
+        $entityManager = null; // Initialise in local scope to avoid unused variable warnings
+        require __DIR__ . '/../../../doctrine/bootstrap_doctrine.php';
+        return $entityManager;
+    }
 
   /**
   * Called after setUp() and before each test. Used for common assertions
   * across all tests.
   */
-  protected function assertPreConditions() {
-    $con = $this->getConnection();
-    $fixture = __DIR__ . '/../../../doctrine/truncateDataTables.xml';
-    $tables = simplexml_load_file($fixture);
+    protected function assertPreConditions()
+    {
+        $con = $this->getConnection();
+        $fixture = __DIR__ . '/../../../doctrine/truncateDataTables.xml';
+        $tables = simplexml_load_file($fixture);
 
-    foreach($tables as $tableName) {
-      $sql = "SELECT * FROM ".$tableName->getName();
-      $result = $con->createQueryTable('results_table', $sql);
-      if($result->getRowCount() != 0){
-        throw new RuntimeException("Invalid fixture. Table has rows: ".$tableName->getName());
-      }
+        foreach ($tables as $tableName) {
+            $sql = "SELECT * FROM " . $tableName->getName();
+            $result = $con->createQueryTable('results_table', $sql);
+            if ($result->getRowCount() != 0) {
+                throw new RuntimeException("Invalid fixture. Table has rows: " . $tableName->getName());
+            }
+        }
     }
-  }
   /**
    * Helper function to persist a test object
    */
-  protected function persistAndFlush ($instance) {
-    $this->entityManager->persist($instance);
-    $this->entityManager->flush();
-  }
+    protected function persistAndFlush($instance)
+    {
+        $this->entityManager->persist($instance);
+        $this->entityManager->flush();
+    }
 
   /*
   * Tests begin here
   * First basic check we can instantiate a Site Service and create a site with it.
   */
-  public function testAddSite() {
-    print __METHOD__ . "\n";
+    public function testAddSite()
+    {
+        print __METHOD__ . "\n";
 
-    $siteData = ServiceTestUtil::getSiteData($this->entityManager);
-    $siteService = ServiceTestUtil::getSiteService($this->entityManager);
+        $siteData = ServiceTestUtil::getSiteData($this->entityManager);
+        $siteService = ServiceTestUtil::getSiteService($this->entityManager);
 
-    // The most basic check
-    $this->assertTrue($siteService instanceof org\gocdb\services\Site,
-                        'Site Service failed to create and return a Site service');
+      // The most basic check
+        $this->assertTrue(
+            $siteService instanceof org\gocdb\services\Site,
+            'Site Service failed to create and return a Site service'
+        );
 
-    ServiceTestUtil::createAndAddSite($this->entityManager, $siteData);
+        ServiceTestUtil::createAndAddSite($this->entityManager, $siteData);
 
-    // Check
-    // N.B. Although getSitesFilterByParams says all the filters are optional,
-    // in fact, if you don't specify a scope 'EGI' is forced on you :-(
+      // Check
+      // N.B. Although getSitesFilterByParams says all the filters are optional,
+      // in fact, if you don't specify a scope 'EGI' is forced on you :-(
 
-    $this->assertCount(1, $siteService->getSitesFilterByParams( array('scope' => 'Scope1')));
-  }
+        $this->assertCount(1, $siteService->getSitesFilterByParams(array('scope' => 'Scope1')));
+    }
   /**
    * @depends testAddSite
    * Check that authentication entities can be added and removed correctly using the Site Service
    */
-  public function testAddAPIAuthentication() {
-    print __METHOD__ . "\n";
+    public function testAddAPIAuthentication()
+    {
+        print __METHOD__ . "\n";
 
-    /** @var \User */
-    $user = $this->testUtil->createSampleUser('Beta','User','/Beta.User');
-    // We don't want to test all the roleAction logic here so simply make us an admin
-    $user->setAdmin(true);
-    $this->persistAndFlush($user);
+      /** @var \User */
+        $user = $this->testUtil->createSampleUser('Beta', 'User', '/Beta.User');
+      // We don't want to test all the roleAction logic here so simply make us an admin
+        $user->setAdmin(true);
+        $this->persistAndFlush($user);
 
-    $siteData = ServiceTestUtil::getSiteData($this->entityManager);
-    $siteService = ServiceTestUtil::getSiteService($this->entityManager);
-    ServiceTestUtil::createAndAddSite($this->entityManager, $siteData);
+        $siteData = ServiceTestUtil::getSiteData($this->entityManager);
+        $siteService = ServiceTestUtil::getSiteService($this->entityManager);
+        ServiceTestUtil::createAndAddSite($this->entityManager, $siteData);
 
-    $sites = $siteService->getSitesFilterByParams(array('scope' => 'Scope1'));
-    $site = $sites[0];
+        $sites = $siteService->getSitesFilterByParams(array('scope' => 'Scope1'));
+        $site = $sites[0];
 
-    // Check we can add an authenticationEntity to a site and it is properly
-    // associated with the user.
+      // Check we can add an authenticationEntity to a site and it is properly
+      // associated with the user.
 
-    $authEnt = $siteService->addAPIAuthEntity($site, $user,
-                              array('IDENTIFIER' => '/CN=A Dummy Subject' ,
+        $authEnt = $siteService->addAPIAuthEntity(
+            $site,
+            $user,
+            array('IDENTIFIER' => '/CN=A Dummy Subject' ,
                               'TYPE' => 'X509',
-                              'ALLOW_WRITE' => false));
+            'ALLOW_WRITE' => false)
+        );
 
-    $this->assertTrue($authEnt instanceof \APIAuthentication,
-                      'Site Service failed to add APIAuthentication');
-    $siteAuthEnts = $site->getAPIAuthenticationEntities();
-    $userAuthEnts = $user->getAPIAuthenticationEntities();
-    $this->assertTrue($userAuthEnts[0] === $siteAuthEnts[0],
-                      'Site Service failed to link user and site APIAuthenticationEntity');
+        $this->assertTrue(
+            $authEnt instanceof \APIAuthentication,
+            'Site Service failed to add APIAuthentication'
+        );
+        $siteAuthEnts = $site->getAPIAuthenticationEntities();
+        $userAuthEnts = $user->getAPIAuthenticationEntities();
+        $this->assertTrue(
+            $userAuthEnts[0] === $siteAuthEnts[0],
+            'Site Service failed to link user and site APIAuthenticationEntity'
+        );
 
-    // Check the delete and cleanup on site and user sides goes ok
+      // Check the delete and cleanup on site and user sides goes ok
 
-    $this->assertNull($siteService->deleteAPIAuthEntity($authEnt, $user),
-                      'Site Service failed to delete APIAuthenticationEntity');
-    $this->assertEmpty($user->getAPIAuthenticationEntities(),
-                      'Site Service failed to remove APIAuthenticationEntity from User');
-    $this->assertEmpty($site->getAPIAuthenticationEntities(),
-                      'Site Service failed to remove APIAuthenticationEntity from Site');
-  }
+        $this->assertNull(
+            $siteService->deleteAPIAuthEntity($authEnt, $user),
+            'Site Service failed to delete APIAuthenticationEntity'
+        );
+        $this->assertEmpty(
+            $user->getAPIAuthenticationEntities(),
+            'Site Service failed to remove APIAuthenticationEntity from User'
+        );
+        $this->assertEmpty(
+            $site->getAPIAuthenticationEntities(),
+            'Site Service failed to remove APIAuthenticationEntity from Site'
+        );
+    }
 }

--- a/tests/unit/lib/Gocdb_Services/UserServiceTest.php
+++ b/tests/unit/lib/Gocdb_Services/UserServiceTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright (C) 2015 STFC
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -26,172 +27,195 @@ use Doctrine\ORM\EntityManager;
  *
  * @author Ian Neilson (after David Meredith)
  */
-class UserServiceTest extends PHPUnit_Extensions_Database_TestCase {
-  private $entityManager;
-  private $dbOpsFactory;
+class UserServiceTest extends PHPUnit_Extensions_Database_TestCase
+{
+    private $entityManager;
+    private $dbOpsFactory;
 
-  function __construct() {
-    parent::__construct();
-    // Use a local instance to avoid Mess Detector's whinging about avoiding
-    // static access.
-    $this->dbOpsFactory = new PHPUnit_Extensions_Database_Operation_Factory();
-  }
+    function __construct()
+    {
+        parent::__construct();
+      // Use a local instance to avoid Mess Detector's whinging about avoiding
+      // static access.
+        $this->dbOpsFactory = new PHPUnit_Extensions_Database_Operation_Factory();
+    }
   /**
   * Overridden.
   */
-  public static function setUpBeforeClass() {
-    parent::setUpBeforeClass();
-    echo "\n\n-------------------------------------------------\n";
-    echo "Executing UserServiceTest. . .\n";
-  }
+    public static function setUpBeforeClass()
+    {
+        parent::setUpBeforeClass();
+        echo "\n\n-------------------------------------------------\n";
+        echo "Executing UserServiceTest. . .\n";
+    }
 
   /**
   * Overridden. Returns the test database connection.
   * @return PHPUnit_Extensions_Database_DB_IDatabaseConnection
   */
-  protected function getConnection() {
-    require_once __DIR__ . '/../../../doctrine/bootstrap_pdo.php';
-    return getConnectionToTestDB();
-  }
+    protected function getConnection()
+    {
+        require_once __DIR__ . '/../../../doctrine/bootstrap_pdo.php';
+        return getConnectionToTestDB();
+    }
 
   /**
   * Overridden. Returns the test dataset.
   * Defines how the initial state of the database should look before each test is executed.
   * @return PHPUnit_Extensions_Database_DataSet_IDataSet
   */
-  protected function getDataSet() {
-    return $this->createFlatXMLDataSet(__DIR__ . '/../../../doctrine/truncateDataTables.xml');
-    // Use below to return an empty data set if we don't want to truncate and seed
-    //return new PHPUnit_Extensions_Database_DataSet_DefaultDataSet();
-  }
+    protected function getDataSet()
+    {
+        return $this->createFlatXMLDataSet(__DIR__ . '/../../../doctrine/truncateDataTables.xml');
+      // Use below to return an empty data set if we don't want to truncate and seed
+      //return new PHPUnit_Extensions_Database_DataSet_DefaultDataSet();
+    }
 
   /**
   * Overridden.
   */
-  protected function getSetUpOperation() {
-    // CLEAN_INSERT is default
-    //return PHPUnit_Extensions_Database_Operation_Factory::CLEAN_INSERT();
-    //return PHPUnit_Extensions_Database_Operation_Factory::UPDATE();
-    //return PHPUnit_Extensions_Database_Operation_Factory::NONE();
-    //
-    // Issue a DELETE from <table> which is more portable than a
-    // TRUNCATE table <table> (some DBs require high privileges for truncate statements
-    // and also do not allow truncates across tables with FK contstraints e.g. Oracle)
-    return $this->dbOpsFactory->DELETE_ALL();
-  }
+    protected function getSetUpOperation()
+    {
+      // CLEAN_INSERT is default
+      //return PHPUnit_Extensions_Database_Operation_Factory::CLEAN_INSERT();
+      //return PHPUnit_Extensions_Database_Operation_Factory::UPDATE();
+      //return PHPUnit_Extensions_Database_Operation_Factory::NONE();
+      //
+      // Issue a DELETE from <table> which is more portable than a
+      // TRUNCATE table <table> (some DBs require high privileges for truncate statements
+      // and also do not allow truncates across tables with FK contstraints e.g. Oracle)
+        return $this->dbOpsFactory->DELETE_ALL();
+    }
 
   /**
   * Overridden.
   */
-  protected function getTearDownOperation() {
-    // NONE is default
-    return $this->dbOpsFactory->NONE();
-  }
+    protected function getTearDownOperation()
+    {
+      // NONE is default
+        return $this->dbOpsFactory->NONE();
+    }
 
   /**
   * Sets up the fixture, e.g create a new entityManager for each test run
   * This method is called before each test method is executed.
   */
-  protected function setUp() {
-    parent::setUp();
-    $this->entityManager = $this->createEntityManager();
-  }
-
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->entityManager = $this->createEntityManager();
+    }
+  /**
+   * Run after each test function to prevent pile-up of database connections.
+   */
+    protected function tearDown()
+    {
+        parent::tearDown();
+        if (!is_null($this->entityManager)) {
+            $this->entityManager->getConnection()->close();
+        }
+    }
   /**
   * @return EntityManager
   */
-  private function createEntityManager(){
-    $entityManager = null; // Initialise in local scope to avoid unused variable warnings
-    require __DIR__ . '/../../../doctrine/bootstrap_doctrine.php';
-    return $entityManager;
-  }
+    private function createEntityManager()
+    {
+        $entityManager = null; // Initialise in local scope to avoid unused variable warnings
+        require __DIR__ . '/../../../doctrine/bootstrap_doctrine.php';
+        return $entityManager;
+    }
 
   /**
   * Called after setUp() and before each test. Used for common assertions
   * across all tests.
   */
-  protected function assertPreConditions() {
-    $con = $this->getConnection();
-    $fixture = __DIR__ . '/../../../doctrine/truncateDataTables.xml';
-    $tables = simplexml_load_file($fixture);
+    protected function assertPreConditions()
+    {
+        $con = $this->getConnection();
+        $fixture = __DIR__ . '/../../../doctrine/truncateDataTables.xml';
+        $tables = simplexml_load_file($fixture);
 
-    foreach($tables as $tableName) {
-      $sql = "SELECT * FROM ".$tableName->getName();
-      $result = $con->createQueryTable('results_table', $sql);
-      if($result->getRowCount() != 0){
-        throw new RuntimeException("Invalid fixture. Table has rows: ".$tableName->getName());
-      }
+        foreach ($tables as $tableName) {
+            $sql = "SELECT * FROM " . $tableName->getName();
+            $result = $con->createQueryTable('results_table', $sql);
+            if ($result->getRowCount() != 0) {
+                throw new RuntimeException("Invalid fixture. Table has rows: " . $tableName->getName());
+            }
+        }
     }
-  }
   /**
    * Create some test user data
    */
-  private function getUserData () {
+    private function getUserData()
+    {
 
-    $userData = array (
-      'TITLE' => 'President',
-      'FORENAME' => 'Forename',
-      'SURNAME' => 'Surname',
-      'EMAIL' => 'forename.surname@somedomain.net',
-      'TELEPHONE' => '01234 56789'
-    );
+        $userData = array (
+        'TITLE' => 'President',
+        'FORENAME' => 'Forename',
+        'SURNAME' => 'Surname',
+        'EMAIL' => 'forename.surname@somedomain.net',
+        'TELEPHONE' => '01234 56789'
+        );
 
-    return $userData;
-  }
+        return $userData;
+    }
   /**
    * Create a minimal identifier
    */
-  private function getUserIdentifier () {
+    private function getUserIdentifier()
+    {
 
-    $userIdentifier = array ('NAME'=>'X.509','VALUE'=>'/CN=Forename Surname');
+        $userIdentifier = array ('NAME' => 'X.509','VALUE' => '/CN=Forename Surname');
 
-    return ($userIdentifier);
-  }
+        return ($userIdentifier);
+    }
 
-  private function createAndRegisterUser ($userData, $userIdentifier) {
+    private function createAndRegisterUser($userData, $userIdentifier)
+    {
 
-    $userService = new org\gocdb\services\User();
-    $userService->setEntityManager($this->entityManager);
-    $userService->register($userData, $userIdentifier);
+        $userService = new org\gocdb\services\User();
+        $userService->setEntityManager($this->entityManager);
+        $userService->register($userData, $userIdentifier);
 
-    return $userService;
-  }
+        return $userService;
+    }
   /*
   * Tests begin here
   */
-  public function testRegisterUser() {
-    print __METHOD__ . "\n";
+    public function testRegisterUser()
+    {
+        print __METHOD__ . "\n";
 
-    $userData = $this->getUserData();
-    $userIdentifier = $this->getUserIdentifier();
-    $userService = $this->createAndRegisterUser($userData, $userIdentifier);
+        $userData = $this->getUserData();
+        $userIdentifier = $this->getUserIdentifier();
+        $userService = $this->createAndRegisterUser($userData, $userIdentifier);
 
-    $user = $userService->getUserByPrinciple($userIdentifier['VALUE']);
+        $user = $userService->getUserByPrinciple($userIdentifier['VALUE']);
 
-    // Check that we get an instance of User class in the correct namespace returned.
-    $this->assertTrue($user instanceof \User, 'User service failed to registered and return a User');
-
-  }
+      // Check that we get an instance of User class in the correct namespace returned.
+        $this->assertTrue($user instanceof \User, 'User service failed to registered and return a User');
+    }
   /**
    * @depends testRegisterUser
    */
-  public function testAddAPIAuthentication () {
-    print __METHOD__ . "\n";
+    public function testAddAPIAuthentication()
+    {
+        print __METHOD__ . "\n";
 
-    $userData = $this->getUserData();
-    $userIdentifier = $this->getUserIdentifier();
-    $userService = $this->createAndRegisterUser($userData, $userIdentifier);
+        $userData = $this->getUserData();
+        $userIdentifier = $this->getUserIdentifier();
+        $userService = $this->createAndRegisterUser($userData, $userIdentifier);
 
-    $authEnt = new \APIAuthentication();
-    $authEnt->setIdentifier($userIdentifier['VALUE']);
-    $authEnt->setType("X509");
+        $authEnt = new \APIAuthentication();
+        $authEnt->setIdentifier($userIdentifier['VALUE']);
+        $authEnt->setType("X509");
 
-    $user = $userService->getUserByPrinciple($userIdentifier['VALUE']);
+        $user = $userService->getUserByPrinciple($userIdentifier['VALUE']);
 
-    $user->addAPIAuthenticationEntitiesDoJoin($authEnt);
+        $user->addAPIAuthenticationEntitiesDoJoin($authEnt);
 
-    $authUser = $authEnt->getUser();
-    // Check that both sides of the relationship match
-    $this->assertEquals($user->getId(), $authUser->getId());
-  }
+        $authUser = $authEnt->getUser();
+      // Check that both sides of the relationship match
+        $this->assertEquals($user->getId(), $authUser->getId());
+    }
 }

--- a/tests/writeAPI/abstractClass.php
+++ b/tests/writeAPI/abstractClass.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright (C) 2020 STFC
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,98 +24,114 @@ use Doctrine\ORM\EntityManager;
  * Abstract class for testing the Write API.
  *
  */
-abstract class AbstractWriteAPITestClass extends PHPUnit_Extensions_Database_TestCase{
-
-  protected $em;
-  protected $validAuthIdent = 'validIdentifierString';
+abstract class AbstractWriteAPITestClass extends PHPUnit_Extensions_Database_TestCase
+{
+    protected $em;
+    protected $validAuthIdent = 'validIdentifierString';
 
   /**
   * Overridden. Returns the test database connection.
   * @return PHPUnit_Extensions_Database_DB_IDatabaseConnection
   */
-  protected function getConnection() {
-    require_once __DIR__ . '/../doctrine/bootstrap_pdo.php';
-    return getConnectionToTestDB();
-  }
+    protected function getConnection()
+    {
+        require_once __DIR__ . '/../doctrine/bootstrap_pdo.php';
+        return getConnectionToTestDB();
+    }
 
   /**
   * Overridden. Returns the test dataset.
   * Defines how the initial state of the database should look before each test is executed.
   * @return PHPUnit_Extensions_Database_DataSet_IDataSet
   */
-  protected function getDataSet() {
-    return $this->createFlatXMLDataSet(__DIR__ . '/../doctrine/truncateDataTables.xml');
-  }
+    protected function getDataSet()
+    {
+        return $this->createFlatXMLDataSet(__DIR__ . '/../doctrine/truncateDataTables.xml');
+    }
 
   /**
   * Overridden.
   */
-  protected function getSetUpOperation() {
-    # ::CLEAN_INSERT is default
-    #
-    # Issue a DELETE from <table> which is more portable than a
-    # TRUNCATE table <table> (some DBs require high privileges for truncate statements
-    # and also do not allow truncates across tables with FK contstraints e.g. Oracle)
-    return PHPUnit_Extensions_Database_Operation_Factory::DELETE_ALL();
-  }
+    protected function getSetUpOperation()
+    {
+      # ::CLEAN_INSERT is default
+      #
+      # Issue a DELETE from <table> which is more portable than a
+      # TRUNCATE table <table> (some DBs require high privileges for truncate statements
+      # and also do not allow truncates across tables with FK contstraints e.g. Oracle)
+        return PHPUnit_Extensions_Database_Operation_Factory::DELETE_ALL();
+    }
 
   /**
   * Overridden.
   */
-  protected function getTearDownOperation() {
-    # NONE is default
-    return PHPUnit_Extensions_Database_Operation_Factory::NONE();
-  }
+    protected function getTearDownOperation()
+    {
+      # NONE is default
+        return PHPUnit_Extensions_Database_Operation_Factory::NONE();
+    }
 
   /**
   * Sets up the fixture, e.g create a new entityManager for each test run
   * This method is called before each test method is executed.
   */
-  protected function setUp() {
-    parent::setUp();
-    $this->em = $this->createEntityManager();
-  }
-
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->em = $this->createEntityManager();
+    }
+  /**
+   * Run after each test function to prevent pile-up of database connections.
+   */
+    protected function tearDown()
+    {
+        parent::tearDown();
+        if (!is_null($this->em)) {
+            $this->em->getConnection()->close();
+        }
+    }
   /**
   * @todo Still need to setup connection to different databases.
   * @return EntityManager
   */
-  private function createEntityManager(){
-    require __DIR__ . '/../doctrine/bootstrap_doctrine.php';
-    return $entityManager;
-  }
+    private function createEntityManager()
+    {
+        require __DIR__ . '/../doctrine/bootstrap_doctrine.php';
+        return $entityManager;
+    }
 
   /**
   * Called after setUp() and before each test. Used for common assertions
   * across all tests.
   */
-  protected function assertPreConditions() {
-    $con = $this->getConnection();
-    $fixture = __DIR__ . '/../doctrine/truncateDataTables.xml';
-    $tables = simplexml_load_file($fixture);
+    protected function assertPreConditions()
+    {
+        $con = $this->getConnection();
+        $fixture = __DIR__ . '/../doctrine/truncateDataTables.xml';
+        $tables = simplexml_load_file($fixture);
 
-    foreach($tables as $tableName) {
-      $sql = "SELECT * FROM ".$tableName->getName();
-      $result = $con->createQueryTable('results_table', $sql);
-      if($result->getRowCount() != 0){
-        throw new RuntimeException("Invalid fixture. Table has rows: ".$tableName->getName());
-      }
+        foreach ($tables as $tableName) {
+            $sql = "SELECT * FROM " . $tableName->getName();
+            $result = $con->createQueryTable('results_table', $sql);
+            if ($result->getRowCount() != 0) {
+                throw new RuntimeException("Invalid fixture. Table has rows: " . $tableName->getName());
+            }
+        }
     }
-  }
 
   /**
    * The test class for each method should test the case of unauthenticated requests.
    * Ideally this should be an otherwise valid request and should explicitly
    * check nothing is changed.
    */
-  abstract protected function test_APIUnauthenticated();
+    abstract protected function test_APIUnauthenticated();
 
   /**
    * The test class for each method should test the case of unauthorised requests.
    * Ideally this should be an otherwise valid request and should explicitly
    * check nothing is changed.
    */
-  abstract protected function test_APIUnauthorised();
+    abstract protected function test_APIUnauthorised();
 
   /**
    * Function to make a call to the write API and return an array containing the
@@ -124,19 +141,19 @@ abstract class AbstractWriteAPITestClass extends PHPUnit_Extensions_Database_Tes
    * @param  string $requestContents contents of the request we are testing against the URL
    * @return array                   array containing response code and API response
    */
-  protected function arbitaryValuesWriteAPICall ($method, $url, $requestContents, $authMethod, $authIdent) {
+    protected function arbitaryValuesWriteAPICall($method, $url, $requestContents, $authMethod, $authIdent)
+    {
 
-    $siteService =   new org\gocdb\services\Site();
-    $siteService->setEntityManager($this->em);
-    $serviceService = new org\gocdb\services\ServiceService();
-    $serviceService->setEntityManager($this->em);
-    $authArray = array('userIdentifier'=>$authIdent,'userIdentifierType'=>$authMethod);
+        $siteService =   new org\gocdb\services\Site();
+        $siteService->setEntityManager($this->em);
+        $serviceService = new org\gocdb\services\ServiceService();
+        $serviceService->setEntityManager($this->em);
+        $authArray = array('userIdentifier' => $authIdent,'userIdentifierType' => $authMethod);
 
-    $piReq = new org\gocdb\services\PIWriteRequest();
-    $piReq->setServiceService($serviceService);
-    return $piReq->processRequest($method, $url, $requestContents, $siteService, $authArray);
-
-  }
+        $piReq = new org\gocdb\services\PIWriteRequest();
+        $piReq->setServiceService($serviceService);
+        return $piReq->processRequest($method, $url, $requestContents, $siteService, $authArray);
+    }
 
 
   /**
@@ -151,29 +168,31 @@ abstract class AbstractWriteAPITestClass extends PHPUnit_Extensions_Database_Tes
    * @param  string $entKey          optionally the key to a value of the propery being changed
    * @return array                   array containing response code and API response
    */
-  protected function wellFormattedWriteAPICall ($method, $requestContents, $authIdent, $entType, $entID, $entProp, $entKey = null ) {
-    #create a url string
-    $urlString = 'v5';
-    $urlString .= '/' . $entType;
-    $urlString .= '/' . $entID;
-    $urlString .= '/' . $entProp;
-    if (!is_null($entKey)) {
-      $urlString .= '/' . $entKey;
-    }
+    protected function wellFormattedWriteAPICall($method, $requestContents, $authIdent, $entType, $entID, $entProp, $entKey = null)
+    {
+      #create a url string
+        $urlString = 'v5';
+        $urlString .= '/' . $entType;
+        $urlString .= '/' . $entID;
+        $urlString .= '/' . $entProp;
+        if (!is_null($entKey)) {
+            $urlString .= '/' . $entKey;
+        }
 
-    return $this->arbitaryValuesWriteAPICall ($method,$urlString, $requestContents, 'X509', $authIdent);
-  }
+        return $this->arbitaryValuesWriteAPICall($method, $urlString, $requestContents, 'X509', $authIdent);
+    }
 
   /**
    * Create a JSON string in a format acceptable to the Write API for a single value
    * @param  string $value single value for JSON
    * @return string        json string
    */
-  protected function singleValToJsonRequest ($value) {
-    $jsonArray = array ('value'=>$value);
-    $json = json_encode ($jsonArray);
-    return $json;
-  }
+    protected function singleValToJsonRequest($value)
+    {
+        $jsonArray = array ('value' => $value);
+        $json = json_encode($jsonArray);
+        return $json;
+    }
 
   /**
    * Create a JSON string in a format acceptable to the Write API for a single
@@ -182,15 +201,16 @@ abstract class AbstractWriteAPITestClass extends PHPUnit_Extensions_Database_Tes
    * @param  boolean $bool single value for JSON
    * @return string        json string
    */
-  protected function boolValToJsonRequest ($bool) {
-    $boolStr = 'false';
-    if ($bool) {
-      $boolStr = 'true';
-    }
+    protected function boolValToJsonRequest($bool)
+    {
+        $boolStr = 'false';
+        if ($bool) {
+            $boolStr = 'true';
+        }
 
-    $json = '{"value":' . $boolStr . '}';
-    return $json;
-  }
+        $json = '{"value":' . $boolStr . '}';
+        return $json;
+    }
 
   /**
    * Creates a sample site for testing which is a member of a sample NGI.
@@ -200,38 +220,39 @@ abstract class AbstractWriteAPITestClass extends PHPUnit_Extensions_Database_Tes
    *                        sample sites without violating unique constraints
    * @return Site the sample site
    */
-  protected function createSampleSite($append="") {
-    #Create an NGI for the site to beong to
-    $NGI = TestUtil::createSampleNGI("SampleNGI" . $append);
+    protected function createSampleSite($append = "")
+    {
+      #Create an NGI for the site to beong to
+        $NGI = TestUtil::createSampleNGI("SampleNGI" . $append);
 
-    #Create the test site
-    $site = TestUtil::createSampleSite("SampleSite" . $append);
+      #Create the test site
+        $site = TestUtil::createSampleSite("SampleSite" . $append);
 
-    #The site needs associating with the NGI
-    $NGI->addSiteDoJoin($site);
+      #The site needs associating with the NGI
+        $NGI->addSiteDoJoin($site);
 
-    #We need a credential that can access the writeAPI associated with the sites
-    $authEnt = new \APIAuthentication();
-    $authEnt->setIdentifier($this->validAuthIdent);
-    $authEnt->setType('X509');
-    $site->addAPIAuthenticationEntitiesDoJoin($authEnt);
+      #We need a credential that can access the writeAPI associated with the sites
+        $authEnt = new \APIAuthentication();
+        $authEnt->setIdentifier($this->validAuthIdent);
+        $authEnt->setType('X509');
+        $site->addAPIAuthenticationEntitiesDoJoin($authEnt);
 
-    #And then we get Doctrine to update the DB
-    $this->em->persist($authEnt);
-    $this->em->persist($NGI);
-    $this->em->persist($site);
-    $this->em->flush();
+      #And then we get Doctrine to update the DB
+        $this->em->persist($authEnt);
+        $this->em->persist($NGI);
+        $this->em->persist($site);
+        $this->em->flush();
 
-    #Check that there is an auth entity and that it is associated with the site (Creation of sites is validated in previous tests)
-    $con = $this->getConnection();
-    $APIAuthId = $authEnt->getId();
-    $siteID = $site->getID();
-    $sql = "SELECT * FROM APIAuthenticationEntities WHERE parentSite_id = '$siteID' AND Id = '$APIAuthId'";
-    $result = $con->createQueryTable('', $sql);
-    $this->assertEquals(1, $result->getRowCount());
+      #Check that there is an auth entity and that it is associated with the site (Creation of sites is validated in previous tests)
+        $con = $this->getConnection();
+        $APIAuthId = $authEnt->getId();
+        $siteID = $site->getID();
+        $sql = "SELECT * FROM APIAuthenticationEntities WHERE parentSite_id = '$siteID' AND Id = '$APIAuthId'";
+        $result = $con->createQueryTable('', $sql);
+        $this->assertEquals(1, $result->getRowCount());
 
-    return $site;
-  }
+        return $site;
+    }
 
   /**
   * Creates a sample service for testing against. In doing so, calls other
@@ -241,22 +262,23 @@ abstract class AbstractWriteAPITestClass extends PHPUnit_Extensions_Database_Tes
   *                        sample services without violating unique constraints
   * @return Service service for testing against
   */
-  protected function createSampleService($append="") {
-    #create a sample site and create a new sample service and join it to that site
-    $sampleService = TestUtil::createSampleService("Sample service" . $append);
-    $sampleST= TestUtil::createSampleServiceType("sample.service.type" .$append);
-    $sampleService->setServiceType($sampleST);
-    $sampleSite = $this->createSampleSite($append);
-    $sampleSite->addServiceDoJoin($sampleService);
+    protected function createSampleService($append = "")
+    {
+      #create a sample site and create a new sample service and join it to that site
+        $sampleService = TestUtil::createSampleService("Sample service" . $append);
+        $sampleST = TestUtil::createSampleServiceType("sample.service.type" . $append);
+        $sampleService->setServiceType($sampleST);
+        $sampleSite = $this->createSampleSite($append);
+        $sampleSite->addServiceDoJoin($sampleService);
 
-    #Update the DB
-    $this->em->persist($sampleST);
-    $this->em->persist($sampleService);
-    $this->em->persist($sampleSite);
-    $this->em->flush();
+      #Update the DB
+        $this->em->persist($sampleST);
+        $this->em->persist($sampleService);
+        $this->em->persist($sampleSite);
+        $this->em->flush();
 
-    return $sampleService;
-  }
+        return $sampleService;
+    }
 
   /**
    * Creates a sample endpoint for testing against. In doing so, calls other
@@ -264,18 +286,18 @@ abstract class AbstractWriteAPITestClass extends PHPUnit_Extensions_Database_Tes
    *
    * @return EndpointLocation endpoint for testing against
  */
-  protected function createSampleEndpoint() {
-    #Create a sample service (and associated gubbins) and create an endpoint associated with it
-    $sampleEP = TestUtil::createSampleEndpointLocation();
-    $sampleSer  = $this->createSampleService();
-    $sampleEP->setServiceDoJoin($sampleSer);
+    protected function createSampleEndpoint()
+    {
+      #Create a sample service (and associated gubbins) and create an endpoint associated with it
+        $sampleEP = TestUtil::createSampleEndpointLocation();
+        $sampleSer  = $this->createSampleService();
+        $sampleEP->setServiceDoJoin($sampleSer);
 
-    #update DB
-    $this->em->persist($sampleSer);
-    $this->em->persist($sampleEP);
-    $this->em->flush();
+      #update DB
+        $this->em->persist($sampleSer);
+        $this->em->persist($sampleEP);
+        $this->em->flush();
 
-    return $sampleEP;
-  }
-
+        return $sampleEP;
+    }
 }


### PR DESCRIPTION
Add tearDown function to tests to properly close the
connection to the database with failure due to >150
connections default max value for MariaDB.

Auto-reformat code.