### PR TITLE
[GT-181] Add last logged in field for admins

### DIFF
--- a/htdocs/web_portal/controllers/user/view_user.php
+++ b/htdocs/web_portal/controllers/user/view_user.php
@@ -156,6 +156,7 @@ function view_user()
         $params['ShowEdit'] = false;
     }
 
+    $params['callingUser'] = $callingUser;
     $params['idString'] = $userService->getDefaultIdString($user);
     $params['projectNamesIds'] = $projectNamesIds;
     $params['role_ProjIds'] = $roleProjectIds;

--- a/htdocs/web_portal/views/user/view_user.php
+++ b/htdocs/web_portal/views/user/view_user.php
@@ -72,7 +72,9 @@
             </ul>
         </div>
 
-
+        <?php
+        $isCallingUserAdmin = $params['callingUser']->isAdmin();
+        ?>
         <!--  User -->
         <div class="tableContainer" style="width: 55%; float: left;">
             <span class="header" style="vertical-align:middle; float: left; padding-top: 0.9em; padding-left: 1em;">
@@ -127,6 +129,21 @@
                         </td>
                     </tr>
                 <?php } ?>
+                <?php if ($isCallingUserAdmin) : ?>
+                <tr class="site_table_row_1">
+                    <td class="site_table">Last Logged In</td>
+                    <td class="site_table">
+                        <?php
+                        if ($params['user']->getLastLoginDate()) {
+                            xecho(
+                                $params['user']->getLastLoginDate()
+                                    ->format('Y-m-d H:i:s')
+                            );
+                        }
+                        ?>
+                    </td>
+                </tr>
+                <?php endif; ?>
             </table>
         </div>
     </div>


### PR DESCRIPTION
[Functionality]

To help with user support when someone queries one of the account deletion emails, it would be useful to be able to see when the account was last logged in to in the web interface.

"Resolves https://github.com/GOCDB/gocdb/issues/456 ".