### PR TITLE
[GT-141] Add support for pre selecting endpoints

### DIFF
--- a/htdocs/web_portal/controllers/downtime/view_endpoint_tree.php
+++ b/htdocs/web_portal/controllers/downtime/view_endpoint_tree.php
@@ -23,6 +23,7 @@ function getServiceandEndpointList() {
     require_once __DIR__ . '/../utils.php';
     require_once __DIR__ . '/../../../web_portal/components/Get_User_Principle.php';
 
+    $params = [];
     $dn = Get_User_Principle();
     $user = \Factory::getUserService()->getUserByPrinciple($dn);
     $params['portalIsReadOnly'] = portalIsReadOnlyAndUserIsNotAdmin($user);
@@ -30,6 +31,10 @@ function getServiceandEndpointList() {
     if (!isset($_REQUEST['site_id']) || !is_numeric($_REQUEST['site_id']) ){
         throw new Exception("An id must be specified");
     }
+    if (isset($_REQUEST['se'])) {
+        $params['se'] = $_REQUEST['se'];
+    }
+
     $site = \Factory::getSiteService()->getSite($_REQUEST['site_id']);
     $services = $site->getServices();
     $params['services'] = $services;

--- a/htdocs/web_portal/views/downtime/add_downtime.php
+++ b/htdocs/web_portal/views/downtime/add_downtime.php
@@ -156,7 +156,14 @@ rather than the Site entities themselves, and specify tz, offset in the DTO/JSON
                     $siteName = $site->getName();
                     $ngiName = $site->getNgi()->getName();
                     $label = xssafe($site."   (".$ngiName.")");
-                    echo "<option value=\"{$site->getId()}\">$label</option>";
+                    echo "<option value=\"{$site->getId()}\"";
+                    if ($params['userCannotPreSelect']) {
+                        echo ">";
+                    } else {
+                        echo " SELECTED>";
+                    }
+                    echo "$label";
+                    echo "</option>";
                 }
                 ?>
             </select> <br /> <br />
@@ -231,7 +238,11 @@ rather than the Site entities themselves, and specify tz, offset in the DTO/JSON
            validate();
        });
 
-
+       /**
+        * Helps us to decide whether to fetch
+        * and `select` all services, endpoints or NOT.
+        */
+       getSitesServices();
 
     });
 
@@ -494,14 +505,44 @@ rather than the Site entities themselves, and specify tz, offset in the DTO/JSON
     }
 
     function getSitesServices(){
-        var siteId=$('#Select_Sites').val();
-        if(siteId != null){ //If the user clicks on the box but not a specific row there will be no input, so catch that here
-            $('#chooseEndpoints').empty(); //Remove any previous content from the endpoints select list
-            $('#chooseServices').load('index.php?Page_Type=Downtime_view_endpoint_tree&site_id='+siteId,function( response, status, xhr ) {
-                if ( status == "success" ) {
-                    validate();
+        let selectedSiteID = $('#Select_Sites').val();
+
+        /**
+         * If the user clicks on the box but not a specific row
+         * there will be no input, so catch that here.
+         */
+        if (selectedSiteID != null) {
+            // Remove any previous content from the endpoints select list.
+            $('#chooseEndpoints').empty();
+
+            let urlpathAndSearchName;
+            const SE_FROM_QUERY_PARAMS = new URL(
+                this.location.href
+                ).searchParams.get('se');
+
+            if (SE_FROM_QUERY_PARAMS) {
+                /**
+                 * NOTE: If you use template literal for string interpolation,
+                 * i.e., `${}`. It has to be in one line.
+                 */
+                urlpathAndSearchName = "index.php?"
+                    + "Page_Type=Downtime_view_endpoint_tree"
+                    + `&se=${SE_FROM_QUERY_PARAMS}`
+                    + `&site_id=${selectedSiteID}`;
+            } else {
+                urlpathAndSearchName = "index.php?"
+                    + "Page_Type=Downtime_view_endpoint_tree"
+                    + `&site_id=${selectedSiteID}`;
+            }
+
+            $('#chooseServices').load(
+                urlpathAndSearchName,
+                function(response, status, xhr) {
+                    if ( status == "success" ) {
+                        validate();
+                    }
                 }
-            });
+            );
         }
     }
 

--- a/htdocs/web_portal/views/downtime/view_nested_endpoints_list.php
+++ b/htdocs/web_portal/views/downtime/view_nested_endpoints_list.php
@@ -1,26 +1,57 @@
 <?php
 $services = $params['services'];
+$specificServiceEndpoint = isset($params['se']) ? $params['se'] : '';
 $configService = \Factory::getConfigService();
-
 ?>
 <!-- Dynamically create a select list from a sites services -->
 <label> Select Affected Services+Endpoints (Ctrl+click to select)</label>
 <select name="IMPACTED_IDS[]" id="Select_Services" size="10" class="form-control" onclick="" style="width:99%; margin-left:1%" onChange="selectServicesEndpoint()" multiple>
 <?php
-    foreach($services as $service){
-        $count=0;
-        echo "<option value=\"s" . $service->getId() . "\" id=\"" . $service->getId() . "\" SELECTED>" . '('.xssafe($service->getServiceType()->getName()).') '.xssafe($service->getHostName()) . "</option>";
-        foreach($service->getEndpointLocations() as $endpoint){
-            if($endpoint->getName() == ''){
-                $name = xssafe('myEndpoint');
-            }else{
-                $name = xssafe($endpoint->getName());
+foreach ($services as $service) {
+    $count = 0;
+
+    if ($specificServiceEndpoint) {
+        if ($service->getId() == $specificServiceEndpoint) {
+            $selected = 'SELECTED';
+        } else {
+            $selected = '';
+        }
+    } else {
+        $selected = 'SELECTED';
+    }
+
+    echo "<option value=\"s" . $service->getId() . "\" id=\""
+        . $service->getId() . "\" " . $selected . ">" . '('
+        . xssafe($service->getServiceType()->getName()) . ') '
+        . xssafe($service->getHostName()) . "</option>";
+
+    foreach ($service->getEndpointLocations() as $endpoint) {
+        if ($specificServiceEndpoint) {
+            if ($service->getId() == $specificServiceEndpoint) {
+                $selected = 'SELECTED';
+            } else {
+                $selected = '';
             }
-            //Option styling doesn't work well cross browser so just use 4 spaces to indent the branch
-            echo "<option id=\"".$service->getId()."\" value=\"e" . $endpoint->getId() . "\" SELECTED>&nbsp&nbsp&nbsp&nbsp-" . $name . "</option>";
-            $count++;
+        } else {
+            $selected = 'SELECTED';
         }
 
+        if ($endpoint->getName() == '') {
+            $name = xssafe('myEndpoint');
+        } else {
+            $name = xssafe($endpoint->getName());
+        }
+
+        /**
+         * Option styling doesn't work well cross browser,
+         * so just use 4 spaces to indent the branch.
+         */
+        echo "<option id=\"" . $service->getId() . "\" value=\"e"
+            . $endpoint->getId() . "\" " . $selected
+            . ">&nbsp&nbsp&nbsp&nbsp-" . $name . "</option>";
+
+        $count++;
     }
+}
 ?>
 </select>


### PR DESCRIPTION
Clean version for #439 .


Case 1: If the user goes to the sites and tries to add recent downtimes. Then the user should be able to see the site, the services, and the endpoints pre-selected. [Pre-Selection enabled]
Case 2: If the user goes to the services and tries to add recent downtimes. Then the user should see the specific service-related endpoints that are pre-selected. [Pre-Selection enabled]
case 3: If the user goes to "Add Downtime" from the left hand menu, no Site should be pre-selected and they should be able to select any Site they have a role over (all Sites for GOCDB admins). [Pre-Selection NOT enabled]

"Resolves #229"
