### PR TITLE
[GT-187] Add support for selecting mutiple sites

### DIFF
--- a/htdocs/web_portal/controllers/downtime/add_downtime.php
+++ b/htdocs/web_portal/controllers/downtime/add_downtime.php
@@ -21,9 +21,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  /*======================================================*/
-require_once __DIR__.'/../../../../lib/Gocdb_Services/Factory.php';
-require_once __DIR__.'/../utils.php';
-require_once __DIR__.'/../../../web_portal/components/Get_User_Principle.php';
+require_once __DIR__ . '/../../../../lib/Gocdb_Services/Factory.php';
+require_once __DIR__ . '/../utils.php';
+require_once __DIR__ . '/../../../web_portal/components/Get_User_Principle.php';
+require_once __DIR__ . '/downtime_utils.php';
 
 /**
  * Controller for a new_downtime request.
@@ -60,64 +61,60 @@ function add() {
 /**
  * Retrieves the raw new downtime's data from a portal request and submit it
  * to the services layer's downtime functions.
+ *
  * @param \User $user current user
- * @return null
  */
-function submit(\User $user = null) {
-
-
-    //Check if this is a confirmed submit or intial submit
+function submit(\User $user = null)
+{
     $confirmed = $_POST['CONFIRMED'];
-    if($confirmed == true){
-        //Downtime is confirmed, submit it
-        //$downtimeInfo = unserialize($_REQUEST['newValues']);  // didn't cater for UTF-8 chars
-        $downtimeInfo = json_decode($_POST['newValues'], TRUE);
-        $serv = \Factory::getDowntimeService();
 
-        $params['dt'] = $serv->addDowntime($downtimeInfo, $user);
-        show_view("downtime/added_downtime.php", $params);
-    }else{
-        //Show user confirmation screen with their input
-        $downtimeInfo = getDtDataFromWeb();
-
-        //Need to sort the impacted_ids into impacted services and impacted endpoints
-        $impactedids = $downtimeInfo['IMPACTED_IDS'];
-
-        $services=array();
-        $endpoints=array();
-
-        //For each impacted id sort between endpoints and services using the prepended letter
-        foreach($impactedids as $id){
-            if (strpos($id, 's') !== FALSE){
-                //This is a service id
-                $services[] = str_replace('s', '', $id); //trim off the identifying char before storing in array
-            }else{
-                //This is an endpoint id
-                $endpoints[] = str_replace('e', '', $id); //trim off the identifying char before storing in array
-            }
-        }
-
-        unset($downtimeInfo['IMPACTED_IDS']); //Delete the unsorted Ids from the downtime info
-
-        $downtimeInfo['Impacted_Endpoints'] = $endpoints;
-
-
-        $serv = \Factory::getServiceService();
-
-        /** For endpoint put into downtime we want the parent service also. If a user has selected
-         * endpoints but not the parent service here we will add the service to maintain the link beteween
-         * a downtime having both the service and the endpoint.
+    if ($confirmed == true) {
+        /**
+         * If confirmed by an user, submit the details of affected services
+         * and endpoints along with other details for each individual site.
          */
-        foreach($downtimeInfo['Impacted_Endpoints'] as $endpointIds){
-           $endpoint = $serv->getEndpoint($endpointIds);
-           $services[] = $endpoint->getService()->getId();
+        $downtimeInfo = json_decode($_POST['newValues'], true);
+        $serv = \Factory::getDowntimeService();
+        $downtimeInfo = unsetVariables($downtimeInfo, 'add');
+        $params = [];
+
+        foreach ($downtimeInfo['SITE_LEVEL_DETAILS'] as $siteID) {
+            $downtimeInfo['Impacted_Services'] = $siteID['services'];
+            $downtimeInfo['Impacted_Endpoints'] = $siteID['endpoints'];
+
+            $params['submittedDowntimes'][$siteID['siteName']] =
+                $serv->addDowntime($downtimeInfo, $user);
         }
 
-        //Remove any duplicate service ids and store the array of ids
-        $services = array_unique($services);
+        show_view("downtime/added_downtime.php", $params);
+    } else {
+        // Show user confirmation screen with their input
+        $downtimeInfo = getDowntimeFormData();
 
-        //Assign the impacted services and endpoints to their own arrays for us by the addDowntime method
-        $downtimeInfo['Impacted_Services'] = $services;
+        list(
+            $siteLevelDetails,
+            $serviceWithEndpoints
+        ) = endpointToServiceMapping($downtimeInfo['IMPACTED_IDS']);
+
+        // Delete the unsorted IDs from the downtime info
+        unset($downtimeInfo['IMPACTED_IDS']);
+
+        if (!count($siteLevelDetails) > 1) {
+            $downtimeInfo['SINGLE_TIMEZONE'] = true;
+        }
+
+        list(
+            $siteLevelDetails,
+            $serviceWithEndpoints
+        ) = addParentServiceForEndpoints(
+            $serviceWithEndpoints,
+            $siteLevelDetails,
+            false,
+            $downtimeInfo['DOWNTIME']
+        );
+
+        $downtimeInfo['SITE_LEVEL_DETAILS'] = $siteLevelDetails;
+        $downtimeInfo['SERVICE_WITH_ENDPOINTS'] = $serviceWithEndpoints;
 
         show_view("downtime/confirm_add_downtime.php", $downtimeInfo);
     }
@@ -215,5 +212,3 @@ function draw(\User $user = null) {
         die();
     }
 }
-
-?>

--- a/htdocs/web_portal/controllers/downtime/downtime_utils.php
+++ b/htdocs/web_portal/controllers/downtime/downtime_utils.php
@@ -1,0 +1,168 @@
+<?php
+
+/*_____________________________________________________________________________
+ *=============================================================================
+ * File: downtime_utils.php
+ * Author: GOCDB DEV TEAM, STFC.
+ * Description: Helper functions which can be re-used while adding
+ *              or editing a downtime.
+ *
+ * License information
+ *
+ * Copyright 2013 STFC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ /*====================================================== */
+require_once __DIR__ . '/../../../../lib/Gocdb_Services/Factory.php';
+
+use DateTime;
+use DateTimeZone;
+
+/**
+ * Sorts the impacted IDs into impacted services and impacted endpoints.
+ *
+ * @param array $impactedIDs An array of `impactedIDs` which user has selected.
+ *
+ * @return array An array containing
+ *               `$siteLevelDetails` and `serviceWithEndpoints`.
+ */
+function endpointToServiceMapping($impactedIDs)
+{
+    $siteLevelDetails = [];
+    $serviceWithEndpoints = [];
+
+    /**
+     * For each impacted ID,
+     * sort between endpoints and services using the prepended letter.
+     */
+    foreach ($impactedIDs as $id) {
+        list($siteNumber, $parentService, $idType) = explode(':', $id);
+
+        $type = strpos($idType, 's') !== false ? 'services' : 'endpoints';
+        $id = str_replace(['s', 'e'], '', $idType);
+
+        $siteLevelDetails[$siteNumber][$type][] = $id;
+        $serviceWithEndpoints[$siteNumber][$parentService][$type][] = $id;
+    }
+
+    return [$siteLevelDetails, $serviceWithEndpoints];
+}
+
+/**
+ * If a user has selected endpoints but not the parent service here
+ * we will add the service to maintain the link between a downtime
+ * having both the service and the endpoint.
+ *
+ * @param array $servWithEndpoints   Used for displaying affected service
+ *                                   with endpoint(s).
+ * @param array $siteDetails         Each site ID will have `services` which
+ *                                   stores all affected service ID(s) and
+ *                                   `endpoints` which stores all affected
+ *                                   endpoint ID(s).
+ * @param bool $hasMultipleTimezones If the user selects multiple sites in
+ *                                   web portal along with the option
+ *                                   "site timezone" it will be true;
+ *                                   otherwise, it will be false.
+ * @param mixed $downtimeDetails     Downtime information.
+ *
+ * @return array An array containing `$siteDetails` and `servWithEndpoints`.
+ */
+function addParentServiceForEndpoints(
+    $servWithEndpoints,
+    $siteDetails,
+    $hasMultipleTimezones,
+    $downtimeDetails
+) {
+    foreach ($servWithEndpoints as $siteID => $siteData) {
+        $siteDetails[$siteID]['services'] = [];
+
+        $newSite = \Factory::getSiteService()->getSite($siteID);
+        $siteDetails[$siteID]['siteName'] = $newSite->getShortName();
+
+        if ($hasMultipleTimezones) {
+            list(
+                $siteDetails[$siteID]['START_TIMESTAMP'],
+                $siteDetails[$siteID]['END_TIMESTAMP']
+            ) = setLocalTimeForSites($downtimeDetails, $siteID);
+        }
+
+        foreach (array_keys($siteData) as $serviceID) {
+            $servWithEndpoints[$siteID][$serviceID]['services'] = [];
+            $servWithEndpoints[$siteID][$serviceID]['services'][] = $serviceID;
+            // Ensuring that service IDs are unique for the selected sites.
+            $siteDetails[$siteID]['services'][] = $serviceID;
+        }
+    }
+
+    return [$siteDetails, $servWithEndpoints];
+}
+
+/**
+ * Converts UTC start and end timestamps to the local timezone
+ * of a specific site based on its timezone.
+ *
+ * @param mixed $downtimeDetails Downtime information.
+ * @param integer $siteID        Site ID
+ */
+function setLocalTimeForSites($downtimeDetails, $siteID)
+{
+    $site = \Factory::getSiteService()->getSite($siteID);
+
+    $siteTimezone = $site->getTimeZoneId();
+
+    $startTimeAsString = $downtimeDetails['START_TIMESTAMP'];
+    $utcEndTime = $downtimeDetails['END_TIMESTAMP'];
+
+    $utcStartDateTime = DateTime::createFromFormat(
+        'd/m/Y H:i',
+        $startTimeAsString,
+        new DateTimeZone('UTC')
+    );
+    $utcEndDateTime = DateTime::createFromFormat(
+        'd/m/Y H:i',
+        $utcEndTime,
+        new DateTimeZone('UTC')
+    );
+
+    $targetSiteTimezone = new DateTimeZone($siteTimezone);
+    $utcOffset = $targetSiteTimezone->getOffset($utcStartDateTime);
+
+    // Calculate the equivalent time in the target timezone.
+    // Ref: https://www.php.net/manual/en/datetime.modify.php
+    $siteStartDateTime = $utcStartDateTime->modify("-$utcOffset seconds");
+    $siteEndDateTime = $utcEndDateTime->modify("-$utcOffset seconds");
+
+    return [
+        $siteStartDateTime->format('d/m/Y H:i'),
+        $siteEndDateTime->format('d/m/Y H:i')
+    ];
+}
+
+/**
+ * Unset a given variable, helper method to destroy the specified variables.
+ *
+ * @param mixed $downtimeObj   Object to destroy specified variables.
+ * @param string $fromLocation Location from where the function is being called.
+ */
+function unsetVariables($downtimeObj, $fromLocation)
+{
+    if ($fromLocation == "add") {
+        unset($downtimeObj['SERVICE_WITH_ENDPOINTS']);
+        unset($downtimeObj['SINGLE_TIMEZONE']);
+    } else {
+        unset($downtimeObj['DOWNTIME']['EXISTINGID']);
+        unset($downtimeObj['isEdit']);
+        unset($downtimeObj['SERVICE_WITH_ENDPOINTS']);
+        unset($downtimeObj['SINGLE_TIMEZONE']);
+    }
+
+    return $downtimeObj;
+}

--- a/htdocs/web_portal/controllers/downtime/edit_downtime.php
+++ b/htdocs/web_portal/controllers/downtime/edit_downtime.php
@@ -21,6 +21,7 @@
 require_once __DIR__ . '/../../../../lib/Gocdb_Services/Factory.php';
 require_once __DIR__ . '/../../../../htdocs/web_portal/components/Get_User_Principle.php';
 require_once __DIR__ . '/../utils.php';
+require_once __DIR__ . '/downtime_utils.php';
 
 /**
  * Controller for an edit downtime request
@@ -77,71 +78,73 @@ function draw(\User $user = null) {
 }
 
 /**
+ * Retrieves the raw edited downtime's data from a portal request
+ * and submit it to the services layer's downtime functions.
  *
  * @param \User $user current user
+ *
  * @throws Exception
  */
-function submit(\User $user = null) {
-
-    //Check if this is a confirmed submit or intial submit
+function submit(\User $user = null)
+{
     $confirmed = $_POST['CONFIRMED'];
-    if($confirmed == true){
-        //Downtime is confirmed, submit it
-        $downtimeInfo = json_decode($_POST['newValues'], TRUE);
 
+    if ($confirmed == true) {
+        // Downtime is confirmed, submit it
+        $downtimeInfo = json_decode($_POST['newValues'], true);
+        $params = [];
         $serv = \Factory::getDowntimeService();
         $dt = $serv->getDowntime($downtimeInfo['DOWNTIME']['EXISTINGID']);
-        unset($downtimeInfo['DOWNTIME']['EXISTINGID']);
-        unset($downtimeInfo['isEdit']);
+        $downtimeInfo = unsetVariables($downtimeInfo, 'edit');
+
+        foreach ($downtimeInfo['SITE_LEVEL_DETAILS'] as $siteIDs) {
+            $downtimeInfo['Impacted_Services'] = $siteIDs['services'];
+            $downtimeInfo['Impacted_Endpoints'] = $siteIDs['endpoints'];
+        }
+
+        unset($downtimeInfo['SITE_LEVEL_DETAILS']);
+
         $params['dt'] = $serv->editDowntime($dt, $downtimeInfo, $user);
 
         show_view("downtime/edited_downtime.php", $params);
-    }else{
-        //Show user confirmation screen with their input
-        $downtimeInfo = getDtDataFromWeb();
+    } else {
+        // Show user confirmation screen with their input
+        $downtimeInfo = getDowntimeFormData();
 
-        //Need to sort the impacted_ids into impacted services and impacted endpoints
-        $impactedids = $downtimeInfo['IMPACTED_IDS'];
-
-        $services=array();
-        $endpoints=array();
-
-        //For each impacted id sort between endpoints and services using the prepended letter
-        foreach($impactedids as $id){
-            if (strpos($id, 's') !== FALSE){
-                //This is a service id
-                $services[] = str_replace('s', '', $id); //trim off the identifying char before storing in array
-            }else{
-                //This is an endpoint id
-                $endpoints[] = str_replace('e', '', $id); //trim off the identifying char before storing in array
-            }
-        }
-
-        unset($downtimeInfo['IMPACTED_IDS']); //Delete the unsorted Ids from the downtime info
-
-        $downtimeInfo['Impacted_Endpoints'] = $endpoints;
-
-
-        $serv = \Factory::getServiceService();
-
-        /** For endpoint put into downtime we want the parent service also. If a user has selected
-         * endpoints but not the parent service here we will add the service to maintain the link beteween
-         * a downtime having both the service and the endpoint.
+        /**
+         * Need to sort the impacted_ids into
+         * impacted services and impacted endpoints.
          */
-        foreach($downtimeInfo['Impacted_Endpoints'] as $endpointIds){
-           $endpoint = $serv->getEndpoint($endpointIds);
-           $services[] = $endpoint->getService()->getId();
+        list(
+            $siteLevelDetails,
+            $serviceWithEndpoints
+        ) = endpointToServiceMapping($downtimeInfo['IMPACTED_IDS']);
+
+        // Delete the unsorted IDs from the downtime info
+        unset($downtimeInfo['IMPACTED_IDS']);
+
+        if (!count($siteLevelDetails) > 1) {
+            $downtimeInfo['SINGLE_TIMEZONE'] = true;
         }
 
-        //Remove any duplicate service ids and store the array of ids
-        $services = array_unique($services);
+        list(
+            $siteLevelDetails,
+            $serviceWithEndpoints
+        ) = addParentServiceForEndpoints(
+            $serviceWithEndpoints,
+            $siteLevelDetails,
+            false,
+            $downtimeInfo['DOWNTIME']
+        );
 
-        //Assign the impacted services and endpoints to their own arrays for us by the addDowntime method
-        $downtimeInfo['Impacted_Services'] = $services;
-        //Pass the edit variable so the confirm_add view works as the confirm edit view.
+        $downtimeInfo['SITE_LEVEL_DETAILS'] = $siteLevelDetails;
+        $downtimeInfo['SERVICE_WITH_ENDPOINTS'] = $serviceWithEndpoints;
+        /**
+         * Pass the edit variable so the `confirm_add_downtime` view
+         * works as the confirm edit view.
+         */
         $downtimeInfo['isEdit'] = true;
+
         show_view("downtime/confirm_add_downtime.php", $downtimeInfo);
     }
 }
-
-?>

--- a/htdocs/web_portal/controllers/utils.php
+++ b/htdocs/web_portal/controllers/utils.php
@@ -2,6 +2,8 @@
 
 require_once __DIR__ . '/../../../lib/Gocdb_Services/Factory.php';
 
+use Exception;
+
 /**
  * Parse properties file
  *
@@ -552,7 +554,7 @@ function getNGIDataFromWeb()
  * @global array $_REQUEST Downtime data submitted by the end user
  * @return array an array representation of a downtime
  */
-function getDtDataFromWeb()
+function getDowntimeFormData()
 {
     $downTime = [];
     $downTime['DOWNTIME'] ['SEVERITY'] = $_REQUEST ['SEVERITY'];
@@ -562,16 +564,21 @@ function getDtDataFromWeb()
 
     $downTime['DOWNTIME'] ['DEFINE_TZ_BY_UTC_OR_SITE'] = 'utc'; //default
     if (isset($_REQUEST ['DEFINE_TZ_BY_UTC_OR_SITE'])) {
-        $downTime['DOWNTIME'] ['DEFINE_TZ_BY_UTC_OR_SITE'] = $_REQUEST ['DEFINE_TZ_BY_UTC_OR_SITE']; // 'utc' or 'site'
+        // 'utc' or 'site'
+        $downTime['DOWNTIME'] ['DEFINE_TZ_BY_UTC_OR_SITE'] =
+            $_REQUEST ['DEFINE_TZ_BY_UTC_OR_SITE'];
     }
 
     if (! isset($_REQUEST ['IMPACTED_IDS'])) {
-        throw new Exception('Error - No endpoints or services selected, downtime must affect at least one endpoint');
+        throw new Exception(
+            'Error - No endpoints or services selected,
+            downtime must affect at least one endpoint'
+        );
     }
     $downTime['IMPACTED_IDS'] = $_REQUEST ['IMPACTED_IDS'];
 
 
-    //Get the previous downtimes ID if we are doing an edit
+    // Get the existing downtime ID, if we are doing an edit.
     if (isset($_REQUEST['DOWNTIME_ID'])) {
         $downTime['DOWNTIME']['EXISTINGID'] = $_REQUEST['DOWNTIME_ID'];
     }

--- a/htdocs/web_portal/index.php
+++ b/htdocs/web_portal/index.php
@@ -294,7 +294,7 @@ function Draw_Page($Page_Type) {
             break;
         case "Downtime":
             rejectIfNotAuthenticated();
-            require_once __DIR__.'/controllers/downtime/view_downtime.php';
+            require_once __DIR__ . '/controllers/downtime/view_downtime.php';
             view();
             break;
         case "My_Sites":
@@ -355,13 +355,13 @@ function Draw_Page($Page_Type) {
             break;
         case "Add_Downtime":
             rejectIfNotAuthenticated();
-            require_once __DIR__.'/controllers/downtime/add_downtime.php';
+            require_once __DIR__ . '/controllers/downtime/add_downtime.php';
             //require_once __DIR__.'/controllers/downtime/add_downtime_old.php';
             add();
             break;
         case "Edit_Downtime":
             rejectIfNotAuthenticated();
-            require_once __DIR__.'/controllers/downtime/edit_downtime.php';
+            require_once __DIR__ . '/controllers/downtime/edit_downtime.php';
             //require_once __DIR__.'/controllers/downtime/edit_downtime_old.php';
             edit();
             break;
@@ -372,12 +372,12 @@ function Draw_Page($Page_Type) {
             break;
         case "Downtime_view_endpoint_tree":
             rejectIfNotAuthenticated();
-            require_once __DIR__.'/controllers/downtime/view_endpoint_tree.php';
+            require_once __DIR__ . '/controllers/downtime/view_endpoint_tree.php';
             getServiceandEndpointList();
             break;
         case "Edit_Downtime_view_endpoint_tree":
             rejectIfNotAuthenticated();
-            require_once __DIR__.'/controllers/downtime/view_endpoint_tree.php';
+            require_once __DIR__ . '/controllers/downtime/view_endpoint_tree.php';
             editDowntimePopulateEndpointTree();
             break;
         case "Downtime_View_Services":
@@ -392,7 +392,7 @@ function Draw_Page($Page_Type) {
             break;
         case "Delete_Downtime":
             rejectIfNotAuthenticated();
-            require_once __DIR__.'/controllers/downtime/delete_downtime.php';
+            require_once __DIR__ . '/controllers/downtime/delete_downtime.php';
             delete();
             break;
         case "Downtimes_Overview":

--- a/htdocs/web_portal/views/downtime/added_downtime.php
+++ b/htdocs/web_portal/views/downtime/added_downtime.php
@@ -1,5 +1,27 @@
 <div class="rightPageContainer">
     <h1 class="Success">Success</h1><br />
-    New Downtime successfully created. <br />
-    <a href="index.php?Page_Type=Downtime&amp;id=<?php echo $params['dt']->getId() ?>">View new downtime</a>
+    <?php
+    if (count($params['submittedDowntimes']) != 1) {
+        echo '<p>';
+        echo 'New Downtimes successfully created. ';
+        echo 'Please click the links below for more information.';
+        echo '</p>';
+    } else {
+        echo '<p>';
+        echo 'New Downtime successfully created. ';
+        echo 'Please click the link below for more information.';
+        echo '</p>';
+    }
+
+    echo '<ul>';
+    foreach ($params['submittedDowntimes'] as $siteName => $downtimeDetails) {
+        echo '<li>';
+        echo $siteName . ':';
+        echo '<a href="index.php?Page_Type=Downtime&id=';
+        echo $downtimeDetails->getId();
+        echo '"> Downtime ' . $downtimeDetails->getId() . '</a>';
+        echo '</li>';
+    }
+    echo '</ul>';
+    ?>
 </div>

--- a/htdocs/web_portal/views/downtime/downtime_edit_view_nested_endpoints_list.php
+++ b/htdocs/web_portal/views/downtime/downtime_edit_view_nested_endpoints_list.php
@@ -3,16 +3,18 @@ $services = $params['services'];
 $dt = $params['downtime'];
 $configService = \Factory::getConfigService();
 
-//Get the affected services and store the ids in an array.
-$affectedServiceIds = array();
-foreach($dt->getServices() as $affectedService){
-    $affectedServiceIds[] = $affectedService->getId();
+// Get the affected services and store the IDs in an array.
+$affectedServiceIDs = array();
+
+foreach ($dt->getServices() as $affectedService) {
+    $affectedServiceIDs[] = $affectedService->getId();
 }
 
-//Get the affected endpoints and store the ids in an array
-$affectedEndpointIds = array();
-foreach($dt->getEndpointLocations() as $affectedEndpoints){
-    $affectedEndpointIds[] = $affectedEndpoints->getId();
+// Get the affected endpoints and store the IDs in an array.
+$affectedEndpointIDs = array();
+
+foreach ($dt->getEndpointLocations() as $affectedEndpoints) {
+    $affectedEndpointIDs[] = $affectedEndpoints->getId();
 }
 
 ?>
@@ -26,36 +28,48 @@ foreach($dt->getEndpointLocations() as $affectedEndpoints){
         style="width:99%; margin-left:1%"
         onChange="selectServicesEndpoint()" multiple>
 <?php
-    foreach($services as $service){
-        $count=0;
+foreach ($services as $siteID => $siteServiceList) {
+    foreach ($siteServiceList as $service) {
+        $count = 0;
 
-        // Set the html 'SELECTED' attribute on the <option> only if this service was affected.
-        if(in_array($service->getId(), $affectedServiceIds)){
+        /**
+         * Set the HTML 'SELECTED' attribute on the <option>
+         * only if this service was affected.
+         */
+        if (in_array($service->getId(), $affectedServiceIDs)) {
             $selected = 'SELECTED';
-        }else{
+        } else {
             $selected = '';
         }
-        echo "<option value=\"s" . $service->getId() . "\" id=\"" . $service->getId() . "\" ".$selected.">";
-                xecho('('.$service->getServiceType()->getName().') ');
-                xecho($service->getHostName());
-                echo("</option>");
 
-        foreach($service->getEndpointLocations() as $endpoint){
-                    if(in_array($endpoint->getId(), $affectedEndpointIds)){
-                        $selected = 'SELECTED';
-                    }else{
-                        $selected = '';
-                    }
-            if($endpoint->getName() == ''){
+        echo "<option value=\"" . $siteID . ":" . $service->getId()
+            . ":s" . $service->getId() . "\" id=\"" . $service->getId()
+            . "\" " . $selected . ">";
+        xecho('(' . $service->getServiceType()->getName() . ') ');
+        xecho($service->getHostName());
+        echo("</option>");
+
+        foreach ($service->getEndpointLocations() as $endpoint) {
+            if (in_array($endpoint->getId(), $affectedEndpointIDs)) {
+                $selected = 'SELECTED';
+            } else {
+                $selected = '';
+            }
+            if ($endpoint->getName() == '') {
                 $name = xssafe('myEndpoint');
-            }else{
+            } else {
                 $name = xssafe($endpoint->getName());
             }
-            //Option styling doesn't work well cross browser so just use 4 spaces to indent the branch
-            echo "<option id=\"".$service->getId()."\" value=\"e" . $endpoint->getId() . "\" ".$selected.">&nbsp&nbsp&nbsp&nbsp-" . $name . "</option>";
+
+            /* Option styling doesn't work well cross browser,
+               so just use 4 spaces to indent the branch.*/
+            echo "<option id=\"" . $service->getId() . "\" value=\""
+                . $siteID . ":" .  $service->getId() . ":e"
+                . $endpoint->getId() . "\" " . $selected
+                . ">&nbsp&nbsp&nbsp&nbsp-" . $name . "</option>";
             $count++;
         }
-
     }
+}
 ?>
 </select>

--- a/htdocs/web_portal/views/downtime/edit_downtime.php
+++ b/htdocs/web_portal/views/downtime/edit_downtime.php
@@ -154,10 +154,15 @@ foreach($downtime->getEndpointLocations() as $endpoints){
                     $size = sizeof($sites) + 2;
             }
             ?>
-            <select style="width: 99%; margin-right: 1%"
-                class="form-control" id="Select_Sites" name="select_sites" size="10"
-                onclick="loadSitesServicesAndEndpoints()">
-
+            <select
+                style="width: 99%; margin-right: 1%"
+                class="form-control"
+                id="Select_Sites"
+                name="select_sites[]"
+                size="10"
+                onclick="loadSitesServicesAndEndpoints()"
+                multiple
+            >
                 <?php
                 foreach($sites as $site){
                     $sName = xssafe($site);
@@ -229,6 +234,7 @@ foreach($downtime->getEndpointLocations() as $endpoints){
          * Set the start and finish times (don't echo in the full date,
          * just the time values, time widget didn't like timestamp with date)
          */
+        $('#startTime').data("DateTimePicker").date("<?php echo date_format($startDate,"H:i"); ?>");
         $('#endTime').data("DateTimePicker").date("<?php echo date_format($endDate,"H:i"); ?>");
 
         // By default select the original affected services and endpoints
@@ -376,21 +382,29 @@ foreach($downtime->getEndpointLocations() as $endpoints){
      *
      * @returns {undefined}
      */
-    function loadSitesServicesAndEndpoints(){
+    function loadSitesServicesAndEndpoints()
+    {
         var dtId = <?php echo $downtime->getId();?>;
         var siteId=$('#Select_Sites').val();
 
-        $('#chooseServices').empty(); //Remove any previous content from the endpoints select list
-        // The Page_Type handler for 'Edit_Downtime_view_endpoint_tree' in the front controller loads the
-        // following view: 'views/downtime/downtime_edit_view_nested_endpoints_list.php'
-        // loading the downtime and the site.
-        $('#chooseServices').load('index.php?Page_Type=Edit_Downtime_view_endpoint_tree&dt_id='+dtId+'&site_id='+siteId,
-          function( response, status, xhr ) {
-              if ( status == "success" ) {
+        // Remove any previous content from the endpoints select list.
+        $('#chooseServices').empty(); 
+        /**
+         * The Page_Type handler for `Edit_Downtime_view_endpoint_tree` in the
+         * front controller loads the following view:
+         * `views/downtime/downtime_edit_view_nested_endpoints_list.php`
+         * loading the downtime and the site.
+         */
+        $('#chooseServices').load(
+            'index.php?Page_Type=Edit_Downtime_view_endpoint_tree&dt_id=' + dtId,
+            {site_id: siteId},
+            function(response, status, xhr)
+            {
+                if (status == "success") {
                     validate();
-                  }
-        });
-
+                }
+            }
+        );
     }
 
     //This function will select all of a services endpoints when the user clicks just the service option in the list

--- a/htdocs/web_portal/views/downtime/view_nested_endpoints_list.php
+++ b/htdocs/web_portal/views/downtime/view_nested_endpoints_list.php
@@ -5,22 +5,42 @@ $configService = \Factory::getConfigService();
 ?>
 <!-- Dynamically create a select list from a sites services -->
 <label> Select Affected Services+Endpoints (Ctrl+click to select)</label>
-<select name="IMPACTED_IDS[]" id="Select_Services" size="10" class="form-control" onclick="" style="width:99%; margin-left:1%" onChange="selectServicesEndpoint()" multiple>
+<select
+    name="IMPACTED_IDS[]"
+    id="Select_Services"
+    size="10"
+    class="form-control"
+    style="width:99%; margin-left:1%"
+    onChange="selectServicesEndpoint()"
+    multiple
+>
 <?php
-    foreach($services as $service){
-        $count=0;
-        echo "<option value=\"s" . $service->getId() . "\" id=\"" . $service->getId() . "\" SELECTED>" . '('.xssafe($service->getServiceType()->getName()).') '.xssafe($service->getHostName()) . "</option>";
-        foreach($service->getEndpointLocations() as $endpoint){
-            if($endpoint->getName() == ''){
+foreach ($services as $siteID => $siteServiceList) {
+    foreach ($siteServiceList as $service) {
+        $count = 0;
+
+        echo "<option value=\"" . $siteID . ":" . $service->getId() . ":s"
+            . $service->getId() . "\" id=\"" . $service->getId()
+            . "\" SELECTED>"
+            . '(' . xssafe($service->getServiceType()->getName()) . ') '
+            . xssafe($service->getHostName())
+            . "</option>";
+
+        foreach ($service->getEndpointLocations() as $endpoint) {
+            if ($endpoint->getName() == '') {
                 $name = xssafe('myEndpoint');
-            }else{
+            } else {
                 $name = xssafe($endpoint->getName());
             }
-            //Option styling doesn't work well cross browser so just use 4 spaces to indent the branch
-            echo "<option id=\"".$service->getId()."\" value=\"e" . $endpoint->getId() . "\" SELECTED>&nbsp&nbsp&nbsp&nbsp-" . $name . "</option>";
+
+            /* Option styling doesn't work well cross browser,
+               so just use 4 spaces to indent the branch.*/
+            echo "<option id=\"" . $service->getId() . "\" value=\""
+                . $siteID . ":" . $service->getId() . ":e" . $endpoint->getId()
+                . "\" SELECTED>&nbsp&nbsp&nbsp&nbsp-" . $name . "</option>";
             $count++;
         }
-
     }
+}
 ?>
 </select>


### PR DESCRIPTION
- Added support for selecting multiple sites in "ADD" downtime.
- Changed the Confirm Downtime and Confirm Edit Downtime pages.
- Changed Add_Downtime success page with relevant content.

Resolves: https://github.com/GOCDB/gocdb/issues/261

Partially address: https://github.com/GOCDB/gocdb/issues/85 and https://github.com/GOCDB/gocdb/issues/66 .

Addressed @gregcorbett  comments:

**### Suggestion 1:**
Include the Site Name next to the downtime link on creation, i.e.:

New Downtimes successfully created. Please click the links below for more information.
- Site A: Downtime 10
- Site B: Downtime 11

**### Suggestion 1:**
Only display the start and end time once on the "Confirm Downtime" page, i.e.:

Severity: WARNING
Description: foo bar
Starting (UTC): 08/09/2023 00:00
Ending (UTC): 18/09/2023 00:00
Site Name: Brunnen GS
...
Site Name: Torch
...