### PR TITLE
[GT-181] Add last Logged In field in users details

### DIFF
--- a/htdocs/web_portal/controllers/user/view_user.php
+++ b/htdocs/web_portal/controllers/user/view_user.php
@@ -96,7 +96,7 @@ function getUserAndUserService()
         throw new Exception("No user with that ID");
     }
 
-    $callingUser = isUserAuthorizedToView($user, $userService);
+    $callingUser = isUserAuthorisedToView($user, $userService);
 
     try {
         $userService->editUserAuthorization($user, $callingUser);
@@ -111,16 +111,16 @@ function getUserAndUserService()
 }
 
 /**
- * Validates whether the viewing/calling user is authorized to perform
+ * Validates whether the viewing/calling user is authorised to perform
  * or viewing the user's details.
  *
  * @param mixed $userDetails The user details to be viewed.
  * @param \org\gocdb\services\User $userServ The user service.
  *
- * @return mixed `$callingUser` The viewing/calling user if authorized.
- * @throws Exception If the viewing/calling user is not authorized.
+ * @return mixed `$callingUser` The viewing/calling user if authorised.
+ * @throws Exception If the viewing/calling user is not authorised.
  */
-function isUserAuthorizedToView($userDetails, $userServ)
+function isUserAuthorisedToView($userDetails, $userServ)
 {
     /** @var \User $callingUser */
     $callingUser = $userServ->getUserByPrinciple(Get_User_Principle());
@@ -146,7 +146,7 @@ function isUserAuthorizedToView($userDetails, $userServ)
 }
 
 /**
- * Helper to retrive `Role` information and project IDs for a given user.
+ * Helper to retrieve `Role` information and project IDs for a given user.
  *
  * @param \User $user User's Details.
  * @param \User $callingUser Viewing/Calling user.
@@ -166,7 +166,7 @@ function getRoleProjectIDs($user, $callingUser)
 
         /**
          * Check that revoking this role will not leave an API credential owned
-         * by a the user at a site over which they no longer have a role.
+         * by a user at a site over which they no longer have a role.
          */
         $blockingSites = $roleService->checkOrphanAPIAuth($role);
 

--- a/htdocs/web_portal/controllers/user/view_user.php
+++ b/htdocs/web_portal/controllers/user/view_user.php
@@ -4,6 +4,7 @@
  *======================================================
  * File: view_user.php
  * Author: John Casson, David Meredith
+ * Owner: GOCDB DEV Team, STFC.
  * Description: Retrieves and draws the data for a user
  *
  * License information
@@ -20,6 +21,8 @@
  * limitations under the License.
  *
  /*====================================================== */
+use Exception;
+
 function view_user()
 {
     require_once __DIR__ . '/utils.php';
@@ -27,10 +30,65 @@ function view_user()
     require_once __DIR__ . '/../../../../lib/Gocdb_Services/Factory.php';
     require_once __DIR__ . '/../../components/Get_User_Principle.php';
 
+    $params = [];
+
+    validateUserID();
+
+    list($user, $callingUser, $params) = getUserAndUserService();
+    // Check if user only has one identifier to disable unlinking
+    $params['lastIdentifier'] = (count($user->getUserIdentifiers()) === 1);
+    // Add the display locations of the policy files.
+    getPolicyURLs($params);
+
+    $params['user'] = $user;
+    $params['callingUser'] = $callingUser;
+
+    list($roleProjectIds) = getRoleProjectIDs($user, $callingUser);
+
+    $currentIdString = Get_User_Principle();
+    $params['currentIdString'] = $currentIdString;
+
+    /**
+     * Get a list of the projects and their Ids for grouping roles
+     * by project in view.
+     */
+    $projectNamesIds = array();
+    $projects = \Factory::getProjectService()->getProjects();
+
+    foreach ($projects as $project) {
+        $projectNamesIds[$project->getId()] = $project->getName();
+    }
+
+    /**
+     * Check to see if the current calling user has permission to
+     * edit the target user.
+     */
+    $params['projectNamesIds'] = $projectNamesIds;
+    $params['role_ProjIds'] = $roleProjectIds;
+    $params['portalIsReadOnly'] = \Factory::getConfigService()->IsPortalReadOnly();
+    $params['APIAuthEnts'] = $user->getAPIAuthenticationEntities();
+    $title = $user->getFullName();
+
+    show_view("user/view_user.php", $params, $title);
+}
+
+function validateUserID()
+{
     if (!isset($_GET['id']) || !is_numeric($_GET['id'])) {
         throw new Exception("An id must be specified");
     }
+}
 
+/**
+ * Helper function to get user(All User's) information, viewing/calling user,
+ * and few parameters for display.
+ *
+ * @return array An array containing user, viewing/calling user, and
+ *               additional parameters.
+ */
+function getUserAndUserService()
+{
+    $childParams = [];
     $userService = \Factory::getUserService();
     $user = $userService->getUser($_GET['id']);
 
@@ -38,129 +96,162 @@ function view_user()
         throw new Exception("No user with that ID");
     }
 
-    $params = array();
+    $callingUser = isUserAuthorizedToView($user, $userService);
 
-    // Check if user only has one identifier to disable unlinking
-    $params['lastIdentifier'] = (count($user->getUserIdentifiers()) === 1);
-    // Add the display locations of the policy files.
-    getPolicyURLs($params);
-
-    $apiAuthEnts = $user->getAPIAuthenticationEntities();
-    $authEntSites = array();
-    /** @var \APIAuthentication $apiAuth */
-    foreach ($apiAuthEnts as $apiAuth) {
-        $authEntSites[$apiAuth->getParentSite()->getId()]++;
+    try {
+        $userService->editUserAuthorization($user, $callingUser);
+        $childParams['ShowEdit'] = true;
+    } catch (Exception $e) {
+        $childParams['ShowEdit'] = false;
     }
 
-    /** @var \User $callingUser */
-    $callingUser = $userService->getUserByPrinciple(Get_User_Principle());
+    $childParams['idString'] = $userService->getDefaultIdString($user);
 
-    // Restrict users to see only their own data unless authorised.
-    // User objects are not 'owned' so we check their authz at connected sites.
+    return [$user, $callingUser, $childParams];
+}
+
+/**
+ * Validates whether the viewing/calling user is authorized to perform
+ * or viewing the user's details.
+ *
+ * @param mixed $userDetails The user details to be viewed.
+ * @param \org\gocdb\services\User $userServ The user service.
+ *
+ * @return mixed `$callingUser` The viewing/calling user if authorized.
+ * @throws Exception If the viewing/calling user is not authorized.
+ */
+function isUserAuthorizedToView($userDetails, $userServ)
+{
+    /** @var \User $callingUser */
+    $callingUser = $userServ->getUserByPrinciple(Get_User_Principle());
+
+    /**
+     * Restrict users to see only their own data unless authorised.
+     * User objects are not 'owned' so we check their authz at connected sites.
+     */
     if (
         is_null($callingUser)
         || (
             !$callingUser->isAdmin()
-            && $user !== $callingUser
-            && !$userService->isAllowReadPD($callingUser)
-            )
+            && $userDetails !== $callingUser
+            && !$userServ->isAllowReadPD($callingUser)
+        )
     ) {
-            throw new Exception('You are not authorised to read other users\' personal data.');
+        throw new Exception(
+            "You are not authorised to read other users\' personal data."
+        );
     }
 
-    $params['user'] = $user;
+    return $callingUser;
+}
 
-    // 2D array, each element stores role and a child array holding project Ids
+/**
+ * Helper to retrive `Role` information and project IDs for a given user.
+ *
+ * @param \User $user User's Details.
+ * @param \User $callingUser Viewing/Calling user.
+ */
+function getRoleProjectIDs($user, $callingUser)
+{
     $roleProjectIds = array();
-
-    // get the targetUser's roles
+    // Get the targetUser's roles.
     $roleService = \Factory::getRoleService();
-    $roles = $roleService->getUserRoles($user, \RoleStatus::GRANTED); //$user->getRoles();
+    $roles = $roleService->getUserRoles($user, \RoleStatus::GRANTED);
 
-    $currentIdString = Get_User_Principle();
-    $params['currentIdString'] = $currentIdString;
-
-    // can the calling user revoke the targetUser's roles?
-    /** @var \Role $r */
-
-    foreach ($roles as $r) {
-        $decoratorString = '';
-
+    // Can the calling user revoke the targetUser's roles?
+    /** @var \Role $role */
+    foreach ($roles as $role) {
         /** @var \OwnedEntity $roleOwnedEntity */
-        $roleOwnedEntity = $r->getOwnedEntity();
+        $roleOwnedEntity = $role->getOwnedEntity();
 
-        // check that revoking this role will not leave an API credential owned by
-        // a the user at a site over which they no longer have a role.
-        $blockingSites = $roleService->checkOrphanAPIAuth($r);
+        /**
+         * Check that revoking this role will not leave an API credential owned
+         * by a the user at a site over which they no longer have a role.
+         */
+        $blockingSites = $roleService->checkOrphanAPIAuth($role);
 
-        // Assign the decorator revokeMessage key value to be either the list of roles permitting
-        // the role revocation or the list of sites with potentially orphaned API credentials
-        // blocking the revocation
+        /**
+         * Assign the decorator revokeMessage key value to be either the list
+         * of roles permitting the role revocation or the list of sites with
+         * potentially orphaned API credentials blocking the revocation.
+         */
         if (count($blockingSites) > 0) {
-            $r->setDecoratorObject(array("revokeButton" => "disabled",
-                                         "revokeMessage" => implode(', ', array_keys($blockingSites))));
+            $role->setDecoratorObject(
+                array(
+                    "revokeButton" => "disabled",
+                    "revokeMessage" => implode(', ', array_keys($blockingSites))
+                )
+            );
         } else {
             $authorisingRoles = \Factory::getRoleActionAuthorisationService()
-                ->authoriseAction(\Action::REVOKE_ROLE, $roleOwnedEntity, $callingUser)
+                ->authoriseAction(
+                    \Action::REVOKE_ROLE,
+                    $roleOwnedEntity,
+                    $callingUser
+                )
                 ->getGrantingRoles();
 
-            if ($user != $callingUser) {
-                // determine if callingUser can REVOKE this role instance
-                if ($callingUser->isAdmin()) {
-                    $decoratorString .= 'GOCDB_ADMIN';
-                    if (count($authorisingRoles) >= 1) {
-                        $decoratorString .= ': ' ;
-                    }
-                }
-                if (count($authorisingRoles) >= 1) {
-                    /** @var \Role $authRole */
-                    $roleNames = array();
-                    foreach ($authorisingRoles as $authRole) {
-                        $roleNames[] = $authRole->getRoleType()->getName();
-                    }
-                    $decoratorString .= '[' . implode(', ', $roleNames) . '] ';
-                }
-            } else {
-                // current user is viewing their own roles, so they can revoke their own roles
-                $decoratorString = '[Self revoke own role]';
-            }
-
-            $r->setDecoratorObject(array("revokeButton" => "", "revokeMessage" => $decoratorString));
+            $role->setDecoratorObject(
+                array(
+                    "revokeButton" => "",
+                    "revokeMessage" => getRevokeMessage(
+                        $user,
+                        $callingUser,
+                        $authorisingRoles
+                    )
+                )
+            );
         }
 
-        // Get the names of the parent project(s) for this role so we can
-        // group by project in the view
+        /**
+         * Get the names of the parent project(s) for this role so we can
+         * group by project in the view.
+         */
         $roleParentProjects = \Factory::getRoleActionAuthorisationService()
-            ->getReachableProjectsFromOwnedEntity($r->getOwnedEntity());
+                        ->getReachableProjectsFromOwnedEntity(
+                            $role->getOwnedEntity()
+                        );
+
         $projIds = array();
         foreach ($roleParentProjects as $proj) {
             $projIds[] = $proj->getId();
         }
 
-        // store role and parent projIds in a 2D array for viewing
-        $roleProjectIds[] = array($r, $projIds);
-    }// end iterating roles
-
-    // Get a list of the projects and their Ids for grouping roles by proj in view
-    $projectNamesIds = array();
-    $projects = \Factory::getProjectService()->getProjects();
-    foreach ($projects as $proj) {
-        $projectNamesIds[$proj->getId()] = $proj->getName();
+        // Store role and parent projIds in a 2D array for viewing.
+        $roleProjectIds[] = array($role, $projIds);
     }
 
-    // Check to see if the current calling user has permission to edit the target user
-    try {
-        $userService->editUserAuthorization($user, $callingUser);
-        $params['ShowEdit'] = true;
-    } catch (Exception $e) {
-        $params['ShowEdit'] = false;
-    }
+    return [$roleProjectIds];
+}
 
-    $params['idString'] = $userService->getDefaultIdString($user);
-    $params['projectNamesIds'] = $projectNamesIds;
-    $params['role_ProjIds'] = $roleProjectIds;
-    $params['portalIsReadOnly'] = \Factory::getConfigService()->IsPortalReadOnly();
-    $params['APIAuthEnts'] = $user->getAPIAuthenticationEntities();
-    $title = $user->getFullName();
-    show_view("user/view_user.php", $params, $title);
+/**
+ * Helper to generate a relevant message for viewing/calling user.
+ */
+function getRevokeMessage($individualUser, $viewingUser, $userRoles)
+{
+    $decoratorString = '';
+
+    if ($individualUser == $viewingUser) {
+        if ($viewingUser->isAdmin()) {
+            $decoratorString .= 'GOCDB_ADMIN';
+
+            if (count($userRoles) >= 1) {
+                $decoratorString .= ': ';
+            }
+        }
+        if (count($userRoles) >= 1) {
+            /** @var \Role $authRole */
+            $roleNames = array();
+            foreach ($userRoles as $authRole) {
+                $roleNames[] = $authRole->getRoleType()->getName();
+            }
+
+            $decoratorString .= '[' . implode(', ', $roleNames) . '] ';
+        }
+
+        return $decoratorString;
+    }
+    $decoratorString = '[Self revoke own role]';
+
+    return $decoratorString;
 }

--- a/htdocs/web_portal/controllers/user/view_user.php
+++ b/htdocs/web_portal/controllers/user/view_user.php
@@ -65,7 +65,8 @@ function view_user()
      */
     $params['projectNamesIds'] = $projectNamesIds;
     $params['role_ProjIds'] = $roleProjectIds;
-    $params['portalIsReadOnly'] = \Factory::getConfigService()->IsPortalReadOnly();
+    $params['portalIsReadOnly'] = \Factory::getConfigService()
+                                    ->IsPortalReadOnly();
     $params['APIAuthEnts'] = $user->getAPIAuthenticationEntities();
     $title = $user->getFullName();
 
@@ -179,7 +180,10 @@ function getRoleProjectIDs($user, $callingUser)
             $role->setDecoratorObject(
                 array(
                     "revokeButton" => "disabled",
-                    "revokeMessage" => implode(', ', array_keys($blockingSites))
+                    "revokeMessage" => implode(
+                        ', ',
+                        array_keys($blockingSites)
+                    )
                 )
             );
         } else {

--- a/htdocs/web_portal/css/web_portal.php
+++ b/htdocs/web_portal/css/web_portal.php
@@ -341,11 +341,11 @@ li {
     background-color: #D3D3D3;
 }
 
-.site_table_row_1 {
+.site_table_row_even {
     background-color: #D0E1F7;
 }
 
-.site_table_row_2 {
+.site_table_row_odd {
     background-color: #F5F5F5;
 }
 

--- a/htdocs/web_portal/javascript/service_group/add_ses_to_vsite.js
+++ b/htdocs/web_portal/javascript/service_group/add_ses_to_vsite.js
@@ -41,7 +41,7 @@ var resultsTable = {
 			addRow(colour, ses[i], table, plusCell(ses[i]));
 			// Swap the row colour
 			if (colour == "") {
-				colour = "1";
+				colour = "even";
 			} else {
 				colour = "";
 			}
@@ -163,7 +163,7 @@ function add(seId) {
 	var firstCell = crossCell(se);
 	addRow(selectedColour, se, table, firstCell, se.id);
 	if (selectedColour == "") {
-		selectedColour = "1";
+		selectedColour = "even";
 	} else {
 		selectedColour = "";
 	}

--- a/htdocs/web_portal/views/admin/users.php
+++ b/htdocs/web_portal/views/admin/users.php
@@ -78,18 +78,18 @@
         <img src="<?php echo \GocContextPath::getPath()?>img/user.png" class="decoration" />
         <?php if ($numUsers > 0): ?>
             <table class="vSiteResults" id="selectedSETable">
-                <tr class="site_table_row_1">
+                <tr class="site_table_row_even">
                     <th class="site_table">Name</th>
                     <th class="site_table">ID String</th>
                     <th class="site_table">GOCDB<br>Admin.?</th>
                 </tr>
                 <?php
-                $num = 2;
                 if ($numUsers > 0) {
-                foreach ($users as $user) {
+                    foreach ($users as $index => $user) {
                 ?>
                 <?php if ($user->isAdmin()) { $style = " style=\"background-color: #A3D7A3;\""; } else { $style = ""; } ?>
-                <tr class="site_table_row_<?php echo $num ?>" <?php echo $style ?>>
+                <tr class="site_table_row_<?php echo ($index % 2 == 0) ? 'odd' : 'even' ?>"
+                        <?php echo $style ?>>
                     <td class="site_table">
                         <div style="background-color: inherit;">
                             <span style="vertical-align: middle;">
@@ -142,7 +142,6 @@
 
                 </tr>
                 <?php
-                    if($num == 1) { $num = 2; } else { $num = 1; }
                     } // End of the foreach loop iterating over sites
                 }
                 ?>

--- a/htdocs/web_portal/views/admin/users.php
+++ b/htdocs/web_portal/views/admin/users.php
@@ -88,7 +88,10 @@
                     foreach ($users as $index => $user) {
                 ?>
                 <?php if ($user->isAdmin()) { $style = " style=\"background-color: #A3D7A3;\""; } else { $style = ""; } ?>
-                <tr class="site_table_row_<?php echo ($index % 2 == 0) ? 'odd' : 'even' ?>"
+                <tr
+                    class="site_table_row_<?php
+                        echo ($index % 2 == 0) ? 'odd' : 'even'
+                    ?>"
                         <?php echo $style ?>>
                     <td class="site_table">
                         <div style="background-color: inherit;">

--- a/htdocs/web_portal/views/admin/view_service_type.php
+++ b/htdocs/web_portal/views/admin/view_service_type.php
@@ -68,7 +68,7 @@ $portalIsReadOnly = $params['portalIsReadOnly'];
         <img src="<?php echo \GocContextPath::getPath()?>img/service.png" class="decoration" />
         <?php if ($SEsCount != 0) : ?>
             <table style="clear: both; width: 100%;">
-                <tr class="site_table_row_1">
+                <tr class="site_table_row_even">
                     <th class="site_table">Hostname</th>
                     <th class="site_table">Production</th>
                     <th class="site_table">Monitored</th>
@@ -76,12 +76,12 @@ $portalIsReadOnly = $params['portalIsReadOnly'];
                 </tr>
 
 
-                <?php $num = 2;
+                <?php
 
-                foreach ($services as $se) {
+                foreach ($services as $index => $se) {
                     ?>
 
-                    <tr class="site_table_row_<?php echo $num ?>">
+                    <tr class="site_table_row_<?php echo ($index % 2 == 0) ? 'odd' : 'even' ?>">
                         <td class="site_table">
                             <div style="background-color: inherit;">
                                 <img src="<?php echo \GocContextPath::getPath()?>img/server.png" class="decoration" />
@@ -137,11 +137,6 @@ $portalIsReadOnly = $params['portalIsReadOnly'];
                         </td>
                     </tr>
                     <?php
-                    if ($num == 1) {
-                        $num = 2;
-                    } else {
-                        $num = 1;
-                    }
                 } // End of the foreach loop iterating over SEs
                 ?>
 

--- a/htdocs/web_portal/views/admin/view_service_type.php
+++ b/htdocs/web_portal/views/admin/view_service_type.php
@@ -81,7 +81,10 @@ $portalIsReadOnly = $params['portalIsReadOnly'];
                 foreach ($services as $index => $se) {
                     ?>
 
-                    <tr class="site_table_row_<?php echo ($index % 2 == 0) ? 'odd' : 'even' ?>">
+                    <tr
+                        class="site_table_row_<?php
+                            echo ($index % 2 == 0) ? 'odd' : 'even' ?>"
+                    >
                         <td class="site_table">
                             <div style="background-color: inherit;">
                                 <img src="<?php echo \GocContextPath::getPath()?>img/server.png" class="decoration" />

--- a/htdocs/web_portal/views/admin/view_service_types.php
+++ b/htdocs/web_portal/views/admin/view_service_types.php
@@ -30,17 +30,16 @@
             }?>
         </span>
         <table class="vSiteResults" id="selectedSETable">
-            <tr class="site_table_row_1">
+            <tr class="site_table_row_even">
                 <th class="site_table">Name</th>
                 <th class="site_table">Services</th>
                 <th class="site_table">Description</th>
             </tr>
             <?php
-            $num = 2;
             if ($numberOfServiceTypes > 0) {
-                foreach ($params['ServiceTypes'] as $serviceType) {
+                foreach ($params['ServiceTypes'] as $index => $serviceType) {
                     ?>
-                <tr class="site_table_row_<?php echo $num ?>">
+                <tr class="site_table_row_<?php echo ($index % 2 == 0) ? 'odd' : 'even' ?>">
                     <td class="site_table" style="width: 30%">
                         <div style="background-color: inherit;">
                             <span style="vertical-align: middle;">
@@ -60,11 +59,6 @@
                     </td>
                 </tr>
                     <?php
-                    if ($num == 1) {
-                        $num = 2;
-                    } else {
-                        $num = 1;
-                    }
                 } // End of the foreach loop iterating over service types
             }
             ?>

--- a/htdocs/web_portal/views/admin/view_service_types.php
+++ b/htdocs/web_portal/views/admin/view_service_types.php
@@ -39,7 +39,10 @@
             if ($numberOfServiceTypes > 0) {
                 foreach ($params['ServiceTypes'] as $index => $serviceType) {
                     ?>
-                <tr class="site_table_row_<?php echo ($index % 2 == 0) ? 'odd' : 'even' ?>">
+                <tr
+                    class="site_table_row_<?php
+                        echo ($index % 2 == 0) ? 'odd' : 'even'?>"
+                >
                     <td class="site_table" style="width: 30%">
                         <div style="background-color: inherit;">
                             <span style="vertical-align: middle;">

--- a/htdocs/web_portal/views/downtime/downtimes_overview.php
+++ b/htdocs/web_portal/views/downtime/downtimes_overview.php
@@ -85,7 +85,8 @@ javascript to show and hide these tables.
                     //There is dynamic creation of table ids here which are used to show and hide the extra services info
                     //when clicked. This sub table by default is hidden
                     echo '</tr>';
-                    echo '<tr class="site_table_row_even"><td colspan="8" style="padding-left:2em">';
+                    echo '<tr class="site_table_row_even">';
+                    echo '<td colspan="8" style="padding-left:2em">';
                     echo '<a href="#a'.$count.'" onclick="showHide(\'tablea_'.$count.'\');toggleMessage(\'diva_'.$count.'\');"/><div id="diva_'.$count.'">+Show Affected Services</div></a>';
                     echo '<table name="a'.$count.'" id="tablea_'.$count.'" style="clear: both; width: 100%; display:none;">';
                     echo '<tr class="site_table_row_even">';
@@ -180,7 +181,8 @@ javascript to show and hide these tables.
                     //There is dynamic creation of table ids here which are used to show and hide the extra services info
                     //when clicked. This sub table by default is hidden
                     echo '</tr>';
-                    echo '<tr class="site_table_row_even"><td colspan="8" style="padding-left:2em">';
+                    echo '<tr class="site_table_row_even">';
+                    echo '<td colspan="8" style="padding-left:2em">';
                     echo '<a href="#b'.$count.'" onclick="showHide(\'tablei_'.$count.'\');toggleMessage(\'divi_'.$count.'\');"/><div id="divi_'.$count.'">+Show Affected Services</div></a>';
                     echo '<table name="b'.$count.'" id="tablei_'.$count.'" style="clear: both; width: 100%; display:none;">';
                     echo '<tr class="site_table_row_even">';

--- a/htdocs/web_portal/views/downtime/downtimes_overview.php
+++ b/htdocs/web_portal/views/downtime/downtimes_overview.php
@@ -38,7 +38,7 @@ javascript to show and hide these tables.
             <span class="header" style="vertical-align:middle; float: left; padding-top: 0.9em; padding-left: 1em;">Currently Active Downtimes</span>
             <img src="<?php echo \GocContextPath::getPath()?>img/service.png" class="decoration"/>
             <table style="clear: both; width: 100%;">
-                <tr class="site_table_row_1">
+                <tr class="site_table_row_even">
                     <th class="site_table">Downtime Id</th>
                     <th class="site_table">Site</th>
                     <th class="site_table">Description</th>
@@ -52,7 +52,7 @@ javascript to show and hide these tables.
                 <?php
                 $count = 0;
                 foreach($dtActive as $dt){
-                    echo '<tr class="site_table_row_2">';
+                    echo '<tr class="site_table_row_odd">';
 
                     $affectedServices = $dt->getServices();
                     $affectedEPs = count($affectedServices);
@@ -85,17 +85,17 @@ javascript to show and hide these tables.
                     //There is dynamic creation of table ids here which are used to show and hide the extra services info
                     //when clicked. This sub table by default is hidden
                     echo '</tr>';
-                    echo '<tr class="site_table_row_1"><td colspan="8" style="padding-left:2em">';
+                    echo '<tr class="site_table_row_even"><td colspan="8" style="padding-left:2em">';
                     echo '<a href="#a'.$count.'" onclick="showHide(\'tablea_'.$count.'\');toggleMessage(\'diva_'.$count.'\');"/><div id="diva_'.$count.'">+Show Affected Services</div></a>';
                     echo '<table name="a'.$count.'" id="tablea_'.$count.'" style="clear: both; width: 100%; display:none;">';
-                    echo '<tr class="site_table_row_1">';
+                    echo '<tr class="site_table_row_even">';
                     echo '<th class="site_table">Sitename</th>';
                     echo '<th class="site_table">Hostname</th>';
                     echo '<th class="site_table">Production</th>';
                     echo '<th class="site_table">Monitored</th>';
 
                     foreach($dt->getServices() as $se){
-                        echo '<tr class="site_table_row_2">';
+                        echo '<tr class="site_table_row_odd">';
                         $sID = $se->getParentSite()->getId();
                         echo $td1np . '<a href="index.php?Page_Type=Site&amp;id='.$sID.'"/>'.xssafe($se->getParentSite()->getName()).'</a>'.$td2;
                         echo $td1np . '<a href="index.php?Page_Type=Service&amp;id='.$se->getId().'"/>'.xssafe($se->getHostName()).'</a>'.$td2;
@@ -133,7 +133,7 @@ javascript to show and hide these tables.
             </form>
             </div>
             <table style="clear: both; width: 100%;">
-                <tr class="site_table_row_1">
+                <tr class="site_table_row_even">
                     <th class="site_table">Downtime Id</th>
                     <th class="site_table">Site</th>
                     <th class="site_table">Description</th>
@@ -147,7 +147,7 @@ javascript to show and hide these tables.
                 <?php
                 $count = 0;
                 foreach($dtImmenent as $dt){
-                    echo '<tr class="site_table_row_2">';
+                    echo '<tr class="site_table_row_odd">';
 
                     $affectedServices = $dt->getServices();
                     $affectedEPs = count($affectedServices);
@@ -180,17 +180,17 @@ javascript to show and hide these tables.
                     //There is dynamic creation of table ids here which are used to show and hide the extra services info
                     //when clicked. This sub table by default is hidden
                     echo '</tr>';
-                    echo '<tr class="site_table_row_1"><td colspan="8" style="padding-left:2em">';
+                    echo '<tr class="site_table_row_even"><td colspan="8" style="padding-left:2em">';
                     echo '<a href="#b'.$count.'" onclick="showHide(\'tablei_'.$count.'\');toggleMessage(\'divi_'.$count.'\');"/><div id="divi_'.$count.'">+Show Affected Services</div></a>';
                     echo '<table name="b'.$count.'" id="tablei_'.$count.'" style="clear: both; width: 100%; display:none;">';
-                    echo '<tr class="site_table_row_1">';
+                    echo '<tr class="site_table_row_even">';
                     echo '<th class="site_table">Sitename</th>';
                     echo '<th class="site_table">Hostname</th>';
                     echo '<th class="site_table">Production</th>';
                     echo '<th class="site_table">Monitored</th>';
 
                     foreach($dt->getServices() as $se){
-                        echo '<tr class="site_table_row_2">';
+                        echo '<tr class="site_table_row_odd">';
                         $sID = $se->getParentSite()->getId();
                         echo $td1np . '<a href="index.php?Page_Type=Site&amp;id='.$sID.'"/>'.xssafe($se->getParentSite()->getName()).'</a>'.$td2;
                         echo $td1np . '<a href="index.php?Page_Type=Service&amp;id='.$se->getId().'"/>'.xssafe($se->getHostName()).'</a>'.$td2;

--- a/htdocs/web_portal/views/downtime/view_downtime.php
+++ b/htdocs/web_portal/views/downtime/view_downtime.php
@@ -51,7 +51,7 @@ $dt = $params['downtime'];
                     </span>
                     <img src="<?php echo \GocContextPath::getPath()?>img/star.png" class="decoration">
                     <table style="clear: both; width: 100%; table-layout: fixed;">
-                        <tr class="site_table_row_1">
+                        <tr class="site_table_row_even">
                             <td class="site_table" style="width: 30%">
                                 <script type="text/javascript">
                                     function submitform()
@@ -78,12 +78,12 @@ $dt = $params['downtime'];
                 <span class="header" style="vertical-align:middle; float: left; padding-top: 0.9em; padding-left: 1em;">Information</span>
                 <img src="<?php echo \GocContextPath::getPath()?>img/contact_card.png" class="decoration" />
                 <table style="clear: both; width: 100%;">
-                    <tr class="site_table_row_2">
+                    <tr class="site_table_row_odd">
                         <td class="site_table">Severity</td><td class="site_table">
                         <?php xecho($dt->getSeverity()) ?></td>
                     </tr>
 
-                    <tr class="site_table_row_1">
+                    <tr class="site_table_row_even">
                         <td class="site_table">Classification</td><td class="site_table">
                             <?php xecho($dt->getClassification()) ?>
                         </td>
@@ -96,25 +96,25 @@ $dt = $params['downtime'];
                 <span class="header" style="vertical-align:middle; float: left; padding-top: 0.9em; padding-left: 1em;">Timing (UTC)</span>
                 <img src="<?php echo \GocContextPath::getPath()?>img/clock.png" class="decoration" />
                 <table style="clear: both; width: 100%;">
-                    <tr class="site_table_row_1">
+                    <tr class="site_table_row_even">
                         <td class="site_table">Start Date</td><td class="site_table">
                             <?php echo $dt->getStartDate()->format($dt::DATE_FORMAT) ?>
                         </td>
                     </tr>
 
-                    <tr class="site_table_row_2">
+                    <tr class="site_table_row_odd">
                         <td class="site_table">End Date</td><td class="site_table">
                             <?php echo $dt->getEndDate()->format($dt::DATE_FORMAT) ?>
                         </td>
                     </tr>
 
-                    <tr class="site_table_row_1">
+                    <tr class="site_table_row_even">
                         <td class="site_table">Declaration Date</td><td class="site_table">
                             <?php echo $dt->getInsertDate()->format($dt::DATE_FORMAT) ?>
                         </td>
                     </tr>
 
-                    <tr class="site_table_row_2">
+                    <tr class="site_table_row_odd">
                         <td class="site_table">Announcement Date</td><td class="site_table">
                             <?php
                                 echo $dt->getAnnounceDate()->format($dt::DATE_FORMAT);
@@ -133,7 +133,7 @@ $dt = $params['downtime'];
             </span>
             <img src="<?php echo \GocContextPath::getPath()?>img/service.png" class="decoration" />
             <table style="clear: both; width: 100%;">
-                <tr class="site_table_row_1">
+                <tr class="site_table_row_even">
                     <th class="site_table">Service Hostname (service type)</th>
                     <th class="site_table">Description</th>
                     <th class="site_table">Production</th>
@@ -141,8 +141,7 @@ $dt = $params['downtime'];
                 </tr>
 
                 <?php
-                $num = 2;
-                foreach($dt->getServices() as $se) {
+                foreach ($dt->getServices() as $index => $se) {
                     $alreadyRenderedSE = array();
 
                     if(in_array($se->getId(), $alreadyRenderedSE)){
@@ -152,7 +151,7 @@ $dt = $params['downtime'];
                     }
                 ?>
 
-                <tr class="site_table_row_<?php echo $num ?>">
+                <tr class="site_table_row_<?php echo ($index % 2 == 0) ? 'odd' : 'even' ?>">
                     <td class="site_table" style="width: 35%">
                         <div style="background-color: inherit;">
                             <span style="vertical-align: middle;">
@@ -184,7 +183,7 @@ $dt = $params['downtime'];
                     </td>
                 </tr>
                 <!--&rdsh; -->
-                <tr class="affectedendpointsrow site_table_row_<?php echo $num ?>">
+                <tr class="affectedendpointsrow site_table_row_<?php echo ($index % 2 == 0) ? 'odd' : 'even' ?>">
                     <td class="site_table" colspan="4" style="padding-left:5em">
                         <table class="site_table" style="width: 100%; border: solid #D5D5D5 thin">
                             <tr>
@@ -212,7 +211,6 @@ $dt = $params['downtime'];
                 </tr>
 
                 <?php
-                    if($num == 1) { $num = 2; } else { $num = 1; }
                 } // End of the foreach loop iterating over SEs
                 ?>
             </table>

--- a/htdocs/web_portal/views/downtime/view_downtime.php
+++ b/htdocs/web_portal/views/downtime/view_downtime.php
@@ -151,7 +151,10 @@ $dt = $params['downtime'];
                     }
                 ?>
 
-                <tr class="site_table_row_<?php echo ($index % 2 == 0) ? 'odd' : 'even' ?>">
+                <tr
+                    class="site_table_row_<?php
+                        echo ($index % 2 == 0) ? 'odd' : 'even' ?>"
+                >
                     <td class="site_table" style="width: 35%">
                         <div style="background-color: inherit;">
                             <span style="vertical-align: middle;">
@@ -183,7 +186,10 @@ $dt = $params['downtime'];
                     </td>
                 </tr>
                 <!--&rdsh; -->
-                <tr class="affectedendpointsrow site_table_row_<?php echo ($index % 2 == 0) ? 'odd' : 'even' ?>">
+                <tr
+                    class="affectedendpointsrow site_table_row_<?php
+                        echo ($index % 2 == 0) ? 'odd' : 'even' ?>"
+                >
                     <td class="site_table" colspan="4" style="padding-left:5em">
                         <table class="site_table" style="width: 100%; border: solid #D5D5D5 thin">
                             <tr>

--- a/htdocs/web_portal/views/my_sites.php
+++ b/htdocs/web_portal/views/my_sites.php
@@ -19,14 +19,13 @@
             <img src="<?php echo \GocContextPath::getPath()?>img/site.png" class="titleIcon"/>
             <table style="clear: both; width: 100%; table-layout: fixed;">
                 <?php if(!empty($params['sites_from_roles'])) {
-                        $num = 1;
-                        foreach($params['sites_from_roles'] as $site) { ?>
-                        <tr class="site_table_row_<?php echo $num ?>">
+                    foreach ($params['sites_from_roles'] as $index => $site) { ?>
+                        <tr class="site_table_row_<?php echo ($index % 2 == 0) ? 'even' : 'odd' ?>">
                             <td class="site_table">
                                 <a href="index.php?Page_Type=Site&amp;id=<?php echo $site->getId()?>"><?php xecho($site->getShortName()) ?></a>
                             </td>
                         </tr>
-                        <?php if($num == 1) { $num = 2; } else { $num = 1; } } ?>
+                    <?php } ?>
 
                 <?php }?>
             </table>
@@ -38,14 +37,14 @@
             <img src="<?php echo \GocContextPath::getPath()?>img/ngi.png" class="titleIcon"/>
             <table style="clear: both; width: 100%; table-layout: fixed;">
                 <?php if(!empty($params['ngis_from_roles'])) {
-                        $num = 1;
-                        foreach($params['ngis_from_roles'] as $ngi) { ?>
-                        <tr class="site_table_row_<?php echo $num ?>">
+                    foreach ($params['ngis_from_roles'] as $index => $ngi) { ?>
+                        <tr class="site_table_row_<?php
+                            echo ($index % 2 == 0) ? 'even' : 'odd' ?>">
                             <td class="site_table">
                                 <a href="index.php?Page_Type=NGI&amp;id=<?php echo $ngi->getId()?>"><?php xecho($ngi->getName())?></a>
                             </td>
                         </tr>
-                        <?php if($num == 1) { $num = 2; } else { $num = 1; } } ?>
+                    <?php } ?>
 
                 <?php } ?>
             </table>
@@ -60,14 +59,14 @@
             <img src="<?php echo \GocContextPath::getPath()?>img/virtualSite.png" class="titleIcon"/>
             <table style="clear: both; width: 100%; table-layout: fixed;">
                 <?php if(!empty($params['sgroups_from_roles'])) {
-                        $num = 1;
-                        foreach($params['sgroups_from_roles'] as $sg) { ?>
-                        <tr class="site_table_row_<?php echo $num ?>">
+                    foreach ($params['sgroups_from_roles'] as $index => $sg) { ?>
+                        <tr class="site_table_row_<?php
+                            echo ($index % 2 == 0) ? 'even' : 'odd' ?>">
                             <td class="site_table">
                                 <a href="index.php?Page_Type=Service_Group&amp;id=<?php echo $sg->getId()?>"><?php xecho($sg->getName())?></a>
                             </td>
                         </tr>
-                        <?php if($num == 1) { $num = 2; } else { $num = 1; } } ?>
+                    <?php } ?>
 
                 <?php }?>
             </table>
@@ -79,14 +78,14 @@
             <img src="<?php echo \GocContextPath::getPath()?>img/project.png" class="titleIcon"/>
             <table style="clear: both; width: 100%; table-layout: fixed;">
                 <?php if(!empty($params['projects_from_roles'])) {
-                        $num = 1;
-                        foreach($params['projects_from_roles'] as $project) { ?>
-                        <tr class="site_table_row_<?php echo $num ?>">
+                    foreach ($params['projects_from_roles'] as $index => $project) { ?>
+                        <tr class="site_table_row_<?php
+                            echo ($index % 2 == 0) ? 'even' : 'odd' ?>">
                             <td class="site_table">
                                 <a href="index.php?Page_Type=Project&amp;id=<?php echo $project->getId()?>"><?php xecho($project->getName())?></a>
                             </td>
                         </tr>
-                        <?php if($num == 1) { $num = 2; } else { $num = 1; } } ?>
+                    <?php } ?>
 
                 <?php } ?>
             </table>

--- a/htdocs/web_portal/views/my_sites.php
+++ b/htdocs/web_portal/views/my_sites.php
@@ -19,8 +19,13 @@
             <img src="<?php echo \GocContextPath::getPath()?>img/site.png" class="titleIcon"/>
             <table style="clear: both; width: 100%; table-layout: fixed;">
                 <?php if(!empty($params['sites_from_roles'])) {
-                    foreach ($params['sites_from_roles'] as $index => $site) { ?>
-                        <tr class="site_table_row_<?php echo ($index % 2 == 0) ? 'even' : 'odd' ?>">
+                    foreach (
+                        $params['sites_from_roles'] as $index => $site
+                    ) { ?>
+                        <tr
+                            class="site_table_row_<?php
+                                echo ($index % 2 == 0) ? 'even' : 'odd' ?>"
+                        >
                             <td class="site_table">
                                 <a href="index.php?Page_Type=Site&amp;id=<?php echo $site->getId()?>"><?php xecho($site->getShortName()) ?></a>
                             </td>
@@ -37,9 +42,13 @@
             <img src="<?php echo \GocContextPath::getPath()?>img/ngi.png" class="titleIcon"/>
             <table style="clear: both; width: 100%; table-layout: fixed;">
                 <?php if(!empty($params['ngis_from_roles'])) {
-                    foreach ($params['ngis_from_roles'] as $index => $ngi) { ?>
-                        <tr class="site_table_row_<?php
-                            echo ($index % 2 == 0) ? 'even' : 'odd' ?>">
+                    foreach (
+                        $params['ngis_from_roles'] as $index => $ngi
+                    ) { ?>
+                        <tr
+                            class="site_table_row_<?php
+                                echo ($index % 2 == 0) ? 'even' : 'odd' ?>"
+                        >
                             <td class="site_table">
                                 <a href="index.php?Page_Type=NGI&amp;id=<?php echo $ngi->getId()?>"><?php xecho($ngi->getName())?></a>
                             </td>
@@ -59,9 +68,13 @@
             <img src="<?php echo \GocContextPath::getPath()?>img/virtualSite.png" class="titleIcon"/>
             <table style="clear: both; width: 100%; table-layout: fixed;">
                 <?php if(!empty($params['sgroups_from_roles'])) {
-                    foreach ($params['sgroups_from_roles'] as $index => $sg) { ?>
-                        <tr class="site_table_row_<?php
-                            echo ($index % 2 == 0) ? 'even' : 'odd' ?>">
+                    foreach (
+                        $params['sgroups_from_roles'] as $index => $sg
+                    ) { ?>
+                        <tr
+                            class="site_table_row_<?php
+                                echo ($index % 2 == 0) ? 'even' : 'odd' ?>"
+                        >
                             <td class="site_table">
                                 <a href="index.php?Page_Type=Service_Group&amp;id=<?php echo $sg->getId()?>"><?php xecho($sg->getName())?></a>
                             </td>
@@ -78,9 +91,13 @@
             <img src="<?php echo \GocContextPath::getPath()?>img/project.png" class="titleIcon"/>
             <table style="clear: both; width: 100%; table-layout: fixed;">
                 <?php if(!empty($params['projects_from_roles'])) {
-                    foreach ($params['projects_from_roles'] as $index => $project) { ?>
-                        <tr class="site_table_row_<?php
-                            echo ($index % 2 == 0) ? 'even' : 'odd' ?>">
+                    foreach (
+                        $params['projects_from_roles'] as $index => $project
+                    ) { ?>
+                        <tr
+                            class="site_table_row_<?php
+                                echo ($index % 2 == 0) ? 'even' : 'odd' ?>"
+                        >
                             <td class="site_table">
                                 <a href="index.php?Page_Type=Project&amp;id=<?php echo $project->getId()?>"><?php xecho($project->getName())?></a>
                             </td>

--- a/htdocs/web_portal/views/ngi/view_ngi.php
+++ b/htdocs/web_portal/views/ngi/view_ngi.php
@@ -104,9 +104,13 @@
             <img src="<?php echo \GocContextPath::getPath()?>img/project.png" class="titleIcon"/>
             <table style="clear: both; width: 100%; table-layout: fixed;">
                 <?php if(!empty($params['Projects'])) {
-                    foreach ($params['Projects'] as $index => $project) { ?>
-                        <tr class="site_table_row_<?php
-                            echo ($index % 2 == 0) ? 'even' : 'odd' ?>">
+                    foreach (
+                        $params['Projects'] as $index => $project
+                    ) { ?>
+                        <tr
+                            class="site_table_row_<?php
+                                echo ($index % 2 == 0) ? 'even' : 'odd' ?>"
+                        >
                             <td class="site_table">
                                 <a href="index.php?Page_Type=Project&amp;id=<?php echo $project->getId()?>"><?php xecho($project->getName())?></a>
                             </td>

--- a/htdocs/web_portal/views/ngi/view_ngi.php
+++ b/htdocs/web_portal/views/ngi/view_ngi.php
@@ -52,7 +52,7 @@
             <span class="header" style="vertical-align:middle; float: left; padding-top: 0.9em; padding-left: 1em;">Contacts</span>
             <img src="<?php echo \GocContextPath::getPath()?>img/contact_card.png" class="titleIcon"/>
                 <table style="clear: both; width: 100%; table-layout: fixed;">
-                    <tr class="site_table_row_1">
+                    <tr class="site_table_row_even">
                         <td class="site_table" style="width: 30%">E-Mail</td><td class="site_table">
                             <?php if($showPD) { ?>
                             <a href="mailto:<?php xecho($params['ngi']->getEmail()) ?>">
@@ -61,7 +61,7 @@
                             <?php } else {echo(getInfoMessage());} ?>
                         </td>
                     </tr>
-                    <tr class="site_table_row_2">
+                    <tr class="site_table_row_odd">
                         <td class="site_table" style="width: 30%">ROD E-Mail</td><td class="site_table">
                             <?php if($showPD) { ?>
                             <a href="mailto:<?php xecho($params['ngi']->getRodEmail()) ?>">
@@ -70,7 +70,7 @@
                             <?php } else {echo(getInfoMessage());} ?>
                         </td>
                     </tr>
-                    <tr class="site_table_row_1">
+                    <tr class="site_table_row_even">
                         <td class="site_table" style="width: 30%">Helpdesk E-Mail</td><td class="site_table">
                             <?php if($showPD) { ?>
                             <a href="mailto:<?php xecho($params['ngi']->getHelpdeskEmail()) ;?>">
@@ -79,7 +79,7 @@
                             <?php } else {echo(getInfoMessage());} ?>
                         </td>
                     </tr>
-                    <tr class="site_table_row_2">
+                    <tr class="site_table_row_odd">
                         <td class="site_table" style="width: 30%">Security E-Mail</td><td class="site_table">
                             <?php if($showPD) { ?>
                             <a href="mailto:<?php echo $params['ngi']->getSecurityEmail() ?>">
@@ -88,7 +88,7 @@
                             <?php } else {echo(getInfoMessage());} ?>
                         </td>
                     </tr>
-                    <tr class="site_table_row_1">
+                    <tr class="site_table_row_even">
                         <td class="site_table" style="width: 30%">GGUS Support Unit</td><td class="site_table">
                             <?php if($showPD) { ?>
                             <?php xecho($params['ngi']->getGgus_Su()) ?>
@@ -104,14 +104,14 @@
             <img src="<?php echo \GocContextPath::getPath()?>img/project.png" class="titleIcon"/>
             <table style="clear: both; width: 100%; table-layout: fixed;">
                 <?php if(!empty($params['Projects'])) {
-                        $num = 1;
-                        foreach($params['Projects'] as $project) { ?>
-                        <tr class="site_table_row_<?php echo $num ?>">
+                    foreach ($params['Projects'] as $index => $project) { ?>
+                        <tr class="site_table_row_<?php
+                            echo ($index % 2 == 0) ? 'even' : 'odd' ?>">
                             <td class="site_table">
                                 <a href="index.php?Page_Type=Project&amp;id=<?php echo $project->getId()?>"><?php xecho($project->getName())?></a>
                             </td>
                         </tr>
-                        <?php if($num == 1) { $num = 2; } else { $num = 1; } } ?>
+                    <?php } ?>
 
                 <?php } ?>
             </table>
@@ -124,7 +124,7 @@
             </span>
             <table style="clear: both; width: 100%; table-layout: fixed;">
 
-                        <tr class="site_table_row_1">
+                        <tr class="site_table_row_even">
                             <td class="site_table" >
                                 <textarea readonly="true" style="width: 100%; height: 60px;"><?php xecho($params['ngi']->getScopeNamesAsString()); ?></textarea>
                             </td>

--- a/htdocs/web_portal/views/political_role/view_requests.php
+++ b/htdocs/web_portal/views/political_role/view_requests.php
@@ -78,7 +78,10 @@
                 if(sizeof($params['myRequests'] > 0)) {
                     foreach ($params['myRequests'] as $index => $request) {
                 ?>
-                <tr class="site_table_row_<?php echo ($index % 2 == 0) ? 'odd' : 'even' ?>">
+                <tr
+                    class="site_table_row_<?php
+                        echo ($index % 2 == 0) ? 'odd' : 'even' ?>"
+                >
                     <td class="site_table" style="width: 50%">
                        <?php xecho($request->getRoleType()->getName())/*.' ['.$request->getId().']'*/?>
                     </td>
@@ -145,7 +148,10 @@
                 if(sizeof($params['allRequests'] > 0)) {
                     foreach ($params['allRequests'] as $index => $request) {
                 ?>
-                <tr class="site_table_row_<?php echo ($index % 2 == 0) ? 'odd' : 'even' ?>">
+                <tr
+                    class="site_table_row_<?php
+                        echo ($index % 2 == 0) ? 'odd' : 'even' ?>"
+                >
                     <td class="site_table">
                        <?php
                          $requestingUser = $request->getUser();

--- a/htdocs/web_portal/views/political_role/view_requests.php
+++ b/htdocs/web_portal/views/political_role/view_requests.php
@@ -66,7 +66,7 @@
             </span>
             <img src="<?php echo \GocContextPath::getPath()?>img/user.png" class="decoration" />
             <table class="vSiteResults" id="selectedSETable">
-                <tr class="site_table_row_1">
+                <tr class="site_table_row_even">
                     <th class="site_table">Role Request</th>
                     <th class="site_table">Target Entity</th>
                     <!-- Do not show delte request when portal is read only -->
@@ -75,11 +75,10 @@
                     <?php endif; ?>
                 </tr>
                 <?php
-                $num = 2;
                 if(sizeof($params['myRequests'] > 0)) {
-                foreach($params['myRequests'] as $request) {
+                    foreach ($params['myRequests'] as $index => $request) {
                 ?>
-                <tr class="site_table_row_<?php echo $num ?>">
+                <tr class="site_table_row_<?php echo ($index % 2 == 0) ? 'odd' : 'even' ?>">
                     <td class="site_table" style="width: 50%">
                        <?php xecho($request->getRoleType()->getName())/*.' ['.$request->getId().']'*/?>
                     </td>
@@ -133,7 +132,7 @@
             </span>
             <img src="<?php echo \GocContextPath::getPath()?>img/user.png" class="decoration" />
             <table class="vSiteResults" id="selectedSETable">
-                <tr class="site_table_row_1">
+                <tr class="site_table_row_even">
                     <th class="site_table">Requestor</th>
                     <th class="site_table">Role Request Type</th>
                     <th class="site_table">Target Entity</th>
@@ -143,11 +142,10 @@
                     <?php endif; ?>
                 </tr>
                 <?php
-                $num = 2;
                 if(sizeof($params['allRequests'] > 0)) {
-                foreach($params['allRequests'] as $request) {
+                    foreach ($params['allRequests'] as $index => $request) {
                 ?>
-                <tr class="site_table_row_<?php echo $num ?>">
+                <tr class="site_table_row_<?php echo ($index % 2 == 0) ? 'odd' : 'even' ?>">
                     <td class="site_table">
                        <?php
                          $requestingUser = $request->getUser();

--- a/htdocs/web_portal/views/scope.php
+++ b/htdocs/web_portal/views/scope.php
@@ -73,18 +73,17 @@ $totalCount = $siteCount + $ngiCount + $serviceCount +$serviceGroupsCount;
 
         <?php if ($ngiCount != 0): ?>
             <table style="clear: both; width: 100%;">
-                <tr class="site_table_row_1">
+                <tr class="site_table_row_even">
                     <th class="site_table">Name</th>
                     <th class="site_table">Description</th>
                 </tr>
 
                 <?php
-                $num = 2;
 
-                foreach($params['NGIs'] as $ngi) {
+                foreach ($params['NGIs'] as $index => $ngi) {
                 ?>
 
-                <tr class="site_table_row_<?php echo $num ?>">
+                <tr class="site_table_row_<?php echo ($index % 2 == 0) ? 'odd' : 'even' ?>">
                     <td class="site_table">
                         <div style="background-color: inherit;">
                             <span style="vertical-align: middle;">
@@ -99,7 +98,6 @@ $totalCount = $siteCount + $ngiCount + $serviceCount +$serviceGroupsCount;
 
                 </tr>
                 <?php
-                    if($num == 1) { $num = 2; } else { $num = 1; }
                 } // End of the foreach loop iterating over SEs
                 ?>
             </table>
@@ -114,17 +112,16 @@ $totalCount = $siteCount + $ngiCount + $serviceCount +$serviceGroupsCount;
         <img src="<?php echo \GocContextPath::getPath()?>img/site.png" class="decoration" />
         <?php if($siteCount > 0): ?>
             <table class="vSiteResults" id="selectedSETable">
-                <tr class="site_table_row_1">
+                <tr class="site_table_row_even">
                     <th class="site_table">Name</th>
                     <th class="site_table">Certification Status</th>
                     <th class="site_table">Production Status</th>
                 </tr>
                 <?php
-                $num = 2;
 
-                foreach($params['Sites'] as $site) {
+                foreach ($params['Sites'] as $index => $site) {
                 ?>
-                <tr class="site_table_row_<?php echo $num ?>">
+                <tr class="site_table_row_<?php echo ($index % 2 == 0) ? 'odd' : 'even' ?>">
                     <td class="site_table" style="width: 30%">
                         <div style="background-color: inherit;">
                             <span style="vertical-align: middle;">
@@ -143,7 +140,7 @@ $totalCount = $siteCount + $ngiCount + $serviceCount +$serviceGroupsCount;
                         <?php xecho($site->getInfrastructure()->getName()) ?>
                     </td>
                 </tr>
-                <?php if($num == 1) { $num = 2; } else { $num = 1; }}?>
+                <?php } ?>
             </table>
         <?php endif;?>
     </div>
@@ -156,16 +153,16 @@ $totalCount = $siteCount + $ngiCount + $serviceCount +$serviceGroupsCount;
         <img src="<?php echo \GocContextPath::getPath()?>img/virtualSite.png" class="decoration" />
         <?php if($serviceGroupsCount>0): ?>
             <table class="vSiteResults" id="selectedSETable">
-                <tr class="site_table_row_1">
+                <tr class="site_table_row_even">
                     <th class="site_table">Name</th>
                     <th class="site_table">Description</th>
                 </tr>
                 <?php
-                $num = 2;
-                foreach($serviceGroups as $sGroup) {
+                foreach ($serviceGroups as $index => $sGroup) {
                 ?>
                 <?php if($sGroup->getScopes()->first()->getName() == "Local") { $style = " style=\"background-color: #A3D7A3;\""; } else { $style = ""; } ?>
-                <tr class="site_table_row_<?php echo $num ?>" <?php echo $style ?>>
+                <tr class="site_table_row_<?php echo ($index % 2 == 0) ? 'odd' : 'even' ?>"
+                    <?php echo $style ?>>
                     <td class="site_table">
                         <div style="background-color: inherit;">
                             <span style="vertical-align: middle;">
@@ -182,7 +179,6 @@ $totalCount = $siteCount + $ngiCount + $serviceCount +$serviceGroupsCount;
 
                 </tr>
                 <?php
-                    if($num == 1) { $num = 2; } else { $num = 1; }
                     } // End of the foreach loop iterating over SEs
                 ?>
             </table>
@@ -197,7 +193,7 @@ $totalCount = $siteCount + $ngiCount + $serviceCount +$serviceGroupsCount;
         <img src="<?php echo \GocContextPath::getPath()?>img/service.png" class="decoration" />
         <?php if($serviceCount>0): ?>
             <table class="vSiteResults" id="selectedSETable">
-                <tr class="site_table_row_1">
+                <tr class="site_table_row_even">
                     <td class="site_table">
                         <a href="index.php?Page_Type=Services&amp;mscope[]=<?php xecho($name)?>">
                             View Services

--- a/htdocs/web_portal/views/scope.php
+++ b/htdocs/web_portal/views/scope.php
@@ -83,7 +83,10 @@ $totalCount = $siteCount + $ngiCount + $serviceCount +$serviceGroupsCount;
                 foreach ($params['NGIs'] as $index => $ngi) {
                 ?>
 
-                <tr class="site_table_row_<?php echo ($index % 2 == 0) ? 'odd' : 'even' ?>">
+                <tr
+                    class="site_table_row_<?php
+                        echo ($index % 2 == 0) ? 'odd' : 'even' ?>"
+                >
                     <td class="site_table">
                         <div style="background-color: inherit;">
                             <span style="vertical-align: middle;">
@@ -121,7 +124,10 @@ $totalCount = $siteCount + $ngiCount + $serviceCount +$serviceGroupsCount;
 
                 foreach ($params['Sites'] as $index => $site) {
                 ?>
-                <tr class="site_table_row_<?php echo ($index % 2 == 0) ? 'odd' : 'even' ?>">
+                <tr
+                    class="site_table_row_<?php
+                        echo ($index % 2 == 0) ? 'odd' : 'even' ?>"
+                >
                     <td class="site_table" style="width: 30%">
                         <div style="background-color: inherit;">
                             <span style="vertical-align: middle;">
@@ -161,7 +167,9 @@ $totalCount = $siteCount + $ngiCount + $serviceCount +$serviceGroupsCount;
                 foreach ($serviceGroups as $index => $sGroup) {
                 ?>
                 <?php if($sGroup->getScopes()->first()->getName() == "Local") { $style = " style=\"background-color: #A3D7A3;\""; } else { $style = ""; } ?>
-                <tr class="site_table_row_<?php echo ($index % 2 == 0) ? 'odd' : 'even' ?>"
+                <tr
+                    class="site_table_row_<?php
+                        echo ($index % 2 == 0) ? 'odd' : 'even' ?>"
                     <?php echo $style ?>>
                     <td class="site_table">
                         <div style="background-color: inherit;">

--- a/htdocs/web_portal/views/scopes.php
+++ b/htdocs/web_portal/views/scopes.php
@@ -126,7 +126,7 @@
             <?php echo $numberOfScopes ?> Scope<?php if ($numberOfScopes !== 1) echo "s"?>
         </span>
         <table class="vSiteResults" id="selectedSETable">
-            <tr class="site_table_row_1">
+            <tr class="site_table_row_even">
                 <th class="site_table">Name</th>
                 <th class="site_table">Description</th>
                 <th class="site_table">Reserved?</th>
@@ -135,11 +135,10 @@
                 <?php endif; ?>
             </tr>
             <?php
-            $num = 2;
             if($numberOfScopes > 0) {
-                foreach($params['Scopes'] as $scope) {
+                foreach ($params['Scopes'] as $index => $scope) {
                 ?>
-                <tr class="site_table_row_<?php echo $num ?>">
+                <tr class="site_table_row_<?php echo ($index % 2 == 0) ? 'odd' : 'even' ?>">
                     <td class="site_table">
                         <div style="background-color: inherit;">
                             <span style="vertical-align: middle;">
@@ -171,7 +170,6 @@
                     <?php endif ?>
                 </tr>
                 <?php
-                    if($num == 1) { $num = 2; } else { $num = 1; }
                     } // End of the foreach loop iterating over scopes
             }
             ?>

--- a/htdocs/web_portal/views/scopes.php
+++ b/htdocs/web_portal/views/scopes.php
@@ -138,7 +138,10 @@
             if($numberOfScopes > 0) {
                 foreach ($params['Scopes'] as $index => $scope) {
                 ?>
-                <tr class="site_table_row_<?php echo ($index % 2 == 0) ? 'odd' : 'even' ?>">
+                <tr
+                    class="site_table_row_<?php
+                        echo ($index % 2 == 0) ? 'odd' : 'even' ?>"
+                >
                     <td class="site_table">
                         <div style="background-color: inherit;">
                             <span style="vertical-align: middle;">

--- a/htdocs/web_portal/views/service/view_service.php
+++ b/htdocs/web_portal/views/service/view_service.php
@@ -241,7 +241,10 @@ $showPD = $params['authenticated'];
                 <?php
                 foreach ($params['sGroups'] as $index => $sg) {
                 ?>
-                <tr class="site_table_row_<?php echo ($index % 2 == 0) ? 'even' : 'odd' ?>">
+                <tr
+                    class="site_table_row_<?php
+                        echo ($index % 2 == 0) ? 'even' : 'odd' ?>"
+                >
                     <td class="site_table">
                         <a href="index.php?Page_Type=Service_Group&amp;id=<?php echo $sg->getId()?>">
                             <?php xecho($sg->getName()) ?>
@@ -287,7 +290,10 @@ $showPD = $params['authenticated'];
             foreach ($se->getEndpointLocations() as $index => $endpoint) {
                 ?>
 
-                <tr class="site_table_row_<?php echo ($index % 2 == 0) ? 'odd' : 'even' ?>">
+                <tr
+                    class="site_table_row_<?php
+                        echo ($index % 2 == 0) ? 'odd' : 'even' ?>"
+                >
                     <td style="width: 30%;"class="site_table">
                         <a href="index.php?Page_Type=View_Service_Endpoint&amp;id=<?php echo $endpoint->getId() ?>">
                             <?php xecho($endpoint->getName()) ?>

--- a/htdocs/web_portal/views/service/view_service.php
+++ b/htdocs/web_portal/views/service/view_service.php
@@ -49,49 +49,49 @@ $showPD = $params['authenticated'];
             <span class="header" style="vertical-align:middle; float: left; padding-top: 0.9em; padding-left: 1em;">System</span>
             <img src="<?php echo \GocContextPath::getPath()?>img/server.png" class="titleIcon"/>
             <table style="clear: both; width: 100%;">
-                <tr class="site_table_row_1">
+                <tr class="site_table_row_even">
                     <td class="site_table">Host name</td><td class="site_table">
                         <?php if ($showPD) {
                             xecho($se->getHostName());
                         } else echo(getInfoMessage()); ?>
                     </td>
                 </tr>
-                <tr class="site_table_row_2">
+                <tr class="site_table_row_odd">
                     <td class="site_table">IP Address</td><td class="site_table">
                         <?php if ($showPD) {
                           xecho($se->getIpAddress());
                         } else echo(getInfoMessage());  ?>
                     </td>
                 </tr>
-                <tr class="site_table_row_1">
+                <tr class="site_table_row_even">
                     <td class="site_table">IP v6 Address</td><td class="site_table">
                         <?php if ($showPD) {
                             xecho($se->getIpV6Address());
                         } else echo(getInfoMessage()); ?>
                     </td>
                 </tr>
-                <tr class="site_table_row_2">
+                <tr class="site_table_row_odd">
                     <td class="site_table">Operating System</td><td class="site_table">
                         <?php if ($showPD) {
                             xecho($se->getOperatingSystem());
                         } else echo(getInfoMessage()); ?>
                     </td>
                 </tr>
-                <tr class="site_table_row_1">
+                <tr class="site_table_row_even">
                     <td class="site_table">Architecture</td><td class="site_table">
                         <?php if ($showPD) {
                             xecho($se->getArchitecture());
                         } else echo(getInfoMessage()); ?>
                     </td>
                 </tr>
-                <tr class="site_table_row_2">
+                <tr class="site_table_row_odd">
                     <td class="site_table">Contact E-Mail</td><td class="site_table">
                     <?php if ($showPD) {
                         xecho($se->getEmail());
                     } else echo(getInfoMessage()); ?>
                     </td>
                 </tr>
-                <tr class="site_table_row_1">
+                <tr class="site_table_row_even">
                     <td class="site_table">Notifications</td>
                     <td class="site_table">
                         <img src="<?php echo(\GocContextPath::getPath());
@@ -111,7 +111,7 @@ $showPD = $params['authenticated'];
             <img src="<?php echo \GocContextPath::getPath()?>img/grid.png" class="titleIcon"/>
             <table style="width: 100%; word-wrap:break-word;
               table-layout: fixed;">
-                <tr class="site_table_row_1">
+                <tr class="site_table_row_even">
                     <td class="site_table" style="width: 5em;">Host DN</td><td class="site_table">
                         <div style="word-wrap: break-word;">
                                 <?php if ($showPD) {
@@ -120,10 +120,10 @@ $showPD = $params['authenticated'];
                         </div>
                     </td>
                 </tr>
-                <tr class="site_table_row_2">
+                <tr class="site_table_row_odd">
                     <td class="site_table">URL</td><td class="site_table"><?php xecho($se->getUrl()) ?></td>
                 </tr>
-                <tr class="site_table_row_1">
+                <tr class="site_table_row_even">
                     <td class="site_table">Parent Site</td>
                     <td class="site_table">
                         <a href="index.php?Page_Type=Site&amp;id=<?php echo $se->getParentSite()->getId() ?>">
@@ -132,7 +132,7 @@ $showPD = $params['authenticated'];
                     </td>
                 </tr>
                 <!-- scope: remove this for a non-scoping version of view_service -->
-                <tr class="site_table_row_2">
+                <tr class="site_table_row_odd">
                     <?php
                         $count = 0;
                         $numScopes = sizeof($params['Scopes']);
@@ -170,7 +170,7 @@ $showPD = $params['authenticated'];
             <span class="header" style="vertical-align:middle; float: left; padding-top: 0.9em; padding-left: 1em;">Project Data</span>
             <img src="<?php echo \GocContextPath::getPath()?>img/project.png" class="titleIcon"/>
             <table style="clear: both; width: 100%;">
-                <tr class="site_table_row_1">
+                <tr class="site_table_row_even">
                     <td class="site_table">Production Level</td>
                     <td class="site_table">
                     <?php
@@ -189,7 +189,7 @@ $showPD = $params['authenticated'];
                     ?>
                     </td>
                 </tr>
-                <tr class="site_table_row_2">
+                <tr class="site_table_row_odd">
                     <td class="site_table">Beta</td><td class="site_table">
                     <?php
                     switch($se->getBeta()) {
@@ -212,7 +212,7 @@ $showPD = $params['authenticated'];
                     ?>
                     </td>
                 </tr>
-                <tr class="site_table_row_1">
+                <tr class="site_table_row_even">
                     <td class="site_table">Monitored</td><td class="site_table">
                     <?php
                     switch($se->getMonitored()) {
@@ -239,10 +239,9 @@ $showPD = $params['authenticated'];
             <img src="<?php echo \GocContextPath::getPath()?>img/virtualSite.png" class="titleIcon"/>
             <table style="clear: both; width: 100%;">
                 <?php
-                    $num = 1;
-                    foreach($params['sGroups'] as $sg) {
+                foreach ($params['sGroups'] as $index => $sg) {
                 ?>
-                <tr class="site_table_row_<?php echo $num; ?>">
+                <tr class="site_table_row_<?php echo ($index % 2 == 0) ? 'even' : 'odd' ?>">
                     <td class="site_table">
                         <a href="index.php?Page_Type=Service_Group&amp;id=<?php echo $sg->getId()?>">
                             <?php xecho($sg->getName()) ?>
@@ -250,7 +249,6 @@ $showPD = $params['authenticated'];
                     </td>
                 </tr>
                 <?php
-                        if($num == 1) { $num = 2; } else { $num = 1; }
                     }
                 ?>
             </table>
@@ -276,7 +274,7 @@ $showPD = $params['authenticated'];
         </span>
         <img src="<?php echo \GocContextPath::getPath()?>img/serviceEndpoint.png" class="titleIcon"/>
         <table style="clear: both; width: 100%;">
-            <tr class="site_table_row_1">
+            <tr class="site_table_row_even">
                 <th class="site_table">Name</th>
                 <th class="site_table">URL</th>
                 <th class="site_table">Interface Name</th>
@@ -286,11 +284,10 @@ $showPD = $params['authenticated'];
                 <?php endif; ?>
             </tr>
             <?php
-            $num = 2;
-            foreach($se->getEndpointLocations() as $endpoint) {
+            foreach ($se->getEndpointLocations() as $index => $endpoint) {
                 ?>
 
-                <tr class="site_table_row_<?php echo $num ?>">
+                <tr class="site_table_row_<?php echo ($index % 2 == 0) ? 'odd' : 'even' ?>">
                     <td style="width: 30%;"class="site_table">
                         <a href="index.php?Page_Type=View_Service_Endpoint&amp;id=<?php echo $endpoint->getId() ?>">
                             <?php xecho($endpoint->getName()) ?>
@@ -313,7 +310,6 @@ $showPD = $params['authenticated'];
 
                 </tr>
                 <?php
-                if($num == 1) { $num = 2; } else { $num = 1; }
             }
             ?>
         </table>

--- a/htdocs/web_portal/views/service/view_service_endpoint.php
+++ b/htdocs/web_portal/views/service/view_service_endpoint.php
@@ -52,7 +52,7 @@ $epTxt = \Factory::getConfigService()->getNameMapping('Service','endpoint');
             <span class="header" style="vertical-align:middle; float: left; padding-top: 0.9em; padding-left: 1em;">Parent Service</span>
             <img src="<?php echo \GocContextPath::getPath() ?>img/service.png" class="titleIcon"/>
             <table style="clear: both; width: 100%;">
-                <tr class="site_table_row_1">
+                <tr class="site_table_row_even">
                     <td class="site_table">Name</td><td class="site_table">
             <a href="index.php?Page_Type=Service&amp;id=<?php echo $se->getId() ?>">
                 <?php xecho($se->getHostname() . " (" . $se->getServiceType()->getName() . ")"); ?>
@@ -71,22 +71,22 @@ $epTxt = \Factory::getConfigService()->getNameMapping('Service','endpoint');
             <span class="header" style="vertical-align:middle; float: left; padding-top: 0.9em; padding-left: 1em;"><?php echo(ucfirst($epTxt)) ?></span>
             <img src="<?php echo \GocContextPath::getPath() ?>img/serviceEndpoint.png" class="titleIcon"/>
             <table style="clear: both; width: 100%;">
-                <tr class="site_table_row_1">
+                <tr class="site_table_row_even">
                     <td class="site_table">Name</td><td class="site_table"><?php xecho($endpoint->getName()) ?></td>
                 </tr>
-                <tr class="site_table_row_2">
+                <tr class="site_table_row_odd">
                     <td class="site_table">Description</td><td class="site_table"><?php xecho($endpoint->getDescription()) ?></td>
                 </tr>
-                <tr class="site_table_row_1">
+                <tr class="site_table_row_even">
                     <td class="site_table">Url</td><td class="site_table"><?php xecho($endpoint->getUrl()) ?></td>
                 </tr>
-                <tr class="site_table_row_2">
+                <tr class="site_table_row_odd">
                     <td class="site_table">Interface Name</td><td class="site_table"><?php xecho($endpoint->getInterfaceName()) ?></td>
                 </tr>
-                <tr class="site_table_row_1">
+                <tr class="site_table_row_even">
                     <td class="site_table">Id</td><td class="site_table"><?php echo $endpoint->getId() ?></td>
                 </tr>
-                <tr class="site_table_row_2">
+                <tr class="site_table_row_odd">
                     <td class="site_table">Contact E-mail</td><td class="site_table">
                         <?php
                             if ($showPD) {
@@ -97,7 +97,7 @@ $epTxt = \Factory::getConfigService()->getNameMapping('Service','endpoint');
                         ?>
                     </td>
                 </tr>
-                <tr class="site_table_row_1">
+                <tr class="site_table_row_even">
                     <td class="site_table">Monitored</td>
                     <td class="site_table">
                         <?php

--- a/htdocs/web_portal/views/service_group/add_ses_body.php
+++ b/htdocs/web_portal/views/service_group/add_ses_body.php
@@ -21,7 +21,7 @@
         </span>
         <br />
         <table class="vSiteResults" id="seTable">
-            <tr class="site_table_row_1">
+            <tr class="site_table_row_even">
                 <th style="width: 5em;" class="site_table">Add</th>
                 <th style="width: 40%;" class="site_table">Service</th>
                 <th class="site_table">Description</th>
@@ -38,7 +38,7 @@
         </span>
         <img src="<?php echo \GocContextPath::getPath()?>img/grid.png" class="decoration" />
         <table class="vSiteResults" id="selectedSETable">
-            <tr class="site_table_row_1">
+            <tr class="site_table_row_even">
                 <th class="site_table">Remove</th>
                 <th class="site_table">Service</th>
                 <th class="site_table">Description</th>

--- a/htdocs/web_portal/views/service_group/remove_ses.php
+++ b/htdocs/web_portal/views/service_group/remove_ses.php
@@ -49,7 +49,9 @@ $sg = $params['sg'];
                     }
 
                 ?>
-                <tr class="site_table_row_<?php echo ($index % 2 == 0) ? 'odd' : 'even' ?>"
+                <tr
+                    class="site_table_row_<?php
+                        echo ($index % 2 == 0) ? 'odd' : 'even' ?>"
                     <?php echo $style; ?> id="<?php echo $se->getId(); ?>Row">
                     <td>
                         <a href="#" onclick="removeSe(<?php echo $se->getId() ?>, <?php echo $sg->getId() ?>, <?php if(is_null($se->getParentSite())) { echo "true"; } else { echo "false"; }?>)">

--- a/htdocs/web_portal/views/service_group/remove_ses.php
+++ b/htdocs/web_portal/views/service_group/remove_ses.php
@@ -33,16 +33,14 @@ $sg = $params['sg'];
             </span>
             <img src="<?php echo \GocContextPath::getPath()?>img/grid.png" class="decoration" />
             <table class="vSiteResults" id="selectedSETable">
-                <tr class="site_table_row_1">
+                <tr class="site_table_row_even">
                     <th class="site_table">Remove</th>
                     <th class="site_table">Service</th>
                     <th class="site_table">Description</th>
                     <th class="site_table">Hosting Site</th>
                 </tr>
                 <?php
-                $num = 2;
-
-                foreach($sg->getServices() as $se) {
+                foreach ($sg->getServices() as $index => $se) {
                     if($se->getScopes()->first()->getName() == 'Local') {
                         $style = "style=\"background-color: #A3D7A3;\"";
                     }
@@ -51,7 +49,8 @@ $sg = $params['sg'];
                     }
 
                 ?>
-                <tr class="site_table_row_<?php echo $num ?>"<?php echo $style; ?> id="<?php echo $se->getId(); ?>Row">
+                <tr class="site_table_row_<?php echo ($index % 2 == 0) ? 'odd' : 'even' ?>"
+                    <?php echo $style; ?> id="<?php echo $se->getId(); ?>Row">
                     <td>
                         <a href="#" onclick="removeSe(<?php echo $se->getId() ?>, <?php echo $sg->getId() ?>, <?php if(is_null($se->getParentSite())) { echo "true"; } else { echo "false"; }?>)">
                            Remove
@@ -82,7 +81,6 @@ $sg = $params['sg'];
                     </td>
                 </tr>
                 <?php
-                    if($num == 1) { $num = 2; } else { $num = 1; }
                     } // End of the foreach loop iterating over SEs
                 ?>
             </table>

--- a/htdocs/web_portal/views/service_group/view_sgroup.php
+++ b/htdocs/web_portal/views/service_group/view_sgroup.php
@@ -51,7 +51,7 @@ $showPD = $params['authenticated'];
             <span class="header" style="vertical-align:middle; float: left; padding-top: 0.9em; padding-left: 1em;">Properties</span>
             <img src="<?php echo \GocContextPath::getPath()?>img/contact_card.png" class="decoration" />
             <table style="clear: both; width: 100%;">
-                <tr class="site_table_row_1">
+                <tr class="site_table_row_even">
                     <td class="site_table">Monitored</td><td class="site_table">
                     <?php
                         switch($params['sGroup']->getMonitored()) {
@@ -73,7 +73,7 @@ $showPD = $params['authenticated'];
                         $params['sGroup']->getScopes()->first()->getName() == "Local") {
                     $style = " style=\"background-color: #A3D7A3;\""; } else { $style = ""; }
                 ?>
-                <tr class="site_table_row_2" <?php echo $style ?>>
+                <tr class="site_table_row_odd" <?php echo $style ?>>
                     <td class="site_table">
                         <a href="index.php?Page_Type=Scopes" style="word-wrap: normal">Scope Tags</a>
                     </td>
@@ -81,7 +81,7 @@ $showPD = $params['authenticated'];
             <textarea readonly="true" style="width: 100%; height: 60px;"><?php xecho($params['sGroup']->getScopeNamesAsString())?></textarea>
                     </td>
                 </tr>
-                <tr class="site_table_row_1">
+                <tr class="site_table_row_even">
                     <td class="site_table">Contact E-Mail</td>
                     <td class="site_table">
                         <?php if($showPD) { ?>
@@ -100,7 +100,7 @@ $showPD = $params['authenticated'];
         <span class="header" style="vertical-align:middle; float: left; padding-top: 0.9em; padding-left: 1em;">Services</span>
         <img src="<?php echo \GocContextPath::getPath()?>img/service.png" class="decoration" />
         <table style="clear: both; width: 100%;">
-            <tr class="site_table_row_1">
+            <tr class="site_table_row_even">
                 <th class="site_table">Hostname (service type)</th>
                 <th class="site_table">Description</th>
                 <th class="site_table">Production</th>
@@ -108,8 +108,7 @@ $showPD = $params['authenticated'];
             </tr>
 
             <?php
-            $num = 2;
-        foreach($params['sGroup']->getServices() as $se) {
+            foreach ($params['sGroup']->getServices() as $index => $se) {
 //	            if($se->getScopes()->first()->getName() == "Local") {
 //					$style = " style=\"background-color: #A3D7A3;\"";
 //				} else {
@@ -117,7 +116,7 @@ $showPD = $params['authenticated'];
 //				}
             ?>
 
-            <tr class="site_table_row_<?php echo $num ?>">
+            <tr class="site_table_row_<?php echo ($index % 2 == 0) ? 'odd' : 'even' ?>">
                 <td class="site_table">
                     <div style="background-color: inherit;">
                        <div style="background-color: inherit;">
@@ -151,7 +150,6 @@ $showPD = $params['authenticated'];
                 </td>
             </tr>
             <?php
-        if($num == 1) { $num = 2; } else { $num = 1; }
             } // End of the foreach loop iterating over SEs
             ?>
         </table>
@@ -182,15 +180,14 @@ $showPD = $params['authenticated'];
             <span class="header" style="vertical-align:middle; float: left; padding-top: 0.9em; padding-left: 1em;">Users (Click on name to manage roles)</span>
             <img src="<?php echo \GocContextPath::getPath()?>img/people.png" class="decoration" />
             <table style="clear: both; width: 100%;">
-                <tr class="site_table_row_1">
+                <tr class="site_table_row_even">
                     <th class="site_table">Name</th>
                     <th class="site_table">Role</th>
                 </tr>
                 <?php
-                    $num = 2;
-                    foreach($params['Roles'] as $role) {
+                foreach ($params['Roles'] as $index => $role) {
                 ?>
-                <tr class="site_table_row_<?php echo $num ?>">
+                <tr class="site_table_row_<?php echo ($index % 2 == 0) ? 'odd' : 'even' ?>">
                     <td class="site_table">
                         <div style="background-color: inherit;">
                             <img src="<?php echo \GocContextPath::getPath()?>img/person.png" class="person" />
@@ -204,8 +201,7 @@ $showPD = $params['authenticated'];
                     </td>
                 </tr>
                 <?php
-                    if($num == 1) { $num = 2; } else { $num = 1; }
-                    } // End of the foreach loop iterating over user roles
+                } // End of the foreach loop iterating over user roles
                 ?>
             </table>
         <?php
@@ -241,17 +237,16 @@ $showPD = $params['authenticated'];
         <a href="index.php?Page_Type=SGroup_Downtimes&amp;id=<?php echo $params['sGroup']->getId(); ?>" style="vertical-align:middle; float: left; padding-top: 1.3em; padding-left: 1em; font-size: 0.8em;">(View all Downtimes)</a>
         <img src="<?php echo \GocContextPath::getPath()?>img/down_arrow.png" class="decoration" />
         <table style="clear: both; width: 100%;">
-            <tr class="site_table_row_1">
+            <tr class="site_table_row_even">
                 <th class="site_table">Description</th>
                 <th class="site_table">From</th>
                 <th class="site_table">To</th>
             </tr>
             <?php
-            $num = 2;
-            foreach($params['downtimes'] as $d) {
+            foreach ($params['downtimes'] as $index => $d) {
             ?>
 
-            <tr class="site_table_row_<?php echo $num ?>">
+            <tr class="site_table_row_<?php echo ($index % 2 == 0) ? 'odd' : 'even' ?>">
                 <td class="site_table">
                     <a style="padding-right: 1em;" href="index.php?Page_Type=Downtime&id=<?php echo $d->getId() ?>">
                         <?php xecho($d->getDescription()) ?>
@@ -261,7 +256,6 @@ $showPD = $params['authenticated'];
                 <td class="site_table"><?php echo $d->getEndDate()->format($d::DATE_FORMAT) ?></td>
             </tr>
             <?php
-            if($num == 1) { $num = 2; } else { $num = 1; }
             }
             ?>
         </table>

--- a/htdocs/web_portal/views/service_group/view_sgroup.php
+++ b/htdocs/web_portal/views/service_group/view_sgroup.php
@@ -116,7 +116,10 @@ $showPD = $params['authenticated'];
 //				}
             ?>
 
-            <tr class="site_table_row_<?php echo ($index % 2 == 0) ? 'odd' : 'even' ?>">
+            <tr
+                class="site_table_row_<?php
+                    echo ($index % 2 == 0) ? 'odd' : 'even' ?>"
+            >
                 <td class="site_table">
                     <div style="background-color: inherit;">
                        <div style="background-color: inherit;">
@@ -187,7 +190,10 @@ $showPD = $params['authenticated'];
                 <?php
                 foreach ($params['Roles'] as $index => $role) {
                 ?>
-                <tr class="site_table_row_<?php echo ($index % 2 == 0) ? 'odd' : 'even' ?>">
+                <tr
+                    class="site_table_row_<?php
+                        echo ($index % 2 == 0) ? 'odd' : 'even' ?>"
+                >
                     <td class="site_table">
                         <div style="background-color: inherit;">
                             <img src="<?php echo \GocContextPath::getPath()?>img/person.png" class="person" />
@@ -246,7 +252,10 @@ $showPD = $params['authenticated'];
             foreach ($params['downtimes'] as $index => $d) {
             ?>
 
-            <tr class="site_table_row_<?php echo ($index % 2 == 0) ? 'odd' : 'even' ?>">
+            <tr
+                class="site_table_row_<?php
+                    echo ($index % 2 == 0) ? 'odd' : 'even' ?>"
+            >
                 <td class="site_table">
                     <a style="padding-right: 1em;" href="index.php?Page_Type=Downtime&id=<?php echo $d->getId() ?>">
                         <?php xecho($d->getDescription()) ?>

--- a/htdocs/web_portal/views/site/view_site.php
+++ b/htdocs/web_portal/views/site/view_site.php
@@ -59,7 +59,7 @@ $showPD = $params['authenticated']; // display Personal Data
             </span>
             <img src="<?php echo \GocContextPath::getPath() ?>img/contact_card.png" class="decoration" />
         <table style="clear: both; width: 100%; table-layout: fixed;">
-        <tr class="site_table_row_1">
+        <tr class="site_table_row_even">
             <td class="site_table" style="width: 30%">E-Mail</td><td class="site_table">
             <?php if ($showPD) { ?>
                 <a href="mailto:<?php xecho($site->getEmail()) ?>">
@@ -70,7 +70,7 @@ $showPD = $params['authenticated']; // display Personal Data
             } ?>
             </td>
         </tr>
-        <tr class="site_table_row_2">
+        <tr class="site_table_row_odd">
             <td class="site_table">Telephone</td><td class="site_table"><?php
             if ($showPD) {
                 xecho($site->getTelephone());
@@ -79,7 +79,7 @@ $showPD = $params['authenticated']; // display Personal Data
             }
             ?></td>
         </tr>
-        <tr class="site_table_row_1">
+        <tr class="site_table_row_even">
             <td class="site_table">Emergency Tel</td><td class="site_table"><?php
             if ($showPD) {
                 xecho($site->getEmergencyTel());
@@ -88,7 +88,7 @@ $showPD = $params['authenticated']; // display Personal Data
             }
             ?></td>
         </tr>
-        <tr class="site_table_row_2">
+        <tr class="site_table_row_odd">
             <td class="site_table">CSIRT Tel</td><td class="site_table"><?php
             if ($showPD) {
                 xecho($site->getCsirtTel());
@@ -97,7 +97,7 @@ $showPD = $params['authenticated']; // display Personal Data
             }
             ?></td>
         </tr>
-        <tr class="site_table_row_1">
+        <tr class="site_table_row_even">
             <td class="site_table">CSIRT E-Mail</td>
             <td class="site_table">
             <?php if ($showPD) { ?>
@@ -109,7 +109,7 @@ $showPD = $params['authenticated']; // display Personal Data
             } ?>
             </td>
         </tr>
-        <tr class="site_table_row_2">
+        <tr class="site_table_row_odd">
             <td class="site_table">Emergency E-Mail</td>
             <td class="site_table">
             <?php if ($showPD) { ?>
@@ -121,7 +121,7 @@ $showPD = $params['authenticated']; // display Personal Data
             } ?>
             </td>
         </tr>
-        <tr class="site_table_row_1">
+        <tr class="site_table_row_even">
             <td class="site_table">Helpdesk E-Mail</td>
             <td class="site_table">
             <?php if ($showPD) { ?>
@@ -133,7 +133,7 @@ $showPD = $params['authenticated']; // display Personal Data
             } ?>
             </td>
         </tr>
-        <tr class="site_table_row_2">
+        <tr class="site_table_row_odd">
             <td class="site_table">Notifications</td>
             <td class="site_table">
                 <img src="<?php echo(\GocContextPath::getPath());
@@ -154,20 +154,20 @@ $showPD = $params['authenticated']; // display Personal Data
             </span>
             <img src="<?php echo \GocContextPath::getPath() ?>img/project.png" class="decoration" />
             <table style="clear: both; width: 100%;">
-                <tr class="site_table_row_1">
+                <tr class="site_table_row_even">
                     <td class="site_table">NGI/ROC</td><td class="site_table">
             <a href="index.php?Page_Type=NGI&amp;id=<?php echo($site->getNgi()->getId()) ?>">
                 <?php xecho($site->getNgi()->getName()) ?>
             </a>
             </td>
                 </tr>
-                <tr class="site_table_row_2">
+                <tr class="site_table_row_odd">
                     <td class="site_table">Infrastructure</td>
                     <td class="site_table">
                         <?php xecho($site->getInfrastructure()->getName()) ?>
                     </td>
                 </tr>
-                <tr class="site_table_row_1">
+                <tr class="site_table_row_even">
                     <td class="site_table">Certification Status</td>
                     <td class="site_table">
             <?php if ($showPD) { ?>
@@ -183,7 +183,7 @@ $showPD = $params['authenticated']; // display Personal Data
                     </td>
                 </tr>
 
-                <tr class="site_table_row_2">
+                <tr class="site_table_row_odd">
                     <?php
                     $count = 0;
                     $numScopes = sizeof($params['Scopes']);
@@ -223,7 +223,7 @@ $showPD = $params['authenticated']; // display Personal Data
             </span>
             <img src="<?php echo \GocContextPath::getPath() ?>img/network.png" class="decoration" />
             <table style="clear: both; width: 100%;">
-                <tr class="site_table_row_1">
+                <tr class="site_table_row_even">
                     <td class="site_table">Home URL</td>
             <td class="site_table">
             <?php if ($showPD) { ?>
@@ -235,7 +235,7 @@ $showPD = $params['authenticated']; // display Personal Data
             } ?>
             </td>
                 </tr>
-                <tr class="site_table_row_2">
+                <tr class="site_table_row_odd">
                     <td class="site_table">GIIS URL</td>
                     <td class="site_table">
             <?php
@@ -247,7 +247,7 @@ $showPD = $params['authenticated']; // display Personal Data
             ?>
                     </td>
                 </tr>
-                <tr class="site_table_row_1">
+                <tr class="site_table_row_even">
                     <td class="site_table">IP Range</td>
                     <td class="site_table">
             <?php
@@ -259,7 +259,7 @@ $showPD = $params['authenticated']; // display Personal Data
             ?>
                     </td>
                 </tr>
-                <tr class="site_table_row_2">
+                <tr class="site_table_row_odd">
                     <td class="site_table" style="width:20%">IP v6 Range</td>
                     <td class="site_table">
             <?php
@@ -271,7 +271,7 @@ $showPD = $params['authenticated']; // display Personal Data
             ?>
                     </td>
                 </tr>
-                <tr class="site_table_row_1">
+                <tr class="site_table_row_even">
                     <td class="site_table">Domain</td>
                     <td class="site_table">
                         <?php
@@ -293,7 +293,7 @@ $showPD = $params['authenticated']; // display Personal Data
             </span>
             <img src="<?php echo \GocContextPath::getPath() ?>img/pin.png" class="decoration" />
             <table style="clear: both; width: 100%;">
-                <tr class="site_table_row_1">
+                <tr class="site_table_row_even">
                     <td class="site_table">Country</td><td class="site_table">
             <?php
             if ($showPD) {
@@ -304,7 +304,7 @@ $showPD = $params['authenticated']; // display Personal Data
             ?>
                     </td>
                 </tr>
-                <tr class="site_table_row_2">
+                <tr class="site_table_row_odd">
                     <td class="site_table">Latitude</td><td class="site_table">
             <?php
             if ($showPD) {
@@ -315,7 +315,7 @@ $showPD = $params['authenticated']; // display Personal Data
             ?>
                     </td>
                 </tr>
-                <tr class="site_table_row_1">
+                <tr class="site_table_row_even">
                     <td class="site_table">Longitude</td><td class="site_table">
             <?php
             if ($showPD) {
@@ -326,7 +326,7 @@ $showPD = $params['authenticated']; // display Personal Data
             ?>
                     </td>
                 </tr>
-                <tr class="site_table_row_2">
+                <tr class="site_table_row_odd">
                     <td class="site_table">Time Zone</td><td class="site_table">
             <?php
             if ($showPD) {
@@ -337,7 +337,7 @@ $showPD = $params['authenticated']; // display Personal Data
             ?>
                     </td>
                 </tr>
-                <tr class="site_table_row_1">
+                <tr class="site_table_row_even">
                     <td class="site_table">Location</td><td class="site_table">
             <?php
             if ($showPD) {

--- a/htdocs/web_portal/views/user/view_user.php
+++ b/htdocs/web_portal/views/user/view_user.php
@@ -88,26 +88,38 @@
                     <td class="site_table">
                         <?php
                         if ($params['user']->getLastLoginDate()) {
-                            xecho($params['user']->getLastLoginDate()->format('Y-m-d H:i:s'));
+                            xecho(
+                                $params['user']->getLastLoginDate()
+                                    ->format('Y-m-d H:i:s')
+                            );
                         }
                         ?>
                     </td>
                 </tr>
             <?php endif; ?>
-                <tr class="site_table_row_<?php echo ($isUserAdmin) ? 'odd' : 'even' ?>">
+                <tr
+                    class="site_table_row_<?php
+                        echo ($isUserAdmin) ? 'odd' : 'even' ?>"
+                >
                     <td class="site_table" style="width: 30%">E-Mail</td><td class="site_table">
             <a href="mailto:<?php xecho($params['user']->getEmail()); ?>">
                 <?php xecho($params['user']->getEmail()) ?>
             </a>
             </td>
                 </tr>
-                <tr class="site_table_row_<?php echo ($isUserAdmin) ? 'even' : 'odd' ?>">
+                <tr
+                    class="site_table_row_<?php
+                        echo ($isUserAdmin) ? 'even' : 'odd' ?>"
+                >
                     <td class="site_table">Telephone</td>
                     <td class="site_table">
                         <?php xecho($params['user']->getTelephone()) ?>
                     </td>
                 </tr>
-                <tr class="site_table_row_<?php echo ($isUserAdmin) ? 'odd' : 'even' ?>">
+                <tr
+                    class="site_table_row_<?php
+                        echo ($isUserAdmin) ? 'odd' : 'even' ?>"
+                >
                     <td class="site_table">Default ID String</td>
                     <td class="site_table">
                         <div style="word-wrap: break-word;">
@@ -131,7 +143,10 @@
                     </td>
                 </tr>-->
                 <?php if (sizeof($params['user']->getHomeSite()) != 0) { ?>
-                    <tr class="site_table_row_<?php echo ($isUserAdmin) ? 'even' : 'odd' ?>">
+                    <tr
+                        class="site_table_row_<?php
+                            echo ($isUserAdmin) ? 'even' : 'odd' ?>"
+                    >
                         <td class="site_table">Home Site</td>
                         <td class="site_table">
                             <a href="index.php?Page_Type=Site&amp;id=
@@ -161,8 +176,13 @@
             </tr>
             <?php
             // Loop through each user identifier
-            foreach ($params['user']->getUserIdentifiers() as $index => $identifier) : ?>
-                <tr class="site_table_row_<?php echo ($index % 2 == 0) ? 'odd' : 'even' ?>">
+            foreach (
+                $params['user']->getUserIdentifiers() as $index => $identifier
+            ) : ?>
+                <tr
+                    class="site_table_row_<?php
+                        echo ($index % 2 == 0) ? 'odd' : 'even' ?>"
+                >
                     <td class="site_table" style="width: 40%">
                         <div style="background-color: inherit;">
                             <?php xecho($identifier->getKeyValue())?>
@@ -245,8 +265,10 @@
 
                 if (in_array($projId, $projIds)) { // if projId in array
                     ?>
-                    <tr class="site_table_row_<?php
-                     echo ($index % 2 == 0) ? 'odd' : 'even' ?>">
+                    <tr
+                        class="site_table_row_<?php
+                            echo ($index % 2 == 0) ? 'odd' : 'even' ?>"
+                    >
                     <td class="site_table" style="width: 40%">
                         <div style="background-color: inherit;">
                             <img src="<?php echo \GocContextPath::getPath()?>img/person.png" class="person" />
@@ -342,8 +364,10 @@
                 $projIds = $role_ProjIds[1];
 
                 if (count($projIds) == 0) { // role with no owning proj ?>
-                    <tr class="site_table_row_<?php
-                        echo ($index % 2 == 0) ? 'odd' : 'even' ?>">
+                    <tr
+                        class="site_table_row_<?php
+                            echo ($index % 2 == 0) ? 'odd' : 'even' ?>"
+                    >
                         <td class="site_table" style="width: 40%">
                             <div style="background-color: inherit;">
                                 <img src="<?php echo \GocContextPath::getPath()?>img/person.png" height="25px"

--- a/htdocs/web_portal/views/user/view_user.php
+++ b/htdocs/web_portal/views/user/view_user.php
@@ -73,7 +73,7 @@
         </div>
 
         <?php
-        $isUserAdmin = ($params['user'] && $params['user']->isAdmin());
+        $isUserAdmin = $params['callingUser']->isAdmin();
         ?>
         <!--  User -->
         <div class="tableContainer" style="width: 55%; float: left;">
@@ -86,7 +86,11 @@
                 <tr class="site_table_row_even">
                     <td class="site_table">Last Logged In</td>
                     <td class="site_table">
-                        <?php xecho($params['user']->getLastLoginDate()->format('Y-m-d H:i:s')) ?>
+                        <?php
+                        if ($params['user']->getLastLoginDate()) {
+                            xecho($params['user']->getLastLoginDate()->format('Y-m-d H:i:s'));
+                        }
+                        ?>
                     </td>
                 </tr>
             <?php endif; ?>

--- a/htdocs/web_portal/views/user/view_user.php
+++ b/htdocs/web_portal/views/user/view_user.php
@@ -72,7 +72,9 @@
             </ul>
         </div>
 
-
+        <?php
+        $isUserAdmin = ($params['user'] && $params['user']->isAdmin());
+        ?>
         <!--  User -->
         <div class="tableContainer" style="width: 55%; float: left;">
             <span class="header" style="vertical-align:middle; float: left; padding-top: 0.9em; padding-left: 1em;">
@@ -80,20 +82,28 @@
             </span>
             <img src="<?php echo \GocContextPath::getPath()?>img/contact_card.png" class="decoration" />
             <table style="clear: both; width: 100%; table-layout: fixed;">
-                <tr class="site_table_row_1">
+            <?php if ($isUserAdmin) : ?>
+                <tr class="site_table_row_even">
+                    <td class="site_table">Last Logged In</td>
+                    <td class="site_table">
+                        <?php xecho($params['user']->getLastLoginDate()->format('Y-m-d H:i:s')) ?>
+                    </td>
+                </tr>
+            <?php endif; ?>
+                <tr class="site_table_row_<?php echo ($isUserAdmin) ? 'odd' : 'even' ?>">
                     <td class="site_table" style="width: 30%">E-Mail</td><td class="site_table">
             <a href="mailto:<?php xecho($params['user']->getEmail()); ?>">
                 <?php xecho($params['user']->getEmail()) ?>
             </a>
             </td>
                 </tr>
-                <tr class="site_table_row_2">
+                <tr class="site_table_row_<?php echo ($isUserAdmin) ? 'even' : 'odd' ?>">
                     <td class="site_table">Telephone</td>
                     <td class="site_table">
                         <?php xecho($params['user']->getTelephone()) ?>
                     </td>
                 </tr>
-                <tr class="site_table_row_1">
+                <tr class="site_table_row_<?php echo ($isUserAdmin) ? 'odd' : 'even' ?>">
                     <td class="site_table">Default ID String</td>
                     <td class="site_table">
                         <div style="word-wrap: break-word;">
@@ -117,7 +127,7 @@
                     </td>
                 </tr>-->
                 <?php if (sizeof($params['user']->getHomeSite()) != 0) { ?>
-                    <tr class="site_table_row_2">
+                    <tr class="site_table_row_<?php echo ($isUserAdmin) ? 'even' : 'odd' ?>">
                         <td class="site_table">Home Site</td>
                         <td class="site_table">
                             <a href="index.php?Page_Type=Site&amp;id=
@@ -138,7 +148,7 @@
         </span>
 
         <table style="clear: both; width: 100%;">
-            <tr class="site_table_row_1">
+            <tr class="site_table_row_even">
                 <th class="site_table">ID String</th>
                 <th class="site_table">Authentication type</th>
                 <?php if (!$params['portalIsReadOnly'] && $params['ShowEdit']) :?>
@@ -146,10 +156,9 @@
                 <?php endif; ?>
             </tr>
             <?php
-            $num = 2;
             // Loop through each user identifier
-            foreach ($params['user']->getUserIdentifiers() as $identifier) : ?>
-                <tr class="site_table_row_<?php echo $num ?>">
+            foreach ($params['user']->getUserIdentifiers() as $index => $identifier) : ?>
+                <tr class="site_table_row_<?php echo ($index % 2 == 0) ? 'odd' : 'even' ?>">
                     <td class="site_table" style="width: 40%">
                         <div style="background-color: inherit;">
                             <?php xecho($identifier->getKeyValue())?>
@@ -194,11 +203,6 @@
                     <?php endif;?>
                 </tr>
                 <?php
-                if ($num == 1) {
-                    $num = 2;
-                } else {
-                    $num = 1;
-                }
             endforeach;?>
         </table>
     </div>
@@ -222,7 +226,7 @@
         <img src="<?php echo \GocContextPath::getPath()?>img/people.png" class="decoration" />
 
         <table style="clear: both; width: 100%;">
-            <tr class="site_table_row_1">
+            <tr class="site_table_row_even">
                 <th class="site_table">Role Type <!--[roleId] --></th>
                 <th class="site_table">Held Over</th>
                 <?php if (!$params['portalIsReadOnly']) :?>
@@ -231,14 +235,14 @@
                 <?php endif; ?>
             </tr>
             <?php
-            $num = 2;
             foreach ($params['role_ProjIds'] as $role_ProjIds) { // foreach role
                 $role = $role_ProjIds[0];
                 $projIds = $role_ProjIds[1];
 
                 if (in_array($projId, $projIds)) { // if projId in array
                     ?>
-                    <tr class="site_table_row_<?php echo $num ?>">
+                    <tr class="site_table_row_<?php
+                     echo ($index % 2 == 0) ? 'odd' : 'even' ?>">
                     <td class="site_table" style="width: 40%">
                         <div style="background-color: inherit;">
                             <img src="<?php echo \GocContextPath::getPath()?>img/person.png" class="person" />
@@ -305,11 +309,6 @@
                     </td>
                     </tr>
                     <?php
-                    if ($num == 1) {
-                        $num = 2;
-                    } else {
-                        $num = 1;
-                    }
                 } // if projId in array
             } // foreach role
             ?>
@@ -326,7 +325,7 @@
 
 
         <table style="clear: both; width: 100%;">
-            <tr class="site_table_row_1">
+            <tr class="site_table_row_even">
                 <th class="site_table">Role Type <!--[roleId] --></th>
                 <th class="site_table">Held Over</th>
                 <?php if (!$params['portalIsReadOnly']) :?>
@@ -334,13 +333,13 @@
                 <?php endif; ?>
             </tr>
             <?php
-            $num = 2;
             foreach ($params['role_ProjIds'] as $role_ProjIds) { // foreach role
                 $role = $role_ProjIds[0];
                 $projIds = $role_ProjIds[1];
 
                 if (count($projIds) == 0) { // role with no owning proj ?>
-                    <tr class="site_table_row_<?php echo $num ?>">
+                    <tr class="site_table_row_<?php
+                        echo ($index % 2 == 0) ? 'odd' : 'even' ?>">
                         <td class="site_table" style="width: 40%">
                             <div style="background-color: inherit;">
                                 <img src="<?php echo \GocContextPath::getPath()?>img/person.png" height="25px"
@@ -393,11 +392,6 @@
                             </td>
                         </tr>
                         <?php
-                        if ($num == 1) {
-                            $num = 2;
-                        } else {
-                            $num = 1;
-                        };
                 } // end role with no owning proj
             } // end foreach role
             ?>
@@ -411,7 +405,7 @@
             </span>
             <img src="<?php echo \GocContextPath::getPath()?>img/key.png" class="decoration" />
             <table style="clear: both; width: 100%;">
-                <tr class="site_table_row_1">
+                <tr class="site_table_row_even">
                     <th class="site_table">Type</th>
                     <th class="site_table">Identifier</th>
                     <th class="site_table">Site</th>


### PR DESCRIPTION
To help with user support when someone queries one of the account deletion emails, it would be useful to be able to see when the account was last logged in to in the web interface.

As part of this ticket, I have used the name like `site_table_row_even` and `site_table_row_odd` for the `Last Logged In` field instead of `site_table_row_1` and  `site_table_row_2`.


"Resolves #456 ".