### PR TITLE
GT-56: Add base class for OIDC AuthTokens, add EOSCAAI AuthToken

### DIFF
--- a/htdocs/web_portal/index.php
+++ b/htdocs/web_portal/index.php
@@ -94,7 +94,7 @@ try {
      *   the user isn't authroised.
      * - setting rawOutput to TRUE also isn't ideal as it displays html tags
      *   in the otherwise nicely formatted output.
-     * die-ing like this atleast gives the user a somewhart nicely formatted
+     * die-ing like this atleast gives the user a somewhat nicely formatted
      * error.
      */
     die($error->getMessage());

--- a/htdocs/web_portal/index.php
+++ b/htdocs/web_portal/index.php
@@ -88,19 +88,19 @@ try {
 
 } catch (BadCredentialsException $error) {
     /**
-     * `show_view('error.php', ...` is not suitable here.
-     * - setting raw to FALSE triggers another exception because it tries
-     *   to render a pretty error in a GOCDB window, which fails because the
-     *   user isn't authroised.
-     * - setting raw to TRUE also isn't ideal as it displays html tags in the
-     *   otherwise nicely formatted output.
+     * `show_view('error.php', ..., $rawOutput)` is not suitable here.
+     * - setting rawOutput to FALSE triggers another exception because it
+     *   tries to render a pretty error in a GOCDB window, which fails because
+     *   the user isn't authroised.
+     * - setting rawOutput to TRUE also isn't ideal as it displays html tags
+     *   in the otherwise nicely formatted output.
      * die-ing like this atleast gives the user a somewhart nicely formatted
      * error.
      */
     die($error->getMessage());
 } catch (ErrorException $e) {
     /* ErrorExceptions may be thrown by an invalid configuration so it is
-       not safe to try to give a pretty output. Set 'raw' to true. */
+       not safe to try to give a pretty output. Set 'rawOutput' to true. */
     show_view('error.php', $e->getMessage(), NULL, TRUE);
     die();
 } catch(Exception $e) {

--- a/htdocs/web_portal/index.php
+++ b/htdocs/web_portal/index.php
@@ -26,6 +26,8 @@ require_once __DIR__.'/../../lib/Gocdb_Services/Factory.php';
 // Require GocContextPath which is used in most of the views scripts
 require_once __DIR__.'/GocContextPath.php';
 
+use org\gocdb\security\authentication\BadCredentialsException;
+
 // Set the timezone
 date_default_timezone_set("UTC");
 
@@ -84,6 +86,18 @@ function rejectIfNotAuthenticated($message = null){
 try {
     Draw_Page($Page_Type);
 
+} catch (BadCredentialsException $error) {
+    /**
+     * `show_view('error.php', ...` is not suitable here.
+     * - setting raw to FALSE triggers another exception because it tries
+     *   to render a pretty error in a GOCDB window, which fails because the
+     *   user isn't authroised.
+     * - setting raw to TRUE also isn't ideal as it displays html tags in the
+     *   otherwise nicely formatted output.
+     * die-ing like this atleast gives the user a somewhart nicely formatted
+     * error.
+     */
+    die($error->getMessage());
 } catch (ErrorException $e) {
     /* ErrorExceptions may be thrown by an invalid configuration so it is
        not safe to try to give a pretty output. Set 'raw' to true. */

--- a/lib/Authentication/AuthTokens/EOSCAAIAuthToken.php
+++ b/lib/Authentication/AuthTokens/EOSCAAIAuthToken.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace org\gocdb\security\authentication;
+
+/**
+ * AuthToken for use with the EOSC AAI
+ *
+ * Requires installation/config of mod_auth_openidc before use.
+ *
+ * The token is stateless because it relies on the mod_auth_openidc
+ * session and simply reads the attributes stored in the session.
+ */
+class EOSCAAIAuthToken extends OIDCAuthToken
+{
+    public function __construct()
+    {
+        $this->acceptedIssuers = array("https://aai-demo.eosc-portal.eu/auth/realms/core");
+        $this->authRealm = "EOSC Proxy IdP";
+        $this->groupHeader = "OIDC_CLAIM_eduperson_entitlement";
+        $this->groupSplitChar = ',';
+        $this->bannedGroups = array();
+        $this->requiredGroups = array("urn:geant:eosc-portal.eu:res:gocdb.eosc-portal.eu");
+        $this->helpString = 'Please seek assistance by opening a ticket against the ' .
+            '"EOSC AAI: Core Infrastructure Proxy" group in ' .
+            '<a href=https://eosc-helpdesk.eosc-portal.eu/>https://eosc-helpdesk.eosc-portal.eu/</a>';
+
+        if (isset($_SERVER['OIDC_access_token'])) {
+            $this->setTokenFromSession();
+        }
+    }
+}

--- a/lib/Authentication/AuthTokens/OIDCAuthToken.php
+++ b/lib/Authentication/AuthTokens/OIDCAuthToken.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace org\gocdb\security\authentication;
+
+abstract class OIDCAuthToken implements IAuthentication
+{
+    private $userDetails = null;
+    private $authorities = array();
+    private $principal;
+
+    /**
+     * {@see IAuthentication::eraseCredentials()}
+     */
+    public function eraseCredentials()
+    {
+    }
+
+    /**
+     * {@see IAuthentication::getAuthorities()}
+     */
+    public function getAuthorities()
+    {
+        return $this->authorities;
+    }
+
+    /**
+     * {@see IAuthentication::getCredentials()}
+     * @return string An empty string as passwords are not used by this token.
+     */
+    public function getCredentials()
+    {
+        return ""; // none used in this token, handled by IdP
+    }
+
+    /**
+     * A custom object used to store additional user details.
+     * Allows non-security related user information (such as email addresses,
+     * telephone numbers etc) to be stored in a convenient location.
+     * {@see IAuthentication::getDetails()}
+     *
+     * @return Object or null if not used
+     */
+    public function getDetails()
+    {
+        return $this->userDetails;
+    }
+
+    /**
+     * {@see IAuthentication::getPrinciple()}
+     * @return string unique principle string of user
+     */
+    public function getPrinciple()
+    {
+        return $this->principal;
+    }
+
+    /**
+     * {@see IAuthentication::setAuthorities($authorities)}
+     */
+    public function setAuthorities($authorities)
+    {
+        $this->authorities = $authorities;
+    }
+
+    /**
+     * {@see IAuthentication::setDetails($userDetails)}
+     * @param Object $userDetails
+     */
+    public function setDetails($userDetails)
+    {
+        $this->userDetails = $userDetails;
+    }
+
+    /**
+     * {@see IAuthentication::validate()}
+     */
+    public function validate()
+    {
+    }
+
+    /**
+     * {@see IAuthentication::isPreAuthenticating()}
+     */
+    public static function isPreAuthenticating()
+    {
+        return true;
+    }
+
+    /**
+     * Returns true, this token reads the session attributes and so
+     * does not need to be stateful itself.
+     * {@see IAuthentication::isStateless()}
+     */
+    public static function isStateless()
+    {
+        return true;
+    }
+}

--- a/lib/Authentication/AuthTokens/OIDCAuthToken.php
+++ b/lib/Authentication/AuthTokens/OIDCAuthToken.php
@@ -7,6 +7,8 @@ abstract class OIDCAuthToken implements IAuthentication
     private $userDetails = null;
     private $authorities = array();
     private $principal;
+    protected $acceptedIssuers;
+    protected $authRealm;
 
     /**
      * {@see IAuthentication::eraseCredentials()}
@@ -94,5 +96,18 @@ abstract class OIDCAuthToken implements IAuthentication
     public static function isStateless()
     {
         return true;
+    }
+
+    /**
+     * Set principal/User details from the session.
+     */
+    protected function setTokenFromSession()
+    {
+        if (in_array($_SERVER['OIDC_CLAIM_iss'], $this->acceptedIssuers, true)) {
+            $this->principal = $_SERVER['REMOTE_USER'];
+            $this->userDetails = array(
+                'AuthenticationRealm' => array($this->authRealm)
+            );
+        }
     }
 }

--- a/lib/Authentication/AuthTokens/OIDCAuthToken.php
+++ b/lib/Authentication/AuthTokens/OIDCAuthToken.php
@@ -166,7 +166,10 @@ abstract class OIDCAuthToken implements IAuthentication
      */
     protected function checkBannedGroups()
     {
-        $groupArray = explode($this->groupSplitChar, $_SERVER[$this->groupHeader]);
+        $groupArray = explode(
+            $this->groupSplitChar,
+            $_SERVER[$this->groupHeader]
+        );
 
         $presentBadGroups = [];
         foreach ($this->bannedGroups as $group) {

--- a/lib/Authentication/AuthTokens/OIDCAuthToken.php
+++ b/lib/Authentication/AuthTokens/OIDCAuthToken.php
@@ -162,7 +162,7 @@ abstract class OIDCAuthToken implements IAuthentication
     }
 
     /**
-     * Check the token lists non of the banned groups.
+     * Check the token lists none of the banned groups.
      */
     protected function checkBannedGroups()
     {

--- a/lib/Authentication/AuthTokens/OIDCAuthToken.php
+++ b/lib/Authentication/AuthTokens/OIDCAuthToken.php
@@ -2,6 +2,20 @@
 
 namespace org\gocdb\security\authentication;
 
+/**
+ * An abstract class for the logic of integrating with IdPs via OIDC.
+ *
+ * It is expected that concrete subclasses are created for each
+ * new IdP GOCDB integrates with via OIDC, providing specific information
+ * for that IdP.
+ *
+ * Any subclass will require installation/config of mod_auth_openidc
+ * before use.
+ *
+ * Any subclass token is expected to be stateless because it relies on the
+ * mod_auth_openidc session and simply reads the attributes stored in the
+ * session.
+ */
 abstract class OIDCAuthToken implements IAuthentication
 {
     private $userDetails = null;


### PR DESCRIPTION
This PR:

- adds an abstract class that future OIDC based IDP integrations can extended.
- provides an concrete class for integrating the EOSC (demo) IDP via OIDC

Rather than proliferate `die()` calls, the OIDC abstract class throws exceptions which are now handled (granted this handling then calls `die()` because it can't make use of `show_view('error.php',...`)

This code is running on [gocdb-preprod.eosc-portal.eu](https://gocdb-preprod.eosc-portal.eu).

Supersedes #348.