### PR TITLE
[GT-180] Add API credentials support to search functionality

### DIFF
--- a/htdocs/web_portal/controllers/search.php
+++ b/htdocs/web_portal/controllers/search.php
@@ -23,7 +23,7 @@
 function search() {
     require_once __DIR__.'/../../../lib/Gocdb_Services/Factory.php';
 
-
+    $params = [];
     $dn = Get_User_Principle();
     $user = \Factory::getUserService()->getUserByPrinciple($dn);
 
@@ -58,11 +58,16 @@ function search() {
     $serviceResults = $searchServ->getServices($params['searchTerm']);
     $userResults = $searchServ->getUsers($params['searchTerm']);
     $ngiResults = $searchServ->getNgis($params['searchTerm']);
+    $siteIdentifiers = $searchServ->getSiteIdentifiers(
+        $user,
+        $params['searchTerm']
+    );
 
     $params['siteResults'] = $siteResults;
     $params['serviceResults'] = $serviceResults;
     $params['userResults'] = $userResults;
     $params['ngiResults'] = $ngiResults;
+    $params['siteIdentifiers'] = $siteIdentifiers;
 
     show_view('search_results.php', $params, "Searching for \"{$params['searchTerm']}\"");
 }

--- a/htdocs/web_portal/views/search_results.php
+++ b/htdocs/web_portal/views/search_results.php
@@ -181,7 +181,61 @@
         </div>
     <?php } // end of "if userResults is > 0"?>
 
-    <?php if(sizeof($params['siteResults']) == 0 && sizeof($params['serviceResults']) == 0 && sizeof($params['userResults']) == 0 && sizeof($params['ngiResults'] == 0))  { ?>
+    <!-- Site Idetifiers -->
+    <?php if (sizeof($params['siteIdentifiers']) > 0) { ?>
+        <div class="listContainer" style="width: 97%;">
+            <div style="padding: 0.5em;">
+                <img style="vertical-align: middle; clear: both; height: 35px; width: 35px;"
+                     src="<?php echo \GocContextPath::getPath()?>img/key.png" />
+                <h3 style="vertical-align: middle; clear: both; display: inline;
+                            margin-left: 0.3em; font-size: 1.3em; padding-bottom: 0em;">
+                    API credentials
+                </h3>
+            </div>
+
+            <?php if ($params['authenticated']) { ?>
+            <table id="usersTable" class="table table-striped table-condensed tablesorter">
+                <thead>
+                    <tr>
+                        <th>Site Name</th>
+                        <th>Identifier</th>
+                    </tr>
+                </thead>
+
+                <tbody>
+                    <?php
+                    foreach ($params['siteIdentifiers'] as $site) {
+                        ?>
+                        <tr>
+                            <td style="width: 25%">
+                                <a href="index.php?Page_Type=Site&amp;id=<?php
+                                    echo $site->getParentSite()->getId() ?>">
+                                    <?php xecho($site->getParentSite()->getShortName()) ?>
+                                </a>
+                            </td>
+                            <td>
+                                <?php xecho($site->getIdentifier()); ?>
+                            </td>
+                        </tr>
+                        <?php
+                    } // End of the foreach loop iterating over userResults
+                    ?>
+                </tbody>
+            </table>
+            <?php } else {
+                 echo 'PROTECTED';
+            }
+            ?>
+        </div>
+    <?php } // end of "if siteIdentifiers is > 0"?>
+
+    <?php if (
+        sizeof($params['siteResults']) == 0 &&
+        sizeof($params['serviceResults']) == 0 &&
+        sizeof($params['userResults']) == 0 &&
+        sizeof($params['ngiResults']) == 0 &&
+        sizeof($params['siteIdentifiers']) == 0
+) { ?>
         <div class="listContainer" style="padding: 0.5em; width: 97%;">
             <span style="float: left;">No results found</span>
         </div>

--- a/lib/Gocdb_Services/Search.php
+++ b/lib/Gocdb_Services/Search.php
@@ -101,4 +101,21 @@ class Search {
         return $ngis;
     }
 
+    /**
+     * When the user is admin, it retrieves the matching identifiers.
+     */
+    public function getSiteIdentifiers($user, $searchTerm)
+    {
+        if ($user->isAdmin()) {
+            $dql = "SELECT ui FROM APIAuthentication ui "
+                . " WHERE UPPER(ui.identifier) "
+                . " LIKE UPPER(concat(concat('%', :searchTerm), '%'))";
+            $siteIdentifiers = $this->em
+                ->createQuery($dql)
+                ->setParameter(":searchTerm", $searchTerm)
+                ->getResult();
+
+            return $siteIdentifiers;
+        }
+    }
 }


### PR DESCRIPTION
It's often quite useful to be able to identify a site associated with an API credential, and at the moment I have to log into the database to do so, which is less than ideal.

Perhaps the "Search" functionality in portal could return the owning Site?


"Resolves #452 "