### PR TITLE
Add http response code to check.php

### DIFF
--- a/htdocs/web_portal/GOCDB_monitor/check.php
+++ b/htdocs/web_portal/GOCDB_monitor/check.php
@@ -12,6 +12,7 @@ if ($errorCount != 0) {
     echo("One or more errors have been detected while checking GOCDB services - " .
         $message .
         ". See https://goc.egi.eu/portal/GOCDB_monitor/ to find out more\n");
+    http_response_code(500);
     exit(2); // return Nagios error code for CRITICAL
 }
 


### PR DESCRIPTION
Resolves #406
Adds http response code to check.php to allow the status of GOCDB to be checked without needing authentication. 