### PR TITLE
Add config calls so email addresses aren't hardwired into code

### DIFF
--- a/config/local_info.xml
+++ b/config/local_info.xml
@@ -14,8 +14,8 @@
     <page_banner></page_banner>
 
     <!-- Email addresses to send from and reply to -->
-    <email_from>no-reply@{goc.egi.eu, gocdb.eosc-portal.eu, gocdb.iris.ac.uk}</email_from>
-    <email_to>gocdb-admins@mailman.egi.eu</email_to>
+    <email_from>no-reply@localhost</email_from>
+    <email_to>gocdb-admins@localhost</email_to>
 
     <!-- Specify the URL and description of the Acceptable Use Policy -->
     <aup>AUP location</aup>

--- a/config/local_info.xml
+++ b/config/local_info.xml
@@ -13,6 +13,10 @@
     <!-- If page_banner is not empty the text is used to create a page banner strip -->
     <page_banner></page_banner>
 
+    <!-- Email addresses to send from and reply to -->
+    <email_from>no-reply@{goc.egi.eu, gocdb.eosc-portal.eu, gocdb.iris.ac.uk}</email_from>
+    <email_to>gocdb-admins@mailman.egi.eu</email_to>
+
     <!-- Specify the URL and description of the Acceptable Use Policy -->
     <aup>AUP location</aup>
     <aup_title>AUP title</aup_title>

--- a/lib/Gocdb_Services/Config.php
+++ b/lib/Gocdb_Services/Config.php
@@ -542,4 +542,18 @@ class Config
 
         return $bannerText;
     }
+
+    public function getEmailFrom()
+    {
+        $emailFrom = $this->GetLocalInfoXML()->email_from;
+
+        return $emailFrom;
+    }
+
+    public function getEmailTo()
+    {
+        $emailTo = $this->GetlocalInfoXML()->email_to;
+
+        return $emailTo;
+    }
 }

--- a/lib/Gocdb_Services/LinkIdentity.php
+++ b/lib/Gocdb_Services/LinkIdentity.php
@@ -243,6 +243,8 @@ class LinkIdentity extends AbstractEntityService {
      */
     private function composeEmail($primaryIdString, $currentIdString, $primaryAuthType, $currentAuthType, $isLinking, $isRegistered, $isPrimary, $link=null) {
 
+        $configService = \Factory::getConfigService();
+
         $subject = "Validation of " . ($isLinking ? "linking" : "recovering") . " your GOCDB account";
 
         $body = "Dear GOCDB User,"
@@ -274,7 +276,8 @@ class LinkIdentity extends AbstractEntityService {
             . "\n\n$link";
         }
 
-        $body .= "\n\nIf you did not create this request, please immediately contact gocdb-admins@mailman.egi.eu";
+        $emailSendTo = $configService->getEmailTo();
+        $body .= "\n\nIf you did not create this request, please immediately contact " . $emailSendTo;
 
         return array('subject'=>$subject, 'body'=>$body);
     }
@@ -293,6 +296,8 @@ class LinkIdentity extends AbstractEntityService {
      */
     private function sendConfirmationEmails($primaryUser, $currentUser, $code, $primaryIdString, $currentIdString, $primaryAuthType, $currentAuthType, $isLinking, $isRegistered) {
 
+        $configService = \Factory::getConfigService();
+
         // Create link to be clicked in email
         $portalUrl = \Factory::getConfigService()->GetPortalURL();
         $link = $portalUrl."/index.php?Page_Type=User_Validate_Identity_Link&c=" . $code;
@@ -304,7 +309,8 @@ class LinkIdentity extends AbstractEntityService {
         $primaryBody = $composedPrimaryEmail['body'];
 
         // If "sendmail_from" is set in php.ini, use second line ($headers = '';):
-        $headers = "From: GOCDB <gocdb-admins@mailman.egi.eu>";
+        $emailSentFrom = $configService->getEmailFrom();
+        $headers = "From: GOCDB <" . $emailSentFrom . ">";
 
         // Mail command returns boolean. False if message not accepted for delivery.
         if (!mail($primaryUser->getEmail(), $primarySubject, $primaryBody, $headers)) {

--- a/lib/Gocdb_Services/NotificationService.php
+++ b/lib/Gocdb_Services/NotificationService.php
@@ -135,7 +135,7 @@ class NotificationService extends AbstractEntityService {
             $roleRequested->getRoleType()->getName(),
             $roleRequested->getOwnedEntity()->getName(),
             $this->getWebPortalURL(),
-            $emailSendTo->configService->getEmailTo()
+            $configService->getEmailTo()
         );
 
         $emailAddress = $approvingUser->getEmail();

--- a/lib/Gocdb_Services/NotificationService.php
+++ b/lib/Gocdb_Services/NotificationService.php
@@ -113,6 +113,8 @@ class NotificationService extends AbstractEntityService {
             $roleRequested->getOwnedEntity()->getName()
         );
 
+        $configService = \Factory::getConfigService();
+
         $body = sprintf(
             implode("\n", array(
                 'Dear %1$s,',
@@ -123,17 +125,23 @@ class NotificationService extends AbstractEntityService {
                 '    %6$s/index.php?Page_Type=Role_Requests',
                 '',
                 'Note: This role could already have been approved or denied by another GOCDB User',
+                '',
+                'Please do not reply to this email. If you would like to get in touch with the ' .
+                'GOCDB admins please send an email to: %7$s',
             )),
             $approvingUser->getForename(),
             $requestingUser->getForename(),
             $requestingUser->getSurname(),
             $roleRequested->getRoleType()->getName(),
             $roleRequested->getOwnedEntity()->getName(),
-            $this->getWebPortalURL()
+            $this->getWebPortalURL(),
+            $emailSendTo->configService->getEmailTo()
         );
 
         $emailAddress = $approvingUser->getEmail();
-        $headers = "From: GOCDB <gocdb-admins@mailman.egi.eu>";
+
+        $emailSentFrom = $configService->getEmailFrom();
+        $headers = "From: GOCDB <" . $emailSentFrom . ">";
 
         \Factory::getEmailService()->send($emailAddress, $subject, $body, $headers);
     }

--- a/resources/RemoveInactiveUsersRunner.php
+++ b/resources/RemoveInactiveUsersRunner.php
@@ -176,8 +176,14 @@ function sendWarningEmail($user, $elapsedMonths, $deletionThreshold)
 {
     $emailAddress = $user->getEmail();
 
+    $configService = \Factory::getConfigService();
+
+    $emailSentFrom = $configService->getEmailFrom();
+
+    $emailSendTo = $configService->getEmailTo();
+
     // Email content
-    $headers = "From: GOCDB <gocdb-admins@mailman.egi.eu>";
+    $headers = "From: GOCDB <" . $emailSentFrom . ">";
     $subject = "GOCDB: User account deletion notice";
 
     $body = "Dear ". $user->getForename() .",\n\n" .
@@ -202,7 +208,9 @@ function sendWarningEmail($user, $elapsedMonths, $deletionThreshold)
     $body .= "\n";
     $body .= "You can prevent the deletion of this account by visiting the " .
              "GOCDB portal while authenticated with one of the above " .
-             "identifiers.\n";
+             "identifiers.\n\n";
+    $body .= "Please do not reply to this email. If you would like to get in touch " .
+             "with the GOCDB admins please send an email to: " . $emailSendTo . "\n";
 
 
     // Handle all mail related printing/debugging


### PR DESCRIPTION
- removed instances where gocdb-admins@mailman.egi.eu was hardwired into code
- replaced the email addresses with a config call
- split email adresses into 'to' and 'from' addresses
- added lines in config file for to and from email adresses
- added reply-to adresses in email text when emails are sent

resolves #410 