### PR TITLE
Add an access_test method to API to master

### DIFF
--- a/htdocs/PI/index.php
+++ b/htdocs/PI/index.php
@@ -141,6 +141,10 @@ class PIRequest {
             $em = \Factory::getEntityManager();
 
             switch ($this->method) {
+                case "access_test":
+                    $this->authByIdentifier(true);
+                    return "<success/>\n";
+                break;
                 case "get_site":
                     require_once($directory . 'GetSite.php');
                     $this->authByIdentifier();
@@ -367,9 +371,14 @@ class PIRequest {
         return $xml;
     }
 
-    /* Authorize a request based on the supplied identifier */
+    /* 
+     * Authorize a request based on the supplied identifier 
+     * @param boolean $forceStrictForHosts If true, restriction of
+     *                                     personal data is forced
+     *                                     for hosts.
+     */
 
-    function authByIdentifier() {
+    function authByIdentifier($forceStrictForHosts = false) {
         require_once __DIR__.'/../web_portal/controllers/utils.php';
         require_once __DIR__.'/../../lib/Doctrine/entities/APIAuthentication.php';
 
@@ -395,7 +404,7 @@ class PIRequest {
                 $authenticated = true;
             }
 
-            if (!\Factory::getConfigService()->isRestrictPDByRole()) {
+            if (!\Factory::getConfigService()->isRestrictPDByRole($forceStrictForHosts)) {
                 // Only a 'valid' identifier is needed.
                 $authenticated = true;
             }

--- a/htdocs/PI/index.php
+++ b/htdocs/PI/index.php
@@ -142,9 +142,10 @@ class PIRequest {
 
             switch ($this->method) {
                 case "access_test":
+                    require_once($directory . 'AccessTest.php');
                     $this->authByIdentifier(true);
-                    return "<success/>\n";
-                break;
+                    $xml = (new AccessTest())->getRenderingOutput();
+                    break;
                 case "get_site":
                     require_once($directory . 'GetSite.php');
                     $this->authByIdentifier();
@@ -371,8 +372,8 @@ class PIRequest {
         return $xml;
     }
 
-    /* 
-     * Authorize a request based on the supplied identifier 
+    /*
+     * Authorize a request based on the supplied identifier
      * @param boolean $forceStrictForHosts If true, restriction of
      *                                     personal data is forced
      *                                     for hosts.

--- a/htdocs/web_portal/static_html/goc5_logo.html
+++ b/htdocs/web_portal/static_html/goc5_logo.html
@@ -4,7 +4,7 @@
 <!--	<img src="img/Logo-1.6.png" class="logo_image" height="39" style="vertical-align: middle;"/>-->
   <h3    class="Logo_Text Small_Bottom_Margin Standard_Padding"
          style="vertical-align: middle; margin-left: 0.2em;">
-         GOCDB 5.10.1
+         GOCDB 5.10.2
      </h3>
 
 </a>

--- a/lib/Gocdb_Services/Config.php
+++ b/lib/Gocdb_Services/Config.php
@@ -334,9 +334,14 @@ class Config {
     /**
      * How Personal Data is restricted;
      * See description in local_info.xml but in brief:
+     * @param boolean $forceStrict If true, restriction of personal data
+     *                             is forced.
      * @returns false for legacy behaviour, true for role-based personal data restriction
      */
-    public function isRestrictPDByRole() {
+    public function isRestrictPDByRole($forceStrict = false) {
+        if ($forceStrict === true)
+            return true;
+
         $localInfo = $this->GetLocalInfoXML();
         $value = $localInfo->restrict_personal_data;
         if((string) $value == "true") {

--- a/lib/Gocdb_Services/Config.php
+++ b/lib/Gocdb_Services/Config.php
@@ -338,7 +338,8 @@ class Config {
      *                             is forced.
      * @returns false for legacy behaviour, true for role-based personal data restriction
      */
-    public function isRestrictPDByRole($forceStrict = false) {
+    public function isRestrictPDByRole($forceStrict = false)
+    {
         if ($forceStrict === true)
             return true;
 

--- a/lib/Gocdb_Services/PI/AccessTest.php
+++ b/lib/Gocdb_Services/PI/AccessTest.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * Class to manage output of the Access Test result
+ */
+
+namespace org\gocdb\services;
+
+use SimpleXMLElement;
+
+class AccessTest
+{
+    /**
+     * @return  string  XML used to signal successful authorization return
+     */
+    public function getRenderingOutput()
+    {
+        $xmlElem = new SimpleXMLElement("<results />");
+        $xmlElem->addAttribute('identifier', Get_User_Principle_PI());
+        $xmlElem->addChild('authorized', 'true');
+
+        $domSxe = dom_import_simplexml($xmlElem);
+
+        $dom = new \DOMDocument('1.0');
+        $dom->encoding = 'UTF-8';
+        $domSxe = $dom->importNode($domSxe, true);
+        $domSxe = $dom->appendChild($domSxe);
+        $dom->formatOutput = true;
+
+        return $dom->saveXML();
+    }
+}


### PR DESCRIPTION
In preparation for restricting access to personal data, this new method enables Service Owners to be able to verify their hosts will retain access to the API after access to personal data is restricted.

Required a change to `authByIdentifier` and `isRestrictPDByRole` to force the restrictions for the test method regardless of the wider API access rules. I haven't included Users in this API check as I don't want to encourage human users talking to the API.

Subject to a positive review here, I'll bump the version number up (probably to 5.10.2) and merge this in. This PR deliberately merges into master so that it can be released in isolation.

It's running in preproduction: https://gocdb-preprod.egi.eu