### PR TITLE
Log database failure details instead of displaying them on the status webpage (to master)

### DIFF
--- a/htdocs/web_portal/GOCDB_monitor/tests.php
+++ b/htdocs/web_portal/GOCDB_monitor/tests.php
@@ -144,9 +144,9 @@ function test_db_connection()
         $retval["status"] = OK;
         $retval["message"] = OKMSG;
     } catch (\Exception $e) {
-        $message = $e->getMessage();
+        error_log($e->getMessage());
         $retval["status"] = NOK;
-        $retval["message"] = "$message";
+        $retval["message"] = "Database connection test failed";
     }
 
     return $retval;
@@ -242,7 +242,7 @@ function run_tests(&$message)
 
     if ($res["status"] != "ok") {
         $errorCount++;
-        $messages[] = "Database connection test failed: " . $res["message"];
+        $messages[] = $res["message"];
     }
 
     $res = test_url(Factory::getConfigService()->GetPiUrl() .

--- a/htdocs/web_portal/static_html/goc5_logo.html
+++ b/htdocs/web_portal/static_html/goc5_logo.html
@@ -4,7 +4,7 @@
 <!--	<img src="img/Logo-1.6.png" class="logo_image" height="39" style="vertical-align: middle;"/>-->
   <h3    class="Logo_Text Small_Bottom_Margin Standard_Padding"
          style="vertical-align: middle; margin-left: 0.2em;">
-         GOCDB 5.12.2
+         GOCDB 5.12.3
      </h3>
 
 </a>


### PR DESCRIPTION
As the error message can leak out information about the underlying database infrastructure.

This new code is currently running on https://host-172-16-113-244.nubes.stfc.ac.uk, i.e. 
- https://host-172-16-113-244.nubes.stfc.ac.uk/portal/GOCDB_monitor/
- https://host-172-16-113-244.nubes.stfc.ac.uk/portal/GOCDB_monitor/check.php

I've fashioned this as a minimal hot fix to roll it out to production quickly.

To be tracked and implemented separately, we should evaluate if more error messages need to / should be logged instead of being displayed on the webpage. If most/all error messages get logged instead of displayed, is there a point to `/portal/GOCDB_monitor/` when `/portal/GOCDB_monitor/check.php` exists for programmatically purposes?