### PR TITLE
 Update ShibToken for Keycloak based EGI Check-in to master

### DIFF
--- a/htdocs/web_portal/static_html/goc5_logo.html
+++ b/htdocs/web_portal/static_html/goc5_logo.html
@@ -4,7 +4,7 @@
 <!--	<img src="img/Logo-1.6.png" class="logo_image" height="39" style="vertical-align: middle;"/>-->
   <h3    class="Logo_Text Small_Bottom_Margin Standard_Padding"
          style="vertical-align: middle; margin-left: 0.2em;">
-         GOCDB 5.10.4
+         GOCDB 5.10.5
      </h3>
 
 </a>

--- a/lib/Authentication/AuthTokens/ShibAuthToken.php
+++ b/lib/Authentication/AuthTokens/ShibAuthToken.php
@@ -79,11 +79,9 @@ class ShibAuthToken implements IAuthentication {
     public function getPrinciple() {
        return $this->principal;
     }
-    
-    
-    
+
     private function getAttributesInitToken(){
-        $hostname = $_SERVER['HTTP_HOST']; // don't use $_SERVER['SERVER_NAME'] as this don't support DNS 
+        $hostname = $_SERVER['HTTP_HOST']; // don't use $_SERVER['SERVER_NAME'] as this don't support DNS
         // specify location of the Shib Logout handler
         \Factory::$properties['LOGOUTURL'] = 'https://'.$hostname.'/Shibboleth.sso/Logout';
         $idp = isset($_SERVER['Shib-Identity-Provider']) ? $_SERVER['Shib-Identity-Provider'] : '';

--- a/lib/Authentication/AuthTokens/ShibAuthToken.php
+++ b/lib/Authentication/AuthTokens/ShibAuthToken.php
@@ -96,9 +96,9 @@ class ShibAuthToken implements IAuthentication {
             $this->userDetails = array('AuthenticationRealm' => array('UK_ACCESS_FED'));
             return;
         }
-        else if($idp == 'https://aai.egi.eu/proxy/saml2/idp/metadata.php'){
+        else if($idp == 'https://aai.egi.eu/auth/realms/egi'){
             // assurance is the old way EGI checkIn used to pass LoA attributes
-            /*if( empty($_SERVER['epuid'])){// || empty($_SERVER['displayName']) ){
+            /*if( empty($_SERVER['voPersonID'])){// || empty($_SERVER['displayName']) ){
                 die('Did not recieve required attributes from the EGI Proxy Identity Provider to complete authentication, please contact gocdb-admins');
             }
             if(empty($_SERVER['assurance'])){
@@ -112,16 +112,16 @@ class ShibAuthToken implements IAuthentication {
                  echo ($HTML);
                  die();
             }
-            $this->principal = $_SERVER['epuid'];
+            $this->principal = $_SERVER['voPersonID'];
             $this->userDetails = array('AuthenticationRealm' => array('EGI Proxy IdP'));
             return;
             */
 
-            if( empty($_SERVER['epuid'])){// || empty($_SERVER['displayName']) ){
+            if( empty($_SERVER['voPersonID'])){// || empty($_SERVER['displayName']) ){
                 die('Did not recieve required attributes from the EGI Proxy Identity Provider to complete authentication, please contact gocdb-admins');
             }
             if(empty($_SERVER['entitlement'])){
-                //die('Did not recieve the required entitlement attribute from the EGI Dev Proxy IdP, please contact gocdb-admins');
+                //die('Did not recieve the required entitlement attribute from the EGI Proxy IdP, please contact gocdb-admins');
                 $HTML = '<ul><li>Login requires a GOCDB entitlement value <a href="https://wiki.egi.eu/wiki/URN_Registry:aai.egi.eu:gocdb" target="_blank">https://wiki.egi.eu/wiki/URN_Registry:aai.egi.eu:gocdb</a></li><li>Please, logout or restart your browser and attempt to login again using an identity provider that provides a GOCDB entitlement</li></ul>';
                 $HTML .= "<div style='text-align: center;'>";
                 $HTML .= '<a href="'.htmlspecialchars(\Factory::$properties['LOGOUTURL']).'"><b><font colour="red">Logout</font></b></a>';
@@ -139,28 +139,28 @@ class ShibAuthToken implements IAuthentication {
                  echo ($HTML);
                  die();
             }
-            $this->principal = $_SERVER['epuid'];
+            $this->principal = $_SERVER['voPersonID'];
             $this->userDetails = array('AuthenticationRealm' => array('EGI Proxy IdP'));
             return;
 
         }
-        else if($idp == 'https://aai-dev.egi.eu/proxy/saml2/idp/metadata.php'){
-            if( empty($_SERVER['epuid'])){
-                die('Did not receive required ePUID attributes from the EGI Dev Proxy Identity Provider to complete authentication, please contact gocdb-admins');
+        else if($idp == 'https://aai-demo.egi.eu/auth/realms/egi'){
+            if( empty($_SERVER['voPersonID'])){
+                die('Did not receive required voPersonID attributes from the EGI Demo Proxy Identity Provider to complete authentication, please contact gocdb-admins');
             }
             if(empty($_SERVER['entitlement'])){
-                die('Did not receive the required entitlement attribute from the EGI Dev Proxy IdP, please contact gocdb-admins');
-            } 
-            $entitlementValuesArray = explode(';', $_SERVER['entitlement']); 
+                die('Did not receive the required entitlement attribute from the EGI Demo Proxy IdP, please contact gocdb-admins');
+            }
+            $entitlementValuesArray = explode(';', $_SERVER['entitlement']);
             if( !in_array('urn:mace:egi.eu:res:gocdb#aai.egi.eu', $entitlementValuesArray) ){
-                 $HTML = '<ul><li>You authenticated to the EGI Dev Identity Provider using a method that does not provide a GOCDB entitlement.</li><li>Login is required with a gocdb entitlement.</li><li>To gain access, you will need to login to the Proxy IdP using a scheme that provides a gocdb entitlement.</li><li>Please logout or restart your browser and attempt to login again.</li></ul>';
+                 $HTML = '<ul><li>You authenticated to the EGI Demo Identity Provider using a method that does not provide a GOCDB entitlement.</li><li>Login is required with a gocdb entitlement.</li><li>To gain access, you will need to login to the Proxy IdP using a scheme that provides a gocdb entitlement.</li><li>Please logout or restart your browser and attempt to login again.</li></ul>';
                  $HTML .= "<div style='text-align: center;'>";
                  $HTML .= '<a href="'.htmlspecialchars(\Factory::$properties['LOGOUTURL']).'"><b><font colour="red">Logout</font></b></a>';
                  $HTML .= "</div>";
                  echo ($HTML);
                  die();
             }
-            $this->principal = $_SERVER['epuid'];
+            $this->principal = $_SERVER['voPersonID'];
             $this->userDetails = array('AuthenticationRealm' => array('EGI Proxy IdP'));
             return;
         }


### PR DESCRIPTION
This has included:
  - switching to aai-demo.egi.eu for preproduction, on the advice of EGI Check In team
  - updating the expected IdPs from `subdomain/proxy/saml2/idp/metadata.php` to `subdomain/auth/realms/egi`
  - moving from using epuid to voPersonID

Related ticket: https://ggus.eu/index.php?mode=ticket_info&ticket_id=164026

Once this is confirmed to work in production, before merging I'll bump the version number up to 5.10.5. This PR deliberately merges into master so that it can be released quckly, in isolation.