### PR TITLE
[GT-183] Add service types page for non-admins

### DIFF
--- a/config/web_portal/menu.xml
+++ b/config/web_portal/menu.xml
@@ -42,6 +42,12 @@
       <link>index.php?Page_Type=Services</link>
     </Services>
 
+    <ServiceTypes>
+        <show_on_instance>all</show_on_instance>
+        <name>Service Types</name>
+        <link>index.php?Page_Type=Service_Types</link>
+    </ServiceTypes>
+
     <Scopes>
       <show_on_instance>all</show_on_instance>
       <name>Scopes</name>
@@ -136,7 +142,13 @@
       <name>Add Project</name>
       <link>index.php?Page_Type=Admin_Add_Project</link>
    </AddProject>
-        	
+
+    <AddServiceTypes>
+        <show_on_instance>admin</show_on_instance>
+        <name>Add Service Type</name>
+        <link>index.php?Page_Type=Admin_Add_Service_Type</link>
+    </AddServiceTypes>
+
    <MoveServiceEndPoint>
 	  <show_on_instance>admin</show_on_instance>
       <name>Move Service</name>
@@ -148,12 +160,6 @@
       <name>Move Site</name>
       <link>index.php?Page_Type=Admin_Move_Site</link>
     </MoveSite>
-    
-    <ServiceTypes>
-	  <show_on_instance>admin</show_on_instance>
-      <name>Service Types</name>
-      <link>index.php?Page_Type=Admin_Service_Types</link>
-    </ServiceTypes>
     
     <Users>
 	  <show_on_instance>admin</show_on_instance>

--- a/config/web_portal/menu.xsd
+++ b/config/web_portal/menu.xsd
@@ -15,6 +15,7 @@
         <xs:element name="Sites" type="showType" minOccurs="0"/>
         <xs:element name="ServiceGroups" type="showType" minOccurs="0"/>
         <xs:element name="Services" type="showType" minOccurs="0"/>
+        <xs:element name="ServiceTypes" type="showType" minOccurs="0"/>
         <xs:element name="Scopes" type="showType" minOccurs="0"/>
         <xs:element name="RoleActionMappings" type="showType" minOccurs="0"/>
         <xs:element name="AddSite" type="showType" minOccurs="0"/>
@@ -26,9 +27,9 @@
         <xs:element name="HelpAndContact" type="showType" minOccurs="0"/>
         <xs:element name="AddNGI" type="showType" minOccurs="0"/>
         <xs:element name="AddProject" type="showType" minOccurs="0"/>
+        <xs:element name="AddServiceType" type="showType" minOccurs="0"/>
         <xs:element name="MoveServiceEndPoint" type="showType" minOccurs="0"/>
         <xs:element name="MoveSite" type="showType" minOccurs="0"/>
-        <xs:element name="ServiceTypes" type="showType" minOccurs="0"/>
         <xs:element name="Users" type="showType" minOccurs="0"/>
     </xs:all>
   </xs:complexType>

--- a/htdocs/web_portal/controllers/service_type/view_service_type.php
+++ b/htdocs/web_portal/controllers/service_type/view_service_type.php
@@ -24,14 +24,17 @@ require_once __DIR__ . '/../../../web_portal/components/Get_User_Principle.php';
 
 function view_service_type()
 {
-     //Check the user has permission to see the page, will throw exception
-    //if correct permissions are lacking
-    checkUserIsAdmin();
+    $params = [];
+
+    $identifier = Get_User_Principle();
+    $user = \Factory::getUserService()->getUserByPrinciple($identifier);
+
+    if ($user != null) {
+        $params['isUserAdmin'] = checkUserForAdminCredentials($user);
+    }
     if (!isset($_REQUEST['id']) || !is_numeric($_REQUEST['id'])) {
         throw new Exception("An id must be specified");
     }
-    $dn = Get_User_Principle();
-    $user = \Factory::getUserService()->getUserByPrinciple($dn);
 
     $serv = \Factory::getServiceTypeService();
     /**
@@ -39,16 +42,11 @@ function view_service_type()
      */
     $serviceType = $serv ->getServiceType($_REQUEST['id']);
 
-    $params = [];
     $params['Name'] = $serviceType->getName();
     $params['Description'] = $serviceType->getDescription();
     $params['ID'] = $serviceType->getId();
     $params['AllowMonitoringException'] = $serviceType->getAllowMonitoringException();
     $params['Services'] = $serv->getServices($params['ID']);
-    /**
-     * @var \User $user
-     */
-    $params['portalIsReadOnly'] = portalIsReadOnlyAndUserIsNotAdmin($user);
 
-    show_view("admin/view_service_type.php", $params, $params['Name']);
+    show_view("service_type/view_service_type.php", $params, $params['Name']);
 }

--- a/htdocs/web_portal/controllers/service_type/view_service_types.php
+++ b/htdocs/web_portal/controllers/service_type/view_service_types.php
@@ -23,15 +23,9 @@ require_once __DIR__ . '/../utils.php';
 require_once __DIR__ . '/../../../web_portal/components/Get_User_Principle.php';
 
 function show_all(){
-    //Check the user has permission to see the page, will throw exception
-    //if correct permissions are lacking
-    checkUserIsAdmin();
-
-    $dn = Get_User_Principle();
-    $user = \Factory::getUserService()->getUserByPrinciple($dn);
 
     $serviceTypes = \Factory::getServiceTypeService()->getServiceTypes();
     $params['ServiceTypes']= $serviceTypes;
-    $params['portalIsReadOnly'] = portalIsReadOnlyAndUserIsNotAdmin($user);
-    show_view('admin/view_service_types.php', $params, 'Service Types');
+
+    show_view('service_type/view_service_types.php', $params, 'Service Types');
 }

--- a/htdocs/web_portal/controllers/utils.php
+++ b/htdocs/web_portal/controllers/utils.php
@@ -817,3 +817,14 @@ function getReadPDParams($user)
     }
     return array($userIsAdmin, $authenticated);
 }
+
+/**
+ * Helper to identify whether the user is an Admin or NOT.
+ * Useful for deciding whether to display elements based on admin status.
+ *
+ * Returns `true` if the user is an Admin, `false` otherwise.
+ */
+function checkUserForAdminCredentials($user)
+{
+    return $user->isAdmin();
+}

--- a/htdocs/web_portal/index.php
+++ b/htdocs/web_portal/index.php
@@ -450,14 +450,14 @@ function Draw_Page($Page_Type) {
             require_once __DIR__.'/controllers/admin/move_service_end_point.php';
             move_service_end_point();
             break;
-        case "Admin_Service_Types":
+        case "Service_Types":
             rejectIfNotAuthenticated();
-            require_once __DIR__.'/controllers/admin/view_service_types.php';
+            require_once __DIR__.'/controllers/service_type/view_service_types.php';
             show_all();
             break;
-        case "Admin_Service_Type":
+        case "Service_Type":
             rejectIfNotAuthenticated();
-            require_once __DIR__.'/controllers/admin/view_service_type.php';
+            require_once __DIR__.'/controllers/service_type/view_service_type.php';
             view_service_type();
             break;
         case "Admin_Edit_Service_Type":

--- a/htdocs/web_portal/views/admin/added_service_type.php
+++ b/htdocs/web_portal/views/admin/added_service_type.php
@@ -4,7 +4,7 @@
 
     <?php require_once __DIR__ . '/../fragments/serviceTypeInfo.php'; ?>
 
-    <a href="index.php?Page_Type=Admin_Service_Type&amp;id=<?php echo $params['ID'] ?>">
+    <a href="index.php?Page_Type=Service_Type&amp;id=<?= $params['ID']; ?>">
      Click here</a> to view the <?php xecho($params['Name'])?> service type.
 
 

--- a/htdocs/web_portal/views/admin/delete_service_type_denied.php
+++ b/htdocs/web_portal/views/admin/delete_service_type_denied.php
@@ -3,7 +3,10 @@
 <div class="rightPageContainer">
     <h1 class="Success">Deletion Failed</h1><br />
     The service type '
-    <a href="index.php?Page_Type=Admin_Service_Type&amp;id=<?php echo $serviceType->getId();?>">
+    <?php
+    $serviceTypeRelPath = "index.php?Page_Type=Service_Type";
+    ?>
+    <a href="<?= $serviceTypeRelPath; ?>&amp;id=<?= $serviceType->getId(); ?>">
     <?php xecho($serviceType->getName());?>
     </a>'
     can not be deleted as the following services are still of this type:

--- a/htdocs/web_portal/views/admin/edited_service_type.php
+++ b/htdocs/web_portal/views/admin/edited_service_type.php
@@ -1,7 +1,9 @@
 <div class="rightPageContainer">
     <h1 class="Success">Success</h1><br />
-    <p><a href="index.php?Page_Type=Admin_Service_Type&amp;id=<?php echo $params['ID']?>">
-       <?php xecho($params['Name'])?></a> Service Type properties have been successfully edited to  -
+    <p>
+        <a href="index.php?Page_Type=Service_Type&amp;id=<?= $params['ID']; ?>"
+        ><?php xecho($params['Name']); ?></a>
+        Service Type properties have been successfully edited to  -
     </p>
 
     <?php require_once __DIR__ . '/../fragments/serviceTypeInfo.php'; ?>

--- a/htdocs/web_portal/views/service_type/view_service_type.php
+++ b/htdocs/web_portal/views/service_type/view_service_type.php
@@ -5,7 +5,7 @@ $allowMonitoringException = xssafe($params['AllowMonitoringExtension']);
 $id = $params['ID'];
 $services = $params['Services'];
 $SEsCount = sizeof($services);
-$portalIsReadOnly = $params['portalIsReadOnly'];
+$isUserAdmin = $params['isUserAdmin'];
 ?>
 
 
@@ -20,8 +20,9 @@ $portalIsReadOnly = $params['portalIsReadOnly'];
     </div>
 
     <!--Edit/Delete buttons-->
-    <!-- Only show when portal is not read only mode -->
-    <?php if (!$portalIsReadOnly) :?>
+    <!--Enable edit and delete functionality ONLY when
+        the web portal is accessed by an Admin.-->
+    <?php if ($isUserAdmin) :?>
         <div style="float: right;">
             <div style="float: right; margin-left: 2em;">
                 <a href="index.php?Page_Type=Admin_Edit_Service_Type&amp;id=<?php echo $id ?>">

--- a/htdocs/web_portal/views/service_type/view_service_types.php
+++ b/htdocs/web_portal/views/service_type/view_service_types.php
@@ -5,22 +5,9 @@
                 Service Types
         </h1>
         <span style="clear: both; float: left; padding-bottom: 0.4em;">
-            Click on the name of a service type to edit or delete it.
+            All Service Types in GOCDB.
         </span>
     </div>
-
-    <!-- Only show add when not in read only mode-->
-    <?php if (!$params['portalIsReadOnly']) :?>
-        <div style="float: right;">
-            <center>
-                <a href="index.php?Page_Type=Admin_Add_Service_Type">
-                <img src="<?php echo \GocContextPath::getPath()?>img/add.png" height="25px" />
-                <br />
-                <span>Add Service <br> Type </span>
-                </a>
-            </center>
-        </div>
-    <?php endif; ?>
 
     <?php $numberOfServiceTypes = sizeof($params['ServiceTypes'])?>
     <div class="listContainer">
@@ -37,6 +24,7 @@
             </tr>
             <?php
             $num = 2;
+
             if ($numberOfServiceTypes > 0) {
                 foreach ($params['ServiceTypes'] as $serviceType) {
                     ?>
@@ -44,9 +32,14 @@
                     <td class="site_table" style="width: 30%">
                         <div style="background-color: inherit;">
                             <span style="vertical-align: middle;">
-                                <a href="index.php?Page_Type=Admin_Service_Type&amp;id=<?php echo $serviceType->getId() ?>">
-                                    <?php xecho($serviceType->getName()); ?>
-                                </a>
+                                <?php
+                                echo "<a href=\"index.php"
+                                    . "?Page_Type=Service_Type"
+                                    . "&amp;id=" . $serviceType->getId()
+                                    . "\">"
+                                    . $serviceType->getName()
+                                    . "</a>";
+                                ?>
                             </span>
                         </div>
                     </td>


### PR DESCRIPTION

- Admin => Can do CRUD operations in `Service Types` page.
- non-Admin => Can ONLY read the data(view) in `Service Types` page.

"Resolves #126 " 

Note:
Sometimes GIT interface will not show the EOL. If the file is NOT having EOL GIT may shows `no_newline_at_end` explicitly. 