### PR TITLE
Improve handling when no certificate is provided.

### DIFF
--- a/lib/Authentication/AuthTokens/X509AuthenticationToken.php
+++ b/lib/Authentication/AuthTokens/X509AuthenticationToken.php
@@ -85,6 +85,14 @@ class X509AuthenticationToken implements IAuthentication {
             $Raw_Client_Certificate = $_SERVER['SSL_CLIENT_CERT'];
             if (isset($Raw_Client_Certificate)) {
                 $Plain_Client_Cerfificate = openssl_x509_parse($Raw_Client_Certificate);
+
+                // $Plain_Client_Cerfificate will be an array in the presence of
+                // a certificate, otherwise, it will be `false`.
+                if (is_array($Plain_Client_Cerfificate)) {
+                    // Then no valid certificate was provided.
+                    return;
+                }
+
                 $User_DN = $Plain_Client_Cerfificate['name'];
                 if (isset($User_DN)) {
                     // Check that the dn does not contain a backslash - utf8 chars


### PR DESCRIPTION
PHP 7.4 (sensibly) raises a notice when trying to access `false` as if it where an array, i.e. via `$Plain_Client_Cerfificate['name']`

Accessing `false` as if it were an array is not enough to break anything currently - but the notice does get raised every time someone access GOCDB via, for example, EGI CheckIn.

This PR address that issue and eliminates the notice.