### PR TITLE
Improvements to GOCDB monitoring page

### DIFF
--- a/htdocs/web_portal/GOCDB_monitor/index.php
+++ b/htdocs/web_portal/GOCDB_monitor/index.php
@@ -48,7 +48,6 @@ show ERROR or UNKNOWN if the configuration is invalid.</p>
             <td><b>Test</b></td>
             <td><b>Status</b></td>
             <td><b>Details</b></td>
-            <td><b>Doc/help</b></td>
         </tr>
     </thead>
     <tbody>
@@ -58,7 +57,6 @@ foreach ($test_statuses as $test => $status) {
     echo("<td><span title=\"{$test_desc[$test]}\">$test</span></font></td>");
     echo($disp[$status]);
     echo("<td>{$test_messages[$test]}</font></td>");
-    echo("<td>{$test_doc[$test]}</font></td>");
     echo("</tr>");
 }
 ?>
@@ -66,27 +64,3 @@ foreach ($test_statuses as $test => $status) {
 </table>
 
 <hr>
-
-<h2>Other tests and check pages</h2>
-<ul>
-    <li><a href='http://sumatran.esc.rl.ac.uk/ganglia/?r=day&amp;
-    c=Grid+services&amp;h=gocdb-base.esc.rl.ac.uk'>GOCDB server
-    ganglia page</a> - Useful to see if there are memory or CPU
-    problems</li>
-    <li><a href='check.php'>Status check</a> - a less verbose check of
-    GOCDB service status. Returns the single line 'All GOCDB tests
-    are looking good' if all tests run without error and 'GOCDB
-    Web Portal is unable to connect to the GOCDB back end database'
-    otherwise. Used for automated tests.</li>
-</ul>
-
-<h2>Further documentation</h2>
-<ul>
-    <li><a href='https://svn.esc.rl.ac.uk/repos/sct-docs/SCT Documents/
-    Servers and Services/GOCDB/Cookbook and recipes/
-    GOCDB_daily_maintenance.txt'>GOCDB_daily_maintenance.txt in
-    SCT docs on SVN</a> - This is where it all starts...</li>
-    <li><a href='https://wiki.egi.eu/wiki/GOCDB_Documentation_Index'>
-    GOCDB public documentation index</a> - The RTFM link to send to
-    anyone who has questions</li>
-</ul>

--- a/htdocs/web_portal/GOCDB_monitor/tests.php
+++ b/htdocs/web_portal/GOCDB_monitor/tests.php
@@ -51,28 +51,6 @@ $test_desc =  array(
         "Server XML configuration validation."
 );
 
-$test_doc =  array(
-    TEST_1 =>
-        "<a href='https://svn.esc.rl.ac.uk/repos/sct-docs/SCT " .
-        "Documents/Servers and Services/GOCDB/Cookbook and " .
-        "recipes/database_is_down.txt' target='_blank'>" .
-        "documentation/recipe</a>",
-    TEST_2 =>
-        "<a href='https://svn.esc.rl.ac.uk/repos/sct-docs/SCT " .
-        "Documents/Servers and Services/GOCDB/Cookbook and " .
-        "recipes/failover_cookbook.txt' target='_blank'>" .
-        "documentation/recipe</a>",
-    TEST_3 =>
-        "<a href='https://svn.esc.rl.ac.uk/repos/sct-docs/SCT " .
-        "Documents/Servers and Services/GOCDB/Cookbook and " .
-        "recipes/failover_cookbook.txt' target='_blank'>" .
-        "documentation/recipe</a>",
-    TEST_4 =>
-        "<p>Contact GOCDB service managers." .
-        "<br>Other tests have dependencies on the server configuration " .
-        "<br>so may show errors if the configuration is invalid.</p>"
-);
-
 $test_messages =  array(
     TEST_1 => UKNMSG,
     TEST_2 => UKNMSG,

--- a/htdocs/web_portal/GOCDB_monitor/tests.php
+++ b/htdocs/web_portal/GOCDB_monitor/tests.php
@@ -139,6 +139,7 @@ function test_url($url)
         $retval["message"] = OKMSG;
     } catch (Exception $exception) {
         $message = $exception->getMessage();
+        error_log($message);
         $retval["status"] = NOK;
         $retval["message"] = "$message";
     }
@@ -250,8 +251,10 @@ function test_config($config)
         $retval["status"] = OK;
         $retval["message"] = OKMSG;
     } catch (Exception $exception) {
+        $message = $exception->getMessage();
+        error_log($message);
         $retval["status"] = NOK;
-        $retval["message"] = $exception->getMessage();
+        $retval["message"] = $message;
     }
     return $retval;
 }


### PR DESCRIPTION
This PR:

- Removes old, dead, internal, deployment specific, links
- Logs errors generated by the monitoring page

You can see the updated page here: https://host-172-16-113-200.nubes.stfc.ac.uk/portal/GOCDB_monitor/