### PR TITLE
Unit test against newer versions of MariaDB

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -14,7 +14,7 @@ jobs:
         # Define jobs for all combinations of php, mariadb and extension, up to "include"
         # Tests will be performed for each combination
         php-version: ["7.4"]
-        mariadb-version: ["10.3"]
+        mariadb-version: ["10.11", "11.4", "11", "latest"]
         extension: ["pdo_mysql"]
         composer-json: ["composer.json"]
 
@@ -27,7 +27,7 @@ jobs:
           MYSQL_USER: "user"
           MYSQL_PASSWORD: "password"
 
-        options: --health-cmd="mysqladmin ping" --health-interval=5s --health-timeout=2s --health-retries=3
+        options: --health-cmd="mariadb-admin ping" --health-interval=5s --health-timeout=2s --health-retries=3
         ports:
           - "3306:3306"
 


### PR DESCRIPTION
- MariaDB 10.11 is readily install-able on Rocky8 and is the version we run in production.
- MariaDB 10.11 would appear to be the last version in the 10.X series.
- MariaDB 11.4 is the first version in the 11.X series with long term support, so test against it.
- Also test against the newest image in the 11.X series.
- Also test against the "latest" docker image available. In the near term, this is likely to the same image as "11". However testing against "latest" will mean we test against 12 automatically when it is released.
- Use `mariadb-admin` as admin command.
  - MariaDB <10.3 required mysqladmin be used.
  - MariaDB 10.4 to <11.0 allow both mysqladmin and mariadb-admin to be used.
  - MariaDB 11+ requires mariadb-admin.