### PR TITLE
Enhance check on database used on monitoring page (master)

### DIFF
--- a/htdocs/web_portal/GOCDB_monitor/tests.php
+++ b/htdocs/web_portal/GOCDB_monitor/tests.php
@@ -136,8 +136,11 @@ function test_db_connection()
         $entityManager = Factory::getNewEntityManager();
         // Get the database connection.
         $connection = $entityManager->getConnection();
-        // Try a simple select statement.
-        $connection->fetchOne('SELECT 1');
+        // Try a simple select statement - attempt to bypass any caching
+        // by requesting the current timestamp to the nearest millisecond.
+        // This is done by the 3, which represents the number of decimal
+        // to display.
+        $connection->fetchOne('SELECT CURRENT_TIMESTAMP(3)');
         $retval["status"] = OK;
         $retval["message"] = OKMSG;
     } catch (\Exception $e) {

--- a/htdocs/web_portal/GOCDB_monitor/tests.php
+++ b/htdocs/web_portal/GOCDB_monitor/tests.php
@@ -134,7 +134,10 @@ function test_db_connection()
     $retval = [];
     try {
         $entityManager = Factory::getNewEntityManager();
-        $entityManager->getConnection()->connect();
+        // Get the database connection.
+        $connection = $entityManager->getConnection();
+        // Try a simple select statement.
+        $connection->fetchOne('SELECT 1');
         $retval["status"] = OK;
         $retval["message"] = OKMSG;
     } catch (\Exception $e) {

--- a/htdocs/web_portal/static_html/goc5_logo.html
+++ b/htdocs/web_portal/static_html/goc5_logo.html
@@ -4,7 +4,7 @@
 <!--	<img src="img/Logo-1.6.png" class="logo_image" height="39" style="vertical-align: middle;"/>-->
   <h3    class="Logo_Text Small_Bottom_Margin Standard_Padding"
          style="vertical-align: middle; margin-left: 0.2em;">
-         GOCDB 5.12.1
+         GOCDB 5.12.2-rc.1
      </h3>
 
 </a>


### PR DESCRIPTION
Resolves GT-759

Reworked branch into a hotfix as discussed in GT-759 and #535, as such it deliberately merges into `master`.

Following updates to database infrastructure, new failure modes have presented themselves - i.e. the database is healthy enough to pass the basic connection check - but not healthy enough to be used beyond that.

This is a heavier weight (but by no means a heavy weight) check that actually tries to use the database and may be more useful here.

It is certainly no worse, i.e. if the database is down - this new check still fails.
