### PR TITLE
Remove "IRIS IAM" login button from landing page to master

### DIFF
--- a/htdocs/landing/index.php
+++ b/htdocs/landing/index.php
@@ -47,17 +47,8 @@
                 $hostname = $_SERVER['HTTP_HOST'];
                 $egi_target = urlencode("https://" . $hostname . "/portal/");
                 $egi_redirect = "https://" . $hostname . "/Shibboleth.sso/Login?target=" . $egi_target;
-                if($_SERVER['REQUEST_URI'] === "/"){
-                    $iam_target = "target_link_uri=" . urlencode("https://" . $hostname . "/portal/");
-                }
-                else{
-                    $iam_target=ltrim($_SERVER['REQUEST_URI'], '/?');
-                }
-                $iris_url = urlencode("https://iris-iam.stfc.ac.uk/");
-                $iam_redirect = "https://" . $hostname . "/portal/redirect_uri?iss=" . $iris_url . "&" . $iam_target;
               ?>
                 <a style="width:30%; display:inline-block; font-size:1.5em" href="<?php echo $egi_redirect; ?>" class="button">EGI Check-In</a>
-                <a style="width:30%; display:inline-block; font-size:1.5em"  href="<?php echo $iam_redirect ?>" class="button">IRIS IAM</a>
             </div>
             <p>Browse the <a href="https://wiki.egi.eu/wiki/GOCDB" class="docLink hover">GOCDB documentation index</a> on the EGI wiki.</p>
           </div>


### PR DESCRIPTION
GOCDB doesn't currently support IRIS IAM "out of the box", so the button doesn't work in most deployments and it does cause confusion for users.

Subject to a positive review here, I'll bump the version number up (probably to 5.10.~~2~~3) and merge this in. This PR deliberately merges into master so that it can be released in isolation.