### PR TITLE
Remove references to EGI wiki on Help and Contact page

### DIFF
--- a/htdocs/web_portal/static_html/Help_And_Contact.html
+++ b/htdocs/web_portal/static_html/Help_And_Contact.html
@@ -6,39 +6,42 @@
        <h2>GOCDB</h2>
         <p><a href="index.php">What is GOCDB?</a></p>
         <p>
-         See <a href="https://github.com/GOCDB/gocdb/blob/master/changeLog.txt">Release notes</a>
+         See <a href="https://github.com/GOCDB/gocdb/releases">Release notes</a>
         <br/>
-        <a href="https://wiki.egi.eu/wiki/GOCDB/Regional_Module_Technical_Documentation">Download, Install</a>
+        <a href="https://github.com/GOCDB/gocdb/blob/dev/INSTALL.md">Download, Install</a>
         </p>
              
     <h2>Need information?</h2> 
     <p>
-      Please browse  
-      <a href="https://wiki.egi.eu/wiki/GOCDB">
-      GOCDB Documentation Index</a> on the EGI wiki.
+      Please browse the GOCDB 
+      <a href="https://gocdb.github.io/">
+      Documentation </a> or your community documentation source.
       <br/><br/>
     </p>
     
     <h2>Found a bug?</h2> 
     <p> 
-      First, <a href='https://rt.egi.eu/rt/Dashboards/5541/GOCDB-Requirements' target='_blank'>
-      check known bugs and feature requests</a> to see if this has not 
-      already been reported.<br/> 
-      If not, please raise a ticket against GOCDB in
-      <a href='https://ggus.eu' target='_blank'> 
-      GGUS.</a>
+      First, check our 
+      <a href='https://github.com/GOCDB/gocdb/issues?q=is%3Aissue+is%3Aopen+label%3Abug' target='_blank'>
+      known bugs</a> to see if this has not already been reported.<br/> 
+      If not, please open a request in your community support desk or our 
+      <a href='https://github.com/GOCDB/gocdb/issues' target='_blank'> 
+      GitHub issues </a> 
+      page, if the former is not appropriate.
       <br/><br/> 
     </p> 
     
     <h2>Want to suggest something?</h2> 
     <p> 
       Before you make any request, check this is not already integrated to our development plans, see 
-      <a href='https://wiki.egi.eu/wiki/GOCDB/Roadmap' target='_blank'>GOCDB Development Plans.</a><br/> 
-      Any suggestion, new feature or improvement request should be submitted to the 
-      <a href='https://rt.egi.eu/rt/Dashboards/5541/GOCDB-Requirements' target='_blank'> 
-      RT requirements tracker</a>. <br/> 
-      Suggestions will be discussed within GOCDB developers, the OTAG, or any political 
-      body involved before inclusion into development plans.
+      <a href='https://github.com/GOCDB/gocdb/milestones' target='_blank'>GOCDB Development Plans.</a><br/> 
+      Any suggestion, new feature or improvement request should 
+      be submitted to your community support desk or our 
+      <a href='https://github.com/GOCDB/gocdb/issues' target='_blank'> 
+      GitHub issues </a>
+      page, if the former is not appropriate.<br/> 
+      Suggestions will be discussed by the GOCDB developers and 
+      any relevant project body before inclusion into development plans. 
       These bodies reserve the right to decline unsuitable requests.
       <br/><br/> 
     </p> 
@@ -46,9 +49,9 @@
     <h2>Need some support?</h2>
     
       <p>
-      For all other enquiries including general questions, temporary problems reports or 
-      support requests please  
-      <a href='https://ggus.eu' target='_blank'>submit a ticket in the GGUS system</a> 
+      For all other enquiries including general questions, temporary 
+      problems reports or support requests please open a 
+      request in your community support desk.
       </p>
   </div>
 </div>

--- a/htdocs/web_portal/static_html/Help_And_Contact.html
+++ b/htdocs/web_portal/static_html/Help_And_Contact.html
@@ -15,7 +15,7 @@
     <p>
       Please browse the GOCDB 
       <a href="https://gocdb.github.io/">
-      Documentation </a> or your community documentation source.
+      Documentation</a> or your community documentation source.
       <br/><br/>
     </p>
     
@@ -26,7 +26,7 @@
       known bugs</a> to see if this has not already been reported.<br/> 
       If not, please open a request in your community support desk or our 
       <a href='https://github.com/GOCDB/gocdb/issues' target='_blank'> 
-      GitHub issues </a> 
+      GitHub issues</a> 
       page, if the former is not appropriate.
       <br/><br/> 
     </p> 
@@ -36,9 +36,9 @@
       Before you make any request, check this is not already integrated to our development plans, see 
       <a href='https://github.com/GOCDB/gocdb/milestones' target='_blank'>GOCDB Development Plans.</a><br/> 
       Any suggestion, new feature or improvement request should 
-      be submitted to your community support desk or our 
+      be submitted to your community request tracker or our 
       <a href='https://github.com/GOCDB/gocdb/issues' target='_blank'> 
-      GitHub issues </a>
+      GitHub issues</a> 
       page, if the former is not appropriate.<br/> 
       Suggestions will be discussed by the GOCDB developers and 
       any relevant project body before inclusion into development plans. 
@@ -50,7 +50,7 @@
     
       <p>
       For all other enquiries including general questions, temporary 
-      problems reports or support requests please open a 
+      problem reports or support requests please open a 
       request in your community support desk.
       </p>
   </div>


### PR DESCRIPTION
- as old egi wiki links are out of date, references are reworked to point to somewhere appropriate
- rewording of text and reformatting of links

First part of #405 