### PR TITLE
Fix handling of missing X509 certificate

### DIFF
--- a/lib/Authentication/AuthTokens/X509AuthenticationToken.php
+++ b/lib/Authentication/AuthTokens/X509AuthenticationToken.php
@@ -88,7 +88,7 @@ class X509AuthenticationToken implements IAuthentication {
 
                 // $Plain_Client_Cerfificate will be an array in the presence of
                 // a certificate, otherwise, it will be `false`.
-                if (is_array($Plain_Client_Cerfificate)) {
+                if (! is_array($Plain_Client_Cerfificate)) {
                     // Then no valid certificate was provided.
                     return;
                 }


### PR DESCRIPTION
- $Plain_Client_Cerfificate is an array when a certificate has been provided, and a boolean (false) when no certificate is provided.
- As such, if _and only if_ $Plain_Client_Cerfificate _is not_ an array do we want to return here.