### PR TITLE
Hotfix 5.12.4 to master

### DIFF
--- a/htdocs/PI/index.php
+++ b/htdocs/PI/index.php
@@ -408,7 +408,7 @@ class PIRequest
         $authEntServ = \Factory::getAPIAuthenticationService();
         $authEnt = $authEntServ->getAPIAuthentication($this->identifier);
 
-        if (!is_null($authEnt)) {
+        if (!empty($authEnt)) {
             $authEntServ->updateLastUseTime($authEnt);
             $authenticated = true;
         }

--- a/htdocs/web_portal/static_html/goc5_logo.html
+++ b/htdocs/web_portal/static_html/goc5_logo.html
@@ -4,7 +4,7 @@
 <!--	<img src="img/Logo-1.6.png" class="logo_image" height="39" style="vertical-align: middle;"/>-->
   <h3    class="Logo_Text Small_Bottom_Margin Standard_Padding"
          style="vertical-align: middle; margin-left: 0.2em;">
-         GOCDB 5.12.3
+         GOCDB 5.12.4-rc.1
      </h3>
 
 </a>

--- a/htdocs/web_portal/static_html/goc5_logo.html
+++ b/htdocs/web_portal/static_html/goc5_logo.html
@@ -4,7 +4,7 @@
 <!--	<img src="img/Logo-1.6.png" class="logo_image" height="39" style="vertical-align: middle;"/>-->
   <h3    class="Logo_Text Small_Bottom_Margin Standard_Padding"
          style="vertical-align: middle; margin-left: 0.2em;">
-         GOCDB 5.12.4-rc.1
+         GOCDB 5.12.4
      </h3>
 
 </a>


### PR DESCRIPTION
- if an identifier is passed that doesn't correspond to an API credential, $authEnt is an empty array, not `null`.
- updateLastUseTime does not fail if $authEnt does not exist.
- this had the affect of authorising all identifiers, which meant having an identifier is sufficient to access [level 3](https://github.com/GOCDB/GOCDB.github.io/blob/main/api/read/index.md#data-protection-levels) methods.

**Testing done**


Behaviour in 5.12.3, credentials vs access to endpoints

| Credential | Level 1 (i.e. [get_service_types](https://gocdb.github.io/api/read/get_service_types/)) | Level 2 (i.e. [get_cert_status_date](https://gocdb.github.io/api/read/get_cert_status_date/)) | Level 3 (i.e. [get_user](https://gocdb.github.io/api/read/get_user/)) |
|--|--|--|--|
| None| Y | N | N |
| Provided (User) | Y | Y | Y* |
| Provided (Host) | Y | Y | Y* |
| Registered (User) | Y | Y | Y |
| Registered (Host) | Y | Y | Y |

\* erroneous behaviour, that is addressed by this fix.

Behaviour in 5.12.4, credentials vs access to endpoints

| Credential | Level 1 (i.e. [get_service_types](https://gocdb.github.io/api/read/get_service_types/)) | Level 2 (i.e. [get_cert_status_date](https://gocdb.github.io/api/read/get_cert_status_date/)) | Level 3 (i.e. [get_user](https://gocdb.github.io/api/read/get_user/)) |
|--|--|--|--|
| Missing | Y | N | N |
| Provided (User) | Y | Y | N |
| Provided (Host) | Y | Y | N |
| Registered (User) | Y | Y | Y |
| Registered (Host) | Y | Y | Y |
