### PR TITLE
Update code to reflect the new EGI checkin error message(Master)

### DIFF
--- a/htdocs/web_portal/static_html/goc5_logo.html
+++ b/htdocs/web_portal/static_html/goc5_logo.html
@@ -4,7 +4,7 @@
 <!--	<img src="img/Logo-1.6.png" class="logo_image" height="39" style="vertical-align: middle;"/>-->
   <h3    class="Logo_Text Small_Bottom_Margin Standard_Padding"
          style="vertical-align: middle; margin-left: 0.2em;">
-         GOCDB 5.12.0
+         GOCDB 5.12.1-rc.1
      </h3>
 
 </a>

--- a/htdocs/web_portal/static_html/goc5_logo.html
+++ b/htdocs/web_portal/static_html/goc5_logo.html
@@ -4,7 +4,7 @@
 <!--	<img src="img/Logo-1.6.png" class="logo_image" height="39" style="vertical-align: middle;"/>-->
   <h3    class="Logo_Text Small_Bottom_Margin Standard_Padding"
          style="vertical-align: middle; margin-left: 0.2em;">
-         GOCDB 5.12.1-rc.1
+         GOCDB 5.12.1
      </h3>
 
 </a>

--- a/lib/Authentication/AuthTokens/ShibAuthToken.php
+++ b/lib/Authentication/AuthTokens/ShibAuthToken.php
@@ -122,7 +122,7 @@ class ShibAuthToken implements IAuthentication {
             }
             if(empty($_SERVER['entitlement'])){
                 //die('Did not recieve the required entitlement attribute from the EGI Proxy IdP, please contact gocdb-admins');
-                $HTML = '<ul><li>Login requires a GOCDB entitlement value <a href="https://wiki.egi.eu/wiki/URN_Registry:aai.egi.eu:gocdb" target="_blank">https://wiki.egi.eu/wiki/URN_Registry:aai.egi.eu:gocdb</a></li><li>Please, logout or restart your browser and attempt to login again using an identity provider that provides a GOCDB entitlement</li></ul>';
+                $HTML = $this->getEntitlementErrorMessage();
                 $HTML .= "<div style='text-align: center;'>";
                 $HTML .= '<a href="'.htmlspecialchars(\Factory::$properties['LOGOUTURL']).'"><b><font colour="red">Logout</font></b></a>';
                 $HTML .= "</div>";
@@ -132,7 +132,7 @@ class ShibAuthToken implements IAuthentication {
 
             $entitlementValuesArray = explode(';', $_SERVER['entitlement']);
             if( !in_array('urn:mace:egi.eu:res:gocdb#aai.egi.eu', $entitlementValuesArray) ){
-                 $HTML = '<ul><li>Login requires a GOCDB entitlement <a href="https://wiki.egi.eu/wiki/URN_Registry:aai.egi.eu:gocdb" target="_blank">https://wiki.egi.eu/wiki/URN_Registry:aai.egi.eu:gocdb</a></li><li>Please, logout or restart your browser and attempt to login again using an identity provider that provides a GOCDB entitlement</li></ul>';
+                 $HTML = $this->getEntitlementErrorMessage();
                  $HTML .= "<div style='text-align: center;'>";
                  $HTML .= '<a href="'.htmlspecialchars(\Factory::$properties['LOGOUTURL']).'"><b><font colour="red">Logout</font></b></a>';
                  $HTML .= "</div>";
@@ -204,4 +204,27 @@ class ShibAuthToken implements IAuthentication {
         return true;
     }
 
+    private function getEntitlementErrorMessage()
+    {
+        $refedsResAndSchURL = "https://refeds.org/category/research-and-scholarship";
+        $refedsSirtfiURL = "https://refeds.org/sirtfi";
+        $resourceLink = "https://docs.egi.eu/internal/configuration-database/access";
+        $sectionFragmentInfo = "/#using-institutional-account-via-egi-check-in";
+        $documentationURL = $resourceLink . $sectionFragmentInfo;
+
+        return "<ul>"
+            . "<li>Login requires the entitlement "
+            . "urn:mace:egi.eu:res:gocdb#aai.egi.eu, "
+            . "which was not provided.</li>"
+            . "<li>This entitlement is automatically granted "
+            . "when using an identity provider compliant with "
+            . "<a href=\"{$refedsResAndSchURL}\" target='_blank'>"
+            . "REFEDS R&amp;S</a> and "
+            . "<a href=\"{$refedsSirtfiURL}\" target='_blank'>"
+            . "REFEDS Sirtfi</a>.</li>"
+            . "<li>Please see here for more information: "
+            . "<a href=\"{$documentationURL}\" target='_blank'>"
+            . "{$documentationURL}</a>.</li>"
+            . "</ul>";
+    }
 }


### PR DESCRIPTION
 - Co-authored-by: gregcorbett <gregcorbett@users.noreply.github.com>
 
 
 Resolves https://github.com/GOCDB/gocdb/issues/498
[GT-469](https://stfc.atlassian.net/browse/GT-469?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ)

If a user authenticates with EGI CheckIn, but does not have the correct permission to view gocdb, they are given a basic error message.

This error message references an older entitlement / the EGI wiki. This should be updated to the newer entitlement and update the references.

[GT-469]: https://stfc.atlassian.net/browse/GT-469?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ