### PR TITLE
[GT-182] Add restrictions on who can create SG's

### DIFF
--- a/htdocs/web_portal/controllers/service_group/add_service_group.php
+++ b/htdocs/web_portal/controllers/service_group/add_service_group.php
@@ -22,6 +22,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
   /*====================================================== */
+use Exception;
+
 require_once __DIR__ . '/../../../../lib/Gocdb_Services/Factory.php';
 require_once __DIR__ . '/../../components/Get_User_Principle.php';
 require_once __DIR__ . '/../utils.php';
@@ -72,6 +74,20 @@ function draw($user) {
         // If the user is registered they're allowed to add a service group
         if (is_null($user)) {
             throw new \Exception("Unregistered users can't create service groups.");
+        }
+
+        $hasAdminCredentials = $user->isAdmin();
+        $roleService = \Factory::getRoleService();
+        $userRoles = $roleService->getUserRoles($user);
+
+        $isUserValid = $hasAdminCredentials ? true : !empty($userRoles);
+
+        if (!$isUserValid) {
+            throw new Exception(
+                "You do not have permission to add a new "
+                . "Service Group. To add a new Service Group, you require "
+                . "at least one role assigned over an entity in GOCDB."
+            );
         }
 
         // can user assign reserved scopes ?


### PR DESCRIPTION
If a user is an `Admin` -> they are allowed to ADD new service group's.

If a user is NOT an `Admin`:
1) Case1: User is NOT allowed to add new SG's. If a User have no roles assigned.
2) Case2: User is allowed to add new SG's. If a user is registered and have at least one role assigned with 'STATUS_GRANTED'.

Resolves #364 
 