### PR TITLE
Release 5.11.1 to dev

### DIFF
--- a/htdocs/web_portal/static_html/goc5_logo.html
+++ b/htdocs/web_portal/static_html/goc5_logo.html
@@ -4,7 +4,7 @@
 <!--	<img src="img/Logo-1.6.png" class="logo_image" height="39" style="vertical-align: middle;"/>-->
   <h3    class="Logo_Text Small_Bottom_Margin Standard_Padding"
          style="vertical-align: middle; margin-left: 0.2em;">
-         GOCDB 5.11.0
+         GOCDB 5.11.1
      </h3>
 
 </a>


### PR DESCRIPTION
A very small release, containing only https://github.com/GOCDB/gocdb/pull/504, which was merged into `dev` during the release process for 5.11.0.

This small release ensures the 5.12.0 will only contain PHP 7.4 / Rocky 8 related changes.