### PR TITLE
[GT-187] Add feature selecting multiple sites

### DIFF
--- a/htdocs/web_portal/controllers/downtime/add_downtime.php
+++ b/htdocs/web_portal/controllers/downtime/add_downtime.php
@@ -106,15 +106,11 @@ function submit(\User $user = null) {
             $downtimeInfo['SINGLE_SITE'] = true;
         }
 
-        list(
-            $siteLevelDetails,
-            $serviceWithEndpoints
-        ) = addParentServiceForEndpoints(
-            $serviceWithEndpoints,
-            $siteLevelDetails,
-            false,
-            $downtimeInfo['DOWNTIME']
-        );
+        list($siteLevelDetails, $serviceWithEndpoints) =
+            addParentServiceForEndpoints(
+                $serviceWithEndpoints,
+                $siteLevelDetails
+            );
 
         $downtimeInfo['SITE_LEVEL_DETAILS'] = $siteLevelDetails;
         $downtimeInfo['SERVICE_WITH_ENDPOINTS'] = $serviceWithEndpoints;

--- a/htdocs/web_portal/controllers/downtime/add_downtime.php
+++ b/htdocs/web_portal/controllers/downtime/add_downtime.php
@@ -94,10 +94,8 @@ function submit(\User $user = null) {
         //Show user confirmation screen with their input
         $downtimeInfo = getDtDataFromWeb();
 
-        list(
-            $siteLevelDetails,
-            $serviceWithEndpoints
-        ) = endpointToServiceMapping($downtimeInfo['IMPACTED_IDS']);
+        list($siteLevelDetails, $serviceWithEndpoints) =
+            endpointToServiceMapping($downtimeInfo['IMPACTED_IDS']);
 
         // Delete the unsorted IDs from the downtime info
         unset($downtimeInfo['IMPACTED_IDS']);

--- a/htdocs/web_portal/controllers/downtime/add_downtime.php
+++ b/htdocs/web_portal/controllers/downtime/add_downtime.php
@@ -103,7 +103,7 @@ function submit(\User $user = null) {
         unset($downtimeInfo['IMPACTED_IDS']);
 
         if (!count($siteLevelDetails) > 1) {
-            $downtimeInfo['SINGLE_TIMEZONE'] = true;
+            $downtimeInfo['SINGLE_SITE'] = true;
         }
 
         list(

--- a/htdocs/web_portal/controllers/downtime/downtime_utils.php
+++ b/htdocs/web_portal/controllers/downtime/downtime_utils.php
@@ -1,0 +1,169 @@
+<?php
+
+/*_____________________________________________________________________________
+ *=============================================================================
+ * File: downtime_utils.php
+ * Author: GOCDB DEV TEAM, STFC.
+ * Description: Helper functions which can be re-used while adding
+ *              or editing a downtime.
+ *
+ * License information
+ *
+ * Copyright 2013 STFC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ /*====================================================== */
+require_once __DIR__ . '/../../../../lib/Gocdb_Services/Factory.php';
+
+use DateTime;
+use DateTimeZone;
+
+/**
+ * Sorts the impacted IDs into impacted services and impacted endpoints.
+ *
+ * @param array $impactedIDs An array of `impactedIDs` which user has selected.
+ *
+ * @return array An array containing
+ *               `$siteLevelDetails` and `serviceWithEndpoints`.
+ */
+function endpointToServiceMapping($impactedIDs)
+{
+    $siteLevelDetails = [];
+    $serviceWithEndpoints = [];
+
+    /**
+     * For each impacted ID,
+     * sort between endpoints and services using the prepended letter.
+     */
+    foreach ($impactedIDs as $id) {
+        list($siteNumber, $parentService, $idType) = explode(':', $id);
+
+        $type = strpos($idType, 's') !== false ? 'services' : 'endpoints';
+        $id = str_replace(['s', 'e'], '', $idType);
+
+        $siteLevelDetails[$siteNumber][$type][] = $id;
+        $serviceWithEndpoints[$siteNumber][$parentService][$type][] = $id;
+    }
+
+    return [$siteLevelDetails, $serviceWithEndpoints];
+}
+
+/**
+ * If a user has selected endpoints but not the parent service here
+ * we will add the service to maintain the link between a downtime
+ * having both the service and the endpoint.
+ *
+ * @param array $servWithEndpoints   Used for displaying affected service
+ *                                   with endpoint(s).
+ * @param array $siteDetails         Each site ID will have a `services` that
+ *                                   stores all affected service ID(s) and an
+ *                                   `endpoints` that stores all affected
+ *                                   endpoint ID(s).
+ * @param bool $hasMultipleTimezones If the user selects multiple sites in
+ *                                   the  web portal along with the option
+ *                                   "site timezone" it will be true;
+ *                                   otherwise, it will be false.
+ * @param mixed $downtimeDetails     Downtime information.
+ *
+ * @return array An array containing `$siteDetails` and `servWithEndpoints`.
+ */
+function addParentServiceForEndpoints(
+    $servWithEndpoints,
+    $siteDetails,
+    $hasMultipleTimezones,
+    $downtimeDetails
+) {
+    foreach ($servWithEndpoints as $siteID => $siteData) {
+        $siteDetails[$siteID]['services'] = [];
+
+        $newSite = \Factory::getSiteService()->getSite($siteID);
+        $siteDetails[$siteID]['siteName'] = $newSite->getShortName();
+
+        if ($hasMultipleTimezones) {
+            list(
+                $siteDetails[$siteID]['START_TIMESTAMP'],
+                $siteDetails[$siteID]['END_TIMESTAMP']
+            ) = setLocalTimeForSites($downtimeDetails, $siteID);
+        }
+
+        foreach (array_keys($siteData) as $serviceID) {
+            $servWithEndpoints[$siteID][$serviceID]['services'] = [];
+            $servWithEndpoints[$siteID][$serviceID]['services'][] = $serviceID;
+            // Ensuring that service IDs are unique for the selected sites.
+            $siteDetails[$siteID]['services'][] = $serviceID;
+        }
+    }
+
+    return [$siteDetails, $servWithEndpoints];
+}
+
+/**
+ * Converts UTC start and end timestamps to the local timezone
+ * of a specific site based on that site's timezone.
+ *
+ * @param mixed $downtimeDetails Downtime information.
+ * @param integer $siteID        Site ID
+ */
+function setLocalTimeForSites($downtimeDetails, $siteID)
+{
+    $site = \Factory::getSiteService()->getSite($siteID);
+
+    $siteTimezone = $site->getTimeZoneId();
+
+    $startTimeAsString = $downtimeDetails['START_TIMESTAMP'];
+    $utcEndTime = $downtimeDetails['END_TIMESTAMP'];
+
+    $utcStartDateTime = DateTime::createFromFormat(
+        'd/m/Y H:i',
+        $startTimeAsString,
+        new DateTimeZone('UTC')
+    );
+    $utcEndDateTime = DateTime::createFromFormat(
+        'd/m/Y H:i',
+        $utcEndTime,
+        new DateTimeZone('UTC')
+    );
+
+    $targetSiteTimezone = new DateTimeZone($siteTimezone);
+    $utcOffset = $targetSiteTimezone->getOffset($utcStartDateTime);
+
+    // Calculate the equivalent time in the target timezone.
+    // Ref: https://www.php.net/manual/en/datetime.modify.php
+    $siteStartDateTime = $utcStartDateTime->modify("-$utcOffset seconds");
+    $siteEndDateTime = $utcEndDateTime->modify("-$utcOffset seconds");
+
+    return [
+        $siteStartDateTime->format('d/m/Y H:i'),
+        $siteEndDateTime->format('d/m/Y H:i')
+    ];
+}
+
+/**
+ * Unset a given variable, helper method to destroy the specified variables.
+ *
+ * @param mixed $downtimeObj   Object to destroy specified variables.
+ * @param string $fromLocation Location from where the
+ *                             function is being called.
+ */
+function unsetVariables($downtimeObj, $fromLocation)
+{
+    if ($fromLocation == "add") {
+        unset($downtimeObj['SERVICE_WITH_ENDPOINTS']);
+        unset($downtimeObj['SINGLE_TIMEZONE']);
+    } else {
+        unset($downtimeObj['DOWNTIME']['EXISTINGID']);
+        unset($downtimeObj['isEdit']);
+        unset($downtimeObj['SERVICE_WITH_ENDPOINTS']);
+        unset($downtimeObj['SINGLE_TIMEZONE']);
+    }
+
+    return $downtimeObj;
+}

--- a/htdocs/web_portal/controllers/downtime/downtime_utils.php
+++ b/htdocs/web_portal/controllers/downtime/downtime_utils.php
@@ -3,13 +3,12 @@
 /*_____________________________________________________________________________
  *=============================================================================
  * File: downtime_utils.php
- * Author: GOCDB DEV TEAM, STFC.
  * Description: Helper functions which can be re-used while adding
  *              or editing a downtime.
  *
  * License information
  *
- * Copyright 2013 STFC
+ * Copyright 2023 STFC
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/htdocs/web_portal/controllers/downtime/downtime_utils.php
+++ b/htdocs/web_portal/controllers/downtime/downtime_utils.php
@@ -157,12 +157,12 @@ function unsetVariables($downtimeObj, $fromLocation)
 {
     if ($fromLocation == "add") {
         unset($downtimeObj['SERVICE_WITH_ENDPOINTS']);
-        unset($downtimeObj['SINGLE_TIMEZONE']);
+        unset($downtimeObj['SINGLE_SITE']);
     } else {
         unset($downtimeObj['DOWNTIME']['EXISTINGID']);
         unset($downtimeObj['isEdit']);
         unset($downtimeObj['SERVICE_WITH_ENDPOINTS']);
-        unset($downtimeObj['SINGLE_TIMEZONE']);
+        unset($downtimeObj['SINGLE_SITE']);
     }
 
     return $downtimeObj;

--- a/htdocs/web_portal/controllers/downtime/downtime_utils.php
+++ b/htdocs/web_portal/controllers/downtime/downtime_utils.php
@@ -44,6 +44,12 @@ function endpointToServiceMapping($impactedIDs)
      * sort between endpoints and services using the prepended letter.
      */
     foreach ($impactedIDs as $id) {
+        /**
+         * `$siteNumber` => It's about Site ID
+         * `$parentService` => It's about service ID endpoint belongs too
+         * `idType` => It's about to differentiate
+         *             the endpoint vs service selection.
+         */
         list($siteNumber, $parentService, $idType) = explode(':', $id);
 
         $type = strpos($idType, 's') !== false ? 'services' : 'endpoints';

--- a/htdocs/web_portal/controllers/downtime/edit_downtime.php
+++ b/htdocs/web_portal/controllers/downtime/edit_downtime.php
@@ -21,6 +21,7 @@
 require_once __DIR__ . '/../../../../lib/Gocdb_Services/Factory.php';
 require_once __DIR__ . '/../../../../htdocs/web_portal/components/Get_User_Principle.php';
 require_once __DIR__ . '/../utils.php';
+require_once __DIR__ . '/downtime_utils.php';
 
 /**
  * Controller for an edit downtime request
@@ -88,11 +89,18 @@ function submit(\User $user = null) {
     if($confirmed == true){
         //Downtime is confirmed, submit it
         $downtimeInfo = json_decode($_POST['newValues'], TRUE);
-
+        $params = [];
         $serv = \Factory::getDowntimeService();
         $dt = $serv->getDowntime($downtimeInfo['DOWNTIME']['EXISTINGID']);
-        unset($downtimeInfo['DOWNTIME']['EXISTINGID']);
-        unset($downtimeInfo['isEdit']);
+        $downtimeInfo = unsetVariables($downtimeInfo, 'edit');
+
+        foreach ($downtimeInfo['SITE_LEVEL_DETAILS'] as $siteIDs) {
+            $downtimeInfo['Impacted_Services'] = $siteIDs['services'];
+            $downtimeInfo['Impacted_Endpoints'] = $siteIDs['endpoints'];
+        }
+
+        unset($downtimeInfo['SITE_LEVEL_DETAILS']);
+
         $params['dt'] = $serv->editDowntime($dt, $downtimeInfo, $user);
 
         show_view("downtime/edited_downtime.php", $params);
@@ -101,43 +109,30 @@ function submit(\User $user = null) {
         $downtimeInfo = getDtDataFromWeb();
 
         //Need to sort the impacted_ids into impacted services and impacted endpoints
-        $impactedids = $downtimeInfo['IMPACTED_IDS'];
+        list(
+            $siteLevelDetails,
+            $serviceWithEndpoints
+        ) = endpointToServiceMapping($downtimeInfo['IMPACTED_IDS']);
 
-        $services=array();
-        $endpoints=array();
+        // Delete the unsorted IDs from the downtime info
+        unset($downtimeInfo['IMPACTED_IDS']);
 
-        //For each impacted id sort between endpoints and services using the prepended letter
-        foreach($impactedids as $id){
-            if (strpos($id, 's') !== FALSE){
-                //This is a service id
-                $services[] = str_replace('s', '', $id); //trim off the identifying char before storing in array
-            }else{
-                //This is an endpoint id
-                $endpoints[] = str_replace('e', '', $id); //trim off the identifying char before storing in array
-            }
+        if (!count($siteLevelDetails) > 1) {
+            $downtimeInfo['SINGLE_TIMEZONE'] = true;
         }
 
-        unset($downtimeInfo['IMPACTED_IDS']); //Delete the unsorted Ids from the downtime info
+        list(
+            $siteLevelDetails,
+            $serviceWithEndpoints
+        ) = addParentServiceForEndpoints(
+            $serviceWithEndpoints,
+            $siteLevelDetails,
+            false,
+            $downtimeInfo['DOWNTIME']
+        );
 
-        $downtimeInfo['Impacted_Endpoints'] = $endpoints;
-
-
-        $serv = \Factory::getServiceService();
-
-        /** For endpoint put into downtime we want the parent service also. If a user has selected
-         * endpoints but not the parent service here we will add the service to maintain the link beteween
-         * a downtime having both the service and the endpoint.
-         */
-        foreach($downtimeInfo['Impacted_Endpoints'] as $endpointIds){
-           $endpoint = $serv->getEndpoint($endpointIds);
-           $services[] = $endpoint->getService()->getId();
-        }
-
-        //Remove any duplicate service ids and store the array of ids
-        $services = array_unique($services);
-
-        //Assign the impacted services and endpoints to their own arrays for us by the addDowntime method
-        $downtimeInfo['Impacted_Services'] = $services;
+        $downtimeInfo['SITE_LEVEL_DETAILS'] = $siteLevelDetails;
+        $downtimeInfo['SERVICE_WITH_ENDPOINTS'] = $serviceWithEndpoints;
         //Pass the edit variable so the confirm_add view works as the confirm edit view.
         $downtimeInfo['isEdit'] = true;
         show_view("downtime/confirm_add_downtime.php", $downtimeInfo);

--- a/htdocs/web_portal/controllers/downtime/edit_downtime.php
+++ b/htdocs/web_portal/controllers/downtime/edit_downtime.php
@@ -121,15 +121,11 @@ function submit(\User $user = null) {
             $downtimeInfo['SINGLE_SITE'] = true;
         }
 
-        list(
-            $siteLevelDetails,
-            $serviceWithEndpoints
-        ) = addParentServiceForEndpoints(
-            $serviceWithEndpoints,
-            $siteLevelDetails,
-            false,
-            $downtimeInfo['DOWNTIME']
-        );
+        list($siteLevelDetails, $serviceWithEndpoints) =
+            addParentServiceForEndpoints(
+                $serviceWithEndpoints,
+                $siteLevelDetails
+            );
 
         $downtimeInfo['SITE_LEVEL_DETAILS'] = $siteLevelDetails;
         $downtimeInfo['SERVICE_WITH_ENDPOINTS'] = $serviceWithEndpoints;

--- a/htdocs/web_portal/controllers/downtime/edit_downtime.php
+++ b/htdocs/web_portal/controllers/downtime/edit_downtime.php
@@ -109,10 +109,8 @@ function submit(\User $user = null) {
         $downtimeInfo = getDtDataFromWeb();
 
         //Need to sort the impacted_ids into impacted services and impacted endpoints
-        list(
-            $siteLevelDetails,
-            $serviceWithEndpoints
-        ) = endpointToServiceMapping($downtimeInfo['IMPACTED_IDS']);
+        list($siteLevelDetails, $serviceWithEndpoints) =
+            endpointToServiceMapping($downtimeInfo['IMPACTED_IDS']);
 
         // Delete the unsorted IDs from the downtime info
         unset($downtimeInfo['IMPACTED_IDS']);

--- a/htdocs/web_portal/controllers/downtime/edit_downtime.php
+++ b/htdocs/web_portal/controllers/downtime/edit_downtime.php
@@ -118,7 +118,7 @@ function submit(\User $user = null) {
         unset($downtimeInfo['IMPACTED_IDS']);
 
         if (!count($siteLevelDetails) > 1) {
-            $downtimeInfo['SINGLE_TIMEZONE'] = true;
+            $downtimeInfo['SINGLE_SITE'] = true;
         }
 
         list(

--- a/htdocs/web_portal/controllers/downtime/view_endpoint_tree.php
+++ b/htdocs/web_portal/controllers/downtime/view_endpoint_tree.php
@@ -36,14 +36,17 @@ function getServiceandEndpointList() {
         throw new Exception("Please select at least one site.");
     }
 
-    $services = new ArrayCollection();
+    $siteIdWithServices = new ArrayCollection();
 
-    foreach ($siteIDs as $value) {
-        $site = \Factory::getSiteService()->getSite($value);
-        $services[$value] = $site->getServices();
+    foreach ($siteIDs as $siteID) {
+        // Using '+' to ensure we have integer value after type coercion.
+        $siteID = +$siteID;
+        $site = \Factory::getSiteService()->getSite($siteID);
+        $siteIdWithServices[$siteID] = $site->getServices();
     }
 
-    $params['services'] = $services;
+    $params['siteIdWithServices'] = $siteIdWithServices;
+
     show_view("downtime/view_nested_endpoints_list.php", $params, null, true);
 }
 
@@ -65,14 +68,16 @@ function editDowntimePopulateEndpointTree() {
         throw new Exception("A downtime id must be specified");
     }
 
-    $services = new ArrayCollection();
+    $siteIdWithServices = new ArrayCollection();
 
-    foreach ($siteIDs as $value) {
-        $site = \Factory::getSiteService()->getSite($value);
-        $services[$value] = $site->getServices();
+    foreach ($siteIDs as $siteID) {
+        // Using '+' to ensure we have integer value after type coercion.
+        $siteID = +$siteID;
+        $site = \Factory::getSiteService()->getSite($siteID);
+        $siteIdWithServices[$siteID] = $site->getServices();
     }
 
-    $params['services'] = $services;
+    $params['siteIdWithServices'] = $siteIdWithServices;
 
     $downtime = \Factory::getDowntimeService()->getDowntime($_REQUEST['dt_id']);
     $params['downtime'] = $downtime;

--- a/htdocs/web_portal/controllers/downtime/view_endpoint_tree.php
+++ b/htdocs/web_portal/controllers/downtime/view_endpoint_tree.php
@@ -19,19 +19,30 @@
  * limitations under the License.
  *
  /*====================================================== */
+use Doctrine\Common\Collections\ArrayCollection;
+use Exception;
+
 function getServiceandEndpointList() {
     require_once __DIR__ . '/../utils.php';
     require_once __DIR__ . '/../../../web_portal/components/Get_User_Principle.php';
 
+    $params = [];
     $dn = Get_User_Principle();
     $user = \Factory::getUserService()->getUserByPrinciple($dn);
     $params['portalIsReadOnly'] = portalIsReadOnlyAndUserIsNotAdmin($user);
+    $siteIDs = $_REQUEST['site_id'];
 
-    if (!isset($_REQUEST['site_id']) || !is_numeric($_REQUEST['site_id']) ){
-        throw new Exception("An id must be specified");
+    if (empty($siteIDs)) {
+        throw new Exception("Please select at least one site.");
     }
-    $site = \Factory::getSiteService()->getSite($_REQUEST['site_id']);
-    $services = $site->getServices();
+
+    $services = new ArrayCollection();
+
+    foreach ($siteIDs as $value) {
+        $site = \Factory::getSiteService()->getSite($value);
+        $services[$value] = $site->getServices();
+    }
+
     $params['services'] = $services;
     show_view("downtime/view_nested_endpoints_list.php", $params, null, true);
 }
@@ -41,18 +52,26 @@ function editDowntimePopulateEndpointTree() {
     require_once __DIR__ . '/../utils.php';
     require_once __DIR__ . '/../../../web_portal/components/Get_User_Principle.php';
 
+    $params = [];
     $dn = Get_User_Principle();
     $user = \Factory::getUserService()->getUserByPrinciple($dn);
     $params['portalIsReadOnly'] = portalIsReadOnlyAndUserIsNotAdmin($user);
+    $siteIDs = $_REQUEST['site_id'];
 
-    if (!isset($_REQUEST['site_id']) || !is_numeric($_REQUEST['site_id']) ){
-        throw new Exception("A site id must be specified");
+    if (empty($_REQUEST['site_id'])) {
+        throw new Exception("Please select at least one site.");
     }
     if (!isset($_REQUEST['dt_id']) || !is_numeric($_REQUEST['dt_id']) ){
         throw new Exception("A downtime id must be specified");
     }
-    $site = \Factory::getSiteService()->getSite($_REQUEST['site_id']);
-    $services = $site->getServices();
+
+    $services = new ArrayCollection();
+
+    foreach ($siteIDs as $value) {
+        $site = \Factory::getSiteService()->getSite($value);
+        $services[$value] = $site->getServices();
+    }
+
     $params['services'] = $services;
 
     $downtime = \Factory::getDowntimeService()->getDowntime($_REQUEST['dt_id']);

--- a/htdocs/web_portal/views/downtime/add_downtime.php
+++ b/htdocs/web_portal/views/downtime/add_downtime.php
@@ -69,9 +69,8 @@ rather than the Site entities themselves, and specify tz, offset in the DTO/JSON
 
         <div class="input-warning" id="invalidSelection">
             <p style="color: #D31F1F;">
-                WARNING: You are NOT allowed to create downtimes
-                when you have selected multiple sites
-                using the <q>Site Timezone</q> option.
+                When selecting multiple sites, you must use the
+                <q>Enter Times In: UTC<q> option.
             </p>
         </div>
 

--- a/htdocs/web_portal/views/downtime/add_downtime.php
+++ b/htdocs/web_portal/views/downtime/add_downtime.php
@@ -69,8 +69,8 @@ rather than the Site entities themselves, and specify tz, offset in the DTO/JSON
 
         <div class="input-warning" id="invalidSelection">
             <p style="color: #D31F1F;">
-                When selecting multiple sites, you must use the
-                <q>Enter Times In: UTC<q> option.
+                WARNING: When selecting multiple sites, you must use the
+                <q>Enter Times In: UTC</q> option.
             </p>
         </div>
 
@@ -242,7 +242,7 @@ rather than the Site entities themselves, and specify tz, offset in the DTO/JSON
            validate();
        });
 
-       hasSitesWithSingleTimezones();
+       selectedValidTimezoneUsecase();
 
     });
 
@@ -305,20 +305,21 @@ rather than the Site entities themselves, and specify tz, offset in the DTO/JSON
         }
    }
 
-    function hasSitesWithSingleTimezones()
+    function selectedValidTimezoneUsecase()
     {
-        let siteId = $('#Select_Sites').val();
-        let selectedSiteTZ = $('#siteRadioButton').is(':checked');
-        let hasSingleTimezone = true;
+        let siteID = $('#Select_Sites').val();
+        let selectedSiteTz = $('#siteRadioButton').is(':checked');
+        let validSelection = true;
 
-        if((siteId && siteId.length > 1) && selectedSiteTZ) {
-            hasSingleTimezone = false;
+        if ((siteID && siteID.length > 1) && selectedSiteTz) {
+            validSelection = false;
+
             $('#invalidSelection').show();
         } else {
             $('#invalidSelection').hide();
         }
 
-        return hasSingleTimezone;
+        return validSelection;
     }
 
    /*
@@ -466,15 +467,15 @@ rather than the Site entities themselves, and specify tz, offset in the DTO/JSON
         }
 
         //----------Verify whether the site has mutiple timezones----------//
-        const hasSingleTimezone = hasSitesWithSingleTimezones();
+        const timezoneValid = selectedValidTimezoneUsecase();
 
         //----------Set the Button based on validate status-------------//
         if (
-            epValid &&
-            severityValid &&
-            descriptionValid &&
-            datesValid &&
-            hasSingleTimezone
+            epValid
+            && severityValid
+            && descriptionValid
+            && datesValid
+            && timezoneValid
         ) {
             $('#submitDowntime_btn').addClass('btn btn-success');
             $('#submitDowntime_btn').prop('disabled', false);
@@ -534,9 +535,8 @@ rather than the Site entities themselves, and specify tz, offset in the DTO/JSON
             $('#chooseEndpoints').empty(); //Remove any previous content from the endpoints select list
             $('#chooseServices').load(
                 'index.php?Page_Type=Downtime_view_endpoint_tree',
-                {site_id: siteId},
-                function(response, status, xhr)
-                {
+                { site_id: siteId },
+                function(response, status, xhr) {
                     if (status == "success") {
                         validate();
                     }
@@ -569,14 +569,14 @@ rather than the Site entities themselves, and specify tz, offset in the DTO/JSON
            //console.log('fetching selected site timezone label');
            $.get(
                 'index.php',
-                {Page_Type: 'Add_Downtime', siteid_timezone: siteId[0]},
-                function(data)
-                {
-                    var jsonRsp = JSON.parse(data);
+                { Page_Type: 'Add_Downtime', siteid_timezone: siteId[0] },
+                function(data) {
+                    let jsonRsp = JSON.parse(data);
                     // Update global variables - used when calculating DT rules
                     TARGETTIMEZONEID = jsonRsp[0];
                     // Returns the targetTimezone offset in seconds from UTC
                     TARGETTIMEZONEOFFSETFROMUTCSECS = jsonRsp[1];
+
                     $('#siteTimezoneText').val(TARGETTIMEZONEID);
 
                     updateStartEndTimesInUtc();
@@ -585,6 +585,7 @@ rather than the Site entities themselves, and specify tz, offset in the DTO/JSON
         } else {
             TARGETTIMEZONEID = "UTC";
             TARGETTIMEZONEOFFSETFROMUTCSECS = 0;
+
             $('#siteTimezoneText').val(TARGETTIMEZONEID);
 
             updateStartEndTimesInUtc();

--- a/htdocs/web_portal/views/downtime/add_downtime.php
+++ b/htdocs/web_portal/views/downtime/add_downtime.php
@@ -67,7 +67,13 @@ rather than the Site entities themselves, and specify tz, offset in the DTO/JSON
             &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<mark><label id="schedulingStatusLabel"></label></mark>
         </div>
 
-
+        <div class="input-warning" id="invalidSelection">
+            <p style="color: #D31F1F;">
+                WARNING: You are NOT allowed to create downtimes
+                when you have selected multiple sites
+                using the <q>Site Timezone</q> option.
+            </p>
+        </div>
 
         <label for="startDate">Starts on:</label>
         <mark><label id="startUtcLabel"></label></mark>
@@ -147,10 +153,15 @@ rather than the Site entities themselves, and specify tz, offset in the DTO/JSON
                     $size = sizeof($sites) + 2;
             }
             ?>
-            <select style="width: 99%; margin-right: 1%"
-                class="form-control" id="Select_Sites" name="select_sites" size="10"
-                onclick="getSitesServices();onSiteSelected();">
-
+            <select
+                style="width: 99%; margin-right: 1%"
+                class="form-control"
+                id="Select_Sites"
+                name="select_sites[]"
+                size="10"
+                onclick="getSitesServices();onSiteSelected();"
+                multiple
+            >
                 <?php
                 foreach($sites as $site){
                     $siteName = $site->getName();
@@ -221,6 +232,7 @@ rather than the Site entities themselves, and specify tz, offset in the DTO/JSON
 
        $("#timezoneSelectGroup").find(":input").change(function(){
            updateStartEndTimesInUtc();
+            validate();
        });
 
        // The bootstrap datetimepickers don't fire the change event
@@ -231,7 +243,7 @@ rather than the Site entities themselves, and specify tz, offset in the DTO/JSON
            validate();
        });
 
-
+       hasSitesWithSingleTimezones();
 
     });
 
@@ -293,6 +305,22 @@ rather than the Site entities themselves, and specify tz, offset in the DTO/JSON
             $('#endTimestamp').val(M_END_UTC.format("DD/MM/YYYY HH:mm"));
         }
    }
+
+    function hasSitesWithSingleTimezones()
+    {
+        let siteId = $('#Select_Sites').val();
+        let selectedSiteTZ = $('#siteRadioButton').is(':checked');
+        let hasSingleTimezone = true;
+
+        if((siteId && siteId.length > 1) && selectedSiteTZ) {
+            hasSingleTimezone = false;
+            $('#invalidSelection').show();
+        } else {
+            $('#invalidSelection').hide();
+        }
+
+        return hasSingleTimezone;
+    }
 
    /*
     * Dynamically update the UTC time label and SCHEDULED/UNSCHEDULED labels.
@@ -438,9 +466,17 @@ rather than the Site entities themselves, and specify tz, offset in the DTO/JSON
             $('#chooseServices').removeClass("has-success");
         }
 
-        //----------Set the Button based on validate status-------------//
+        //----------Verify whether the site has mutiple timezones----------//
+        const hasSingleTimezone = hasSitesWithSingleTimezones();
 
-        if(epValid && severityValid && descriptionValid && datesValid){
+        //----------Set the Button based on validate status-------------//
+        if (
+            epValid &&
+            severityValid &&
+            descriptionValid &&
+            datesValid &&
+            hasSingleTimezone
+        ) {
             $('#submitDowntime_btn').addClass('btn btn-success');
             $('#submitDowntime_btn').prop('disabled', false);
         }else{
@@ -497,11 +533,16 @@ rather than the Site entities themselves, and specify tz, offset in the DTO/JSON
         var siteId=$('#Select_Sites').val();
         if(siteId != null){ //If the user clicks on the box but not a specific row there will be no input, so catch that here
             $('#chooseEndpoints').empty(); //Remove any previous content from the endpoints select list
-            $('#chooseServices').load('index.php?Page_Type=Downtime_view_endpoint_tree&site_id='+siteId,function( response, status, xhr ) {
-                if ( status == "success" ) {
-                    validate();
+            $('#chooseServices').load(
+                'index.php?Page_Type=Downtime_view_endpoint_tree',
+                {site_id: siteId},
+                function(response, status, xhr)
+                {
+                    if (status == "success") {
+                        validate();
+                    }
                 }
-            });
+            );
         }
     }
 
@@ -513,6 +554,7 @@ rather than the Site entities themselves, and specify tz, offset in the DTO/JSON
     function onSiteSelected(){
         var siteId=$('#Select_Sites').val();
         updateSiteTimezoneVars(siteId);
+        validate();
     }
 
     /**
@@ -522,19 +564,31 @@ rather than the Site entities themselves, and specify tz, offset in the DTO/JSON
      * @returns {null}
      */
     function updateSiteTimezoneVars(siteId){
-        if(siteId){
+        if (siteId && siteId.length <= 1 ) {
            // use ajax to get the selected site's timezone label and offset
            // and update display+vars
            //console.log('fetching selected site timezone label');
-           $.get('index.php', {Page_Type: 'Add_Downtime', siteid_timezone: siteId},
-           function(data){
-              var jsonRsp = JSON.parse(data);
-              // update global variables - used when calculating DT rules
-              TARGETTIMEZONEID = jsonRsp[0];
-              TARGETTIMEZONEOFFSETFROMUTCSECS = jsonRsp[1]; //Returns the targetTimezone offset in seconds from UTC
-              //console.log("updateSiteTimezoneVars, siteId: ["+siteId+"] TARGETTIMEZONEID: ["+TARGETTIMEZONEID+"] TARGETTIMEZONEOFFSETFROMUTCSECS: ["+TARGETTIMEZONEOFFSETFROMUTCSECS+"]");
-              $('#siteTimezoneText').val(TARGETTIMEZONEID);
-           });
+           $.get(
+                'index.php',
+                {Page_Type: 'Add_Downtime', siteid_timezone: siteId[0]},
+                function(data)
+                {
+                    var jsonRsp = JSON.parse(data);
+                    // Update global variables - used when calculating DT rules
+                    TARGETTIMEZONEID = jsonRsp[0];
+                    // Returns the targetTimezone offset in seconds from UTC
+                    TARGETTIMEZONEOFFSETFROMUTCSECS = jsonRsp[1];
+                    $('#siteTimezoneText').val(TARGETTIMEZONEID);
+
+                    updateStartEndTimesInUtc();
+                }
+            );
+        } else {
+            TARGETTIMEZONEID = "UTC";
+            TARGETTIMEZONEOFFSETFROMUTCSECS = 0;
+            $('#siteTimezoneText').val(TARGETTIMEZONEID);
+
+            updateStartEndTimesInUtc();
         }
     }
 

--- a/htdocs/web_portal/views/downtime/added_downtime.php
+++ b/htdocs/web_portal/views/downtime/added_downtime.php
@@ -16,10 +16,10 @@
     echo '<ul>';
     foreach ($params['submittedDowntimes'] as $siteName => $downtimeDetails) {
         echo '<li>';
-        echo $siteName . ':';
+        echo $siteName . ': ';
         echo '<a href="index.php?Page_Type=Downtime&id=';
         echo $downtimeDetails->getId();
-        echo '"> Downtime ' . $downtimeDetails->getId() . '</a>';
+        echo '">Downtime ' . $downtimeDetails->getId() . '</a>';
         echo '</li>';
     }
     echo '</ul>';

--- a/htdocs/web_portal/views/downtime/added_downtime.php
+++ b/htdocs/web_portal/views/downtime/added_downtime.php
@@ -1,5 +1,27 @@
 <div class="rightPageContainer">
     <h1 class="Success">Success</h1><br />
-    New Downtime successfully created. <br />
-    <a href="index.php?Page_Type=Downtime&amp;id=<?php echo $params['dt']->getId() ?>">View new downtime</a>
+    <?php
+    if (count($params['submittedDowntimes']) != 1) {
+        echo '<p>';
+        echo 'New Downtimes successfully created. ';
+        echo 'Please click the links below for more information.';
+        echo '</p>';
+    } else {
+        echo '<p>';
+        echo 'New Downtime successfully created. ';
+        echo 'Please click the link below for more information.';
+        echo '</p>';
+    }
+
+    echo '<ul>';
+    foreach ($params['submittedDowntimes'] as $siteName => $downtimeDetails) {
+        echo '<li>';
+        echo $siteName . ':';
+        echo '<a href="index.php?Page_Type=Downtime&id=';
+        echo $downtimeDetails->getId();
+        echo '"> Downtime ' . $downtimeDetails->getId() . '</a>';
+        echo '</li>';
+    }
+    echo '</ul>';
+    ?>
 </div>

--- a/htdocs/web_portal/views/downtime/added_downtime.php
+++ b/htdocs/web_portal/views/downtime/added_downtime.php
@@ -14,6 +14,7 @@
     }
 
     echo '<ul>';
+
     foreach ($params['submittedDowntimes'] as $siteName => $downtimeDetails) {
         echo '<li>';
         echo $siteName . ': ';
@@ -22,6 +23,7 @@
         echo '">Downtime ' . $downtimeDetails->getId() . '</a>';
         echo '</li>';
     }
+
     echo '</ul>';
     ?>
 </div>

--- a/htdocs/web_portal/views/downtime/confirm_add_downtime.php
+++ b/htdocs/web_portal/views/downtime/confirm_add_downtime.php
@@ -1,8 +1,6 @@
 <?php
 $configService = \Factory::getConfigService();
-
-$services = $params['Impacted_Services'];
-$endpoints = $params['Impacted_Endpoints'];
+$serviceWithEndpoints = $params['SERVICE_WITH_ENDPOINTS'];
 
 //To reuse this page for 'add' and 'edit' we use this boolean to change a couple of bits in the page
 if(isset($params['isEdit'])){
@@ -18,7 +16,24 @@ if(isset($params['isEdit'])){
         echo "Edit";
     }?>
      Downtime</h1><br />
-    Please review your downtime before submitting.<br />
+    <?php
+    echo '<p>';
+    echo 'Please review your ';
+
+    if (!($edit)) {
+        if ($params['SINGLE_TIMEZONE']) {
+            echo 'chosen site and the downtime ';
+        } else {
+            echo 'chosen sites and their downtimes ';
+        }
+    } else {
+        echo 'downtime ';
+    }
+
+    echo 'before submitting.';
+    echo '</p>';
+    ?>
+
     <ul>
     <li><b>Severity: </b><?php xecho($params['DOWNTIME']['SEVERITY'])?></li>
     <li><b>Description: </b><?php xecho($params['DOWNTIME']['DESCRIPTION'])?></li>
@@ -38,30 +53,38 @@ if(isset($params['isEdit'])){
         //echo date_format($timestamp, 'l jS \of F Y \a\t\: h:i A');
         xecho($params['DOWNTIME']['END_TIMESTAMP']);
     ?></li>
-    <?php
-    if(count($services > 1)){
-        echo "<li><b>Affecting Services:</b>";
-    }else{
-        echo "<li><b>Affecting Service:</b>";
-    }
-    ?>
-        <ul>
+
+    <?php foreach ($serviceWithEndpoints as $siteID => $siteDetails) : ?>
         <?php
-        foreach($services as $id){
-            $service = \Factory::getServiceService()->getService($id);
-            $safeHostName = xssafe($service->getHostname());
-            echo "<li>" . $safeHostName . "</li>";
-            }
+         $siteName = $params['SITE_LEVEL_DETAILS'][$siteID]['siteName'];
+
+         echo '<li><strong>Site Name: </strong>';
+         echo $siteName;
+         echo '</li>';
         ?>
-        </ul>
-    </li>
-    <?php
-    if(count($endpoints > 1)){
-        echo "<li><b>Affecting Endpoints:</b>";
-    }else{
-        echo "<li><b>Affecting Endpoint:</b>";
-    }
-    ?>
+
+        <ul>
+            <li>
+                <b>Affecting Service and Endpoint(s):</b>
+
+                <?php foreach ($siteDetails as $serviceID => $data) : ?>
+                    <?php
+                    $endpoints = $data['endpoints'];
+                    $service = \Factory::getServiceService()
+                                    ->getService($serviceID);
+            $safeHostName = xssafe($service->getHostname());
+                    ?>
+
+                    <ul>
+                        <li>
+                            <?php
+                            xecho(
+                                '(' .
+                                $service->getServiceType()->getName() .
+                                ') '
+                            );
+                            echo $safeHostName;
+                            ?>
         <ul>
         <?php
         foreach($endpoints as $id){
@@ -75,7 +98,12 @@ if(isset($params['isEdit'])){
             }
         ?>
         </ul>
-    </li>
+                        </li>
+                    </ul>
+                <?php endforeach; ?>
+            </li>
+        </ul>
+    <?php endforeach; ?>
     </ul>
     <!-- Echo out a page type of edit or add downtime depending on type.  -->
     <?php if(!$edit):?>

--- a/htdocs/web_portal/views/downtime/confirm_add_downtime.php
+++ b/htdocs/web_portal/views/downtime/confirm_add_downtime.php
@@ -21,7 +21,7 @@ if(isset($params['isEdit'])){
     echo 'Please review your ';
 
     if (!($edit)) {
-        if ($params['SINGLE_TIMEZONE']) {
+        if ($params['SINGLE_SITE']) {
             echo 'chosen site and the downtime ';
         } else {
             echo 'chosen sites and their downtimes ';

--- a/htdocs/web_portal/views/downtime/confirm_add_downtime.php
+++ b/htdocs/web_portal/views/downtime/confirm_add_downtime.php
@@ -21,7 +21,7 @@ if(isset($params['isEdit'])){
     echo 'Please review your ';
 
     if (!($edit)) {
-        if ($params['SINGLE_SITE']) {
+        if ($params['SELECTED_SINGLE_SITE']) {
             echo 'chosen site and the downtime ';
         } else {
             echo 'chosen sites and their downtimes ';
@@ -54,24 +54,25 @@ if(isset($params['isEdit'])){
         xecho($params['DOWNTIME']['END_TIMESTAMP']);
     ?></li>
 
-    <?php foreach ($serviceWithEndpoints as $siteID => $siteDetails) : ?>
+    <?php foreach ($serviceWithEndpoints as $siteID => $serviceIDs) : ?>
         <?php
-         $siteName = $params['SITE_LEVEL_DETAILS'][$siteID]['siteName'];
+        $siteDetails = \Factory::getSiteService()->getSite($siteID);
+        $siteName = $siteDetails->getShortName();
 
-         echo '<li><strong>Site Name: </strong>';
-         echo $siteName;
-         echo '</li>';
+        echo '<li><strong>Site Name: </strong>';
+        echo $siteName;
+        echo '</li>';
         ?>
 
         <ul>
             <li>
                 <b>Affecting Service and Endpoint(s):</b>
 
-                <?php foreach ($siteDetails as $serviceID => $data) : ?>
+                <?php foreach ($serviceIDs as $serviceID => $endpointsInfo) : ?>
                     <?php
-                    $endpoints = $data['endpoints'];
+                    $endpointIDs = $endpointsInfo['endpointIDs'];
                     $service = \Factory::getServiceService()
-                                    ->getService($serviceID);
+                        ->getService($serviceID);
                     $safeHostName = xssafe($service->getHostname());
                     ?>
 
@@ -85,19 +86,22 @@ if(isset($params['isEdit'])){
                             );
                             echo $safeHostName;
                             ?>
-        <ul>
-        <?php
-        foreach($endpoints as $id){
-            $endpoint = \Factory::getServiceService()->getEndpoint($id);
-            if($endpoint->getName() != ''){
-                $name = xssafe($endpoint->getName());
-            }else{
-                $name = xssafe("myEndpoint");
-            }
-            echo "<li>" . $name . "</li>";
-            }
-        ?>
-        </ul>
+                            <ul>
+                                <?php
+                                foreach ($endpointIDs as $endpointID) {
+                                    $endpoint = \Factory::getServiceService()
+                                        ->getEndpoint($endpointID);
+
+                                    if ($endpoint->getName() != '') {
+                                        $name = xssafe($endpoint->getName());
+                                    } else {
+                                        $name = xssafe("myEndpoint");
+                                    }
+
+                                    echo "<li>" . $name . "</li>";
+                                }
+                                ?>
+                            </ul>
                         </li>
                     </ul>
                 <?php endforeach; ?>

--- a/htdocs/web_portal/views/downtime/confirm_add_downtime.php
+++ b/htdocs/web_portal/views/downtime/confirm_add_downtime.php
@@ -72,7 +72,7 @@ if(isset($params['isEdit'])){
                     $endpoints = $data['endpoints'];
                     $service = \Factory::getServiceService()
                                     ->getService($serviceID);
-            $safeHostName = xssafe($service->getHostname());
+                    $safeHostName = xssafe($service->getHostname());
                     ?>
 
                     <ul>

--- a/htdocs/web_portal/views/downtime/downtime_edit_view_nested_endpoints_list.php
+++ b/htdocs/web_portal/views/downtime/downtime_edit_view_nested_endpoints_list.php
@@ -26,7 +26,8 @@ foreach($dt->getEndpointLocations() as $affectedEndpoints){
         style="width:99%; margin-left:1%"
         onChange="selectServicesEndpoint()" multiple>
 <?php
-    foreach($services as $service){
+foreach ($services as $siteID => $siteServiceList) {
+    foreach ($siteServiceList as $service) {
         $count=0;
 
         // Set the html 'SELECTED' attribute on the <option> only if this service was affected.
@@ -35,7 +36,10 @@ foreach($dt->getEndpointLocations() as $affectedEndpoints){
         }else{
             $selected = '';
         }
-        echo "<option value=\"s" . $service->getId() . "\" id=\"" . $service->getId() . "\" ".$selected.">";
+
+        echo "<option value=\"" . $siteID . ":" . $service->getId()
+            . ":s" . $service->getId() . "\" id=\"" . $service->getId()
+            . "\" " . $selected . ">";
                 xecho('('.$service->getServiceType()->getName().') ');
                 xecho($service->getHostName());
                 echo("</option>");
@@ -52,10 +56,14 @@ foreach($dt->getEndpointLocations() as $affectedEndpoints){
                 $name = xssafe($endpoint->getName());
             }
             //Option styling doesn't work well cross browser so just use 4 spaces to indent the branch
-            echo "<option id=\"".$service->getId()."\" value=\"e" . $endpoint->getId() . "\" ".$selected.">&nbsp&nbsp&nbsp&nbsp-" . $name . "</option>";
+            echo "<option id=\"" . $service->getId() . "\" value=\""
+                . $siteID . ":" .  $service->getId() . ":e"
+                . $endpoint->getId() . "\" " . $selected
+                . ">&nbsp&nbsp&nbsp&nbsp-" . $name . "</option>";
             $count++;
         }
 
     }
+}
 ?>
 </select>

--- a/htdocs/web_portal/views/downtime/downtime_edit_view_nested_endpoints_list.php
+++ b/htdocs/web_portal/views/downtime/downtime_edit_view_nested_endpoints_list.php
@@ -1,5 +1,5 @@
 <?php
-$services = $params['services'];
+$siteIdWithServices = $params['siteIdWithServices'];
 $dt = $params['downtime'];
 $configService = \Factory::getConfigService();
 
@@ -26,8 +26,8 @@ foreach($dt->getEndpointLocations() as $affectedEndpoints){
         style="width:99%; margin-left:1%"
         onChange="selectServicesEndpoint()" multiple>
 <?php
-foreach ($services as $siteID => $siteServiceList) {
-    foreach ($siteServiceList as $service) {
+foreach ($siteIdWithServices as $siteID => $services) {
+    foreach ($services as $service) {
         $count=0;
 
         // Set the html 'SELECTED' attribute on the <option> only if this service was affected.

--- a/htdocs/web_portal/views/downtime/edit_downtime.php
+++ b/htdocs/web_portal/views/downtime/edit_downtime.php
@@ -154,10 +154,15 @@ foreach($downtime->getEndpointLocations() as $endpoints){
                     $size = sizeof($sites) + 2;
             }
             ?>
-            <select style="width: 99%; margin-right: 1%"
-                class="form-control" id="Select_Sites" name="select_sites" size="10"
-                onclick="loadSitesServicesAndEndpoints()">
-
+            <select
+                style="width: 99%; margin-right: 1%"
+                class="form-control"
+                id="Select_Sites"
+                name="select_sites[]"
+                size="10"
+                onclick="loadSitesServicesAndEndpoints()"
+                multiple
+            >
                 <?php
                 foreach($sites as $site){
                     $sName = xssafe($site);
@@ -384,12 +389,17 @@ foreach($downtime->getEndpointLocations() as $endpoints){
         // The Page_Type handler for 'Edit_Downtime_view_endpoint_tree' in the front controller loads the
         // following view: 'views/downtime/downtime_edit_view_nested_endpoints_list.php'
         // loading the downtime and the site.
-        $('#chooseServices').load('index.php?Page_Type=Edit_Downtime_view_endpoint_tree&dt_id='+dtId+'&site_id='+siteId,
-          function( response, status, xhr ) {
-              if ( status == "success" ) {
+        $('#chooseServices').load(
+            'index.php?Page_Type=Edit_Downtime_view_endpoint_tree&dt_id='
+            + dtId,
+            {site_id: siteId},
+            function(response, status, xhr)
+            {
+                if (status == "success") {
                     validate();
-                  }
-        });
+                }
+            }
+        );
 
     }
 

--- a/htdocs/web_portal/views/downtime/edit_downtime.php
+++ b/htdocs/web_portal/views/downtime/edit_downtime.php
@@ -392,9 +392,8 @@ foreach($downtime->getEndpointLocations() as $endpoints){
         $('#chooseServices').load(
             'index.php?Page_Type=Edit_Downtime_view_endpoint_tree&dt_id='
             + dtId,
-            {site_id: siteId},
-            function(response, status, xhr)
-            {
+            { site_id: siteId },
+            function(response, status, xhr) {
                 if (status == "success") {
                     validate();
                 }

--- a/htdocs/web_portal/views/downtime/view_nested_endpoints_list.php
+++ b/htdocs/web_portal/views/downtime/view_nested_endpoints_list.php
@@ -7,9 +7,17 @@ $configService = \Factory::getConfigService();
 <label> Select Affected Services+Endpoints (Ctrl+click to select)</label>
 <select name="IMPACTED_IDS[]" id="Select_Services" size="10" class="form-control" onclick="" style="width:99%; margin-left:1%" onChange="selectServicesEndpoint()" multiple>
 <?php
-    foreach($services as $service){
+foreach ($services as $siteID => $siteServiceList) {
+    foreach ($siteServiceList as $service) {
         $count=0;
-        echo "<option value=\"s" . $service->getId() . "\" id=\"" . $service->getId() . "\" SELECTED>" . '('.xssafe($service->getServiceType()->getName()).') '.xssafe($service->getHostName()) . "</option>";
+
+        echo "<option value=\"" . $siteID . ":" . $service->getId() . ":s"
+            . $service->getId() . "\" id=\"" . $service->getId()
+            . "\" SELECTED>"
+            . '(' . xssafe($service->getServiceType()->getName()) . ') '
+            . xssafe($service->getHostName())
+            . "</option>";
+
         foreach($service->getEndpointLocations() as $endpoint){
             if($endpoint->getName() == ''){
                 $name = xssafe('myEndpoint');
@@ -17,10 +25,13 @@ $configService = \Factory::getConfigService();
                 $name = xssafe($endpoint->getName());
             }
             //Option styling doesn't work well cross browser so just use 4 spaces to indent the branch
-            echo "<option id=\"".$service->getId()."\" value=\"e" . $endpoint->getId() . "\" SELECTED>&nbsp&nbsp&nbsp&nbsp-" . $name . "</option>";
+            echo "<option id=\"" . $service->getId() . "\" value=\""
+                . $siteID . ":" . $service->getId() . ":e" . $endpoint->getId()
+                . "\" SELECTED>&nbsp&nbsp&nbsp&nbsp-" . $name . "</option>";
             $count++;
         }
 
     }
+}
 ?>
 </select>

--- a/htdocs/web_portal/views/downtime/view_nested_endpoints_list.php
+++ b/htdocs/web_portal/views/downtime/view_nested_endpoints_list.php
@@ -1,5 +1,5 @@
 <?php
-$services = $params['services'];
+$siteIdWithServices = $params['siteIdWithServices'];
 $configService = \Factory::getConfigService();
 
 ?>
@@ -7,8 +7,8 @@ $configService = \Factory::getConfigService();
 <label> Select Affected Services+Endpoints (Ctrl+click to select)</label>
 <select name="IMPACTED_IDS[]" id="Select_Services" size="10" class="form-control" onclick="" style="width:99%; margin-left:1%" onChange="selectServicesEndpoint()" multiple>
 <?php
-foreach ($services as $siteID => $siteServiceList) {
-    foreach ($siteServiceList as $service) {
+foreach ($siteIdWithServices as $siteID => $services) {
+    foreach ($services as $service) {
         $count=0;
 
         echo "<option value=\"" . $siteID . ":" . $service->getId() . ":s"


### PR DESCRIPTION
[MAIN Functionality]
Added support for selecting multiple sites in "ADD" downtime.
Changed the Confirm Downtime and Confirm Edit Downtime pages.
Changed Add_Downtime success page with relevant content.

Resolves: https://github.com/GOCDB/gocdb/issues/261

Partially address: https://github.com/GOCDB/gocdb/issues/85 and https://github.com/GOCDB/gocdb/issues/66 .

Addressed @gregcorbett comments:

### Suggestion 1:
Include the Site Name next to the downtime link on creation, i.e.:

New Downtimes successfully created. Please click the links below for more information.

Site A: Downtime 10
Site B: Downtime 11
### Suggestion 1:
Only display the start and end time once on the "Confirm Downtime" page, i.e.:

Severity: WARNING
Description: foo bar
Starting (UTC): 08/09/2023 00:00
Ending (UTC): 18/09/2023 00:00
Site Name: Brunnen GS
...
Site Name: Torch
...