### PR TITLE
[GT-141]-pre-select site, services and endpoints

### DIFF
--- a/htdocs/web_portal/controllers/downtime/view_endpoint_tree.php
+++ b/htdocs/web_portal/controllers/downtime/view_endpoint_tree.php
@@ -19,7 +19,17 @@
  * limitations under the License.
  *
  /*====================================================== */
-function getServiceandEndpointList() {
+
+ /*
+ * This is to authenticate a request, lookup a User object by the user's principle ID
+ * and decide if the user is an Admin or NOT.
+ *
+ * @return $params['portalIsReadOnly'] = BooleanValue
+ */
+function initAuthRequest()
+{
+    $params = [];
+
     require_once __DIR__ . '/../utils.php';
     require_once __DIR__ . '/../../../web_portal/components/Get_User_Principle.php';
 
@@ -27,30 +37,39 @@ function getServiceandEndpointList() {
     $user = \Factory::getUserService()->getUserByPrinciple($dn);
     $params['portalIsReadOnly'] = portalIsReadOnlyAndUserIsNotAdmin($user);
 
-    if (!isset($_REQUEST['site_id']) || !is_numeric($_REQUEST['site_id']) ){
+    return $params;
+}
+
+function getServiceAndEndpointList()
+{
+    $params = initAuthRequest();
+
+    if (!isset($_REQUEST['site_id']) || !is_numeric($_REQUEST['site_id'])) {
         throw new Exception("An id must be specified");
     }
+    if (isset($_REQUEST['se'])) {
+        $params['se'] = $_REQUEST['se'];
+    }
+
     $site = \Factory::getSiteService()->getSite($_REQUEST['site_id']);
     $services = $site->getServices();
     $params['services'] = $services;
+
     show_view("downtime/view_nested_endpoints_list.php", $params, null, true);
 }
 
 //This is a secondary function to handle the rendering of this page when editing the downtime
-function editDowntimePopulateEndpointTree() {
-    require_once __DIR__ . '/../utils.php';
-    require_once __DIR__ . '/../../../web_portal/components/Get_User_Principle.php';
+function editDowntimePopulateEndpointTree()
+{
+    $params = initAuthRequest();
 
-    $dn = Get_User_Principle();
-    $user = \Factory::getUserService()->getUserByPrinciple($dn);
-    $params['portalIsReadOnly'] = portalIsReadOnlyAndUserIsNotAdmin($user);
-
-    if (!isset($_REQUEST['site_id']) || !is_numeric($_REQUEST['site_id']) ){
+    if (!isset($_REQUEST['site_id']) || !is_numeric($_REQUEST['site_id'])) {
         throw new Exception("A site id must be specified");
     }
-    if (!isset($_REQUEST['dt_id']) || !is_numeric($_REQUEST['dt_id']) ){
+    if (!isset($_REQUEST['dt_id']) || !is_numeric($_REQUEST['dt_id'])) {
         throw new Exception("A downtime id must be specified");
     }
+
     $site = \Factory::getSiteService()->getSite($_REQUEST['site_id']);
     $services = $site->getServices();
     $params['services'] = $services;

--- a/htdocs/web_portal/index.php
+++ b/htdocs/web_portal/index.php
@@ -76,7 +76,7 @@ function rejectIfNotAuthenticated($message = null){
 //rejectIfNotAuthenticated();
 
 // Initialise the configuration service with the host url of the incoming request.
-// Allows the overriding of configuration values. Do not use 'new' to create a new 
+// Allows the overriding of configuration values. Do not use 'new' to create a new
 // instance after this.
 
 \Factory::getConfigService()->setLocalInfoOverride($_SERVER['SERVER_NAME']);
@@ -373,7 +373,7 @@ function Draw_Page($Page_Type) {
         case "Downtime_view_endpoint_tree":
             rejectIfNotAuthenticated();
             require_once __DIR__.'/controllers/downtime/view_endpoint_tree.php';
-            getServiceandEndpointList();
+            getServiceAndEndpointList();
             break;
         case "Edit_Downtime_view_endpoint_tree":
             rejectIfNotAuthenticated();

--- a/htdocs/web_portal/views/downtime/add_downtime.php
+++ b/htdocs/web_portal/views/downtime/add_downtime.php
@@ -156,7 +156,7 @@ rather than the Site entities themselves, and specify tz, offset in the DTO/JSON
                     $siteName = $site->getName();
                     $ngiName = $site->getNgi()->getName();
                     $label = xssafe($site."   (".$ngiName.")");
-                    echo "<option value=\"{$site->getId()}\">$label</option>";
+                    echo "<option value=\"{$site->getId()}\" SELECTED>$label</option>";
                 }
                 ?>
             </select> <br /> <br />
@@ -231,7 +231,8 @@ rather than the Site entities themselves, and specify tz, offset in the DTO/JSON
            validate();
        });
 
-
+       // This will help us to decide whether to fetch and `select` all services, endpoints or Not.       
+       getSitesServices();
 
     });
 
@@ -493,11 +494,28 @@ rather than the Site entities themselves, and specify tz, offset in the DTO/JSON
        return datesValid;
     }
 
-    function getSitesServices(){
+    function getSitesServices()
+    {
         var siteId=$('#Select_Sites').val();
+
         if(siteId != null){ //If the user clicks on the box but not a specific row there will be no input, so catch that here
             $('#chooseEndpoints').empty(); //Remove any previous content from the endpoints select list
-            $('#chooseServices').load('index.php?Page_Type=Downtime_view_endpoint_tree&site_id='+siteId,function( response, status, xhr ) {
+
+            let DVET_Path;
+            const getServiceIDFromQueryParams = new URL(this.location.href).searchParams.get('se');
+
+            if (getServiceIDFromQueryParams) {
+                /**
+                 * NOTE: If you use template literal for string interpolation,
+                 * i.e., `${}`. It has to be in one line.
+                 */
+                DVET_Path = 'index.php?Page_Type=Downtime_view_endpoint_tree' +
+                            `&se=${getServiceIDFromQueryParams}&site_id=${siteId}`;
+            } else {
+                DVET_Path = `index.php?Page_Type=Downtime_view_endpoint_tree&site_id=${siteId}`;
+            }
+
+            $('#chooseServices').load(DVET_Path, function( response, status, xhr ) {
                 if ( status == "success" ) {
                     validate();
                 }
@@ -631,21 +649,3 @@ rather than the Site entities themselves, and specify tz, offset in the DTO/JSON
     }*/
 
 </script>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/htdocs/web_portal/views/downtime/view_nested_endpoints_list.php
+++ b/htdocs/web_portal/views/downtime/view_nested_endpoints_list.php
@@ -1,26 +1,56 @@
 <?php
 $services = $params['services'];
+$specificServiceEndpoints = isset($params['se']) ? $params['se'] : '';
 $configService = \Factory::getConfigService();
-
 ?>
+
 <!-- Dynamically create a select list from a sites services -->
 <label> Select Affected Services+Endpoints (Ctrl+click to select)</label>
-<select name="IMPACTED_IDS[]" id="Select_Services" size="10" class="form-control" onclick="" style="width:99%; margin-left:1%" onChange="selectServicesEndpoint()" multiple>
+
+<select name="IMPACTED_IDS[]" id="Select_Services" size="10" class="form-control"
+onclick="" style="width:99%; margin-left:1%" onChange="selectServicesEndpoint()" multiple>
+
 <?php
-    foreach($services as $service){
-        $count=0;
-        echo "<option value=\"s" . $service->getId() . "\" id=\"" . $service->getId() . "\" SELECTED>" . '('.xssafe($service->getServiceType()->getName()).') '.xssafe($service->getHostName()) . "</option>";
-        foreach($service->getEndpointLocations() as $endpoint){
-            if($endpoint->getName() == ''){
-                $name = xssafe('myEndpoint');
-            }else{
-                $name = xssafe($endpoint->getName());
+foreach ($services as $service) {
+    $count = 0;
+
+    if ($specificServiceEndpoints) {
+        if ($service->getId() == $specificServiceEndpoints) {
+            $selected = 'SELECTED';
+        } else {
+            $selected = '';
+        }
+    } else {
+        $selected = 'SELECTED';
+    }
+
+    echo "<option value=\"s" . $service->getId() . "\" id=\"" . $service->getId() . "\" "
+        . $selected . ">" . '(' . xssafe($service->getServiceType()->getName()) . ') '
+        . xssafe($service->getHostName()) . "</option>";
+
+    foreach ($service->getEndpointLocations() as $endpoint) {
+        if ($specificServiceEndpoints) {
+            if ($service->getId() == $specificServiceEndpoints) {
+                $selected = 'SELECTED';
+            } else {
+                $selected = '';
             }
-            //Option styling doesn't work well cross browser so just use 4 spaces to indent the branch
-            echo "<option id=\"".$service->getId()."\" value=\"e" . $endpoint->getId() . "\" SELECTED>&nbsp&nbsp&nbsp&nbsp-" . $name . "</option>";
-            $count++;
+        } else {
+            $selected = 'SELECTED';
         }
 
+        if ($endpoint->getName() == '') {
+            $name = xssafe('myEndpoint');
+        } else {
+            $name = xssafe($endpoint->getName());
+        }
+
+        //Option styling doesn't work well cross browser so just use 4 spaces to indent the branch
+        echo "<option id=\"" . $service->getId() . "\" value=\"e" . $endpoint->getId()
+            . "\" " . $selected . ">&nbsp&nbsp&nbsp&nbsp-" . $name . "</option>";
+
+        $count++;
     }
+}
 ?>
 </select>


### PR DESCRIPTION
**Case 1:** If the user goes to the sites and tries to add recent downtimes. Then the user should be able to see the site, the services, and the endpoints pre-selected. 
**Case 2:**  If the user goes to the services and tries to add recent downtimes. Then the user should see the specific service-related endpoints that are pre-selected.

"Resolves #229"