### PR TITLE
Extend WLCG scope migration scripts to cover Services

### DIFF
--- a/resources/wlcg-scope-tag-migration/WLCGScopeTagAddRunner.php
+++ b/resources/wlcg-scope-tag-migration/WLCGScopeTagAddRunner.php
@@ -1,17 +1,19 @@
 <?php
 
 /*
- * Script to query and update each Site with WLCG scope tags to migrate them
- * to a new heirachical structure.
+ * Script to query and update each Site and Service with WLCG scope tags to
+ * migrate them to a new heirachical structure.
  *
  * Desired Behaviour:
- * Sites get every possible combination of their existing WLCG VO and tierN
- * scope tags in the new heirachical structure.
- * - a site with alice and tier1 should get alice.tier1
- * - a site with alice, atlas and tier2 should get alice.tier2 and atlas.tier2
- * - a site with atlas and tier2 should get atlas.tier2
- * - a site with alice, tier1 and tier2 should get alice.tier1 and alice.tier2
- * - a site with alice, atlas, tier1 and tier2 should get
+ * Entities (Sites and Services) get every possible combination of their
+ * existing WLCG VO and tierN scope tags in the new heirachical structure.
+ * - a entity with alice and tier1 should get alice.tier1
+ * - a entity with alice, atlas and tier2 should get alice.tier2 and
+ *   atlas.tier2
+ * - a entity with atlas and tier2 should get atlas.tier2
+ * - a entity with alice, tier1 and tier2 should get alice.tier1 and
+ *   alice.tier2
+ * - a entity with alice, atlas, tier1 and tier2 should get
  *   - alice.tier1
  *   - alice.tier2
  *   - atlas.tier1
@@ -37,32 +39,50 @@ require_once dirname(__FILE__) . "/WLCGScopeTagList.php";
 $sectionBreak = "=========================================================\n";
 $em = $entityManager;
 
-echo "Querying for all sites\n";
+echo "Querying for all sites and services\n";
 // Fetch all Sites using a Doctrine Query Language (DQL) query.
 $siteDql = "SELECT s FROM Site s";
 $allSitesList = $entityManager->createQuery($siteDql)->getResult();
 
-echo "Starting update of Sites: " . date('D, d M Y H:i:s') . "\n";
+// Fetch all Services using a Doctrine Query Language (DQL) query.
+$serviceDql = "SELECT s FROM Service s";
+$allServicesList = $entityManager->createQuery($serviceDql)->getResult();
+
+// Merge into a single list to loop through.
+$allEntitiesList = array_merge($allSitesList, $allServicesList);
+
+echo "Starting update of Entities: " . date('D, d M Y H:i:s') . "\n";
 echo $sectionBreak;
 
-foreach ($allSitesList as $site) {
-    echo $site->getShortName() . ":\n";
+foreach ($allEntitiesList as $entity) {
+    // Handle different ways to refer (in a human readable sense) to
+    // different entities.
+    if (get_class($entity) === "Site") {
+        $shortName = $entity->getShortName();
+    } elseif (get_class($entity) === "Service") {
+        $shortName = $entity->getServiceType() . ': ' . $entity->getHostName();
+    } else {
+        echo "unexpected entity class! " . get_class($entity) . "\n";
+        die();
+    }
 
-    $siteScopes = $site->getScopes()->toArray();
+    echo $shortName . ":\n";
 
-    // Sites can support multiple CERN VOs - at any and multiple tiers.
+    $entityScopes = $entity->getScopes()->toArray();
+
+    // Enities can support multiple CERN VOs - at any and multiple tiers.
     // Check each combination in turn.
     foreach ($wlcgScopesList as $wlcgScope) {
         // If the WLCG scope in question this iteration is not applied to the
-        // site, no need to check tier scopes.
-        if (!in_array($wlcgScope, $siteScopes)) {
+        // entity, no need to check tier scopes.
+        if (!in_array($wlcgScope, $entityScopes)) {
             continue;
         }
 
         foreach ($tierScopesList as $tierScope) {
-            if (!in_array($tierScope, $siteScopes)) {
+            if (!in_array($tierScope, $entityScopes)) {
                 // If the tier scope in question this iteration is not applied
-                // to the site, no need to progress any further.
+                // to the entity, no need to progress any further.
                 continue;
             }
 
@@ -70,17 +90,17 @@ foreach ($allSitesList as $site) {
 
             // check if new scope has been already applied
             // (from a previous run).
-            if (in_array($newScopeName, $siteScopes)) {
-                echo "Skipping, site already has " . $newScopeName . "\n";
+            if (in_array($newScopeName, $entityScopes)) {
+                echo "Skipping, enitity already has " . $newScopeName . "\n";
                 continue;
             }
 
             // apply new scope tag in a transaction.
             $em->getConnection()->beginTransaction();
             try {
-                // need the object not the name to add to a site.
-                $site->addScope($allScopeDict[$newScopeName]);
-                $em->merge($site);
+                // need the object not the name to add to an entity.
+                $entity->addScope($allScopeDict[$newScopeName]);
+                $em->merge($entity);
                 $em->flush();
                 $em->getConnection()->commit();
                 echo "Added " . $newScopeName . "\n";


### PR DESCRIPTION
As a follow on from #548.

Much like Sites, the desired end state for Services can be inferred from the current scope tag set.

This will save Site admin's going through and updating all their services by hand.