### PR TITLE
Fix incorrect function call in config

### DIFF
--- a/lib/Gocdb_Services/Config.php
+++ b/lib/Gocdb_Services/Config.php
@@ -552,7 +552,7 @@ class Config
 
     public function getEmailTo()
     {
-        $emailTo = $this->GetlocalInfoXML()->email_to;
+        $emailTo = $this->GetLocalInfoXML()->email_to;
 
         return $emailTo;
     }


### PR DESCRIPTION
- there was a typo in Config.php when calling GetLocalInfoXML()
- this fixes it

Resolves #434 