### PR TITLE
Same API identifier at multiple sites to master.

### DIFF
--- a/htdocs/PI/index.php
+++ b/htdocs/PI/index.php
@@ -398,10 +398,10 @@ class PIRequest {
             // Check if it is registered API Authentication credential.
 
             $authEntServ = \Factory::getAPIAuthenticationService();
-            $authEnt = $authEntServ->getAPIAuthentication($this->identifier);
+            $authEnts = $authEntServ->getAPIAuthentication($this->identifier);
 
-            if (!is_null($authEnt)) {
-                $authEntServ->updateLastUseTime($authEnt);
+            if (count($authEnts) > 0) {
+                $authEntServ->updateLastUseTime($authEnts);
                 $authenticated = true;
             }
 

--- a/htdocs/web_portal/static_html/goc5_logo.html
+++ b/htdocs/web_portal/static_html/goc5_logo.html
@@ -4,7 +4,7 @@
 <!--	<img src="img/Logo-1.6.png" class="logo_image" height="39" style="vertical-align: middle;"/>-->
   <h3    class="Logo_Text Small_Bottom_Margin Standard_Padding"
          style="vertical-align: middle; margin-left: 0.2em;">
-         GOCDB 5.10.2
+         GOCDB 5.10.3
      </h3>
 
 </a>

--- a/tests/unit/lib/Gocdb_Services/APIAuthenticationServiceTest.php
+++ b/tests/unit/lib/Gocdb_Services/APIAuthenticationServiceTest.php
@@ -172,8 +172,8 @@ class APIAuthEnticationServiceTest extends PHPUnit_Extensions_Database_TestCase
         $type = 'X.509';
         // Start with no APIAuthentication entities to be found
         $this->assertCount(
-          0,
-          $authEntServ->getAPIAuthentication($ident),
+            0,
+            $authEntServ->getAPIAuthentication($ident),
             "Non-zero count returned when searching for APIAuthentication entity " .
             "for id:{$ident} when expected none."
         );

--- a/tests/unit/lib/Gocdb_Services/APIAuthenticationServiceTest.php
+++ b/tests/unit/lib/Gocdb_Services/APIAuthenticationServiceTest.php
@@ -170,10 +170,11 @@ class APIAuthEnticationServiceTest extends PHPUnit_Extensions_Database_TestCase
 
         $ident = '/CN=A Dummy Subject';
         $type = 'X.509';
-      // Start with no APIAuthentication entities to be found
-        $this->assertNull(
-            $authEntServ->getAPIAuthentication($ident),
-            "Non-null value returned when searching for APIAuthentication entity " .
+        // Start with no APIAuthentication entities to be found
+        $this->assertCount(
+          0,
+          $authEntServ->getAPIAuthentication($ident),
+            "Non-zero count returned when searching for APIAuthentication entity " .
             "for id:{$ident} when expected none."
         );
 
@@ -194,9 +195,15 @@ class APIAuthEnticationServiceTest extends PHPUnit_Extensions_Database_TestCase
 
         $authEntMatched = $authEntServ->getAPIAuthentication($ident);
 
+        $this->assertCount(
+            1,
+            $authEntMatched,
+            "Failed to return single APIAuthentication entity searching for id:{$ident}."
+        );
+
         $this->assertTrue(
-            $authEnt === $authEntMatched,
-            "Failed to return APIAuthentication entity for id:{$ident}."
+            $authEnt === $authEntMatched[0],
+            "Failed to return matching APIAuthentication entity searching for for id:{$ident}."
         );
     }
 }


### PR DESCRIPTION
Allow the same identifier to be used for APIauthentication entities at multiple sites