### PR TITLE
GT-91 Manage API credentials

### DIFF
--- a/htdocs/PI/index.php
+++ b/htdocs/PI/index.php
@@ -404,6 +404,16 @@ class PIRequest
         $admin = false;
         $authenticated = false;
 
+        // Check if incoming identifier is a registered API Authentication credential.
+
+        $authEntServ = \Factory::getAPIAuthenticationService();
+        $authEnt = $authEntServ->getAPIAuthentication($this->identifier);
+
+        if (!is_null($authEnt)) {
+            $authEntServ->updateLastUseTime($authEnt);
+            $authenticated = true;
+        }
+
         $user = \Factory::getUserService()->getUserByPrinciple($this->identifier);
 
         if ($user == null) {

--- a/resources/ManageAPICredentials/ManageAPICredentials.php
+++ b/resources/ManageAPICredentials/ManageAPICredentials.php
@@ -1,0 +1,74 @@
+<?php
+
+/**
+ * Maintenance utility for API credential management.
+ *
+ * Finds API credentials that have not been used for a given number of months and
+ * deletes them, then finds credentials that have not been used for a different,
+ * smaller number of months and sends warning email messages to the owners telling
+ * them the credentials will be deleted if not used before the larger month
+ * deadline is reached. A dry-run option is provided to report what would have been
+ * done but without taking any actions.
+ *
+ * Sender and reply-to email addresses are taken from the local_info.xml config file.
+ *
+ * Usage: php ManageAPICredentials.php [ --help | -h ] [ --dry-run ] \\
+ *                                   [[ --warning_threshold | -w ] LITTLE_MONTHS ] \\
+ *                                   [[ --deletion_threshold | -d ] BIG_MONTHS ]
+ *
+ * Warning and deletion thresholds are optional. If missing the respective action is not taken.
+ * If both are specified, the deletion threshold MUST be greater than the warning threshold.
+ */
+
+namespace org\gocdb\scripts;
+
+require_once dirname(__FILE__) . "/../../lib/Gocdb_Services/Factory.php";
+require_once dirname(__FILE__) . "/ManageAPICredentialsActions.php";
+require_once dirname(__FILE__) . "/ManageAPICredentialsOptions.php";
+
+use DateTime;
+use DateTimeZone;
+use InvalidArgumentException;
+
+require_once dirname(__FILE__) . "/../../lib/Doctrine/bootstrap.php";
+
+// Fetch sender and replyTo email addresses from the local config file.
+// There is no capability to override based on URL as the webserver does with -
+// \Factory::getConfigService()->setLocalInfoOverride($_SERVER['SERVER_NAME']);
+
+$configService = \Factory::getConfigService();
+$fromEmail = (string) $configService->getEmailFrom();
+$replyToEmail = (string) $configService->getEmailTo();
+
+try {
+    $options = new ManageAPICredentialsOptions();
+
+    if ($options->isShowHelp()) {
+        return;
+    }
+
+    $baseTime = new DateTime("now", new DateTimeZone('UTC'));
+
+    $actions = new ManageAPICredentialsActions($options->isDryRun(), $entityManager, $baseTime);
+
+    $creds = $actions->getCreds($options->getThreshold());
+
+    if ($options->isDeleteEnabled()) {
+        $creds = $actions->deleteCreds(
+            $creds,
+            $options->getDelete()
+        );
+    }
+
+    if ($options->isWarnEnabled()) {
+        $actions->warnUsers(
+            $creds,
+            $options->getWarn(),
+            $options->getDelete(),
+            $fromEmail,
+            $replyToEmail
+        );
+    }
+} catch (InvalidArgumentException $except) {
+    ManageAPICredentialsOptions::usage($except->getMessage());
+}

--- a/resources/ManageAPICredentials/ManageAPICredentialsActions.php
+++ b/resources/ManageAPICredentials/ManageAPICredentialsActions.php
@@ -1,0 +1,263 @@
+<?php
+
+/**
+ * Implement API credential management actions such as listing, sending warning emails and
+ * deleting credentials.
+ */
+
+namespace org\gocdb\scripts;
+
+require_once dirname(__FILE__) . "/../../lib/Gocdb_Services/APIAuthenticationService.php";
+require_once dirname(__FILE__) . "/../../lib/Gocdb_Services/Factory.php";
+
+use APIAuthentication;
+use DateInterval;
+use DateTime;
+use Factory;
+use org\gocdb\services\APIAuthenticationService;
+
+class ManageAPICredentialsActions
+{
+    private $dryRun;
+    private $entityManager;
+    private $baseTime;
+
+    public function __construct($dryRun, $entityManager, $baseTime)
+    {
+        /**
+        * @param \Doctrine\Orm\EntityManager $entitymanager A valid Doctrine Entity Manager
+        * @param bool          $dryRun         If true no action is taken and a report is generated instead
+        * @param \DateTime     $baseTime       Time from which interval of no-use is measured
+        **/
+        $this->dryRun = $dryRun;
+        $this->entityManager = $entityManager;
+        $this->baseTime = $baseTime;
+    }
+    /**
+     * Find API credentials unused for a number of months.
+     *
+     * Find API credentials which have not been used for a number of months prior to a given base time based
+     * on the credential property lastUseTime.
+     *
+     * @param int           $threshold      The number of months of no-use prior to $baseTime to use for selection
+     */
+    public function getCreds($threshold)
+    {
+        $qbl = $this->entityManager->createQueryBuilder();
+
+        $qbl->select('cred')
+            ->from('APIAuthentication', 'cred')
+            ->where('cred.lastUseTime < :threshold')
+            ->andWhere($qbl->expr()->isNotNull("cred.user")); // cope with legacy entities
+
+        $timeThresh = clone $this->baseTime;
+
+        if ($threshold > 0) {
+            $timeThresh->sub(new DateInterval("P" . $threshold . "M"));
+        }
+
+        $qbl->setParameter('threshold', $timeThresh->format('Y-m-d 00:00:00'));
+
+        $creds = $qbl->getQuery()->getResult();
+
+        return $creds;
+    }
+    /**
+     * Select API credentials for deletion.
+     *
+     * Find API credentials which have not been used for a given number of months
+     * and delete them or, if dry-run option is true, generate a summary report
+     * of the credentils found.
+     *
+     * @param array             $creds              Array of credentials to process.
+     * @param \Doctrine\Orm\EntityManager $entitymanager A valid Doctrine Entity Manager
+     * @param \DateTime         $baseTime           Time from which interval of no-use is measured
+     * @param int               $deleteThreshold    The number of months of no-use which will trigger deletion
+     * @return array                                Credentials which were not deleted.
+     */
+    public function deleteCreds($creds, $deleteThreshold)
+    {
+        $deletedCreds = [];
+
+        $serv = new APIAuthenticationService();
+        $serv->setEntityManager($this->entityManager);
+
+        /* @var $apiCred APIAuthentication */
+        foreach ($creds as $apiCred) {
+            if ($this->isOverThreshold($apiCred, $this->baseTime, $deleteThreshold)) {
+                $deletedCreds[] = $apiCred;
+                if (!$this->dryRun) {
+                    $serv->deleteAPIAuthentication($apiCred);
+                }
+            }
+        }
+        if ($this->dryRun) {
+            $this->reportDryRun($deletedCreds, "deleting");
+        }
+
+        return array_udiff($creds, $deletedCreds, array($this, 'compareCredIds'));
+    }
+    /**
+     * Send of warning emails where credentials have not been used for a given number of months
+     *
+     * Find API credentials from the input array which have not been used for a given number of months
+     * and send emails to the owners and site address, taken from the credential object,
+     * warning of impending deletion if the period of no-use reaches a given threshold.
+     * If dry-run option is true, generate a summary report of the credentials found
+     * instead of sending emails.
+     *
+     * @param array         $creds              Array of credentials to process.
+     * @param int           $warningThreshold   The number of months of no-use which triggers warning emails
+     * @param int           $deleteThreshold    The number of months of no-use which will trigger deletion
+     * @param string        $fromEmail          Email address to use as sender's (From:) address
+     * @param string        $replyToEmail       Email address for replies (Reply-To:)
+     * @return array                            Array of credentials identifed for sending warning emails
+     */
+    public function warnUsers(
+        $creds,
+        $warningThreshold,
+        $deletionThreshold,
+        $fromEmail,
+        $replyToEmail
+    ) {
+        $warnedCreds = [];
+
+        /* @var $api APIAuthentication */
+        foreach ($creds as $apiCred) {
+            // The credentials list is pre-selected based on the given threshold in the query
+            // so this check is probably redundant.
+            if ($this->isOverThreshold($apiCred, $this->baseTime, $warningThreshold)) {
+                $lastUsed = $apiCred->getLastUseTime();
+                $lastUseMonths = $this->baseTime->diff($lastUsed)->format('%m');
+
+                if (!$this->dryRun) {
+                    $this->sendWarningEmail(
+                        $fromEmail,
+                        $replyToEmail,
+                        $apiCred,
+                        intval($lastUseMonths),
+                        $deletionThreshold
+                    );
+                }
+
+                $warnedCreds[] = $apiCred;
+            }
+        }
+
+        if ($this->dryRun) {
+            $this->reportDryRun($warnedCreds, "sending warning emails");
+        }
+
+        return array_udiff($creds, $warnedCreds, array($this, 'compareCredIds'));
+    }
+/**
+ * @return boolean true if the credential has not been used within $threshold months, else false
+ */
+    private function isOverThreshold(APIAuthentication $cred, DateTime $baseTime, $threshold)
+    {
+        $lastUsed = $cred->getLastUseTime();
+
+        $diffTime = $baseTime->diff($lastUsed);
+        $lastUseMonths = ($diffTime->y * 12) + $diffTime->m;
+
+        return $lastUseMonths >= $threshold;
+    }
+/**
+ * Helper function to check if two API credentials have the same id.
+ *
+ * @return integer zero if equal, -1 if id1 < id2, 1 if id1 > id2
+ *
+*/
+    private function compareCredIds(APIAuthentication $cred1, APIAuthentication $cred2)
+    {
+        $id1 = $cred1->getId();
+        $id2 = $cred2->getId();
+
+        if ($id1 == $id2) {
+            return 0;
+        };
+
+        return $id1 > $id2 ? 1 : -1;
+    }
+
+/**
+ * Format and send warning emails.
+ *
+ * Send emails to API credential owner and the registered site address warning of impending credential deletion
+ * if the credential remains unused until a given threshold of months.
+ *
+ * @param string    $fromEmail          Email address to use as sender's (From:) address
+ * @param string    $replyToEmail       Email address for replies (Reply-To:)
+ * @param \APIAuthentication $api       Credential to warn about
+ * @param int       $elapsedMonths      The number of months of non-use so far.
+ * @param int       $deleteionThreshold The number of months of no-use which will trigger deletion if reached.
+ * @return void
+ */
+    private function sendWarningEmail(
+        $fromEmail,
+        $replyToEmail,
+        \APIAuthentication $api,
+        $elapsedMonths,
+        $deletionThreshold
+    ) {
+        $user = $api->getUser();
+        $userEmail = $user->getEmail();
+        $siteName = $api->getParentSite()->getShortName();
+        $siteEmail = $siteName . ' <' . $api->getParentSite()->getEmail() . '>';
+
+        $headersArray = array ("From: $fromEmail",
+                           "Cc: $siteEmail");
+        if (strlen($replyToEmail) > 0 && $fromEmail !== $replyToEmail) {
+            $headersArray[] = "Reply-To: $replyToEmail";
+        }
+        $headers = join("\r\n", $headersArray);
+
+        $subject = "GOCDB: Site API credential deletion notice";
+
+        $body = "Dear " . $user->getForename() . ",\n\n" .
+        "The API credential associated with the following identifier registered\n" .
+        "at site $siteName has not been used during\n" .
+        "the last $elapsedMonths months and will be deleted if this period of inactivity\n" .
+        "reaches $deletionThreshold months.\n\n";
+
+        $body .= "Identifier:  " . $api->getIdentifier() . "\n";
+        $body .= "Owner email: " . $userEmail . "\n";
+
+        $body .= "\n";
+        $body .= "Use of the credential will prevent its deletion.\n";
+        $body .= "\nRegards,\nGOCDB Administrators\n";
+
+        // Send the email (or not, according to local configuration)
+        Factory::getEmailService()->send($userEmail, $subject, $body, $headers);
+    }
+/**
+ * Generate a summary report.
+ *
+ * Generate a report to stdout summarising information about each credential in an array when
+ * a dry-run operation is in progress.
+ *
+ * @param array      $creds          Array of API credential objects to be summarised.
+ * @param string     $text           Brief description of the operation which would have been
+ *                                   performed without dry-run to be included in the report.
+ * @return void
+ */
+    private function reportDryRun(array $creds, $text)
+    {
+        if (count($creds) == 0) {
+            print("Dry run: No matching credentials found for $text.\n");
+            return;
+        }
+
+        print("Dry run: Found " . count($creds) . " credentials for $text.\n");
+
+        foreach ($creds as $api) {
+            print("Dry run: Processing credential id " . $api->getId() . "\n" .
+              "         Identifier: " . $api->getIdentifier() . "\n" .
+              "         User email: " . $api->getUser()->getEmail() . "\n" .
+              "         Site:       " . $api->getParentSite()->getShortName() . "\n" .
+              "         Last used:  " . $api->getLastUseTime() // DateTimeInterface::ISO8601
+                                            ->format("Y-m-d\\TH:i:sO") . "\n"
+            );
+        }
+    }
+}

--- a/resources/ManageAPICredentials/ManageAPICredentialsOptions.php
+++ b/resources/ManageAPICredentials/ManageAPICredentialsOptions.php
@@ -1,0 +1,140 @@
+<?php
+
+/**
+ * Handle command line options parsing for ManageAPICredentials.php script.
+ *
+ * If --help or -h are given no other options are processed or defined.
+ */
+
+namespace org\gocdb\scripts;
+
+use InvalidArgumentException;
+
+class ManageAPICredentialsOptions
+{
+    protected $showHelp = false;
+    protected $warn;
+    protected $delete;
+    protected $dryRun;
+
+    public function __construct()
+    {
+        $this->getOptions();
+    }
+    /**
+     * @throws \InvInvalidArgumentException If errors found in argument processing
+     */
+    public function getOptions()
+    {
+        $shortOptions = 'hw:d:';
+
+        $longOptions = [
+            'help',
+            'dry-run',
+            'warning_threshold:',
+            'deletion_threshold:'
+        ];
+
+        // Beware that getopt is not clever at spotting invalid/misspelled arguments
+        $given = getopt($shortOptions, $longOptions);
+
+        if ($given === false) {
+            throw new InvalidArgumentException('failed to  parse command line arguments');
+        }
+
+        if ($this->getBoolOption($given, 'help', 'h')) {
+            $this->usage();
+            $this->showHelp = true;
+            return;
+        }
+
+        $this->dryRun = isset($given['dry-run']);
+
+        $this->delete = $this->getValOption($given, 'deletion_threshold', 'd');
+        $this->warn = $this->getValOption($given, 'warning_threshold', 'w');
+
+        if (!(is_null($this->delete) || is_null($this->warn))) {
+            if ($this->delete < $this->warn) {
+                throw new InvalidArgumentException(
+                    "deletion_threshold must be greater than warning_threshold"
+                );
+            }
+        }
+        return;
+    }
+    private function getValOption($given, $long, $short)
+    {
+        if (isset($given[$long]) || isset($given[$short])) {
+            $tValGiven = isset($given[$short]) ? $given[$short] : $given[$long];
+            return $this->positiveInteger($tValGiven, $long);
+        }
+        return;
+    }
+    private function getBoolOption($given, $long, $short)
+    {
+        return isset($given[$long]) || isset($given[$short]);
+    }
+    private function positiveInteger($val, $txt)
+    {
+        if ((string)abs((int)$val) != $val) {
+            throw new InvalidArgumentException(
+                "$txt must be integer and greater than zero . Received: $val"
+            );
+        }
+        return (int)$val;
+    }
+    public static function usage($message = '')
+    {
+        if ($message != '') {
+            print
+            (
+                "Error: $message\n"
+            );
+        }
+        print
+        (
+            "Usage: php ManageAPICredentials.php [--help | -h] [--dry-run] \\\ \n" .
+            "                                    [[--warning_threshold | -w] MONTHS ] \\\ \n" .
+            "                                    [[--deletion_threshold | -d ] MONTHS ] \n" .
+            "Options: \n" .
+            "        -h, --help                      Print this message.\n" .
+            "        --dry-run                       Report but do nothing.\n" .
+            "        -w, --warning_threshold MONTHS  Email the owning user about credentials \n" .
+            "                                        which have not been used for MONTHS months.\n" .
+            "        -d, --deletion_threshold MONTHS Delete credentials which have not been used\n" .
+            "                                        for MONTHS months.\n"
+        );
+    }
+    public function isShowHelp()
+    {
+        return $this->showHelp;
+    }
+    public function isDryRun()
+    {
+        return $this->dryRun;
+    }
+    public function isDeleteEnabled()
+    {
+        return !is_null($this->getDelete());
+    }
+    public function isWarnEnabled()
+    {
+        return !is_null($this->getWarn());
+    }
+    public function getWarn()
+    {
+        return $this->warn;
+    }
+    public function getDelete()
+    {
+        return $this->delete;
+    }
+    /**
+     * The delete threshold may not be given in which case the warning threshold should be used.
+     * Note that it is an error is delete is greater than warning.
+     */
+    public function getThreshold()
+    {
+        return $this->isWarnEnabled() ? $this->getWarn() : $this->getDelete();
+    }
+}

--- a/tests/DoctrineTestSuite1.php
+++ b/tests/DoctrineTestSuite1.php
@@ -64,7 +64,7 @@ class DoctrineTestSuite1
         $suite->addTestSuite('RoleActionMappingServiceTest');
         $suite->addTestSuite('ScopeServiceTest');
         $suite->addTestSuite('UserServiceTest');
-        $suite->addTestSuite('SiteServiceTest');
+        $suite->addTestSuite('org\gocdb\tests\SiteServiceTest');
         $suite->addTestSuite('RoleServiceTest2');
         $suite->addTestSuite('org\gocdb\tests\APIAuthenticationServiceTest');
         $suite->addTestSuite('WriteAPIsiteMethodsTests');

--- a/tests/DoctrineTestSuite1.php
+++ b/tests/DoctrineTestSuite1.php
@@ -29,6 +29,7 @@ require_once __DIR__ . '/unit/lib/Gocdb_Services/APIAuthenticationServiceTest.ph
 require_once __DIR__ . '/writeAPI/siteMethods.php';
 require_once __DIR__ . '/writeAPI/serviceMethods.php';
 require_once __DIR__ . '/writeAPI/endpointMethods.php';
+require_once __DIR__ . '/resourcesTests/ManageAPICredentialsTest.php';
 
 require_once __DIR__ . '/unit/lib/Gocdb_Services/ServiceServiceTest.php';
 
@@ -69,6 +70,7 @@ class DoctrineTestSuite1
         $suite->addTestSuite('WriteAPIsiteMethodsTests');
         $suite->addTestSuite('WriteAPIserviceMethodsTests');
         $suite->addTestSuite('WriteAPIendpointMethodsTests');
+        $suite->addTestSuite('org\gocdb\tests\ManageAPICredentialsTest');
 
         $suite->addTestSuite('ServiceServiceTest');
 

--- a/tests/resourcesTests/ManageAPICredentialsTest.php
+++ b/tests/resourcesTests/ManageAPICredentialsTest.php
@@ -1,0 +1,203 @@
+<?php
+
+/*
+ * Copyright (C) 2015 STFC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+namespace org\gocdb\tests;
+
+use DateInterval;
+use DateTime;
+use DateTimeZone;
+use org\gocdb\scripts\ManageAPICredentialsActions;
+use PHPUnit_Extensions_Database_Operation_Factory;
+use PHPUnit_Extensions_Database_TestCase;
+use ServiceTestUtil;
+use TestUtil;
+
+require_once __DIR__ . '/../unit/lib/Gocdb_Services/ServiceTestUtil.php';
+require_once __DIR__ . '/../../resources/ManageAPICredentials/ManageAPICredentialsActions.php';
+
+class ManageAPICredentialsTest extends PHPUnit_Extensions_Database_TestCase
+{
+    private $entityManager;
+    private $dbOpsFactory;
+
+    public function __construct()
+    {
+        parent::__construct();
+        // Use a local instance to avoid Mess Detector's whinging about avoiding
+        // static access.
+        $this->dbOpsFactory = new PHPUnit_Extensions_Database_Operation_Factory();
+    }
+    /**
+     * Overridden.
+     */
+    public static function setUpBeforeClass()
+    {
+        parent::setUpBeforeClass();
+        echo "\n\n-------------------------------------------------\n";
+        echo "Executing ManageAPICredentialsTest. . .\n";
+    }
+    /**
+     * Overridden. Returns the test database connection.
+     * @return PHPUnit_Extensions_Database_DB_IDatabaseConnection
+     */
+    protected function getConnection()
+    {
+        require_once __DIR__ . '/../doctrine/bootstrap_pdo.php';
+        return getConnectionToTestDB();
+    }
+    /**
+     * Overridden. Returns the test dataset.
+     * Defines how the initial state of the database should look before each test is executed.
+     * @return PHPUnit_Extensions_Database_DataSet_IDataSet
+     */
+    protected function getDataSet()
+    {
+        $dataset = $this->createFlatXMLDataSet(__DIR__ . '/../doctrine/truncateDataTables.xml');
+        return $dataset;
+      // Use below to return an empty data set if we don't want to truncate and seed
+      //return new PHPUnit_Extensions_Database_DataSet_DefaultDataSet();
+    }
+    /**
+     * Overridden.
+     */
+    protected function getSetUpOperation()
+    {
+      // CLEAN_INSERT is default
+      //return PHPUnit_Extensions_Database_Operation_Factory::CLEAN_INSERT();
+      //return PHPUnit_Extensions_Database_Operation_Factory::UPDATE();
+      //return PHPUnit_Extensions_Database_Operation_Factory::NONE();
+      //
+      // Issue a DELETE from <table> which is more portable than a
+      // TRUNCATE table <table> (some DBs require high privileges for truncate statements
+      // and also do not allow truncates across tables with FK contstraints e.g. Oracle)
+        return $this->dbOpsFactory->DELETE_ALL();
+    }
+    /**
+     * Overridden.
+     */
+    protected function getTearDownOperation()
+    {
+      // NONE is default
+        return $this->dbOpsFactory->NONE();
+    }
+    /**
+     * Sets up the fixture, e.g create a new entityManager for each test run
+     * This method is called before each test method is executed.
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->entityManager = $this->createEntityManager();
+      // Pass the Entity Manager into the Factory to allow Gocdb_Services
+      // to use other Gocdb_Services.
+        \Factory::setEntityManager($this->entityManager);
+
+        date_default_timezone_set("UTC");
+    }
+    /**
+     * Run after each test function to prevent pile-up of database connections.
+     */
+    protected function tearDown()
+    {
+        parent::tearDown();
+        if (!is_null($this->entityManager)) {
+            $this->entityManager->getConnection()->close();
+        }
+    }
+    /**
+     * @return EntityManager
+     */
+    private function createEntityManager()
+    {
+        $entityManager = null; // Initialise in local scope to avoid unused variable warnings
+        require __DIR__ . '/../doctrine/bootstrap_doctrine.php';
+        return $entityManager;
+    }
+    private function createTestAuthEnts($number)
+    {
+        /**
+         * Create a number of unique API authentication credentials, evenly spaced each
+         * with last used time 6 months before the previous, starting 6 months behind
+         * the current time.
+         *
+         * @return \DateTime Time used as 'current' time.
+         */
+
+        list($user, $site, $siteService) =
+            ServiceTestUtil::createGocdbEntities($this->entityManager);
+
+        $baseTime = new DateTime('now', new DateTimeZone('UTC'));
+
+        $type = 'X.509';
+
+        $useTime = clone $baseTime;
+
+        for ($count = 1; $count <= $number; $count++) {
+            // $useTime will be decremented by 6M for each loop
+            $useTime->sub(new DateInterval('P6M'));
+            $ident = '/CN=A Dummy Subject ' . $count;
+            $authEnt = $siteService->addAPIAuthEntity(
+                $site,
+                $user,
+                array(
+                    'IDENTIFIER' =>  $ident,
+                    'TYPE' => $type,
+                    'ALLOW_WRITE' => false
+                )
+            );
+
+            $authEnt->setLastUseTime($useTime);
+        }
+        return $baseTime;
+    }
+    public function testLastUseTime()
+    {
+        print __METHOD__ . "\n";
+
+        $baseTime = $this->createTestAuthEnts(3);
+
+        $entityManager = $this->createEntityManager();
+
+        $actions = new ManageAPICredentialsActions(false, $entityManager, $baseTime);
+
+        // Fetch credentials not used in the last 7 months - should be 2
+        $creds = $actions->getCreds(7);
+
+        $this->assertCount(
+            2,
+            $creds,
+            'Failed to filter credentials by time.'
+        );
+
+        // remove credentials last used more than 13 months ago
+        // there should be one left after this operation
+        $creds = $actions->deleteCreds($creds, 13);
+
+        $this->assertCount(
+            1,
+            $creds,
+            'Failed to delete credential by use time.'
+        );
+
+        // If we now repeat the original query there should be just one
+        // credential following the delete.
+        $creds = $actions->getCreds(7);
+
+        $this->assertCount(
+            1,
+            $creds,
+            'Unexpected credential count following deletion.'
+        );
+    }
+}

--- a/tests/resourcesTests/ManageAPICredentialsTest.php
+++ b/tests/resourcesTests/ManageAPICredentialsTest.php
@@ -18,10 +18,9 @@ use DateInterval;
 use DateTime;
 use DateTimeZone;
 use org\gocdb\scripts\ManageAPICredentialsActions;
+use org\gocdb\tests\ServiceTestUtil;
 use PHPUnit_Extensions_Database_Operation_Factory;
 use PHPUnit_Extensions_Database_TestCase;
-use ServiceTestUtil;
-use TestUtil;
 
 require_once __DIR__ . '/../unit/lib/Gocdb_Services/ServiceTestUtil.php';
 require_once __DIR__ . '/../../resources/ManageAPICredentials/ManageAPICredentialsActions.php';
@@ -30,6 +29,7 @@ class ManageAPICredentialsTest extends PHPUnit_Extensions_Database_TestCase
 {
     private $entityManager;
     private $dbOpsFactory;
+    private $serviceTestUtil;
 
     public function __construct()
     {
@@ -37,6 +37,7 @@ class ManageAPICredentialsTest extends PHPUnit_Extensions_Database_TestCase
         // Use a local instance to avoid Mess Detector's whinging about avoiding
         // static access.
         $this->dbOpsFactory = new PHPUnit_Extensions_Database_Operation_Factory();
+        $this->serviceTestUtil = new ServiceTestUtil();
     }
     /**
      * Overridden.
@@ -135,7 +136,7 @@ class ManageAPICredentialsTest extends PHPUnit_Extensions_Database_TestCase
          */
 
         list($user, $site, $siteService) =
-            ServiceTestUtil::createGocdbEntities($this->entityManager);
+            $this->serviceTestUtil->createGocdbEntities($this->entityManager);
 
         $baseTime = new DateTime('now', new DateTimeZone('UTC'));
 

--- a/tests/unit/lib/Gocdb_Services/APIAuthenticationServiceTest.php
+++ b/tests/unit/lib/Gocdb_Services/APIAuthenticationServiceTest.php
@@ -22,7 +22,7 @@ use org\gocdb\services\APIAuthenticationService;
 use PHPUnit_Extensions_Database_Operation_Factory;
 use PHPUnit_Extensions_Database_TestCase;
 use RuntimeException;
-use ServiceTestUtil;
+use org\gocdb\tests\ServiceTestUtil;
 use TestUtil;
 
 /**
@@ -34,6 +34,7 @@ class APIAuthEnticationServiceTest extends PHPUnit_Extensions_Database_TestCase
 {
     private $entityManager;
     private $dbOpsFactory;
+    private $serviceTestUtil;
 
     public function __construct()
     {
@@ -41,6 +42,7 @@ class APIAuthEnticationServiceTest extends PHPUnit_Extensions_Database_TestCase
       // Use a local instance to avoid Mess Detector's whinging about avoiding
       // static access.
         $this->dbOpsFactory = new PHPUnit_Extensions_Database_Operation_Factory();
+        $this->serviceTestUtil = new ServiceTestUtil();
     }
   /**
   * Overridden.
@@ -155,7 +157,7 @@ class APIAuthEnticationServiceTest extends PHPUnit_Extensions_Database_TestCase
         print __METHOD__ . "\n";
 
         list($user, $site, $siteService, $authEntServ) =
-        ServiceTestUtil::createGocdbEntities($this->entityManager);
+          $this->serviceTestUtil->createGocdbEntities($this->entityManager);
 
         $this->assertTrue(
             $authEntServ instanceof APIAuthenticationService,

--- a/tests/unit/lib/Gocdb_Services/APIAuthenticationServiceTest.php
+++ b/tests/unit/lib/Gocdb_Services/APIAuthenticationServiceTest.php
@@ -154,22 +154,8 @@ class APIAuthEnticationServiceTest extends PHPUnit_Extensions_Database_TestCase
     {
         print __METHOD__ . "\n";
 
-        $siteData = ServiceTestUtil::getSiteData($this->entityManager);
-        $siteService = ServiceTestUtil::getSiteService($this->entityManager);
-        $site = ServiceTestUtil::createAndAddSite($this->entityManager, $siteData);
-
-        $user = TestUtil::createSampleUser('Beta', 'User');
-        $user->setAdmin(true);
-
-        $identifier = TestUtil::createSampleUserIdentifier('X.509', '/Beta.User');
-        ServiceTestUtil::persistAndFlush($this->entityManager, $identifier);
-
-        $user->addUserIdentifierDoJoin($identifier);
-
-        ServiceTestUtil::persistAndFlush($this->entityManager, $user);
-
-        $authEntServ = new APIAuthenticationService();
-        $authEntServ->setEntityManager($this->entityManager);
+        list($user, $site, $siteService, $authEntServ) =
+        ServiceTestUtil::createGocdbEntities($this->entityManager);
 
         $this->assertTrue(
             $authEntServ instanceof APIAuthenticationService,

--- a/tests/unit/lib/Gocdb_Services/ServiceTestUtil.php
+++ b/tests/unit/lib/Gocdb_Services/ServiceTestUtil.php
@@ -2,6 +2,8 @@
 
 require_once __DIR__ . "/../../../doctrine/TestUtil.php";
 
+use org\gocdb\services\APIAuthenticationService;
+
 /**
  *  Helper functions for GOCDB_Services tests
  *
@@ -125,4 +127,33 @@ class ServiceTestUtil {
 
     return $scopeService;
   }
+  public static function createGocdbEntities($entityManager)
+  {
+    /**
+     * Set up the site, user and service objects shared by
+     * some tests.
+     *
+     * @return array Created User, Site and SiteService instances
+     */
+
+    $siteData = ServiceTestUtil::getSiteData($entityManager);
+    $siteService = ServiceTestUtil::getSiteService($entityManager);
+    $site = ServiceTestUtil::createAndAddSite($entityManager, $siteData);
+
+    $user = TestUtil::createSampleUser('Beta', 'User');
+    $user->setAdmin(true);
+
+    $identifier = TestUtil::createSampleUserIdentifier('X.509', '/Beta.User');
+    ServiceTestUtil::persistAndFlush($entityManager, $identifier);
+
+    $user->addUserIdentifierDoJoin($identifier);
+
+    ServiceTestUtil::persistAndFlush($entityManager, $user);
+
+    $authEntServ = new APIAuthenticationService();
+    $authEntServ->setEntityManager($entityManager);
+
+    return [$user, $site, $siteService, $authEntServ];
+  }
+
 }

--- a/tests/unit/lib/Gocdb_Services/ServiceTestUtil.php
+++ b/tests/unit/lib/Gocdb_Services/ServiceTestUtil.php
@@ -1,50 +1,59 @@
 <?php
 
+namespace org\gocdb\tests;
+
 require_once __DIR__ . "/../../../doctrine/TestUtil.php";
 
+use Doctrine\ORM\EntityManager;
 use org\gocdb\services\APIAuthenticationService;
+use org\gocdb\services\Scope;
+use org\gocdb\services\Site;
+use TestUtil;
 
 /**
  *  Helper functions for GOCDB_Services tests
  *
- * @author Ian Neilsony
+ * @author Ian Neilson
  */
-class ServiceTestUtil {
-  /**
-   * Persist and flush an entity
-   * @param \Doctrine\ORM\EntityManager $em Entity manager
-   * @param Object $instance
-   */
-  public static function persistAndFlush ($em, $instance) {
-      $em->persist($instance);
-      $em->flush();
-  }
-  /**
-   * Create some test site data
-   * @param EntityManager $em Entity Manager handle
-   */
-  public static function getSiteData ($em) {
+class ServiceTestUtil
+{
+    /**
+     * Persist and flush an entity
+     * @param \Doctrine\ORM\EntityManager $em Entity manager
+     * @param Object $instance
+     */
+    public static function persistAndFlush($em, $instance)
+    {
+        $em->persist($instance);
+        $em->flush();
+    }
+    /**
+     * Create some test site data
+     * @param EntityManager $em Entity Manager handle
+     */
+    public static function getSiteData($em)
+    {
 
-    $infra = TestUtil::createSampleInfrastructure('Production');
-    $em->persist($infra);
+        $infra = TestUtil::createSampleInfrastructure('Production');
+        $em->persist($infra);
 
-    $ngi = TestUtil::createSampleNGI('ngi1_');
-    $em->persist($ngi);
+        $ngi = TestUtil::createSampleNGI('ngi1_');
+        $em->persist($ngi);
 
-    $scope = TestUtil::createSampleScope('scope 1', 'Scope1');
-    $em->persist($scope);
+        $scope = TestUtil::createSampleScope('scope 1', 'Scope1');
+        $em->persist($scope);
 
-    $certStatus = TestUtil::createSampleCertStatus('Certified');
-    $em->persist($certStatus);
+        $certStatus = TestUtil::createSampleCertStatus('Certified');
+        $em->persist($certStatus);
 
-    $country = TestUtil::createSampleCountry('Utopia');
-    $em->persist($country);
+        $country = TestUtil::createSampleCountry('Utopia');
+        $em->persist($country);
 
-    $em->flush();
+        $em->flush();
 
-    $siteData = array (
-      'NGI' => $ngi->getId(),
-      'Site' => array(
+        $siteData = array (
+        'NGI' => $ngi->getId(),
+        'Site' => array(
         'SHORT_NAME' => 's1',
         'DESCRIPTION' => 'A test site',
         'OFFICIAL_NAME' => 'An-official-site',
@@ -64,96 +73,98 @@ class ServiceTestUtil {
         'EMERGENCYEMAIL' => 'anon@localhost.net',
         'HELPDESKEMAIL' => 'anon@localhost.net',
         'TIMEZONE' => 'GMT'),
-      'Scope_ids' => array($scope->getId()),
-      'ReservedScope_ids' => array(),
-      'ProductionStatus' => $infra->getId(),
-      'Certification_Status' => $certStatus->getId(),
-      'Country' => $country->getId()
-    );
+        'Scope_ids' => array($scope->getId()),
+        'ReservedScope_ids' => array(),
+        'ProductionStatus' => $infra->getId(),
+        'Certification_Status' => $certStatus->getId(),
+        'Country' => $country->getId()
+        );
 
-    return $siteData;
-  }
+        return $siteData;
+    }
   /**
    * Create and return a minimal Site Service instance
    * @param \Doctrine\ORM\EntityManager EntityManager $em
    * @param array $siteData Minimal initial site data array
    * @return \Site $site
    */
-  public static function createAndAddSite ($em, $siteData) {
+    public function createAndAddSite($em, $siteData)
+    {
 
-    $user = TestUtil::createSampleUser('Alpha','User');
+        $user = TestUtil::createSampleUser('Alpha', 'User');
     // We don't want to test all the roleAction logic here so simply make us an admin
-    $user->setAdmin(true);
+        $user->setAdmin(true);
 
-    $identifier = TestUtil::createSampleUserIdentifier('X.509', '/Alpha.User');
-    ServiceTestUtil::persistAndFlush($em, $identifier);
+        $identifier = TestUtil::createSampleUserIdentifier('X.509', '/Alpha.User');
+        $this->persistAndFlush($em, $identifier);
 
-    $user->addUserIdentifierDoJoin($identifier);
+        $user->addUserIdentifierDoJoin($identifier);
 
-    ServiceTestUtil::persistAndFlush($em, $user);
+        $this->persistAndFlush($em, $user);
 
-    $siteService = ServiceTestUtil::getSiteService($em);
+        $siteService = $this->getSiteService($em);
 
-    $site = $siteService->addSite($siteData, $user);
+        $site = $siteService->addSite($siteData, $user);
 
-    return $site;
-  }
+        return $site;
+    }
   /**
    * Generate minimal Site Service
-   * @param \Doctrine\ORM\EntityManager EntityManager $em
-   * @return org\gocdb\services\Site $siteService
+   * @param EntityManager EntityManager $em
+   * @return Site $siteService
    */
-  public static function getSiteService ($em) {
-    $siteService = new org\gocdb\services\Site();
-    $siteService->setEntityManager($em);
+    public function getSiteService($em)
+    {
+        $siteService = new Site();
+        $siteService->setEntityManager($em);
 
     // Need stubs for both role and scope services
-    $roleAAS = TestUtil::createSampleRoleAAS(__DIR__ .
+        $roleAAS = TestUtil::createSampleRoleAAS(__DIR__ .
               "/../../resources/roleActionMappingSamples/TestRoleActionMappings5.xml");
 
-    $roleAAS->setEntityManager($em);
-    $siteService->setRoleActionAuthorisationService($roleAAS);
-    $siteService->setScopeService(ServiceTestUtil::getScopeService($em));
+        $roleAAS->setEntityManager($em);
+        $siteService->setRoleActionAuthorisationService($roleAAS);
+        $siteService->setScopeService($this->getScopeService($em));
 
-    return $siteService;
-  }
+        return $siteService;
+    }
     /**
    * Generate a useless minimal Scope Service
    * NB. Should be done in the siteService constructor (?)
    */
-  private static function getScopeService($em) {
-    $scopeService = new \org\gocdb\services\Scope();
-    $scopeService->setEntityManager($em);
+    private static function getScopeService($em)
+    {
+        $scopeService = new Scope();
+        $scopeService->setEntityManager($em);
 
-    return $scopeService;
-  }
-  public static function createGocdbEntities($entityManager)
-  {
-    /**
-     * Set up the site, user and service objects shared by
-     * some tests.
-     *
-     * @return array Created User, Site and SiteService instances
-     */
+        return $scopeService;
+    }
+    public function createGocdbEntities($entityManager)
+    {
+      /**
+       * Set up the site, user and service objects shared by
+       * some tests.
+       *
+       * @return array Created User, Site and SiteService instances
+       */
 
-    $siteData = ServiceTestUtil::getSiteData($entityManager);
-    $siteService = ServiceTestUtil::getSiteService($entityManager);
-    $site = ServiceTestUtil::createAndAddSite($entityManager, $siteData);
+        $siteData = $this->getSiteData($entityManager);
+        $siteService = $this->getSiteService($entityManager);
+        $site = $this->createAndAddSite($entityManager, $siteData);
 
-    $user = TestUtil::createSampleUser('Beta', 'User');
-    $user->setAdmin(true);
+        $user = TestUtil::createSampleUser('Beta', 'User');
+        $user->setAdmin(true);
 
-    $identifier = TestUtil::createSampleUserIdentifier('X.509', '/Beta.User');
-    ServiceTestUtil::persistAndFlush($entityManager, $identifier);
+        $identifier = TestUtil::createSampleUserIdentifier('X.509', '/Beta.User');
+        $this->persistAndFlush($entityManager, $identifier);
 
-    $user->addUserIdentifierDoJoin($identifier);
+        $user->addUserIdentifierDoJoin($identifier);
 
-    ServiceTestUtil::persistAndFlush($entityManager, $user);
+        $this->persistAndFlush($entityManager, $user);
 
-    $authEntServ = new APIAuthenticationService();
-    $authEntServ->setEntityManager($entityManager);
+        $authEntServ = new APIAuthenticationService();
+        $authEntServ->setEntityManager($entityManager);
 
-    return [$user, $site, $siteService, $authEntServ];
-  }
-
+        return [$user, $site, $siteService, $authEntServ];
+    }
 }

--- a/tests/unit/lib/Gocdb_Services/SiteServiceTest.php
+++ b/tests/unit/lib/Gocdb_Services/SiteServiceTest.php
@@ -12,6 +12,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+namespace org\gocdb\tests;
+
 require_once __DIR__ . '/../../../doctrine/TestUtil.php';
 require_once __DIR__ . '/ServiceTestUtil.php';
 require_once __DIR__ . '/../../../../lib/Doctrine/entities/User.php';
@@ -21,25 +24,32 @@ require_once __DIR__ . '/../../../../lib/Gocdb_Services/Factory.php';
 require_once __DIR__ . '/../../../../lib/Gocdb_Services/Scope.php';
 
 use Doctrine\ORM\EntityManager;
+use org\gocdb\tests\ServiceTestUtil;
+use PHPUnit_Extensions_Database_Operation_Factory;
+use PHPUnit_Extensions_Database_TestCase;
+use RuntimeException;
+use TestUtil;
 
 /**
  * DBUnit test class for the {@see \org\gocdb\services\Site} service.
  *
  * @author Ian Neilson (after David Meredith)
  */
-class siteServiceTest extends PHPUnit_Extensions_Database_TestCase
+class SiteServiceTest extends PHPUnit_Extensions_Database_TestCase
 {
     private $entityManager;
     private $dbOpsFactory;
   /** @var TestUtil $testUtil */
     private $testUtil;
+    private $serviceTestUtil;
 
-    function __construct()
+    public function __construct()
     {
         parent::__construct();
       // Use a local instance to avoid Mess Detector's whinging about avoiding
       // static access.
         $this->dbOpsFactory = new PHPUnit_Extensions_Database_Operation_Factory();
+        $this->serviceTestUtil = new ServiceTestUtil();
     }
   /**
   * Overridden.
@@ -167,16 +177,16 @@ class siteServiceTest extends PHPUnit_Extensions_Database_TestCase
     {
         print __METHOD__ . "\n";
 
-        $siteData = ServiceTestUtil::getSiteData($this->entityManager);
-        $siteService = ServiceTestUtil::getSiteService($this->entityManager);
+        $siteData = $this->serviceTestUtil->getSiteData($this->entityManager);
+        $siteService = $this->serviceTestUtil->getSiteService($this->entityManager);
 
       // The most basic check
         $this->assertTrue(
-            $siteService instanceof org\gocdb\services\Site,
+            $siteService instanceof \org\gocdb\services\Site,
             'Site Service failed to create and return a Site service'
         );
 
-        ServiceTestUtil::createAndAddSite($this->entityManager, $siteData);
+        $this->serviceTestUtil->createAndAddSite($this->entityManager, $siteData);
 
       // Check
       // N.B. Although getSitesFilterByParams says all the filters are optional,
@@ -198,9 +208,9 @@ class siteServiceTest extends PHPUnit_Extensions_Database_TestCase
         $user->setAdmin(true);
         $this->persistAndFlush($user);
 
-        $siteData = ServiceTestUtil::getSiteData($this->entityManager);
-        $siteService = ServiceTestUtil::getSiteService($this->entityManager);
-        ServiceTestUtil::createAndAddSite($this->entityManager, $siteData);
+        $siteData = $this->serviceTestUtil->getSiteData($this->entityManager);
+        $siteService = $this->serviceTestUtil->getSiteService($this->entityManager);
+        $this->serviceTestUtil->createAndAddSite($this->entityManager, $siteData);
 
         $sites = $siteService->getSitesFilterByParams(array('scope' => 'Scope1'));
         $site = $sites[0];


### PR DESCRIPTION
Script and accompanying tests to filter API credentials by last-use time to allow sending warning emails and deletion of unused credentials.

Old PR: https://github.com/GOCDB/gocdb/pull/409