### PR TITLE
381 user removal dry run

### DIFF
--- a/resources/RemoveInactiveUsersRunner.php
+++ b/resources/RemoveInactiveUsersRunner.php
@@ -35,27 +35,29 @@ if (isset($options["deletion_threshold"])) {
 };
 
 if (isset($options["dry_run"])) {
-    $dryRun = true; // If the dry_run option is added, variable dryRun set to true.
-    echo "Dry run is on.\n";
+    // If the dry_run option is added, variable dryRun set to true.
+    $dryRun = true;
+    echo "Dry run is on.\n\n";
 } else {
-    $dryRun = false; // If the dry_run option isn't added, variable dryRun set to false.
-    echo "Dry run is off.\n";
+    // If the dry_run option isn't added, variable dryRun set to false.
+    $dryRun = false;
+    echo "Dry run is off.\n\n";
 };
 
 $dql = "SELECT u FROM User u";
 $users = $entityManager->createQuery($dql)->getResult();
 
-echo "\nScanning user login dates in database at: " . date('D, d M Y H:i:s') . "\n\n";
+echo "Scanning user login dates in database at: " . date('D, d M Y H:i:s') . "\n\n";
 
-if ($dryRun == true) {  // If dry run option has been selected
-    // Text is overwritten to InactiveUsersToBeDeleted.txt
-    file_put_contents("InactiveUsersToBeDeleted.txt", "userID, lastLoginDate, elapsedMonths\n");
+if ($dryRun == true) {
+    // If dry run option has been selected, text is overwritten to InactiveUsersToBeDeleted.csv
+    file_put_contents("InactiveUsersToBeDeleted.csv", "userID, lastLoginDate, elapsedMonths\n");
 };
 
 $today = new DateTime();
 
 foreach ($users as $user) {
-    echo "\nUser ID: " . $user->getId() . "\n";
+    echo "User ID: " . $user->getId() . "\n";
 
     $creationDate = $user->getCreationDate();
     $creationStr = $creationDate->format('Y-m-d H:i:s');
@@ -63,60 +65,78 @@ foreach ($users as $user) {
     $lastLoginDate = $user->getLastLoginDate();
     if (!$user->getAPIAuthenticationEntities()->isEmpty()) {
        // Prevent creating orphaned API credentials.
-       echo "Cannot delete a user with attached API credentials.\n";
+       echo "Cannot delete a user with attached API credentials.\n\n";
        // Move onto the next users.
        continue;
     }
 
-    if ($lastLoginDate) { // null lastLoginDate check
+    if ($lastLoginDate) {
+        // null lastLoginDate check
         $interval = $today->diff($lastLoginDate);
-    } else { // This might only be run once, since new users always have field filled.
+    } else {
+        // This might only be run once, since new users always have field filled.
         echo "Deleting this user as it has no last login date " .
-        "(it may have been a very long time). \n";
-        if ($dryRun == true) {  // If dry run option has been selected
-             //writing to file to say who would have been deleted
-            file_put_contents("InactiveUsersToBeDeleted.txt", $user->getId() . ", `null`, " .
+        "(it may have been a very long time).\n";
+        if ($dryRun == true) {
+            // As dry run option is true, writing to file to say who would have been deleted
+            file_put_contents("InactiveUsersToBeDeleted.csv", $user->getId() . ", `null`, " .
             "`?`\n", FILE_APPEND);
-        };  // no else needed.
-        deleteUser($user, $entityManager);
-        echo "\n";
-        // Move onto the next users.
+            echo "\n";
+        } else {
+            // As dry run option is false, user can be deleted.
+            deleteUser($user, $entityManager);
+            // Move onto the next users.
+            continue;
+        }
         continue;
     }
 
-    $elapsedMonths = (int) $interval->format('%a') / 30.4375; // 30.4375 is 365.25/12
+    // 30.4375 is used becuase it is 365.25/12
+    $elapsedMonths = (int) $interval->format('%a') / 30.4375;
     // Rounded months since last login to 2 decimal places on line below for easier reading.
     echo 'Months elapsed since last login: ' . round($elapsedMonths, 2) . "\n";
 
-    if ($elapsedMonths > $deletionThreshold) { // Delete user
-        // Check if it is a dry run
+    if ($elapsedMonths > $deletionThreshold) {
+        // Delete user, but first check if it is a dry run
         if ($dryRun == true) {
             // Dry run option is set, so append user to be deleted to the file
-            echo "This user will be deleted when it isn't a dry run. \n\n";
-            file_put_contents("InactiveUsersToBeDeleted.txt", $user->getId() . "," .
+            echo "This user will be deleted when it isn't a dry run.\n\n";
+            file_put_contents("InactiveUsersToBeDeleted.csv", $user->getId() . "," .
             " " . $lastLoginDate->format("D d M Y H:i:s") . "," .
             " " . floor($elapsedMonths) . "\n", FILE_APPEND);
-        } else {  // Delete user as dry run option not set.
-            echo "Deleting user. \n";
+        } else {
+            // Delete user as dry run option not set.
+            echo "Deleting user.\n";
             deleteUser($user, $entityManager);
         };
-    } elseif ($elapsedMonths > $warningThreshold) { // Warn user
-        echo "Sending user warning email.\n\n";
-        sendWarningEmail($user, $elapsedMonths, $deletionThreshold);
-        echo "\n";
-    } elseif ($elapsedMonths < $warningThreshold) { // Do Nothing
-        echo "Doing nothing.\n";
+    } elseif ($elapsedMonths > $warningThreshold) {
+        // Warn user, but first check if it is a dry run
+        if ($dryRun == true) {
+            // Dry run option is set, so warning email isn't sent
+            echo "This user would have been sent a warning email if dry run was not set.\n\n";
+        } else {
+            // Dry run option not set, so warning email is sent
+            echo "Sending the user a warning email.\n\n";
+            sendWarningEmail($user, $elapsedMonths, $deletionThreshold);
+            echo "\n";
+        }
+    } elseif ($elapsedMonths < $warningThreshold) {
+        // Do Nothing
+        echo "Doing nothing.\n\n";
     }
 }
 
 $entityManager->flush();
-if ($dryRun == true) {  // Check if it is a dry run
+// Check if it is a dry run
+if ($dryRun == true) {
     // Telling the user to check the file we appended to see who would have been deleted
-    echo "\nView the contents of InactiveUsersToBeDeleted.txt to see the list of users " .
+    echo "View the contents of InactiveUsersToBeDeleted.csv to see the list of users " .
     "who would have been deleted had this not have been a dry run.\n";
-};  // No else statement needed
+};
+// No else statement needed
 
-echo "\nCompleted ok: " . date('D, d M Y H:i:s') . "\n\n";
+echo "\n";
+echo "Completed ok: " . date('D, d M Y H:i:s') . "\n\n";
 
 
 function usage() {

--- a/resources/RemoveInactiveUsersRunner.php
+++ b/resources/RemoveInactiveUsersRunner.php
@@ -85,8 +85,6 @@ foreach ($users as $user) {
         } else {
             // As dry run option is false, user can be deleted.
             deleteUser($user, $entityManager);
-            // Move onto the next users.
-            continue;
         }
         continue;
     }
@@ -165,11 +163,11 @@ function deleteUser($user, $entityManager)
         $entityManager->remove($user);
         $entityManager->flush();
         $entityManager->getConnection()->commit();
-        echo "User deleted.\n";
+        echo "User deleted.\n\n";
     } catch (\Exception $e) {
         $entityManager->getConnection()->rollback();
         $entityManager->close();
-        echo "User not deleted.\n";
+        echo "User not deleted.\n\n";
         throw $e;
     }
 }

--- a/resources/RemoveInactiveUsersRunner.php
+++ b/resources/RemoveInactiveUsersRunner.php
@@ -190,4 +190,3 @@ function sendWarningEmail($user, $elapsedMonths, $deletionThreshold)
     // Handle all mail related printing/debugging
     \Factory::getEmailService()->send($emailAddress, $subject, $body, $headers);
 }
-

--- a/resources/RemoveInactiveUsersRunner.php
+++ b/resources/RemoveInactiveUsersRunner.php
@@ -10,6 +10,8 @@ $longOptions = array(
     "warning_threshold:",
     // Required Option. After this many months, users will be deleted.
     "deletion_threshold:",
+    // Not required. If this option is added, it will be a dry run. Else it won't be.
+    "dry_run"
 );
 
 $options = getopt("", $longOptions);
@@ -32,21 +34,34 @@ if (isset($options["deletion_threshold"])) {
     return;
 };
 
+if (isset($options["dry_run"])) {
+    $dryRun = 1; // If the dry_run option is added, variable dryRun set to 1.
+    echo "Dry run is on.\n";
+} else {
+    $dryRun = 0; // If the dry_run option isn't added, variable dryRun set to 0.
+    echo "Dry run is off.\n";
+};
+
 $dql = "SELECT u FROM User u";
 $users = $entityManager->createQuery($dql)->getResult();
 
-echo "Scanning user login dates in database at: ".date('D, d M Y H:i:s')."\n";
+echo "\nScanning user login dates in database at: ".date('D, d M Y H:i:s')."\n\n";
+
+if ($dryRun == '1') {  // If dry run option has been selected
+    file_put_contents("InactiveUsersToBeDeleted.txt", "These are the users that " .
+    "would have been deleted during the dry run on: ".date('D, d M Y H:i:s')."\n");
+    // Text is overwritten to InactiveUsersToBeDeleted.txt
+};
 
 $today = new DateTime();
 
 foreach ($users as $user) {
-    echo 'User ID: ' . $user->getId() . "\n";
+    echo "\nUser ID: " . $user->getId() . "\n";
 
     $creationDate = $user->getCreationDate();
     $creationStr = $creationDate->format('Y-m-d H:i:s');
 
     $lastLoginDate = $user->getLastLoginDate();
-
     if (!$user->getAPIAuthenticationEntities()->isEmpty()) {
        // Prevent creating orphaned API credentials.
        echo "Cannot delete a user with attached API credentials.\n";
@@ -57,36 +72,58 @@ foreach ($users as $user) {
     if ($lastLoginDate) { // null lastLoginDate check
         $interval = $today->diff($lastLoginDate);
     } else { // This might only be run once, since new users always have field filled.
-        echo "User has no lastLoginDate (it may have been a very long time.)\n";
-        echo "Deleting user.\n";
+        echo "Deleting this user as it has no last login date " .
+        "(it may have been a very long time). \n";
+        //writing to file to say who would have been deleted
+        file_put_contents("InactiveUsersToBeDeleted.txt", "The user " .
+        "with Id ".$user->getId()." would have been deleted as it " .
+        "has no last login date.\n", FILE_APPEND);
         deleteUser($user, $entityManager);
         echo "\n";
         // Move onto the next users.
         continue;
     }
 
-    $elapsedMonths = (int) $interval->format('%a') / 30;
-    echo 'Months elapsed since last login: ' . $elapsedMonths . "\n";
+    $elapsedMonths = (int) $interval->format('%a') / 30.4375; // 30.4375 is 365.25/12
+    echo 'Months elapsed since last login: ' . round($elapsedMonths,2) . "\n";
+    // Rounded months since last login to 2 decimal places for easier reading.
 
-    if ($elapsedMonths > $deletionThreshold) { // Delete user
-        echo "Deleting user\n";
-        deleteUser($user, $entityManager);
+    if ($elapsedMonths > $deletionThreshold) // Delete user
+        // Check if it is a dry run
+        if ($dryRun == '1') {
+            // Dry run option is set, so append user to be deleted to the file
+            echo "This user will be deleted when it isn't a dry run. \n\n";
+            file_put_contents("InactiveUsersToBeDeleted.txt", "The user with " .
+            "Id ".$user->getId()." would have been deleted as they last " .
+            "logged in ".floor($elapsedMonths)." months ago.\n", FILE_APPEND); 
+        } else {  // Delete user as dry run option not set.
+            echo "Deleting user. \n";
+            deleteUser($user, $entityManager);
     } elseif ($elapsedMonths > $warningThreshold) { // Warn user
-        echo "Sending user warning email.\n";
+        echo "Sending user warning email.\n\n";
         sendWarningEmail($user, $elapsedMonths, $deletionThreshold);
+        echo "\n";
     } elseif ($elapsedMonths < $warningThreshold) { // Do Nothing
         echo "Doing nothing.\n";
     }
 }
 
 $entityManager->flush();
-echo "Completed ok: ".date('D, d M Y H:i:s');
+if ($dryRun == '1') {  // Check if it is a dry run
+    // Telling the user to check the file we appended to see who would have been deleted
+    echo "\nView the contents of InactiveUsersToBeDeleted.txt to see the list of users " .
+    "who would have been deleted had this not have been a dry run.\n";
+};  // No else statement needed
+
+echo "\nCompleted ok: ".date('D, d M Y H:i:s')."\n\n";
+
 
 function usage() {
     echo "Usage: " .
          "RemoveInactiveUsersRunner.php " .
          "--warning_threshold X " .
-         "--deletion_threshold Y" .
+         "--deletion_threshold Y " .
+         "--dry_run" .
          "\n\n";
     echo "Options:\n\n";
     echo "--warning_threshold X " .
@@ -95,7 +132,8 @@ function usage() {
     echo "--deletion_threshold Y" .
         "    After this many months, users will be deleted." .
         "\n";
-
+    echo "--dry_run" .
+        "                 Use dry_run option if you want a dry run.\n";
     echo "\n";
 };
 
@@ -151,3 +189,4 @@ function sendWarningEmail($user, $elapsedMonths, $deletionThreshold)
     // Handle all mail related printing/debugging
     \Factory::getEmailService()->send($emailAddress, $subject, $body, $headers);
 }
+

--- a/resources/RemoveInactiveUsersRunner.php
+++ b/resources/RemoveInactiveUsersRunner.php
@@ -73,7 +73,7 @@ foreach ($users as $user) {
     } else { // This might only be run once, since new users always have field filled.
         echo "Deleting this user as it has no last login date " .
         "(it may have been a very long time). \n";
-        if ($dryRun == true) {  // If dry run option has been selected        
+        if ($dryRun == true) {  // If dry run option has been selected
              //writing to file to say who would have been deleted
             file_put_contents("InactiveUsersToBeDeleted.txt", $user->getId() . ", `null`, " .
             "`?`\n", FILE_APPEND);

--- a/resources/RemoveInactiveUsersRunner.php
+++ b/resources/RemoveInactiveUsersRunner.php
@@ -64,10 +64,10 @@ foreach ($users as $user) {
 
     $lastLoginDate = $user->getLastLoginDate();
     if (!$user->getAPIAuthenticationEntities()->isEmpty()) {
-       // Prevent creating orphaned API credentials.
-       echo "Cannot delete a user with attached API credentials.\n\n";
-       // Move onto the next users.
-       continue;
+        // Prevent creating orphaned API credentials.
+        echo "Cannot delete a user with attached API credentials.\n\n";
+        // Move onto the next users.
+        continue;
     }
 
     if ($lastLoginDate) {


### PR DESCRIPTION
Resolves #381 

The output:
```[root@host-172-16-113-110 resources]# php RemoveInactiveUsersRunner.php --warning_threshold 4 --deletion_threshold 8 --dry_run
Dry run is on.

Scanning user login dates in database at: Mon, 10 Oct 2022 16:08:51


User ID: 1
Months elapsed since last login: 12.78
This user will be deleted when it isn't a dry run.


User ID: 2
Months elapsed since last login: 1.81
Doing nothing.

User ID: 4
Months elapsed since last login: 5.98
Sending user warning email.

<!--
Sending mail disabled, but would have sent:
From: GOCDB <gocdb-admins@mailman.egi.eu>
To: sample@sample.com
Subject: GOCDB: User account deletion notice

Dear Donna,

Your GOCDB account, associated with the following identifiers, has not been signed into during the last 5 months and will be deleted when this period of inactivity reaches 8 months.

Identifiers:
  - X.509: /C=00/O=00000/OU=000000/CN=Donna Moss

You can prevent the deletion of this account by visiting the GOCDB portal while authenticated with one of the above identifiers.


Additional Parameters:
-->


User ID: 5
Months elapsed since last login: 10.35
This user will be deleted when it isn't a dry run.


User ID: 6
Months elapsed since last login: 0.1
Doing nothing.

View the contents of InactiveUsersToBeDeleted.txt to see the list of users who would have been deleted had this not have been a dry run.

Completed ok: Mon, 10 Oct 2022 16:08:51

[root@host-172-16-113-110 resources]# cat InactiveUsersToBeDeleted.txt
These are the users that would have been deleted during the dry run on: Mon, 10 Oct 2022 16:08:51
The user with Id 1 would have been deleted as they last logged in 12 months ago.
The user with Id 5 would have been deleted as they last logged in 10 months ago.
```