### PR TITLE
Release 5.10.0 to dev

### DIFF
--- a/htdocs/web_portal/static_html/goc5_logo.html
+++ b/htdocs/web_portal/static_html/goc5_logo.html
@@ -4,7 +4,7 @@
 <!--	<img src="img/Logo-1.6.png" class="logo_image" height="39" style="vertical-align: middle;"/>-->
   <h3    class="Logo_Text Small_Bottom_Margin Standard_Padding"
          style="vertical-align: middle; margin-left: 0.2em;">
-         GOCDB 5.9.0
+         GOCDB 5.10.0-rc.1
      </h3>
 
 </a>

--- a/htdocs/web_portal/static_html/goc5_logo.html
+++ b/htdocs/web_portal/static_html/goc5_logo.html
@@ -4,7 +4,7 @@
 <!--	<img src="img/Logo-1.6.png" class="logo_image" height="39" style="vertical-align: middle;"/>-->
   <h3    class="Logo_Text Small_Bottom_Margin Standard_Padding"
          style="vertical-align: middle; margin-left: 0.2em;">
-         GOCDB 5.10.0-rc.1
+         GOCDB 5.10.0-rc.2
      </h3>
 
 </a>

--- a/htdocs/web_portal/static_html/goc5_logo.html
+++ b/htdocs/web_portal/static_html/goc5_logo.html
@@ -4,7 +4,7 @@
 <!--	<img src="img/Logo-1.6.png" class="logo_image" height="39" style="vertical-align: middle;"/>-->
   <h3    class="Logo_Text Small_Bottom_Margin Standard_Padding"
          style="vertical-align: middle; margin-left: 0.2em;">
-         GOCDB 5.10.0-rc.2
+         GOCDB 5.10.0
      </h3>
 
 </a>

--- a/resources/RemoveInactiveUsersRunner.php
+++ b/resources/RemoveInactiveUsersRunner.php
@@ -131,9 +131,16 @@ function sendWarningEmail($user, $elapsedMonths, $deletionThreshold)
             $deletionThreshold . " months.\n\n";
 
     $body .= "Identifiers:\n";
-    foreach ($user->getUserIdentifiers() as $identifier) {
-        $body .= "  - " . $identifier->getKeyName() .": " . $identifier->getKeyValue(). "\n";
-    }
+    
+    $user_ids = $user->getUserIdentifiers();
+    // If a user has identifiers, use them in the email. If not, use the cert DN field.
+    if (!$user_ids->isEmpty()) {
+        foreach ($user_ids as $identifier) {
+            $body .= "  - " . $identifier->getKeyName() .": " . $identifier->getKeyValue(). "\n";
+        };
+    } else {
+        $body .= "  - ". $user->getCertificateDn() . "\n";
+    }; 
 
     $body .= "\n";
     $body .= "You can prevent the deletion of this account by visiting the " .

--- a/resources/RemoveInactiveUsersRunner.php
+++ b/resources/RemoveInactiveUsersRunner.php
@@ -133,7 +133,7 @@ function sendWarningEmail($user, $elapsedMonths, $deletionThreshold)
     $body .= "Identifiers:\n";
     
     $user_ids = $user->getUserIdentifiers();
-    // If a user has identifiers, use them in the email. If not, use the cert DN field.
+    // If a user has identifiers, show the user them in the warning email. If not, show the cert DN.
     if (!$user_ids->isEmpty()) {
         foreach ($user_ids as $identifier) {
             $body .= "  - " . $identifier->getKeyName() .": " . $identifier->getKeyValue(). "\n";


### PR DESCRIPTION
Whilst testing the release, I noticed the user deletion script didn't properly handle the case where users don't have the new identifier mechanism in place (and most, if not all, of the inactive users fall into this category). Hence 0346f652fd829b97a4d06738d2b2c4dd20ec7cf0.