### PR TITLE
Re-add authByAnyCert/Identifier method

### DIFF
--- a/htdocs/PI/index.php
+++ b/htdocs/PI/index.php
@@ -362,8 +362,7 @@ class PIRequest {
                     break;
             }
         } catch (\Exception $e) {
-            print_r($e->getMessage());
-            die("An error has occured, please contact the GOCDB administrators at gocdb-admins@egi.eu");
+            die($e->getMessage());
         }
         return $xml;
     }
@@ -416,8 +415,10 @@ class PIRequest {
     function authByAnyIdentifier()
     {
         if (empty($this->identifier)) {
-            die("No valid identifier found. Try accessing the " .
-                "resource through the private interface.");
+            throw new \Exception(
+                "No valid identifier found. Try accessing the resource " .
+                "through the private interface."
+            );
         }
     }
 }

--- a/htdocs/PI/index.php
+++ b/htdocs/PI/index.php
@@ -328,7 +328,7 @@ class PIRequest {
                     break;
                 case "get_cert_status_date" :
                     require_once($directory . 'GetCertStatusDate.php');
-                    $this->authByIdentifier();
+                    $this->authByAnyIdentifier();
                     $getCertStatusDate = new GetCertStatusDate($em, $this->baseApiUrl);
                     $getCertStatusDate->setDefaultPaging($this->defaultPaging);
                     $getCertStatusDate->setPageSize($this->defaultPageSize);
@@ -413,6 +413,13 @@ class PIRequest {
         }
     }
 
+    function authByAnyIdentifier()
+    {
+        if (empty($this->identifier)) {
+            die("No valid identifier found. Try accessing the " .
+                "resource through the private interface.");
+        }
+    }
 }
 
 ?>


### PR DESCRIPTION
~~Depends on #368~~

So some methods can be accessed with just a valid identifier. 

i.e. `get_cert_status_date`, for GOCDB 5.9 it's accessible with just a valid identifier and it doesn't contain personal/contact so it should remain accessible with just a valid identifier.