### PR TITLE
Add scripts to ease migration to new WLCG hierarchical scope structure

### DIFF
--- a/resources/wlcg-scope-tag-migration/WLCGScopeTagAddRunner.php
+++ b/resources/wlcg-scope-tag-migration/WLCGScopeTagAddRunner.php
@@ -38,6 +38,7 @@ $sectionBreak = "=========================================================\n";
 $em = $entityManager;
 
 echo "Querying for all sites\n";
+// Fetch all Sites using a Doctrine Query Language (DQL) query.
 $siteDql = "SELECT s FROM Site s";
 $allSitesList = $entityManager->createQuery($siteDql)->getResult();
 

--- a/resources/wlcg-scope-tag-migration/WLCGScopeTagAddRunner.php
+++ b/resources/wlcg-scope-tag-migration/WLCGScopeTagAddRunner.php
@@ -1,0 +1,89 @@
+<?php
+
+/*
+ * Script to query and update each Site with WLCG scope tags to migrate them
+ * to a new heirachical structure.
+ *
+ * Desired Behaviour:
+ * Sites get every possible combination of their existing WLCG VO and tierN
+ * scope tags in the new heirachical structure.
+ * - a site with alice and tier1 should get alice.tier1
+ * - a site with alice, atlas and tier2 should get alice.tier2 and atlas.tier2
+ * - a site with atlas and tier2 should get atlas.tier2
+ * - a site with alice, tier1 and tier2 should get alice.tier1 and alice.tier2
+ * - a site with alice, atlas, tier1 and tier2 should get
+ *   - alice.tier1
+ *   - alice.tier2
+ *   - atlas.tier1
+ *   - atlas.tier2
+ *
+ * This script is intended to be one time use, i.e. once it has run to
+ * completion - I don't anticpate needing the script again.
+ * However, effort has been taken to ensure the script can be safely
+ * run muliptle times - i.e. should a update randomly fail, the whole
+ * script can be re-run.
+ *
+ * Usage: php resources/wlcg-scope-tag-migration/WLCGScopeTagAddRunner.php
+ */
+
+require_once dirname(__FILE__) . "/../../lib/Doctrine/bootstrap.php";
+require dirname(__FILE__) . '/../../lib/Doctrine/bootstrap_doctrine.php';
+require_once dirname(__FILE__) . '/../../lib/Gocdb_Services/Factory.php';
+
+// This will supply the WLCG VO and tierN scope tags.
+require_once dirname(__FILE__) . "/WLCGScopeTagList.php";
+
+
+$sectionBreak = "=========================================================\n";
+$em = $entityManager;
+
+echo "Querying for all sites\n";
+$siteDql = "SELECT s FROM Site s";
+$allSitesList = $entityManager->createQuery($siteDql)->getResult();
+
+echo "Starting update of Sites: " . date('D, d M Y H:i:s') . "\n";
+echo $sectionBreak;
+
+foreach ($allSitesList as $site) {
+    echo $site->getShortName() . ":\n";
+
+    $siteScopes = $site->getScopes()->toArray();
+
+    // Sites can support multiple CERN VOs - at any and multiple tiers.
+    // Check each combination in turn.
+    foreach ($wlcgScopesList as $wlcgScope) {
+        foreach ($tierScopesList as $tierScope) {
+            if (
+                (in_array($wlcgScope, $siteScopes)) &&
+                (in_array($tierScope, $siteScopes))
+            ) {
+                $newScopeName = $wlcgScope . "." . $tierScope;
+
+                // check if new scope has been already applied
+                // (from a previous run).
+                if (in_array($newScopeName, $siteScopes)) {
+                    echo "Skipping, site already has " . $newScopeName . "\n";
+                    continue;
+                } else {
+                    // apply new scope tag in a transaction.
+                    $em->getConnection()->beginTransaction();
+                    try {
+                        // need the object not the name to add to a site.
+                        $site->addScope($allScopeDict[$newScopeName]);
+                        $em->merge($site);
+                        $em->flush();
+                        $em->getConnection()->commit();
+                        echo "Added " . $newScopeName . "\n";
+                    } catch (\Exception $ex) {
+                        $em->getConnection()->rollback();
+                        $em->close();
+                        throw $ex;
+                    }
+                }
+            }
+        }
+    }
+}
+
+$em->flush();
+echo "Completed ok: " . date('D, d M Y H:i:s') . "\n";

--- a/resources/wlcg-scope-tag-migration/WLCGScopeTagCreateRunner.php
+++ b/resources/wlcg-scope-tag-migration/WLCGScopeTagCreateRunner.php
@@ -1,0 +1,68 @@
+<?php
+
+/*
+ * Script to create new scope tags for the WLCG new heirachical structure.
+ *
+ * Desired Behaviour:
+ * Create every combination of VO.tierN for the supplied WLCG VO and tierN
+ * scope tags.
+ *
+ * This script is intended to be one time use, i.e. once it has run to
+ * completion - I don't anticpate needing the script again.
+ * However, effort has been taken to ensure the script can be safely
+ * run muliptle times - i.e. should a update randomly fail, the whole
+ * script can be re-run.
+ *
+ * Usage: php resources/wlcg-scope-tag-migration/WLCGScopeTagCreateRunner.php
+ */
+
+require_once dirname(__FILE__) . "/../../lib/Doctrine/bootstrap.php";
+require dirname(__FILE__) . '/../../lib/Doctrine/bootstrap_doctrine.php';
+require_once dirname(__FILE__) . '/../../lib/Gocdb_Services/Factory.php';
+
+// This will supply the WLCG VO and tierN scope tags.
+require_once dirname(__FILE__) . "/WLCGScopeTagList.php";
+
+$sectionBreak = "=========================================================\n";
+$em = $entityManager;
+$serv = \Factory::getScopeService();
+
+echo "Starting creation of Scopes: " . date('D, d M Y H:i:s') . "\n";
+
+foreach ($wlcgScopesList as $wlcgScope) {
+    foreach ($tierScopesList as $tierScope) {
+        $newScopeName = $wlcgScope . "." . $tierScope;
+
+        echo "Trying to create " . $newScopeName . "\n";
+
+        if (in_array($newScopeName, array_keys($allScopeDict))) {
+            echo "Skipping " . $newScopeName . "\n";
+            echo "It already exists\n";
+            echo $sectionBreak;
+            continue;
+        }
+
+        $newScope = new Scope();
+        $newScope->setName($newScopeName);
+        $newScope->setDescription("Tag for WLCG " . $tierScope . " " .
+            "resources that support the " . $wlcgScope . " VO ");
+        $newScope->setReserved(true);
+
+        $em->getConnection()->beginTransaction();
+        try {
+            $em->persist($newScope);
+            $em->flush();
+            $em->getConnection()->commit();
+        } catch (\Exception $e) {
+            $em->getConnection()->rollback();
+            $em->close();
+            throw $e;
+        }
+
+        echo "Done" . "\n";
+        echo $sectionBreak;
+    }
+}
+
+$em->flush();
+echo "Completed ok: " . date('D, d M Y H:i:s') . "\n";

--- a/resources/wlcg-scope-tag-migration/WLCGScopeTagList.php
+++ b/resources/wlcg-scope-tag-migration/WLCGScopeTagList.php
@@ -1,8 +1,7 @@
 <?php
 
 /*
- * A simple script to home some variables useful for the WLCG Scope tag
- * migration.
+ * A simple script to store variables useful for the WLCG Scope tag migration.
  */
 
 $wlcgScopesList = ["alice", "atlas", "belle", "cms", "dune", "lhcb"];

--- a/resources/wlcg-scope-tag-migration/WLCGScopeTagList.php
+++ b/resources/wlcg-scope-tag-migration/WLCGScopeTagList.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * A simple script to home some variables useful for the WLCG Scope tag
+ * migration.
+ */
+
+$wlcgScopesList = ["alice", "atlas", "belle", "cms", "dune", "lhcb"];
+$tierScopesList = ["tier0", "tier1", "tier2", "tier3"];
+
+// Retrieve all scope objects from the DB and store as an dict, with the
+// name as the key, for later reference.
+$scopeDql = "SELECT s FROM Scope s";
+$allScopeList = $entityManager->createQuery($scopeDql)->getResult();
+$allScopeDict = [];
+foreach ($allScopeList as $scope) {
+    $allScopeDict[$scope->getName()] = $scope;
+}

--- a/resources/wlcg-scope-tag-migration/WLCGScopeTagList.php
+++ b/resources/wlcg-scope-tag-migration/WLCGScopeTagList.php
@@ -7,8 +7,9 @@
 $wlcgScopesList = ["alice", "atlas", "belle", "cms", "dune", "lhcb"];
 $tierScopesList = ["tier0", "tier1", "tier2", "tier3"];
 
-// Retrieve all scope objects from the DB and store as an dict, with the
-// name as the key, for later reference.
+// Retrieve all scope objects from the DB using a Doctrine Query
+// Language (DQL) query and store as an dict, with the name as the key, for
+// later reference.
 $scopeDql = "SELECT s FROM Scope s";
 $allScopeList = $entityManager->createQuery($scopeDql)->getResult();
 $allScopeDict = [];


### PR DESCRIPTION
Resolves GT-1074

Add scripts should automate creation and then application of the new scope tags.

WLCGScopeTagCreateRunner.php, desired behaviour: Create every combination of VO.tierN for the supplied WLCG VO and tierN scope tags.

WLCGScopeTagAddRunner.php, desired behaviour: Sites get every possible combination of their existing WLCG VO and tierN scope tags in the new hierarchical structure.

I'd particularly appreciate checks that the logic is correct and achieves the desired behaviour.